### PR TITLE
To Delete: Palette Virtual Cluster Pause/Resume

### DIFF
--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -55,7 +55,7 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 
 <br />
 
-### Resource Allocation Behaviors
+### System and Resource Impact
 
 * The quota allocation is independent of a Virtual Cluster's Pause or Resume status.
 

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -57,22 +57,22 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 
 ### System and Resource Impact
 
-* The quota allocation is independent of a Virtual Cluster's Pause or Resume status.
+* The quota allocation is independent of a virtual cluster's pause or resume status.
 
 
-* The CPU and memory are freed and returned to the Cluster Group when you pause a virtual cluster.
+* The CPU and memory are freed and returned to the cluster group when you pause a virtual cluster.
 
 
-* Resources such as storage, and Load Balancers remain allocated to a Virtual Cluster regardless of the state.
+* Resources such as storage, and load balancers remain allocated to a virtual cluster regardless of the state.
 
 
-* The Apps deployed on a Virtual Cluster go to a pause state when the cluster is paused.
+* The Apps deployed on a virtual cluster go to a pause state when the cluster is paused.
 
 
-* New Apps cannot be deployed on a Virtual Cluster in the paused state.
+* New Apps cannot be deployed on a virtual cluster in the paused state.
 
 
-* Virtual Clusters in a paused state will continue to appear as an entry in the Palette Dev Engine Console. 
+* Virtual clusters in a paused state will continue to appear as an entry in the Palette Dev Engine Console. 
 
 <br />
 

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -69,7 +69,7 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 * The Apps deployed on a Virtual Cluster go to a pause state when the cluster is paused.
 
 
-* New apps cannot be deployed on a Virtual Cluster in the paused state.
+* New Apps cannot be deployed on a Virtual Cluster in the paused state.
 
 
 * Virtual Clusters in a paused state will continue to appear as an entry in the Palette Dev Engine Console. 

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -60,7 +60,7 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 * The quota allocation is independent of a Virtual Cluster's Pause or Resume status.
 
 
-* The CPU and memory are freed and returned to the Cluster Group upon pausing a Virtual Cluster.
+* The CPU and memory are freed and returned to the Cluster Group when you pause a virtual cluster.
 
 
 * Resources such as storage, and Load Balancers remain allocated to a Virtual Cluster regardless of the state.

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -63,16 +63,16 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 * The CPU and Memory are freed to the Cluster Group upon pausing a Virtual Cluster.
 
 
-* Resources like Storage and Load Balancers are allocated to the paused Virtual Cluster.
+* Resources such as storage, and Load Balancers remain allocated to a virtual cluster regardless of the state.
 
 
-* The Apps deployed on a Palette Virtual Cluster goes to a Pause state when the Virtual Cluster is paused.
+* The Apps deployed on a virtual cluster go to a pause state when the cluster is paused.
 
 
-* To a paused Palette Virtual Cluster, deploying new apps cannot be done until it is resumed.
+* New apps cannot be deployed on a virtual cluster in the paused state.
 
 
-* The paused virtual clusters will still appear as an entry in the Palette Dev Engine Console. 
+* Virtual clusters in a paused state will continue to appear as an entry in the Palette Dev Engine Console. 
 
 <br />
 

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -60,7 +60,7 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 * The quota allocation is independent of a Virtual Cluster's Pause or Resume status.
 
 
-* The CPU and Memory are freed to the Cluster Group upon pausing a Virtual Cluster.
+* The CPU and memory are freed and returned to the Cluster Group upon pausing a Virtual Cluster.
 
 
 * Resources such as storage, and Load Balancers remain allocated to a Virtual Cluster regardless of the state.

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -47,3 +47,57 @@ To create your new sandbox cluster:
    * Review the information and deploy the Palette virtual cluster. The Palette virtual cluster will be provisioned within the next few minutes.
 
 <br />
