### PR TITLE
3.0-pack-updates

### DIFF
--- a/content/docs/04.5-devx.md
+++ b/content/docs/04.5-devx.md
@@ -1,5 +1,5 @@
 ---
-title: "Palette Dev Engine"
+title: "Palette Dev Engine (Beta)"
 metaTitle: "Palette Dev Engine "
 metaDescription: "Explore Palette Dev Engine"
 icon: "users"

--- a/content/docs/06-integrations/00-aws-autoscaler.md
+++ b/content/docs/06-integrations/00-aws-autoscaler.md
@@ -76,6 +76,12 @@ managedMachinePool:
 
 <Tabs>
 
+<Tabs.TabPane tab="1.22.x" key="1.22.x">
+
+**1.22.2**
+
+</Tabs.TabPane>
+
 <Tabs.TabPane tab="1.0.x" key="1.0.x">
 
 **1.0.0**

--- a/content/docs/06-integrations/00-aws-ebs.md
+++ b/content/docs/06-integrations/00-aws-ebs.md
@@ -21,6 +21,11 @@ AWS Elastic Block Store is an easy to use, high performance block storage at any
 
 <Tabs>
 
+<Tabs.TabPane tab="1.10.x" key="1.10.x">
+
+* ** 1.10.0**
+
+</Tabs.TabPane>
 <Tabs.TabPane tab="1.8.x" key="1.8.x">
 
 * ** 1.8.0**

--- a/content/docs/06-integrations/00-calico.md
+++ b/content/docs/06-integrations/00-calico.md
@@ -41,6 +41,12 @@ Azure supports VXLAN encapsulation type.
 
 <Tabs>
 
+<Tabs.TabPane tab="3.24.x" key="3.24.x">
+
+* ** 3.24.0**
+
+</Tabs.TabPane>
+
 <Tabs.TabPane tab="3.23.x" key="3.23.x">
 
 * ** 3.23.0**

--- a/content/docs/06-integrations/00-certmanager.md
+++ b/content/docs/06-integrations/00-certmanager.md
@@ -23,6 +23,13 @@ cert-manager adds certificates and certificate issuers as resource types in Kube
 
 <Tabs>
 
+<Tabs.TabPane tab="1.9.x" key="1.9.x">
+
+**1.9.1**
+
+</Tabs.TabPane>
+
+
 <Tabs.TabPane tab="1.8.x" key="1.8.x">
 
 **1.8.1**

--- a/content/docs/06-integrations/00-dex.md
+++ b/content/docs/06-integrations/00-dex.md
@@ -24,6 +24,13 @@ Dex is an identity service to drive authentication for Kubernetes API Server thr
 ## Versions Supported
 
 <Tabs>
+
+<Tabs.TabPane tab="2.35.x" key="2.35.x">
+
+* **2.35.1** 
+
+</Tabs.TabPane>
+
 <Tabs.TabPane tab="2.30.x" key="2.30.x">
 
 * **2.30.0** 

--- a/content/docs/06-integrations/00-external-dns.md
+++ b/content/docs/06-integrations/00-external-dns.md
@@ -27,6 +27,12 @@ Providers have to be set up for this pack to get deployed and work seamlessly. F
 
 ## Versions Supported
 <Tabs>
+
+<Tabs.TabPane tab="0.12.x" key="0.12.x">
+
+* **0.12.2** 
+
+</Tabs.TabPane>
 <Tabs.TabPane tab="0.7.x" key="0.7.x">
 
 * **0.7.2** 

--- a/content/docs/06-integrations/00-fluentbit.md
+++ b/content/docs/06-integrations/00-fluentbit.md
@@ -14,6 +14,10 @@ import WarningBox from 'shared/components/WarningBox';
 
 Fluent-Bit is a multi-platform log forwarder. The default integration will help forward logs from the Kubernetes cluster to an external ElasticSearch cluster
 
+## Version
+
+* **1.9.6**
+
 ## Contents
 
 Fluent-Bit is installed as a DaemonSet & so, an instance of fluent-bit will be running on all the nodes in the cluster.

--- a/content/docs/06-integrations/00-frp.md
+++ b/content/docs/06-integrations/00-frp.md
@@ -26,8 +26,14 @@ Do not change any values which are available by default, as it is required by ou
 </InfoBox>
 
 ## Versions Supported
+
 <Tabs>
 
