### PR TITLE
Update 04.5-devx.md

### DIFF
--- a/content/docs/04.5-devx.md
+++ b/content/docs/04.5-devx.md
@@ -1,5 +1,5 @@
 ---
-title: "Palette Dev Engine (Beta)"
+title: "Palette Dev Engine"
 metaTitle: "Palette Dev Engine "
 metaDescription: "Explore Palette Dev Engine"
 icon: "users"


### PR DESCRIPTION
docs: removed the beta tag from the navigation title