### PR TITLE
docs: added explanation for AWSEBSCSI policy to virtual clusters

### DIFF
--- a/content/docs/04-clusters/04-palette-virtual-clusters/00-add-virtual-cluster-to-host-cluster.md
+++ b/content/docs/04-clusters/04-palette-virtual-clusters/00-add-virtual-cluster-to-host-cluster.md
@@ -25,11 +25,12 @@ Follow steps below to enable and deploy a virtual cluster.
 
 # Prerequisites
 
-- A Spectro Cloud account.
+-  A Spectro Cloud account.
 
 - A configured [Cluster](/clusters).
 
-- Attach any required policies in your cloud account that must be added to your virtual cluster deployment. Refer to [Add Node-Level Policies in your Cloud Account](#add-node-level-policies-in-your-cloud-account).
+- Attach any required policies in your cloud account that must be added to your virtual cluster deployment. 
+  - For AWS, refer to the [Required IAM Policies](/clusters/public-cloud/aws/required-iam-policies#globalroleadditionalpolicies) documentation.
 
 <InfoBox>
 
@@ -45,8 +46,9 @@ To add node-level policies:
 
 1. In **Cluster Mode**, switch to the **Tenant Admin**  project.
 2. Select **Tenant Settings** in the **Main Menu**. 
-3. Click **Cloud Accounts** and ensure `Add IAM policies` is enabled for your cloud account. If an account does not already exist, you must add one. 
+3. Click **Cloud Accounts** and ensure **Add IAM policies** is enabled for your cloud account. If an account does not already exist, you must add one. 
 4. You can specify any additional policies to include in virtual clusters deployed with this cloud account.
+    - For AWS, add the **AmazonEBSCSIDriver** policy so that the virtual clusters can access the underlying host cluster's storage. Check out the [Palette required IAM policies](/clusters/public-cloud/aws/required-iam-policies#globalroleadditionalpolicies) documentation to learn more about additional IAM policies.
 5. Confirm your changes.
 
 # Enable Virtual Clusters on a Host Cluster

--- a/content/docs/04-clusters/04-palette-virtual-clusters/00-add-virtual-cluster-to-host-cluster.md
+++ b/content/docs/04-clusters/04-palette-virtual-clusters/00-add-virtual-cluster-to-host-cluster.md
@@ -25,7 +25,7 @@ Follow steps below to enable and deploy a virtual cluster.
 
 # Prerequisites
 
--  A Spectro Cloud account.
+- A Spectro Cloud account.
 
 - A configured [Cluster](/clusters).
 

--- a/content/docs/04-clusters/04-palette-virtual-clusters/00-add-virtual-cluster-to-host-cluster.md
+++ b/content/docs/04-clusters/04-palette-virtual-clusters/00-add-virtual-cluster-to-host-cluster.md
@@ -31,6 +31,7 @@ Follow steps below to enable and deploy a virtual cluster.
 
 - Attach any required policies in your cloud account that must be added to your virtual cluster deployment. 
   - For AWS, refer to the [Required IAM Policies](/clusters/public-cloud/aws/required-iam-policies#globalroleadditionalpolicies) documentation.
+  - For Azure, no additional policies are required.
 
 <InfoBox>
 


### PR DESCRIPTION
This PR addresses feedback about missing IAM Policies for virtual clusters in an AWS environment.  The highlighted area in the following image displays the new additions. 
![CleanShot 2023-01-27 at 07 54 56](https://user-images.githubusercontent.com/29551334/215116506-fd023c19-04f5-4118-9672-b34009a19108.png)
