### PR TITLE
docs: removed duplicate yaml entry

### DIFF
--- a/content/docs/06-integrations/00-external-secrets-operator.md
+++ b/content/docs/06-integrations/00-external-secrets-operator.md
@@ -32,9 +32,11 @@ You can use the External-Secrets-Operator Add-on pack as an authenticator, withi
 <br />
 
 
-### Sample ExternalSecret YAML file
+### Example ExternalSecret YAML file
 
 <br />
+
+First example.
 
 ```yml
 apiVersion: [external-secrets.io/v1beta1](http://external-secrets.io/v1beta1)
@@ -53,6 +55,31 @@ spec:
     remoteRef:
       key: secret/foo   # custom value
       property: my-value # custom value
+
+```
+
+<br />
+
+Second example.
+
+```yml
+apiVersion: [external-secrets.io/v1beta1](http://external-secrets.io/v1beta1)
+kind: ExternalSecret
+metadata:
+  name: vault-example # Custom name
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend # Custom value
+    kind: SecretStore
+  target:
+    name: mysecretfoobar
+  data:
+  - secretKey: foobar
+    remoteRef:
+      key: secret/foo   # custom value
+      property: my-value # custom value
+
 ```
 
 # References

--- a/content/docs/06-integrations/00-external-secrets-operator.md
+++ b/content/docs/06-integrations/00-external-secrets-operator.md
@@ -32,11 +32,9 @@ You can use the External-Secrets-Operator Add-on pack as an authenticator, withi
 <br />
 
 
-### Example ExternalSecret YAML file
+### Sample SecretStore YAML file
 
 <br />
-
-First example.
 
 ```yml
 apiVersion: [external-secrets.io/v1beta1](http://external-secrets.io/v1beta1)
@@ -58,28 +56,34 @@ spec:
 
 ```
 
+### Sample ExternalSecret YAML file
+
 <br />
 
-Second example.
-
 ```yml
-apiVersion: [external-secrets.io/v1beta1](http://external-secrets.io/v1beta1)
-kind: ExternalSecret
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
 metadata:
-  name: vault-example # Custom name
+  name: custom-name
 spec:
-  refreshInterval: "15s"
-  secretStoreRef:
-    name: vault-backend # Custom value
-    kind: SecretStore
-  target:
-    name: mysecretfoobar
-  data:
-  - secretKey: foobar
-    remoteRef:
-      key: secret/foo   # custom value
-      property: my-value # custom value
-
+  provider:
+    vault:
+      server: "http://12.34.567.133:0000" # custom server end point
+      path: "secret" # custom path
+      version: "v2" # custom version
+      auth:
+        # points to a secret that contains a vault token
+        # https://www.vaultproject.io/docs/auth/token
+        tokenSecretRef:
+          name: "vault-token1"  # Custom name and key
+          key: "token1"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-token1
+data:
+  token: cm9vdA== # "root"   # custome value
 ```
 
 # References

--- a/content/docs/06-integrations/00-external-secrets-operator.md
+++ b/content/docs/06-integrations/00-external-secrets-operator.md
@@ -55,31 +55,6 @@ spec:
       property: my-value # custom value
 ```
 
-
-### Sample ExternalSecret YAML file
-
-
-<br />
-
-```yml
-
-apiVersion: [external-secrets.io/v1beta1](http://external-secrets.io/v1beta1)
-kind: ExternalSecret
-metadata:
-  name: vault-example # Custom name
-spec:
-  refreshInterval: "15s"
-  secretStoreRef:
-    name: vault-backend # Custom value
-    kind: SecretStore
-  target:
-    name: mysecretfoobar
-  data:
-  - secretKey: foobar
-    remoteRef:
-      key: secret/foo   # custom value
-      property: my-value # custom value
-```
 # References
 
 [Amazon IAM-Policy-Examples-ASM-Secrets](https://docs.aws.amazon.com/mediaconnect/latest/ug/iam-policy-examples-asm-secrets.html)


### PR DESCRIPTION
This PR removes a duplicate YAML entry in the [External Secrets Operator Page](https://docs.spectrocloud.com/integrations/external-secrets-operator/)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/jira/software/c/projects/DOC/boards/62?modal=detail&selectedIssue=DOC-373) 


## Before:

![CleanShot 2022-10-25 at 13 43 06](https://user-images.githubusercontent.com/29551334/197877971-c2950c21-50f4-4217-a10e-6441f1429692.png)

## After:
![CleanShot 2022-10-25 at 13 43 24](https://user-images.githubusercontent.com/29551334/197878010-dfca09c1-124e-477b-ae25-59fbb79397d7.png)
