### PR TITLE
docs: terraform related changes and minor header fix

### DIFF
--- a/content/docs/13-terraform.md
+++ b/content/docs/13-terraform.md
@@ -65,13 +65,14 @@ The [Spectro Cloud Terraform Modules](https://registry.terraform.io/modules/spec
 
 Palette Terraform Supports:
 
-* Sandbox Clusters starting from Provider version 0.10.1
+* Palette Virtual Clusters starting from Provider version 0.10.1
 * Edge Native Clusters starting from Provider version 0.10.1
 
 </InfoBox>
 
 |Module|Provider Version|Module Example|
 |----- |------|------------------------|
+|0.4.1 |0.10.7|
 |0.4.1 |0.10.5|
 |0.4.1 |0.10.2|
 |0.4.1 |0.10.1|            |

--- a/content/docs/14-troubleshooting/04-cluster-deployment.md
+++ b/content/docs/14-troubleshooting/04-cluster-deployment.md
@@ -11,6 +11,8 @@ import Tabs from 'shared/components/ui/Tabs';
 import WarningBox from 'shared/components/WarningBox';
 import InfoBox from 'shared/components/InfoBox';
 
+# Cluster Deployment Errors Scenarios
+
 The following steps will help you troubleshoot errors in the event issues arise while deploying a cluster.  
 
 


### PR DESCRIPTION
This PR updates the Cluster Deployment page to include the main heading. A New Terraform version has also been added.