### PR TITLE
pci-dss-removed

### DIFF
--- a/packages/docs/content/15-compliance.md
+++ b/packages/docs/content/15-compliance.md
@@ -19,7 +19,7 @@ import Tooltip from "@librarium/shared/src/components/ui/Tooltip";
 ![soc2.png](soc2.png "#width=180px")
 
 Spectro Cloud is certified against SOC2 Type II, compliance with the AICPA’s (American Institute of Certified Public Accountants) TSC (Trust Services Criteria). 
-* Spectro Cloud SOC 2 Type II audit report assures our organization’s   
+* Spectro Cloud SOC 2 Type II audit report assures our organization’s:
    * Security
    * Availability
    * Processing integrity
@@ -31,16 +31,4 @@ Spectro Cloud is certified against SOC2 Type II, compliance with the AICPA’s (
 * Spectro Cloud SOC 2 Type II report is available upon request for any customers or prospects with signed MNDA.
 
 
-
-![pci-dss.png](pci-dss.png "#width=240px")
-Spectro Cloud is Payment Card Industry – Data Security Standard (PCI DSS) compliant.
-
-* Spectro Cloud satisfies the 12 requirements of PCI DSS set as 6 control objectives as below:
-	* Build and maintain a secure network.
-	* Protect cardholder data.
-	* Vulnerability management.
-	* Implement strong access control measures.
-	* Regular monitoring and testing of the network.
-	* Maintained information security policy.
-* Spectro Cloud is supported by Stripe as a PCI advocate to maintain compliance standards.
 


### PR DESCRIPTION
https://spectrocloud.atlassian.net/browse/DOC-86

Removed PCI-DSS compliance. Spectro Cloud is not PCI-compliant. Only Stripe is compliant, which is our payment processor.