+
+
+## Palette Virtual Cluster Pause and Resume
+
+The Palette allows the Pause and Resume of Palette Virtual Clusters when not in use. This feature enables the users with optimized resource sharing by pausing the virtual clusters, not in use. This adds significant flexibility in managing operating costs and resource management for the Palette virtual clusters. 
+
+<br />
+
+### Resource Dependencies
+
+* The Quota allocation is independent of a Virtual Cluster's Pause or Resume status.
+
+
+* The CPU and Memory are freed upon pausing a Virtual Cluster.
+
+
+* Resources like Storage and Load Balancers are allocated to the paused Virtual Cluster.
+
+
+* The Apps deployed on a Palette Virtual Cluster goes to a Pause state when the Virtual Cluster is paused.
+
+
+* To a paused Palette Virtual Cluster, deploying new apps cannot be done until it is resumed.
+
+
+* The paused virtual clusters will still appear as an entry in the Palette Dev Engine Console. 
+
+<br />
+
+### How to Pause and Resume your Palette Virtual Cluster
+
+Invoke the pause and resume operations from the Palette Console. 
+
+* Log in to the **Palette Dev Engine** Console.
+
+
+* Select Palette Virtual Cluster from the **left ribbon menu**.
+
+
+* Go to the cluster details page by clicking the name of the Palette Virtual Cluster to be paused.
+
+
+* Click **Settings** and Select the **Pause** option. To resume a paused Virtual Cluster, select the **Resume** option.
+
+
+
+<br />
+<br />
+
+
+
+
+
+

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -51,7 +51,7 @@ To create your new sandbox cluster:
 
 ## Palette Virtual Cluster Pause and Resume
 
-Palette allows the pause and resume of Palette Virtual Clusters when not in use. This feature enables the users with optimized resource sharing by pausing the Virtual Clusters, not in use. This adds significant flexibility in managing operating costs and resource management for the Palette Virtual Clusters. 
+Palette allows the pause and resume of Palette Virtual Clusters when not in use. This feature enables the users to optimize resource utilization by pausing the Virtual Clusters, not in use. This adds significant flexibility in managing operating costs and resource management for the Palette Virtual Clusters. 
 
 <br />
 
@@ -63,16 +63,16 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 * The CPU and Memory are freed to the Cluster Group upon pausing a Virtual Cluster.
 
 
-* Resources such as storage, and Load Balancers remain allocated to a virtual cluster regardless of the state.
+* Resources such as storage, and Load Balancers remain allocated to a Virtual Cluster regardless of the state.
 
 
-* The Apps deployed on a virtual cluster go to a pause state when the cluster is paused.
+* The Apps deployed on a Virtual Cluster go to a pause state when the cluster is paused.
 
 
-* New apps cannot be deployed on a virtual cluster in the paused state.
+* New apps cannot be deployed on a Virtual Cluster in the paused state.
 
 
-* Virtual clusters in a paused state will continue to appear as an entry in the Palette Dev Engine Console. 
+* Virtual Clusters in a paused state will continue to appear as an entry in the Palette Dev Engine Console. 
 
 <br />
 

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -51,13 +51,13 @@ To create your new sandbox cluster:
 
 ## Palette Virtual Cluster Pause and Resume
 
-The Palette allows the Pause and Resume of Palette Virtual Clusters when not in use. This feature enables the users with optimized resource sharing by pausing the virtual clusters, not in use. This adds significant flexibility in managing operating costs and resource management for the Palette virtual clusters. 
+Palette allows the pause and resume of Palette Virtual Clusters when not in use. This feature enables the users with optimized resource sharing by pausing the Virtual Clusters, not in use. This adds significant flexibility in managing operating costs and resource management for the Palette Virtual Clusters. 
 
 <br />
 
-### Resource Dependencies
+### Resource Allocation Behaviors
 
-* The Quota allocation is independent of a Virtual Cluster's Pause or Resume status.
+* The quota allocation is independent of a Virtual Cluster's Pause or Resume status.
 
 
 * The CPU and Memory are freed upon pausing a Virtual Cluster.
@@ -76,7 +76,7 @@ The Palette allows the Pause and Resume of Palette Virtual Clusters when not in 
 
 <br />
 
