### PR TITLE
docs: added clarification about bastion hosts

### DIFF
--- a/content/docs/04-clusters/01-public-cloud/03-azure/1-gateways.md
+++ b/content/docs/04-clusters/01-public-cloud/03-azure/1-gateways.md
@@ -13,7 +13,7 @@ import Tooltip from 'shared/components/ui/Tooltip';
 
 # Overview
 <br />
-Palette enables the provisioning of private AKS clusters within Azure Virtual networks (VNet) for enhanced security by offloading the orchestration to a Private Cloud Gateway deployed within the same account as the private AKS clusters. This private cloud gateway (Self Hosted PCGs) is an AKS cluster that needs to be launched manually and linked to an Azure cloud account in Palette Management Console. The following sections discuss the prerequisites and detailed steps towards deploying Palette self-hosted PCG for Azure Cloud Accounts. Once the self-hosted PCG is created and linked with an Azure cloud account in Palette, any Azure clusters provisioned using that cloud account will be orchestrated via this self-hosted PCG, thereby enabling the provisioning of Private AKS clusters. 
+Palette enables the provisioning of private AKS clusters within Azure Virtual networks (VNet) for enhanced security by offloading the orchestration to a Private Cloud Gateway deployed within the same account as the private AKS clusters. This private cloud gateway (Self Hosted PCGs) is an AKS cluster that needs to be launched manually and linked to an Azure cloud account in Palette Management Console. The following sections discuss the prerequisites and detailed steps towards deploying Palette self-hosted PCG for Azure Cloud Accounts. Once the self-hosted PCG is created and linked with an Azure cloud account in Palette, any Azure clusters provisioned using that cloud account will be orchestrated via the self-hosted PCG, thereby enabling the provisioning of Private AKS clusters. 
 
 # Prerequisites
 
@@ -56,6 +56,12 @@ Log in to the Azure portal and create a Virtual Network taking care of the follo
 3. This VNet needs to be linked with:
     * Azure Kubernetes Cluster
     * Azure Bastion Host (Jump Box Virtual Machine) to connect to the Azure target Kubernetes cluster securely.
+
+<InfoBox>
+
+  **Note**: A bastion hosted is only required if accessing a Kubernetes cluster that is located inside a private Azure Virtual Network (VNet) that only exposes private endpoints. If you have direct network access to the PCG cluster then you do not require a bastion host. Alternatively, you can also deploy a bastion host and remove later if no longer required. 
+
+</InfoBox>
 
 
 ## Create an Azure Kubernetes Target Cluster in the Azure Console


### PR DESCRIPTION
This PR adds clarification behind why a bastion host may be required when attempting to connect to a PCG cluster.
Please see the Slack 🧵 [thread](https://spectrocloud.slack.com/archives/C02NBUMCE9J/p1667341682203859?thread_ts=1667338805.561049&cid=C02NBUMCE9J) for more details 

![CleanShot 2022-11-01 at 15 34 05](https://user-images.githubusercontent.com/29551334/199354658-34408e71-347c-4166-ade8-36876d7bad6e.png)
