### PR TITLE
Project Force Deletion

### DIFF
--- a/content/docs/07-projects.md
+++ b/content/docs/07-projects.md
@@ -16,19 +16,15 @@ A **Project** helps you organize the cluster resources in a logical grouping. Th
 
 # Project Dashboard
 
-The **Tenant Admin** > **Projects** page displays the project-related dashboard cards that capture the usage and metrics about projects.
+The **Tenant Admin** > **Projects** page displays the project-related dashboard cards for all projects in the tenant. 
 
-## Monthly kilo-Core hours Usage
-
-The **Monthly Usage** card shows the Daily Cluster Usage in kilo-Core hours (kCh) for a month across all the projects.  The kilo-Core hours is an aggregate measure of how many core hours the worker nodes consume, while under management, across all your deployments. The metering of the kilo-Core hours for the node is done in increments of seconds. The monthly usage card also shows project-wide kilo-Core hours. Based on the plan type, the kilo-Core hours' subscription information will be shown. A tenant starts with a Trial plan and can upgrade to a Monthly On-Demand plan or an Annual Subscription plan.
-
-## Cores per Project Usage
-
-By default, the active worker node usage of CPU **Cores** is grouped across all projects and shown as an hourly interval. You can change the interval value to days or months.
 
 ## Project Card
 
-Every **Project Card** displays the cluster's state. The cluster information is grouped by its health and error states. Cluster health is derived from the health of the cluster nodes. The health of each node is determined based on several conditions such as memory and CPU utilization, disk pressure, and network availability.
+The **Project card** shows the status and relevant details of a cluster, grouping information about healthy, unhealthy, and errored clusters. It calculates cluster health by evaluating the health of each node, taking into account factors such as memory and CPU utilization, disk pressure, and network availability. Additionally, it displays the number of clusters imported and those provisioned by Palette.
+### Cores per Project Usage
+
+By default, the active worker node usage of CPU **Cores** is grouped across all projects and shown as an hourly interval. You can change the interval value to days or months.
 
 
 # Create a Project
