### PR TITLE
doc-159

### DIFF
--- a/content/docs/00-release-notes.md
+++ b/content/docs/00-release-notes.md
@@ -31,6 +31,10 @@ Spectro Cloud Palette 2.6 is released with the support of Cluster Profile Versio
 
 * Palette allows reconciliation of CSI layer Storageclass for managed clusters of Amazon Elastic Kubernetes Service (EKS).
 
+**Bug Fixes**
+
+* We request our users to please add the `ec2:ReplaceRoute` permission to their [AWS](/clusters/new-clusters/aws#awscloudaccountpermissions) and [EKS-AWS](/clusters/new-clusters/eks#awscloudaccountpermissions) cloud account Controller Policy Permissions to replaces an existing route within a route table in a Virtula Private Cloud.
+
 
 # April 26, 2022 - Release 2.5.0
 

--- a/content/docs/00-release-notes.md
+++ b/content/docs/00-release-notes.md
@@ -16,7 +16,7 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 # May 23, 2022 - Release 2.6.0
 
-Spectro Cloud Palette 2.6 is released with the support of Cluster Profile Versioning, EKS Secret Encryption, and reconciling CSI Storageclass with added parameters support.
+Spectro Cloud Palette 2.6 is released to support of Cluster Profile Version, EKS Secret Encryption, CSI Storageclass, and added Parameters capabilities.
 
 **Features:**
 
@@ -24,7 +24,7 @@ Spectro Cloud Palette 2.6 is released with the support of Cluster Profile Versio
 
 * Palette leverages AWS Key Management Service (KMS) to provide envelope [encryption](/clusters/new-clusters/eks#eksclustersecretsencryption) of Kubernetes Secrets stored in Amazon Elastic Kubernetes Service (EKS) clusters.
 
-* Palette covers wide list of [parameters](https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters) and customization capabilities for [csi-aws-1.0.0](/integrations/aws-ebs#parametersupportcsi-aws-1.0.0packmanifest) pack manifest. 
+* Palette covers a long list of [parameters](https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters) and customization capabilities for the[csi-aws-1.0.0](/integrations/aws-ebs#parametersupportcsi-aws-1.0.0packmanifest) pack manifest. 
 
 **Enhancement:**
 
@@ -32,7 +32,7 @@ Spectro Cloud Palette 2.6 is released with the support of Cluster Profile Versio
 
 **Bug Fixes**
 
-* We request our users to please add the `ec2:ReplaceRoute` permission to the [AWS](/clusters/new-clusters/aws#awscloudaccountpermissions) and [EKS-AWS](/clusters/new-clusters/eks#awscloudaccountpermissions) cloud account Controller Policy to replace an existing route within a route table in a Virtula Private Cloud to smoothen the cluster deletion.
+* We request our users to add the `ec2:ReplaceRoute` permission to the [AWS](/clusters/new-clusters/aws#awscloudaccountpermissions) and [EKS-AWS](/clusters/new-clusters/eks#awscloudaccountpermissions) cloud account Controller Policy to replace an existing route within a route table in a Virtual Private Cloud to smoothen the cluster deletion process.
 
 
 # April 26, 2022 - Release 2.5.0

--- a/content/docs/00-release-notes.md
+++ b/content/docs/00-release-notes.md
@@ -24,8 +24,7 @@ Spectro Cloud Palette 2.6 is released with the support of Cluster Profile Versio
 
 * Palette leverages AWS Key Management Service (KMS) to provide envelope [encryption](/clusters/new-clusters/eks#eksclustersecretsencryption) of Kubernetes Secrets stored in Amazon Elastic Kubernetes Service (EKS) clusters.
 
-* Palette covers wide list of [parameters](https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters) and customization capabilities for [csi-aws-1.0.0](/integrations/aws-ebs#parametersupportcsi-aws-1.0.0packmanifest) pack manifest.
-  
+* Palette covers wide list of [parameters](https://github.com/kubernetes-sigs/aws-ebs-csi-driver#createvolume-parameters) and customization capabilities for [csi-aws-1.0.0](/integrations/aws-ebs#parametersupportcsi-aws-1.0.0packmanifest) pack manifest. 
 
 **Enhancement:**
 
@@ -33,7 +32,7 @@ Spectro Cloud Palette 2.6 is released with the support of Cluster Profile Versio
 
 **Bug Fixes**
 
-* We request our users to please add the `ec2:ReplaceRoute` permission to their [AWS](/clusters/new-clusters/aws#awscloudaccountpermissions) and [EKS-AWS](/clusters/new-clusters/eks#awscloudaccountpermissions) cloud account Controller Policy Permissions to replaces an existing route within a route table in a Virtula Private Cloud.
+* We request our users to please add the `ec2:ReplaceRoute` permission to the [AWS](/clusters/new-clusters/aws#awscloudaccountpermissions) and [EKS-AWS](/clusters/new-clusters/eks#awscloudaccountpermissions) cloud account Controller Policy to replace an existing route within a route table in a Virtula Private Cloud to smoothen the cluster deletion.
 
 
 # April 26, 2022 - Release 2.5.0

--- a/content/docs/04-clusters/1-new-clusters/01-aws.md
+++ b/content/docs/04-clusters/1-new-clusters/01-aws.md
@@ -65,7 +65,7 @@ The following **four** policies include all the required permissions for provisi
 
 ### Controller Policy 
 
-**Last Update**: April 26, 2022
+**Last Update**: May 25, 2022
 
 ``` json
 {
@@ -81,6 +81,7 @@ The following **four** policies include all the required permissions for provisi
         "ec2:CreateInternetGateway",
         "ec2:CreateNatGateway",
         "ec2:CreateRoute",
+        "ec2:ReplaceRoute",
         "ec2:CreateRouteTable",
         "ec2:CreateSecurityGroup",
         "ec2:CreateSubnet",

--- a/content/docs/04-clusters/1-new-clusters/02-eks.md
+++ b/content/docs/04-clusters/1-new-clusters/02-eks.md
@@ -56,7 +56,7 @@ The following **four** policies include all the required permissions for provisi
 
 ### Controller Policy
 
-**Last Update**: June 1, 2021
+**Last Update**: May 25, 2022
 
 ``` json
 {
@@ -73,6 +73,7 @@ The following **four** policies include all the required permissions for provisi
         "ec2:CreateNatGateway",
         "ec2:CreateRoute",
         "ec2:CreateRouteTable",
+        "ec2:ReplaceRoute",       
         "ec2:CreateSecurityGroup",
         "ec2:CreateSubnet",
         "ec2:CreateTags",


### PR DESCRIPTION
Add new permission to AWS - Controller Policy.  `ec2:ReplaceRoute`

For both AWS Cluster and EKS Cluster, as a fix to the [BET-5206: AwsCluster stuck at deleting state throwing ErrorBACKLOG](https://spectrocloud.atlassian.net/browse/BET-5206)