### PR TITLE
minor-typo-fix

### DIFF
--- a/content/docs/09-registries-and-packs/3-add-custom-packs.md
+++ b/content/docs/09-registries-and-packs/3-add-custom-packs.md
@@ -29,7 +29,7 @@ Custom packs are built by users and deployed to custom registries using the Spec
     ```json
     {
         "annotations": {
-            "name": "value",
+            "name": "value"
         },
         "ansibleRoles": [],
         "displayName": "<PACK_DISPLAY_NAME>",


### PR DESCRIPTION
**User feed back from appzi:**
The Example pack.json has a typo. There should not be a comma after "name": "value",

**from:**
saad@spectrocloud.com