### PR TITLE
Adding Tag OIDC permission for EKS as IAM policy

### DIFF
--- a/content/docs/04-clusters/01-public-cloud/01-aws/10-required-iam-policies.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws/10-required-iam-policies.md
@@ -238,9 +238,11 @@ The following four policies include all the required permissions for provisionin
             "Effect": "Allow",
             "Action": [
                 "iam:ListOpenIDConnectProviders",
+                "iam:GetOpenIDConnectProvider",
                 "iam:CreateOpenIDConnectProvider",
                 "iam:AddClientIDToOpenIDConnectProvider",
                 "iam:UpdateOpenIDConnectProviderThumbprint",
+                "iam:TagOpenIDConnectProvider",
                 "iam:DeleteOpenIDConnectProvider"
             ],
             "Resource": [


### PR DESCRIPTION
Recently we have made a change that when EKS clusters are created, a functionality has been added to also tag OIDC providers. The AWS user should have the required permission in its attached IAM policy to be able to tag OIDC providers.

This PR is for the information to the user to also have `iam:TagOpenIDConnectProvider"` as a permission. The `iam:GetOpenIDConnectProvider"` permission wasn't present previously, so I have added it now.