### PR TITLE
ci: added steps for local docker development that support arm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules/
+package-lock.json
+README.md
+CHANGES
+.gitignore
+.cache
+prow/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM node:18-alpine
 
-RUN apk add util-linux
 WORKDIR /librarium
 COPY ./scripts/entry.sh /entry.sh
+COPY --chown=node . .
+RUN apk add util-linux && \
+chmod +x /entry.sh && \
+mkdir .cache && \
+npm install && \
+chown -R node:node /librarium
+
+EXPOSE 9000
 USER node
 ENTRYPOINT ["/entry.sh"]
 CMD ["npm", "run", "start"]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 	docker image rm $(IMAGE)
 
 initialize:
-	npm install
+	npm ci
 
 start:
 	npm run start
@@ -25,12 +25,5 @@ build:
 docker-image:
 	docker build -t $(IMAGE) .
 
-docker-initialize: docker-image
-	docker run --rm -it -v $(CURDIR):/librarium $(IMAGE) npm install
-
-docker-start: docker-image
-	docker run --rm -it -v $(CURDIR):/librarium -p 9000:9000 $(IMAGE)
-
-docker-build: docker-image
-	rm -rf public
-	docker run --rm -it -v $(CURDIR):/librarium $(IMAGE) npm run build
+docker-start:
+	docker run --rm -it -v $(CURDIR)/content:/librarium/content/ -p 9000:9000 $(IMAGE)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,62 @@
-# Prerequisites
+# Overview
 
-- an text editor (I recommend [vscode](https://code.visualstudio.com/))
+![Spectro Cloud logo with docs inline](/assets/logo_landscape_for_white.png)
+
+Welcome to the Spectro Cloud documentation repository. To get started with contributions, please review the entire README. 
+
+For internal Spectro Cloud users, please review the [contributions](https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765572627/Contribution) section of the Documentation & Education's teams home page. 
+
+There are two local development paths available; Docker based, and non-Docker based. To reduce complexities, we recommended the Docker based development approach. 
+
+## Prerequisites
+
+To contribute, we recommende having the following software installed locally on your workstation.
+
+- Text Editor
+- [Docker](https://docs.docker.com/desktop/)
 - git configured and access to github repository
+- node and npm (optional)
 
-```sh
-git config --global user.name "Sam Smith"
-git config --global user.email sam@example.com
+## Local Development (Docker)
+
+To get started with the Docker based local development approach ensure you are in the root context of this repository. 
+
+Next, issue the following command to build the Docker image.
+
+**Note**: The first time issuing the command may take several minutes.
+
+```shell
+make docker-image
 ```
 
-- node and npm
-  - install https://brew.sh/
-  - `brew install node`
+To start the Dockererized local development server, issue the command:
 
-# Setup (one time)
+```
+make docker-start
+```
+
+The local development server is ready when the following output is displayed in your terminal.
+
+```shell
+You can now view root in the browser.
+⠀
+  Local:            http://localhost:9000/
+  On Your Network:  http://172.17.0.2:9000/
+⠀
+View GraphiQL, an in-browser IDE, to explore your site's data and schema
+⠀
+  Local:            http://localhost:9000/___graphql
+  On Your Network:  http://172.17.0.2:9000/___graphql
+⠀
+Note that the development build is not optimized.
+To create a production build, use gatsby build
+```
+
+Visit [http://localhost:9000](http://localhost:9000) to view the local development documentation site.
+
+To exit from the local development Docker container. Press `Ctrl + Z`.
+
+## Local Development Setup (Non-Docker)
 
 Make a folder somewhere you can easily find
 
@@ -28,6 +72,7 @@ git clone https://github.com/spectrocloud/librarium.git
 cd librarium
 make initialize
 ```
+
 
 # Documentation Content
 

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-
+cd /librarium
 exec "$@"


### PR DESCRIPTION
This PR adds support for local development with Docker for Arm architecture-based workstations.  The current Makefile logic copies over the users `node_modules/`. Copying the node modules folder generates an issue with the dependencies [Sharp](https://github.com/lovell/sharp/issues/3166). The workaround is to issue an `npm install` from inside the container during the build. 

- Added a `.dockerignore` file
- Updated README with logo, overview section, and Docker local development steps.
- Updated `entry.sh` script

The Makefile also had the following updates:
- initialize now does an `npm ci` vs `npm install`. This removes the situation where a contributor updates the `package-lock.json` when not intending to.
- Unused make commands are removed
- Split out the docker build step from the docker-start command

![CleanShot 2022-10-28 at 08 29 07](https://user-images.githubusercontent.com/29551334/198675482-821c6922-5424-465b-a801-6e768e32f98f.png)