### PR TITLE
Romain - fix typos on VMware and vSphere

### DIFF
--- a/content/docs/00-release-notes.md
+++ b/content/docs/00-release-notes.md
@@ -168,7 +168,7 @@ Spectro Cloud Palette 2.8.0 is now available with the support of Palette Virtual
   * Image template support
 
 **Enhancements**
-* Palette upgrades the Vsphere Public Cloud Gateways and On-Prem cluster specifications to newer versions:
+* Palette upgrades the vSphere Public Cloud Gateways and On-Prem cluster specifications to newer versions:
 
    * K8s version has been upgraded from 1.21 to 1.22.12 [ the latest version in 1.22 ]
    

--- a/content/docs/02.5-architecture/04-networking-ports.md
+++ b/content/docs/02.5-architecture/04-networking-ports.md
@@ -50,7 +50,7 @@ The following diagram maps the network connections between the Palette component
 |HTTPS (tcp/443) |IN        |Browser/API access to Management Platform|
 |SSH (tcp/22)    |IN        |Troubleshooting via SSH (optional) |
 |NATS (tcp/4222) |IN        |Message Bus for workload clusters|
-|HTTPS (tcp/443) |OUT       |VSphere vCenter API,  Registry (packs, integrations), Pack containers, app updates.|
+|HTTPS (tcp/443) |OUT       |vSphere vCenter API,  Registry (packs, integrations), Pack containers, app updates.|
 |HTTPS (tcp/6443)|OUT       |Workload K8s cluster API Server|
 
 
@@ -62,4 +62,4 @@ The following diagram maps the network connections between the Palette component
 |HTTPS (tcp/6443)|IN        |Kubernetes API Server|
 |SSH (tcp/22)    |IN        |Troubleshooting via SSH (optional) |
 |NATS (tcp/4222) |OUT       |Agent communication via Message Bus |
-|HTTPS (tcp/443) |OUT       |VSphere vCenter API, Registry (packs, integrations), Pack containers, Application updates.
+|HTTPS (tcp/443) |OUT       |vSphere vCenter API, Registry (packs, integrations), Pack containers, Application updates.

--- a/content/docs/09-registries-and-packs/3-add-custom-packs.md
+++ b/content/docs/09-registries-and-packs/3-add-custom-packs.md
@@ -209,7 +209,7 @@ A few sample pack manifests for building a custom OS pack are shown in the follo
 
 <Tabs.TabPane tab="VMware Custom OS Pack" key="vmware_custom_os_pack">
 
-### VMWare Custom OS Pack - Local Image
+### VMware Custom OS Pack - Local Image
 
 ```yaml
 {
@@ -236,7 +236,7 @@ A few sample pack manifests for building a custom OS pack are shown in the follo
 }
 ```
 
-### VMWare Custom OS Pack - Remote Image
+### VMware Custom OS Pack - Remote Image
 
 ```yaml
 {

--- a/vale/styles/Vocab/Internal/accept.txt
+++ b/vale/styles/Vocab/Internal/accept.txt
@@ -50,3 +50,4 @@ IaaS
 autoscaling
 Tencent
 serverless
+vCenter

--- a/vale/styles/Vocab/Internal/reject.txt
+++ b/vale/styles/Vocab/Internal/reject.txt
@@ -13,3 +13,5 @@ Pre-requisite
 pre-requisite
 Hence
 hence
+VSphere
+VMWare


### PR DESCRIPTION
I noticed and fixed minor typos on 3 pages:
- VMWare > VMware
- Vsphere > vSphere
- VSphere > vSphere