### PR TITLE
Add cluster group auto update detail

### DIFF
--- a/content/docs/04.5-devx/04-resource-quota.md
+++ b/content/docs/04.5-devx/04-resource-quota.md
@@ -45,6 +45,8 @@ To create your cluster groups, you must manage the developer quota in Palette by
 |Memory| 16 GiB|4 GiB|
 |Storage| 20 GiB|2 GiB|
 
+If limits defined for cluster groups are lower than the default quota shown in the table, the size of the respective resource (CPU, memory, or storage) will update automatically to the lower limit. You can verify cluster group limits on the **Cluster Group Settings** page. 
+
 Palette offers a default ephemeral-storage of 1 GiB for virtual clusters launched on the Beehive cluster group.
 
  You can track the status of the resource quota from **Overview** in the **Main Menu** of Palette Dev Engine console.


### PR DESCRIPTION
This PR adds details about size limits automatically updated if cluster group limits are lower than default size limits.

Jira: https://spectrocloud.atlassian.net/browse/PPD-791

[Preview](https://deploy-preview-1048--docs-spectrocloud.netlify.app/devx/resource-quota)