### PR TITLE
AWS Resource Tags

### DIFF
--- a/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
@@ -97,8 +97,8 @@ In addition to the custom tags provided by you, Palette-provisioned AWS resource
 | Key                                                        | Value         | Description                                                                    |
 |------------------------------------------------------------|---------------|--------------------------------------------------------------------------------|
 | `Name`                                                       | [clusterName-resource] | The name of the AWS resource. Use the format [cluster name] - [resource type name]. Example: `mycluste2r-vpc` |
-| `kubernetes.io/cluster/[clusterName] `                       | owned         | This tag only applies to cluster nodes. Used for Palette internal purposes to help manage the lifecyle of the cluster. |
+| `kubernetes.io/cluster/[clusterName]`.                       | owned         | This tag only applies to cluster nodes. Used for Palette internal purposes to help manage the lifecyle of the cluster. |
 | `sigs.k8s.io/cluster-api-provider-aws/cluster/[clusterName]` | owned         | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
 | `sigs.k8s.io/cluster-api-provider-aws/role`                  | common        | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
-| `spectro__ownerUid`                                          | [uniqueId]    | The Palette tenant's id. Example: `1356fc37ab1aac03a5d66b4c` |
+| `spectro__ownerUid`                                          | [uniqueId]    | The Palette tenant's id. Example: `1356fc37ab1aac03a5d66b4c`. |
 

--- a/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
@@ -85,3 +85,20 @@ When setting the desired size of the worker pool, make the choice as per pod req
 ## Spot Instances
 
 By default, worker pools are configured to use on-demand instances. However, to take advantage of discounted spot instance pricing you can specify spot instances when creating a cluster. The **On-Spot** option can be selected in the node configuration page during cluster creation. This option allows you to specify a maximum bid price for the nodes as a percentage of the on-demand price. Palette tracks the current price for spot instances and launches nodes, when the spot price falls in the specified range.
+
+
+# Tags
+
+You can assign tags to clusters deployed to AWS. Tags can help you with user access control management and more granularly restrict access to various Palette resources, including clusters. Check out the [Resource Filters](/clusters/cluster-management/cluster-tag-filter/create-add-filter) documentation page to learn more about using tags to restrict resource access. 
+
+The custom tags you create are assigned to the clusters during the creation process. Tags follow the key-value-pair format: `department: finance`.
+In addition to the custom tags provided by you, Palette provisioned AWS resources will receive the following default tags.
+
+| Key                                                        | Value         | Description                                                                    |
+|------------------------------------------------------------|---------------|--------------------------------------------------------------------------------|
+| `Name`                                                       | [clusterName-resource] | The name of the AWS resource. Use the format [cluster name] - [resource type name]. Example: `mycluste2r-vpc` |
+| `kubernetes.io/cluster/[clusterName] `                       | owned         | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
+| `sigs.k8s.io/cluster-api-provider-aws/cluster/[clusterName]` | owned         | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
+| `sigs.k8s.io/cluster-api-provider-aws/role`                  | common        | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
+| `spectro__ownerUid`                                          | [uniqueId]    | The Palette tenant's id. Example: `1356fc37ab1aac03a5d66b4c` |
+

--- a/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
@@ -97,8 +97,8 @@ In addition to the custom tags provided by you, Palette-provisioned AWS resource
 | Key                                                        | Value         | Description                                                                    |
 |------------------------------------------------------------|---------------|--------------------------------------------------------------------------------|
 | `Name`                                                       | [clusterName-resource] | The name of the AWS resource. Use the format [cluster name] - [resource type name]. Example: `mycluste2r-vpc` |
