### PR TITLE
New Changes to AWS Cluster Page

### DIFF
--- a/content/docs/04-clusters/01-public-cloud/01-aws.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws.md
@@ -12,7 +12,11 @@ import InfoBox from 'shared/components/InfoBox';
 import PointsOfInterest from 'shared/components/common/PointOfInterest';
 
 
+# New Section
 
+Blah Blah Blah
+
+Here is more content.
 # Overview
 
 Following are some architectural highlights of the Amazon Web Services (AWS) clusters, provisioned by Palette:


### PR DESCRIPTION
This PR adds a new section to the beginning of the AWS Cluster Page under the Public Cloud folder.