@@ -52,16 +48,17 @@ You can associate users and teams with a project. Check out the [Project Associa
 1. Log in to [Palette](https://console.spectrocloud.com).
 
 
-1. Navigate to **Tenant Admin** > **Projects** and click the **Create Project** button.
+2. Navigate to **Tenant Admin** > **Projects** and click the **Create Project** button.
 
 
-1. Fill out the following fields: **Name**, **Description**, and **Tags** to create a Project.
+3. Fill out the following fields: **Name**, **Description**, and **Tags** to create a Project.
 
 ## Validation
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
-1. Navigate to **Tenant Admin** > **Projects** 
+
+2. Navigate to **Tenant Admin** > **Projects** 
 
 Your newly created project is listed along with other existing projects.
 
@@ -81,20 +78,25 @@ You can remove projects by following these steps.
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
+
 2. Switch to **Tenant Admin** scope.
+
 
 3. Navigate to the left **Main Menu** and select **Projects**.
 
+
 4. Locate the project card for the project you want to remove.
+
 
 5. Click on the **three-dot Menu** and select **Delete**.
 
-6. A pop-up box will ask you to confirm the action. Click on **Yes, delete project**.
+
+6. A pop-up box will ask you to confirm the action. Confirm the deletion.
 
 
 <WarningBox>
 
-You can force delete projects as long as there are no active clusters. All resources that belong to the project will be deleted.
+You can delete projects with force as long as there are no active clusters. Force deleting will eliminate all resources linked to the project, such as app profiles, cluster profiles, workspaces, audit logs, and custom project settings. However, if a project has active clusters, you must remove them first before deleting the project.
 
 </WarningBox>
 
@@ -103,6 +105,7 @@ You can force delete projects as long as there are no active clusters. All resou
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
-1. Navigate to **Tenant Admin** > **Projects** .
+
+2. Navigate to **Tenant Admin** > **Projects** .
 
 The project you deleted is no longer displayed and available for interaction.

--- a/content/docs/07-projects.md
+++ b/content/docs/07-projects.md
@@ -8,28 +8,15 @@ fullWidth: false
 ---
 
 import WarningBox from 'shared/components/WarningBox';
-import Tooltip from "shared/components/ui/Tooltip";
+import InfoBox from 'shared/components/InfoBox';
 
 # Projects
 
-A **Project** helps to organize the cluster resources in a logical grouping. The resources which are created within a project are scoped to that specific project and not available to other projects. Users and teams with specific roles can be associated with the project.
-
-## Creating a Project
-
-1. Navigate to **Tenant Admin** > **Projects** and click on the **Create Project** button to show the Project Creation form.
-
-1. Enter the **Name**, **Description**, and **Tags** to create a Project.
-
-## Associating Users and Teams to a Project
-
-The <Tooltip trigger={<u>Users</u>}><a href="/glossary-all/#users">Users</a> are members of a tenant who are assigned roles that control their access within the platform.</Tooltip> and <Tooltip trigger={<u>Teams</u>}>A <a href="/glossary-all/#team">Team</a> is a group of users.</Tooltip> can be associated via **Admin** > **User & Teams** page. Select the **User** or **Team** and under **Project Roles**, select *Add Roles* for the project association.
-
-The user permission is always the union of the Tenant and Project roles along with the roles inherited from the team association. Hence, if a user is a *Tenant Admin*, then the user has the *Project Admin* role to all the projects, even if an explicit project role is not assigned. If a user has the *Project Viewer* role at the Tenant scope, then the user gets *View* permissions on all the projects, and the user can be provided a *Project Admin* role for a specific project using the *Project Roles*.
+A **Project** helps you organize the cluster resources in a logical grouping. The resources which are created within a project are scoped to that project and not available to other projects. You can also assign users and teams with specific roles to specific projects.
 
 # Project Dashboard
 
 The **Tenant Admin** > **Projects** page displays the projects-related dashboard cards, capturing the usage and metrics about the projects.
-
 
 ## Monthly kilo-Core hours Usage
 
@@ -37,8 +24,85 @@ The **Monthly Usage** card shows the Daily Cluster Usage in kilo-Core hours (kCh
 
 ## Cores per Project Usage
 
-The usage of the active worker nodes' CPU **Cores** is grouped across all projects and shown at an hourly interval, by default. The interval can be changed to days or months.
+The usage of the active worker nodes' CPU **Cores** is grouped across all projects and shown at an hourly interval, by default. You can change the interval value to days or months.
 
 ## Project Card
 
-Every **Project Card** shows the cluster's state information grouped by its health and error states. Cluster health is derived based on the cluster nodes' health. The health of each node is determined based on several conditions such as node state, memory & disk pressure, and network availability.
+Every **Project Card** displays the cluster's state. The cluster information is grouped by its health and error states. Cluster health is derived based on the cluster nodes' health. The health of each node is determined based on several conditions such as memory and CPU utilizaiton, disk pressure, and network availability.
+
+
+# Create a Project
+
+Use the following steps to create a new project.
+
+<br />
+
+<InfoBox>
+
+You can associate users and teams with a project. Check out the [Project Association](/user-management/project-association) page to learn more.
+
+</InfoBox>
+
+## Prerequisites
+
+* Tenant Admin access
+
+## Enablement
+
+1. Log in to [Palette](https://console.spectrocloud.com)
+
+
+1. Navigate to **Tenant Admin** > **Projects** and click on the **Create Project** button to trigger the project creation wizard.
+
+
+1. Fill out the the following fields: **Name**, **Description**, and **Tags** to create a Project.
+
+## Validation
+
+1. Log in to [Palette](https://console.spectrocloud.com)
+
+1. Navigate to **Tenant Admin** > **Projects** 
+
+Your newly created project is listed along with other existing projects.
+
+
+# Delete a Project
+
+
+You can remove projects by following the steps below.
+
+## Prerequisites
+
+* Tenant Admin access
+
+* No active clusters in the project. 
+
+## Remove Project
+
+1. Log in to [Palette](https://console.spectrocloud.com)
+
+2. Switch to the **Tenant Admin** scope.
+
+3. Navigate to the left **Main Menu** and select **Projects**
+
+4. Locate the project card for the project you want to remove.
+
+5. Click on the **three-dot Menu** and select **Delete**.
+
+6. A pop-up box will ask you to confirm the action. Click on **Yes, delete project**.
+
+
+<WarningBox>
+
+You can force delete projects as long as there are no active clusters. All resources that belong to the project will be deleted.
+
+</WarningBox>
+
+
+## Validation
+
+1. Log in to [Palette](https://console.spectrocloud.com)
+
+1. Navigate to **Tenant Admin** > **Projects** 
+
+The project you deleted is no longer displayed and available for interaction.

--- a/content/docs/07-projects.md
+++ b/content/docs/07-projects.md
@@ -12,11 +12,11 @@ import InfoBox from 'shared/components/InfoBox';
 
 # Projects
 
-A **Project** helps you organize the cluster resources in a logical grouping. The resources which are created within a project are scoped to that project and not available to other projects. You can also assign users and teams with specific roles to specific projects.
+A **Project** helps you organize the cluster resources in a logical grouping. The resources that are created within a project are scoped to that project and not available to other projects. You can also assign users and teams with specific roles to specific projects.
 
 # Project Dashboard
 
-The **Tenant Admin** > **Projects** page displays the projects-related dashboard cards, capturing the usage and metrics about the projects.
+The **Tenant Admin** > **Projects** page displays the project-related dashboard cards that capture the usage and metrics about projects.
 
 ## Monthly kilo-Core hours Usage
 
@@ -24,11 +24,11 @@ The **Monthly Usage** card shows the Daily Cluster Usage in kilo-Core hours (kCh
 
 ## Cores per Project Usage
 
-The usage of the active worker nodes' CPU **Cores** is grouped across all projects and shown at an hourly interval, by default. You can change the interval value to days or months.
+By default, the active worker node usage of CPU **Cores** is grouped across all projects and shown as an hourly interval. You can change the interval value to days or months.
 
 ## Project Card
 
-Every **Project Card** displays the cluster's state. The cluster information is grouped by its health and error states. Cluster health is derived based on the cluster nodes' health. The health of each node is determined based on several conditions such as memory and CPU utilization, disk pressure, and network availability.
+Every **Project Card** displays the cluster's state. The cluster information is grouped by its health and error states. Cluster health is derived from the health of the cluster nodes. The health of each node is determined based on several conditions such as memory and CPU utilization, disk pressure, and network availability.
 
 
 # Create a Project
@@ -49,17 +49,17 @@ You can associate users and teams with a project. Check out the [Project Associa
 
 ## Enablement
 
-1. Log in to [Palette](https://console.spectrocloud.com)
+1. Log in to [Palette](https://console.spectrocloud.com).
 
 
-1. Navigate to **Tenant Admin** > **Projects** and click on the **Create Project** button to trigger the project creation wizard.
+1. Navigate to **Tenant Admin** > **Projects** and click the **Create Project** button.
 
 
 1. Fill out the following fields: **Name**, **Description**, and **Tags** to create a Project.
 
 ## Validation
 
-1. Log in to [Palette](https://console.spectrocloud.com)
+1. Log in to [Palette](https://console.spectrocloud.com).
 
 1. Navigate to **Tenant Admin** > **Projects** 
 
@@ -69,21 +69,21 @@ Your newly created project is listed along with other existing projects.
 # Delete a Project
 
 
-You can remove projects by following the steps below.
+You can remove projects by following these steps.
 
 ## Prerequisites
 
-* Tenant admin access
+* Tenant admin access.
 
 * No active clusters in the project. 
 
 ## Remove Project
 
-1. Log in to [Palette](https://console.spectrocloud.com)
+1. Log in to [Palette](https://console.spectrocloud.com).
 
-2. Switch to the **Tenant Admin** scope.
+2. Switch to **Tenant Admin** scope.
 
-3. Navigate to the left **Main Menu** and select **Projects**
+3. Navigate to the left **Main Menu** and select **Projects**.
 
 4. Locate the project card for the project you want to remove.
 
@@ -101,8 +101,8 @@ You can force delete projects as long as there are no active clusters. All resou
 
 ## Validation
 
-1. Log in to [Palette](https://console.spectrocloud.com)
+1. Log in to [Palette](https://console.spectrocloud.com).
 
-1. Navigate to **Tenant Admin** > **Projects** 
+1. Navigate to **Tenant Admin** > **Projects** .
 
 The project you deleted is no longer displayed and available for interaction.

--- a/content/docs/07-projects.md
+++ b/content/docs/07-projects.md
@@ -28,7 +28,7 @@ The usage of the active worker nodes' CPU **Cores** is grouped across all projec
 
 ## Project Card
 
-Every **Project Card** displays the cluster's state. The cluster information is grouped by its health and error states. Cluster health is derived based on the cluster nodes' health. The health of each node is determined based on several conditions such as memory and CPU utilizaiton, disk pressure, and network availability.
+Every **Project Card** displays the cluster's state. The cluster information is grouped by its health and error states. Cluster health is derived based on the cluster nodes' health. The health of each node is determined based on several conditions such as memory and CPU utilization, disk pressure, and network availability.
 
 
 # Create a Project
@@ -45,7 +45,7 @@ You can associate users and teams with a project. Check out the [Project Associa
 
 ## Prerequisites
 
-* Tenant Admin access
+* Tenant admin access
 
 ## Enablement
 
@@ -55,7 +55,7 @@ You can associate users and teams with a project. Check out the [Project Associa
 1. Navigate to **Tenant Admin** > **Projects** and click on the **Create Project** button to trigger the project creation wizard.
 
 
-1. Fill out the the following fields: **Name**, **Description**, and **Tags** to create a Project.
+1. Fill out the following fields: **Name**, **Description**, and **Tags** to create a Project.
 
 ## Validation
 
@@ -73,7 +73,7 @@ You can remove projects by following the steps below.
 
 ## Prerequisites
 
-* Tenant Admin access
+* Tenant admin access
 
 * No active clusters in the project. 
 

--- a/content/docs/08-user-management/1.8-project-association.md
+++ b/content/docs/08-user-management/1.8-project-association.md
@@ -8,17 +8,17 @@ fullWidth: false
 
 # Overview
 
-Associating a user or team with a specific project creates a clear distinction between who is allowed in the project and their access control permissions. By grouping resources together, you ensure that only the designated members have access to and control over the project resources, preventing others from accidentally or intentionally modifying them. This improves resource accountability, reduces confusion and conflicts, and helps maintain the integrity and security of the project.
+Associating a user or team with a specific project creates a clear distinction between who is allowed in the project and their access control permissions. By grouping resources together, you ensure that only designated members have access to and control over the project resources, preventing others from accidentally or intentionally modifying them. This improves resource accountability, reduces confusion and conflicts, and helps maintain the integrity and security of the project.
 
-The user's permissions are determined by the combination of their tenant and project roles, as well as any roles inherited from their team association. If a user is a *Tenant Admin*, they have project admin permissions in all projects. A user with the *Project Viewer* role at the tenant level will have *View* permissions for all projects. However, if a user or team has the *Project Viewer* role assigned specifically to a project, they will only have viewing access to that project. The extent of the user's permissions, either at the tenant or project level, determines the number of projects they can access.
+User permissions are determined by the combination of their tenant and project roles, as well as any roles inherited from their team association. If a user is a *Tenant Admin*, they have admin permissions in all projects. A user with the *Project Viewer* role at the tenant level has *View* permissions for all projects. However, if a user or team has the *Project Viewer* role assigned to a specific project, they only have view access to that project. The extent of user permissions, either at the tenant or project level, determines the number of projects they can access.
 
 # Associate a User or Team
 
-To associate a user or a team with a project, use the following steps.
+To associate a user or team with a project, use the following steps.
 
 # Prerequisites
 
-* Tenant Admin access
+* Tenant Admin access.
 
 * An available project. Check out the [Create a Project](/projects#createaproject) guide to learn how to create a project.
 
@@ -26,7 +26,7 @@ To associate a user or a team with a project, use the following steps.
 
 # Enablement
 
-1. Log in to [Palette](https://console.spectrocloud.com)
+1. Log in to [Palette](https://console.spectrocloud.com).
 
 
 2. Select the **Tenant Admin** scope.
@@ -50,7 +50,7 @@ To associate a user or a team with a project, use the following steps.
 8.  Next, assign permissions to the project role. To learn more about each permission and available roles, check out the [Palette RBAC](/user-management/palette-rbac) documentation.
 
 
-Click on **Confirm** to create the project role and complete the project association process.
+Click **Confirm** to create the project role and complete the project association process.
 
 
 # Validation 

--- a/content/docs/08-user-management/1.8-project-association.md
+++ b/content/docs/08-user-management/1.8-project-association.md
@@ -1,0 +1,65 @@
+---
+title: "Project Association"
+metaTitle: "Associate a User or Team with a Project"
+metaDescription: "Associate a User or Team with a Project"
+hideToC: false
+fullWidth: false
+---
+
+# Overview
+
+Associating a user or team with a specific project creates a clear distinction between who is allowed in the project and their access control permissions. By grouping resources together, you ensure that only the designated members have access to and control over the project resources, preventing others from accidentally or intentionally modifying them. This improves resource accountability, reduces confusion and conflicts, and helps maintain the integrity and security of the project.
+
+The user's permissions are determined by the combination of their tenant and project roles, as well as any roles inherited from their team association. If a user is a *Tenant Admin*, they have project admin permissions in all projects. A user with the *Project Viewer* role at the tenant level will have *View* permissions for all projects. However, if a user or team has the *Project Viewer* role assigned specifically to a project, they will only have viewing access to that project. The extent of the user's permissions, either at the tenant or project level, determines the number of projects they can access.
+
+# Associate a User or Team
+
+To associate a user or a team with a project, use the following steps.
+
+# Prerequisites
+
+* Tenant Admin access
+
+* An available project. Check out the [Create a Project](/projects#createaproject) guide to learn how to create a project.
+
+* A user or a team.
+
+# Enablement
+
+1. Log in to [Palette](https://console.spectrocloud.com)
+
+
+2. Select the **Tenant Admin** scope.
+
+
+3. Navigate to the left **Main Menu** and select **Users & Teams**.
+
+
+4. Select the tab of the resource you want to associate with a project, either a user or a team.
+
+
+5. Click on the row of the user or team to display its overview page.
+
+
+6. Select **Project Roles**.
+
+
+7. A **drop-down Menu** containing all the available projects in the tenant is available. Select the project you want to associate with the project role.
+
+
+8.  Next, assign permissions to the project role. To learn more about each permission and available roles, check out the [Palette RBAC](/user-management/palette-rbac) documentation.
+
+
+Click on **Confirm** to create the project role and complete the project association process.
+
+
+# Validation 
+
+1. Have a user or a user assigned to a team log in to [Palette](https://console.spectrocloud.com).
+
+2. Ask the user to switch the scope to the project you associated their role with.
+
+The user will now be able to select the associated project and complete actions within the scope of their project role permissions. 
+
+
+<br />

--- a/vale.ini
+++ b/vale.ini
@@ -12,7 +12,9 @@ IgnoredScopes = code, tt,
 ; BlockIgnores = 
 
 ; The following line ignores all import statements in markdown files
-TokenIgnores = (?s) *(import).*?(;)
+TokenIgnores = (?s) *(import).*?(;),\*\*.*?\*\*
+
+
 
 [formats]
 mdx = md


### PR DESCRIPTION
This PR adds content related to project deletion and the force delete behavior. The project page was also restructured to comply with the how-to layout format. Associating users to a project has been moved into its own page in the User Management section.

💻 [Preview](https://deploy-preview-1107--docs-spectrocloud.netlify.app/projects)
🎫 [PEM-801](https://spectrocloud.atlassian.net/browse/PEM-801)
