### PR TITLE
docs: fixed issue related to redirect error

### DIFF
--- a/content/docs/06-integrations/00-frp.md
+++ b/content/docs/06-integrations/00-frp.md
@@ -436,7 +436,7 @@ data "spectrocloud_pack_simple" "spectro-proxy" {
 
 # References
 
-- [Enable Kubernetes Dashboard](/clusters/cluster-management/reverse-proxy-dashboard)
+- [Enable Kubernetes Dashboard](/clusters/cluster-management/kubernetes-dashboard)
 
 - [Terraform Data Resource](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack)
 

--- a/content/docs/06-integrations/00-kubernetes-dashboard.md
+++ b/content/docs/06-integrations/00-kubernetes-dashboard.md
@@ -23,7 +23,7 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 <InfoBox>
 
-Palette supports provisioning a [reverse proxy dashboard](/clusters/cluster-management/reverse-proxy-dashboard) that can expose the Kubernetes dashboard. Use the [Spectro Proxy](/integrations/frp)  pack to enable this capability.
+Palette supports provisioning a [reverse proxy dashboard](/clusters/cluster-management/kubernetes-dashboard) that can expose the Kubernetes dashboard. Use the [Spectro Proxy](/integrations/frp)  pack to enable this capability.
 
 
 </InfoBox>


### PR DESCRIPTION
This PR fixes an issue with broken links related to the Kubernetes dashboard page.