### PR TITLE
pack-version-updates

### DIFF
--- a/content/docs/06-integrations/00-calico.md
+++ b/content/docs/06-integrations/00-calico.md
@@ -24,6 +24,12 @@ Spectro Network Pack(s) helps provision resources for setting up Cluster network
 [Calico](/integrations/calico)
 
 <Tabs>
+<Tabs.TabPane tab="3.22.x" key="3.22.x">
+
+* ** 3.22.0** 
+
+</Tabs.TabPane>
+
 <Tabs.TabPane tab="3.19.x" key="3.19.x">
 
 * **3.19.0** 

--- a/content/docs/06-integrations/00-certmanager.md
+++ b/content/docs/06-integrations/00-certmanager.md
@@ -23,6 +23,12 @@ cert-manager adds certificates and certificate issuers as resource types in Kube
 
 <Tabs>
 
+<Tabs.TabPane tab="1.7.x" key="1.7.x">
+
+**1.7.1**
+
+</Tabs.TabPane>
+
 <Tabs.TabPane tab="1.4.x" key="1.4.x">
 
 **1.4.0**

--- a/content/docs/06-integrations/00-falco.md
+++ b/content/docs/06-integrations/00-falco.md
@@ -22,6 +22,13 @@ Falco integration is a behavioral activity monitor designed to detect anomalous 
 ## Versions Supported
 
 <Tabs>
+
+<Tabs.TabPane tab="1.16.x" key="1.16.x">
+
+* **1.16.3**
+
+ 
+</Tabs.TabPane>
 <Tabs.TabPane tab="1.0.x" key="1.0.x">
 
 * **1.0.11**

--- a/content/docs/06-integrations/00-portworx.md
+++ b/content/docs/06-integrations/00-portworx.md
@@ -21,6 +21,12 @@ import Tooltip from "shared/components/ui/Tooltip";
 ## Versions Supported
 
 <Tabs>
+<Tabs.TabPane tab="2.8.x" key="2.8.x">
+
+* **2.8.0** 
+
+</Tabs.TabPane>
+
 <Tabs.TabPane tab="2.6.x" key="2.6.x">
 
 * **2.6.1** 

--- a/content/docs/06-integrations/00-rook-ceph.md
+++ b/content/docs/06-integrations/00-rook-ceph.md
@@ -41,6 +41,13 @@ Please make sure that your worker node pool size satisfies the minimum nodes req
 
 <Tabs>
 
+<Tabs.TabPane tab="1.8.x" key="1.8.x">
+
+**1.8.3**
+
+</Tabs.TabPane>
+
+
 <Tabs.TabPane tab="1.5.x" key="1.5.x">
 
 **1.5.9**


### PR DESCRIPTION
Version updated for the following packs:

- cert-manager 1.7.1
 
- calico - 3.22.0
 
- calico-azure - 3.22.0
 
- falco - 1.16.3 
 
- portworx-vsphere - 2.8.0

- rook-ceph - 1.8.3
 