+<Tabs.TabPane tab="1.1.x" key="1.1.x">
+
+**1.1.0**
+
+</Tabs.TabPane>
 <Tabs.TabPane tab="1.0.x" key="1.0.x">
 
 **1.0.x**

--- a/content/docs/06-integrations/00-generic-vm-libvirt.md
+++ b/content/docs/06-integrations/00-generic-vm-libvirt.md
@@ -23,7 +23,8 @@ Generic-VM-Libvirt is a Palette Add-on pack used to simplify deploying the virtu
 <Tabs>
 <Tabs.TabPane tab="1.0.x" key="1.0.x">
 
-**generic-vm-libvirt** **1.0.0**
+* **1.0.1**
+* **1.0.0**
 
 </Tabs.TabPane>
 </Tabs>

--- a/content/docs/06-integrations/00-generic-vm-vsphere.md
+++ b/content/docs/06-integrations/00-generic-vm-vsphere.md
@@ -25,7 +25,8 @@ Generic-VM-vSphere is a Palette Add-on pack used to simplify deploying the virtu
 <Tabs>
 <Tabs.TabPane tab="1.0.x" key="1.0.x">
 
-**generic-vm-vsphere** **1.0.0**
+* **1.0.3**
+* **1.0.0**
 
 </Tabs.TabPane>
 </Tabs>

--- a/content/docs/06-integrations/00-istio.md
+++ b/content/docs/06-integrations/00-istio.md
@@ -25,6 +25,7 @@ This Integration aims to automate and simplify the rollout of the various Istio 
 
 <Tabs.TabPane tab="1.14.x" key="1.14.x">
 
+* **1.14.3**
 * **1.14.1**
 
 </Tabs.TabPane>

--- a/content/docs/06-integrations/00-kubernetes-dashboard.md
+++ b/content/docs/06-integrations/00-kubernetes-dashboard.md
@@ -25,6 +25,7 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 <Tabs.TabPane tab="2.6.x" key="2.6.x">
 
+* **2.6.1**
 * **2.6.0**
 
 </Tabs.TabPane>

--- a/content/docs/06-integrations/00-kubernetes.md
+++ b/content/docs/06-integrations/00-kubernetes.md
@@ -94,6 +94,11 @@ Versions supported in the latest [release](/release-notes/) are highlighted.
 
 </Tabs.TabPane>
 
+<Tabs.TabPane tab="1.24.x" key="k8s_v1.24">
+
+- **1.24.4**
+
+</Tabs.TabPane>
 </Tabs>
 
 ## Notable parameters

--- a/content/docs/06-integrations/00-metallb.md
+++ b/content/docs/06-integrations/00-metallb.md
@@ -37,11 +37,19 @@ MetalLB is a load-balancer implementation for bare metal [Kubernetes](https://ku
 ## Versions Supported
 
 <Tabs>
+
+<Tabs.TabPane tab="0.13.x" key="0.13.x">
+
+* **0.13.5**
+
+</Tabs.TabPane>
+
 <Tabs.TabPane tab="0.11.x" key="0.11.x">
 
 * **0.11.0**
 
 </Tabs.TabPane>
+
 <Tabs.TabPane tab="0.9.x" key="0.9.x">
 
 * **0.9.5** 

--- a/content/docs/06-integrations/00-opa-gatekeeper.md
+++ b/content/docs/06-integrations/00-opa-gatekeeper.md
@@ -39,6 +39,13 @@ The major features of OPA are:
 
 <Tabs>
 
+<Tabs.TabPane tab="3.9.x" key="3.9.x">
+
+**3.9.0**
+
+</Tabs.TabPane>
+
+
 <Tabs.TabPane tab="3.7.x" key="3.7.x">
 
 **3.7.0**


### PR DESCRIPTION
**Release 3.0 Pack Version Updates**

* Istio version 1.14.3
* Spectro Proxy version 1.1.0
* Kubernetes-dashboard-2.6.1
* Generic VM vSphere version 1.0.3
* Calico version 3.24
* Calico version 3.24_azure
* MetalLB-version 0.13.5
* AWS Cluster Autoscaler version 1.22.2
* K3s version 1.24.4
* Calico Network Policy version 3.24
* Generic-VM Libvirt version 1.0.1
* Cert-Manager version 1.9.1
* AWS EBS CSI version 1.10.0
* External DNS version 0.12.2
* Open Policy Agent version 3.9.0
* Fluentbit version 1.9.6