-### How to Pause and Resume your Palette Virtual Cluster
+###  Pause and Resume your Palette Virtual Cluster
 
 Invoke the pause and resume operations from the Palette Console. 
 

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -60,7 +60,7 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 * The quota allocation is independent of a Virtual Cluster's Pause or Resume status.
 
 
-* The CPU and Memory are freed upon pausing a Virtual Cluster.
+* The CPU and Memory are freed to the Cluster Group upon pausing a Virtual Cluster.
 
 
 * Resources like Storage and Load Balancers are allocated to the paused Virtual Cluster.

--- a/content/docs/04.5-devx/07-sandbox-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters.md
@@ -51,7 +51,7 @@ To create your new sandbox cluster:
 
 ## Palette Virtual Cluster Pause and Resume
 
-Palette allows the pause and resume of Palette Virtual Clusters when not in use. This feature enables the users to optimize resource utilization by pausing the Virtual Clusters, not in use. This adds significant flexibility in managing operating costs and resource management for the Palette Virtual Clusters. 
+Palette allows the pause and resume of Palette Virtual Clusters when not in use. This feature enables the users to optimize resource utilization by pausing the virtual clusters not in use. This adds significant flexibility in managing operating costs and resource management for the Palette Virtual Clusters. 
 
 <br />
 

--- a/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
@@ -29,7 +29,7 @@ Invoke the pause and resume operations from the Palette Console.
 1. Log in to the **Palette Dev Engine** Console.
 
 
-2. Select Palette Virtual Cluster from the **left ribbon menu**.
+2. Navigate to the **Main Menu** and select **Palette Virtual Cluster**.
 
 
 3. Go to the cluster details page by clicking the name of the Palette Virtual Cluster to be paused.

--- a/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
@@ -16,7 +16,7 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 # Overview
 
-Palette allows the pause and resume of Palette Virtual Clusters when not in use. This feature enables the users to optimize resource utilization by pausing the Virtual Clusters, not in use. This adds significant flexibility in managing operating costs and resource management for the Palette Virtual Clusters. 
+Palette allows the pause and resume of Palette Virtual Clusters when not in use. This feature enables the users to optimize resource utilization by pausing the virtual clusters not in use. This adds significant flexibility in managing operating costs and resource management for the Palette Virtual Clusters. 
 
 # Prerequisite
 

--- a/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
@@ -1,5 +1,5 @@
 ---
-title: "Pause and Restore Palette Virtual Clusters"
+title: "Pause and Resume Palette Virtual Clusters"
 metaTitle: "Palette Dev Engine Pause and Restore Palette Virtual Clusters"
 metaDescription: "Pause and Restore Palette Virtual Clusters"
 hideToC: false

--- a/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
@@ -20,7 +20,7 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 
 # Prerequisite
 