-| `kubernetes.io/cluster/[clusterName]`.                       | owned         | This tag only applies to cluster nodes. Used for Palette internal purposes to help manage the lifecyle of the cluster. |
-| `sigs.k8s.io/cluster-api-provider-aws/cluster/[clusterName]` | owned         | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
-| `sigs.k8s.io/cluster-api-provider-aws/role`                  | common        | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
+| `kubernetes.io/cluster/[clusterName]`.                       | owned         | This tag only applies to cluster nodes. Used for Palette internal purposes to help manage the lifecycle of the cluster. |
+| `sigs.k8s.io/cluster-api-provider-aws/cluster/[clusterName]` | owned         | Used for Palette internal purposes to help manage the lifecycle of the cluster. |
+| `sigs.k8s.io/cluster-api-provider-aws/role`                  | common        | Used for Palette internal purposes to help manage the lifecycle of the cluster. |
 | `spectro__ownerUid`                                          | [uniqueId]    | The Palette tenant's id. Example: `1356fc37ab1aac03a5d66b4c`. |
 

--- a/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
@@ -92,12 +92,12 @@ By default, worker pools are configured to use on-demand instances. However, to 
 You can assign tags to clusters deployed to AWS. Tags can help you with user access control management and more granularly restrict access to various Palette resources, including clusters. Check out the [Resource Filters](/clusters/cluster-management/cluster-tag-filter/create-add-filter) documentation page to learn more about using tags to restrict resource access. 
 
 The custom tags you create are assigned to the clusters during the creation process. Tags follow the key-value-pair format: `department: finance`.
-In addition to the custom tags provided by you, Palette provisioned AWS resources will receive the following default tags.
+In addition to the custom tags provided by you, Palette-provisioned AWS resources will receive the following default tags.
 
 | Key                                                        | Value         | Description                                                                    |
 |------------------------------------------------------------|---------------|--------------------------------------------------------------------------------|
 | `Name`                                                       | [clusterName-resource] | The name of the AWS resource. Use the format [cluster name] - [resource type name]. Example: `mycluste2r-vpc` |
-| `kubernetes.io/cluster/[clusterName] `                       | owned         | This tag is only applicable to cluster nodes. Used for Palette internal purposes to help manage the lifecyle of the cluster. |
+| `kubernetes.io/cluster/[clusterName] `                       | owned         | This tag only applies to cluster nodes. Used for Palette internal purposes to help manage the lifecyle of the cluster. |
 | `sigs.k8s.io/cluster-api-provider-aws/cluster/[clusterName]` | owned         | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
 | `sigs.k8s.io/cluster-api-provider-aws/role`                  | common        | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
 | `spectro__ownerUid`                                          | [uniqueId]    | The Palette tenant's id. Example: `1356fc37ab1aac03a5d66b4c` |

--- a/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws/02-architecture.md
@@ -97,7 +97,7 @@ In addition to the custom tags provided by you, Palette provisioned AWS resource
 | Key                                                        | Value         | Description                                                                    |
 |------------------------------------------------------------|---------------|--------------------------------------------------------------------------------|
 | `Name`                                                       | [clusterName-resource] | The name of the AWS resource. Use the format [cluster name] - [resource type name]. Example: `mycluste2r-vpc` |
-| `kubernetes.io/cluster/[clusterName] `                       | owned         | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
+| `kubernetes.io/cluster/[clusterName] `                       | owned         | This tag is only applicable to cluster nodes. Used for Palette internal purposes to help manage the lifecyle of the cluster. |
 | `sigs.k8s.io/cluster-api-provider-aws/cluster/[clusterName]` | owned         | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
 | `sigs.k8s.io/cluster-api-provider-aws/role`                  | common        | Used for Palette internal purposes to help manage the lifecyle of the cluster. |
 | `spectro__ownerUid`                                          | [uniqueId]    | The Palette tenant's id. Example: `1356fc37ab1aac03a5d66b4c` |


### PR DESCRIPTION
This PR adds a section related to tags for AWS resources. 
🎫 [PCP-753](https://spectrocloud.atlassian.net/browse/PCP-753)
💻 [Preview](https://deploy-preview-1105--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/architecture#tags)

![CleanShot 2023-02-03 at 10 17 23](https://user-images.githubusercontent.com/29551334/216666116-06647411-a0d9-47ac-b175-080253db1157.png)
