### PR TITLE
Review Downloads doc page

### DIFF
--- a/content/docs/16-spectro-downloads.md
+++ b/content/docs/16-spectro-downloads.md
@@ -63,21 +63,21 @@ PCG is Palette's on-prem component to enable support for isolated private cloud 
 
 |Version|URL|Info|
 |---|---|--|
-|1.2.0|https://vmwaregoldenimage.s3.amazonaws.com/gateway-installer-120.ova|May 29 2022|
+|1.3.0|https://vmwaregoldenimage.s3.amazonaws.com/gateway-installer-130.ova|Nov 02 2022|
 ------
 
 ## MAAS PCG Image
 
 |Version|URL|Info|
 |---|---|--|
-|1.0.11|gcr.io/spectro-images-public/release/spectro-installer:v1.0.11|May 28 2022|
+|1.0.11|https://gcr.io/spectro-images-public/release/spectro-installer:1.0.11|May 28 2021|
 ---------
 
 ## OpenStack PCG Image
 
 |Version|URL|Info|
 |---|---|--|
-|1.0.11|gcr.io/spectro-images-public/release/spectro-installer:v1.0.11|May 28 2022|
+|1.0.11|https://gcr.io/spectro-images-public/release/spectro-installer:1.0.11|May 28 2021|
 -------
 
 


### PR DESCRIPTION
Please review changes to the Downloads page for https://spectrocloud.atlassian.net/browse/DOC-397:

- Fixed URLs for MAAS PCG image and for OpenStack PCG image.
- Updated URL for vSphere PCG image to 1.3.0.
- Updated dates for all three URLs - please check that these are correct. The doc page showed 2022, but https://spectrocloud.atlassian.net/wiki/spaces/ENGINEERIN/pages/802947073/Golden+Images+List shows 2021. 

Screenshot of the page:

![CleanShot 2022-11-08 at 15 55 21](https://user-images.githubusercontent.com/117382432/200702507-9cc06494-c98c-44be-806d-ae464e40f1ca.png)
