### PR TITLE
on-prem-installer-2.6-rel

### DIFF
--- a/content/docs/16-component.md
+++ b/content/docs/16-component.md
@@ -43,7 +43,7 @@ The page lists the version details of various Palette components with respect to
 
 |Palette Release|On-Premises Installer Version|
 |--|---|
-|2.6|2.0.2|
+|2.6|2.1.0|
 |2.5|2.0.2|
 |2.3|2.0.2|
 

--- a/content/docs/16-spectro-downloads.md
+++ b/content/docs/16-spectro-downloads.md
@@ -28,7 +28,7 @@ The Palette Quickstart and Enterprise Mode on-prem installations are highly avai
 
 |Version|URL|Info|
 |--|---|--|
-|2.0.2|hubble-installer-202-10152021.ova|Oct 15 2021|
+|2.1.0|hubble-installer-210.ova|Jun 1 2022 (Cert Manager change to 1.8)|
 ------
 
 


### PR DESCRIPTION
 **|Palette Release|On-Premises Installer Version|**
-|2.6|2.0.2| - Removed
+|2.6|2.1.0| - Added

**|Version|URL|Info|**
-|2.0.2|hubble-installer-202-10152021.ova|Oct 15 2021| -Removed 
+|2.1.0|hubble-installer-210.ova|Jun 1 2022 (Cert Manager change to 1.8)| - Added
