### PR TITLE
Fixed Resource typo

### DIFF
--- a/content/docs/04.5-devx/04-resource-quota.md
+++ b/content/docs/04.5-devx/04-resource-quota.md
@@ -1,5 +1,5 @@
 ---
-title: "Resourse Quota"
+title: "Resource Quota"
 metaTitle: "Palette Dev Engine for Enterprise developers"
 metaDescription: "Explore Palette Dev Engine as Free developers"
 hideToC: false


### PR DESCRIPTION
Changed 'Resourse' to 'Resource' in navigation.