### PR TITLE
docs: added more context pertatining to the certificate field

### DIFF
--- a/content/docs/04-clusters/02-data-center/03-vmware.md
+++ b/content/docs/04-clusters/02-data-center/03-vmware.md
@@ -317,7 +317,7 @@ Additional properties that are required to be set only for a proxy environment. 
 |HTTP PROXY | The endpoint for the HTTP proxy server | This setting will be propagated to all the nodes launched in the proxy network. e.g., `http://USERNAME:PASSWORD@PROXYIP:PROXYPORT` |
 | HTTPS PROXY | The endpoint for the HTTPS proxy server | This setting will be propagated to all the nodes launched in the proxy network. e.g., `http://USERNAME:PASSWORD@PROXYIP:PROXYPORT` |
 | NO Proxy | A comma-separated list of vCenter server, local network CIDR, hostnames, domain names that should be excluded from proxying | This setting will be propagated to all the nodes to bypass the proxy server . e.g., vcenter.company.com, .company.org, 10.10.0.0/16 |
-| Certificate | The base64 encoded value of the proxy server's cerficate OR the base64 encoded root and issuing CA certificates used to sign the proxy server's certificate | Depending on how the certificate is decoded, an additonal `=` character may appear at the tailend of the value. The following command can be used to encode the certificate properly `base64 -w0 &vert; sed "s/=$//" 
+| Certificate | The base64 encoded value of the proxy server's cerficate OR the base64 encoded root and issuing certificate authority (CA) certificates used to sign the proxy server's certificate | Depending on how the certificate is decoded, an additonal `=` character may appear at the tailend of the value. The following command can be used to encode the certificate properly `base64 -w0 &vert; sed "s/=$//" 
  
 4. Finish the OVF deployment wizard and wait for the OVA to be imported and virtual machine to be deployed.
 

--- a/content/docs/04-clusters/02-data-center/03-vmware.md
+++ b/content/docs/04-clusters/02-data-center/03-vmware.md
@@ -317,7 +317,7 @@ Additional properties that are required to be set only for a proxy environment. 
 |HTTP PROXY | The endpoint for the HTTP proxy server | This setting will be propagated to all the nodes launched in the proxy network. e.g., `http://USERNAME:PASSWORD@PROXYIP:PROXYPORT` |
 | HTTPS PROXY | The endpoint for the HTTPS proxy server | This setting will be propagated to all the nodes launched in the proxy network. e.g., `http://USERNAME:PASSWORD@PROXYIP:PROXYPORT` |
 | NO Proxy | A comma-separated list of vCenter server, local network CIDR, hostnames, domain names that should be excluded from proxying | This setting will be propagated to all the nodes to bypass the proxy server . e.g., vcenter.company.com, .company.org, 10.10.0.0/16 |
-| Certificate | The base64 encoded value of the proxy server's cerficate OR the base64 encoded root and issuing certificate authority (CA) certificates used to sign the proxy server's certificate | Depending on how the certificate is decoded, an additonal `=` character may appear at the tailend of the value. The following command can be used to encode the certificate properly `base64 -w0 &vert; sed "s/=$//" 
+| Certificate | The base64 encoded value of the proxy server's cerficate OR the base64 encoded root and issuing certificate authority (CA) certificates used to sign the proxy server's certificate | Depending on how the certificate is decoded, an additonal `=` character may appear at the tailend of the value. The following command can be used to encode the certificate properly base64 -w0 &vert; sed "s/=$//" 
  
 4. Finish the OVF deployment wizard and wait for the OVA to be imported and virtual machine to be deployed.
 

--- a/content/docs/04-clusters/02-data-center/03-vmware.md
+++ b/content/docs/04-clusters/02-data-center/03-vmware.md
@@ -314,10 +314,11 @@ Additional properties that are required to be set only for a proxy environment. 
 
 | **Parameter** | **Value** | **Remarks** |
 |---|---|---|
-|**HTTP PROXY** | The endpoint for the HTTP proxy server | This setting will be propagated to all the nodes launched in the proxy network. e.g., http://USERNAME: PASSWORD@PROXYIP: PROXYPORT |
-| **HTTPS PROXY** | The endpoint for the HTTPS proxy server | This setting will be propagated to all the nodes launched in the proxy network. e.g., http://USERNAME: PASSWORD@PROXYIP: PROXYPORT |
-| **NO Proxy** | A comma-separated list of vCenter server, local network CIDR, hostnames, domain names that should be excluded from proxying | This setting will be propagated to all the nodes to bypass the proxy server . e.g., vcenter.company.com, .company.org, 10.10.0.0/16 |
-
+|HTTP PROXY | The endpoint for the HTTP proxy server | This setting will be propagated to all the nodes launched in the proxy network. e.g., `http://USERNAME:PASSWORD@PROXYIP:PROXYPORT` |
+| HTTPS PROXY | The endpoint for the HTTPS proxy server | This setting will be propagated to all the nodes launched in the proxy network. e.g., `http://USERNAME:PASSWORD@PROXYIP:PROXYPORT` |
+| NO Proxy | A comma-separated list of vCenter server, local network CIDR, hostnames, domain names that should be excluded from proxying | This setting will be propagated to all the nodes to bypass the proxy server . e.g., vcenter.company.com, .company.org, 10.10.0.0/16 |
+| Certificate | The base64 encoded value of the proxy server's cerficate OR the base64 encoded root and issuing CA certificates used to sign the proxy server's certificate | Depending on how the certificate is decoded, an additonal `=` character may appear at the tailend of the value. The following command can be used to encode the certificate properly `base64 -w0 &vert; sed "s/=$//" 
+ 
 4. Finish the OVF deployment wizard and wait for the OVA to be imported and virtual machine to be deployed.
 
 


### PR DESCRIPTION
This PR addresses missing information when standing up a VMware Private Cloud Gateway
![CleanShot 2022-11-03 at 11 14 58](https://user-images.githubusercontent.com/29551334/199802381-5aa0f4b9-ff04-4c69-bf7e-ce4129400752.png)

Note: The `|` cannot be escaped inside a markdown table, so the command has to be displayed without code blocks. 