### PR TITLE
ci: change behavior for CI flow

### DIFF
--- a/prow/functions.sh
+++ b/prow/functions.sh
@@ -28,7 +28,7 @@ sync_s3() {
 
 # Sync docs to docs
 sync_s3_release() {
-        rm -f public/robots.txt
+    rm -f public/robots.txt
 	aws s3 sync --cache-control 'max-age=604800' --exclude '*.html' --exclude '*page-data/*' --exclude '*.txt' --exclude '*.xml' --exclude '*/sw.js' public/ s3://docs.spectrocloud.com --delete
 	aws s3 sync --cache-control 'max-age=0, s-maxage=604800' public/ s3://docs.spectrocloud.com --delete
 	aws cloudfront create-invalidation --distribution-id E1LK6TRNPR90DX --paths "/*"

--- a/prow/presubmit.sh
+++ b/prow/presubmit.sh
@@ -8,4 +8,5 @@ set -e
 set -u
 source prow/functions.sh
 
-build_docs
+build_release_docs
+sync_s3_release


### PR DESCRIPTION
This PR changes the behavior of the CI flow.  In order to push the changes to production, a comment with the following value is required `/test librarium_release_build`. The comment in the PR triggers the build step for production. Now that preview URLs are available, we no longer need the `docs-latests.spectrocloud.com` URL and flow. We want to merge into the base branch, `master`, to automatically deploy to production.