### PR TITLE
k8s-packs-2.1.0

### DIFF
--- a/packages/docs/content/06-integrations/00-kubernetes.md
+++ b/packages/docs/content/06-integrations/00-kubernetes.md
@@ -79,6 +79,7 @@ Versions supported in the latest [release](/release-notes/) are highlighted.
 
 <Tabs.TabPane tab="1.19.x" key="k8s_v1.19">
 
+* **1.19.16**
 * **1.19.15**
 * **1.19.14**
 * **1.19.13**
@@ -114,6 +115,7 @@ Versions supported in the latest [release](/release-notes/) are highlighted.
 
 <Tabs.TabPane tab="1.21.x" key="k8s_v1.21">
 
+* **1.21.6**
 * **1.21.5**
 * **1.21.4**
 * **1.21.3**


### PR DESCRIPTION
Kubernetes packs versions: Release 2.1.0
1. 1.19.16
2. 1.21.6