-* Running [Palette Virtual Cluster](/devx/sandbox-clusters#createyoursandboxcluster:).
+* A Running [Palette Virtual Cluster](/devx/sandbox-clusters#createyoursandboxcluster:).
 
 #  How to Pause and Resume your Palette Virtual Cluster
 

--- a/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
@@ -26,13 +26,13 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 
 Invoke the pause and resume operations from the Palette Console.
 
-* Log in to the **Palette Dev Engine** Console.
+1. Log in to the **Palette Dev Engine** Console.
 
 
-* Select Palette Virtual Cluster from the **left ribbon menu**.
+2. Select Palette Virtual Cluster from the **left ribbon menu**.
 
 
-* Go to the cluster details page by clicking the name of the Palette Virtual Cluster to be paused.
+3. Go to the cluster details page by clicking the name of the Palette Virtual Cluster to be paused.
 
 
-* Click **Settings** and Select the **Pause** option. To resume a paused Virtual Cluster, select the **Resume** option.
+4. Click **Settings** and Select the **Pause** option. To resume a paused Virtual Cluster, select the **Resume** option.

--- a/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
@@ -22,7 +22,7 @@ Palette allows the pause and resume of Palette Virtual Clusters when not in use.
 
 * A Running [Palette Virtual Cluster](/devx/sandbox-clusters#createyoursandboxcluster:).
 
-#  How to Pause and Resume your Palette Virtual Cluster
+#  Pause and Resume a Palette Virtual Cluster
 
 Invoke the pause and resume operations from the Palette Console.
 

--- a/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
@@ -16,7 +16,7 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 # Overview
 
-Palette allows the pause and resume of Palette Virtual Clusters when not in use. This feature enables the users to optimize resource utilization by pausing the virtual clusters not in use. This adds significant flexibility in managing operating costs and resource management for the Palette Virtual Clusters. 
+To optimize resource utilization, Palette allows you to pause and resume virtual clusters that are not in use. This adds significant flexibility in managing operating costs and resource management for virtual clusters. 
 
 # Prerequisite
 

--- a/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
+++ b/content/docs/04.5-devx/07-sandbox-clusters/00-pause-restore-virtual-clusters.md
@@ -1,0 +1,38 @@
+---
+title: "Pause and Restore Palette Virtual Clusters"
+metaTitle: "Palette Dev Engine Pause and Restore Palette Virtual Clusters"
+metaDescription: "Pause and Restore Palette Virtual Clusters"
+hideToC: false
+fullWidth: false
+---
+
+import Tabs from 'shared/components/ui/Tabs';
+import InfoBox from 'shared/components/InfoBox';
+import WarningBox from 'shared/components/WarningBox';
+import PointsOfInterest from 'shared/components/common/PointOfInterest';
+import Tooltip from "shared/components/ui/Tooltip";
+
+
+
+# Overview
+
+Palette allows the pause and resume of Palette Virtual Clusters when not in use. This feature enables the users to optimize resource utilization by pausing the Virtual Clusters, not in use. This adds significant flexibility in managing operating costs and resource management for the Palette Virtual Clusters. 
+
+# Prerequisite
+
+* Running [Palette Virtual Cluster](/devx/sandbox-clusters#createyoursandboxcluster:).
+
+#  How to Pause and Resume your Palette Virtual Cluster
+
+Invoke the pause and resume operations from the Palette Console.
+
+* Log in to the **Palette Dev Engine** Console.
+
+
+* Select Palette Virtual Cluster from the **left ribbon menu**.
+
+
+* Go to the cluster details page by clicking the name of the Palette Virtual Cluster to be paused.
+
+
+* Click **Settings** and Select the **Pause** option. To resume a paused Virtual Cluster, select the **Resume** option.

--- a/content/docs/16-spectro-downloads.md
+++ b/content/docs/16-spectro-downloads.md
@@ -63,21 +63,21 @@ PCG is Palette's on-prem component to enable support for isolated private cloud 
 
 |Version|URL|Info|
 |---|---|--|
-|1.2.0|https://vmwaregoldenimage.s3.amazonaws.com/gateway-installer-120.ova|May 29 2022|
+|1.3.0|https://vmwaregoldenimage.s3.amazonaws.com/gateway-installer-130.ova|Nov 02 2022|
 ------
 
 ## MAAS PCG Image
 
 |Version|URL|Info|
 |---|---|--|
-|1.0.11|gcr.io/spectro-images-public/release/spectro-installer:v1.0.11|May 28 2022|
+|1.0.11|https://gcr.io/spectro-images-public/release/spectro-installer:1.0.11|May 28 2021|
 ---------
 
 ## OpenStack PCG Image
 
 |Version|URL|Info|
 |---|---|--|
-|1.0.11|gcr.io/spectro-images-public/release/spectro-installer:v1.0.11|May 28 2022|
+|1.0.11|https://gcr.io/spectro-images-public/release/spectro-installer:1.0.11|May 28 2021|
 -------
 
 


### PR DESCRIPTION
*To be Released Feature*. (Draft)
Palette Virtual Cluster Pause/Resume
<img width="598" alt="image" src="https://user-images.githubusercontent.com/49595451/201611564-84333006-799e-4e15-9d9a-8442601a336e.png">



Some links to be updated. Other PR dependencies are there, so can be updated post-merge of dependent Prs.
