### PR TITLE
Revise pack overview doc

### DIFF
--- a/content/docs/06-integrations.mdx
+++ b/content/docs/06-integrations.mdx
@@ -20,7 +20,7 @@ Palette provides packs that are tailored for specific uses to support the core i
 
 When you create a cluster profile, you choose the type of pack you want to add: **Full**, **Infrastructure**, or **Add-on**. **Full** refers to the combination of **Infrastructure** and **Add-on** packs. 
 
-When you choose **Infrastructure** or **Add-on**, Palette presents only packs that provide functionality for the selected pack type. When you choose **Full**, Palette presents all the packs so you can build your cluster profile from the base layer up.  To learn more about cluster profiles, check out the [Cluster Profiles](/cluster-profiles) guide.     
+When you choose **Infrastructure** or **Add-on**, Palette presents only packs that provide functionality for the selected pack type. When you choose **Full**, Palette presents all the packs so you can build your cluster profile from the base layer up. To learn more about cluster profiles, check out the [Cluster Profiles](/cluster-profiles) guide.     
 
 To learn more about individual packs, use the search bar below to find a specific option. Alternatively, use the filter buttons to display available options. 
 <Packs />

--- a/content/docs/06-integrations.mdx
+++ b/content/docs/06-integrations.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Pack Integrations"
-metaTitle: "Layers and Pack Integrations"
-metaDescription: "A brief look into the concepts of layers and packs within Spectro Cloud. Also lists the available integrations."
+title: "Packs List"
+metaTitle: "Packs List"
+metaDescription: "Learn about packs that Palette offers and choose from Pallette packs."
 icon: "teams"
 hideToC: true
 fullWidth: true
@@ -15,13 +15,13 @@ import AppTiers from "shared/components/common/Integrations/AppTiers"
 
 <Content>
 
-  # Integrations
-  Integrations are the additional entities that are used to ensure and/or improve on the functionality of Kubernetes. Integrations are better understood as the options that are available for the various "layers" of the Spectro Cloud SaaS.
+# Overview
+Palette provides packs that are tailored for specific uses to support the core infrastructure a cluster needs and add-on packs to extend Kubernetes functionality. Each pack you add to a cluster profile is considered a layer in the profile.  
 
-  # Layers
-  Kubernetes, as the official document [says](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/#what-kubernetes-is-not), is "not a traditional, all-inclusive PaaS system". As such, it requires a lot of [add-ons](https://kubernetes.io/docs/concepts/overview/components/#addons) tailored for specific uses. ([A full list of add-ons is available here](https://kubernetes.io/docs/concepts/cluster-administration/addons/)). The specific uses (or the functionalities) that the add-ons provide are called "Layers" in the Spectro Cloud universe. For example, authentication is a layer that has the options of Dex and Permission Manager. Monitoring is another layer with options of Kubernetes Dashboard, Prometheus Grafana, and a whole lot more. To learn more about individual integrations, use the search bar below to find a specific option. Alternatively, use the filter buttons to see the available options.
-  <br/>
+When you create a cluster profile, you choose the type of pack you want to add: **Full**, **Infrastructure**, or **Add-on**. **Full** refers to the combination of **Infrastructure** and **Add-on** packs. 
 
-  
+When you choose **Infrastructure** or **Add-on**, Palette presents only packs that provide functionality for the selected pack type. When you choose **Full**, Palette presents all the packs so you can build your cluster profile from the base layer up.  To learn more about cluster profiles, check out the [Cluster Profiles](/cluster-profiles) guide. 
+
+To learn more about individual packs, use the search bar below to find a specific option. Alternatively, use the filter buttons to display available options. 
 <Packs />
 </Content>

--- a/content/docs/06-integrations.mdx
+++ b/content/docs/06-integrations.mdx
@@ -20,7 +20,7 @@ Palette provides packs that are tailored for specific uses to support the core i
 
 When you create a cluster profile, you choose the type of pack you want to add: **Full**, **Infrastructure**, or **Add-on**. **Full** refers to the combination of **Infrastructure** and **Add-on** packs. 
 
-When you choose **Infrastructure** or **Add-on**, Palette presents only packs that provide functionality for the selected pack type. When you choose **Full**, Palette presents all the packs so you can build your cluster profile from the base layer up.  To learn more about cluster profiles, check out the [Cluster Profiles](/cluster-profiles) guide. 
+When you choose **Infrastructure** or **Add-on**, Palette presents only packs that provide functionality for the selected pack type. When you choose **Full**, Palette presents all the packs so you can build your cluster profile from the base layer up.  To learn more about cluster profiles, check out the [Cluster Profiles](/cluster-profiles) guide.     
 
 To learn more about individual packs, use the search bar below to find a specific option. Alternatively, use the filter buttons to display available options. 
 <Packs />

--- a/content/docs/06-integrations/01-standalone-integrated-packs.md
+++ b/content/docs/06-integrations/01-standalone-integrated-packs.md
@@ -1,0 +1,31 @@
+---
+title: "Stand-alone and Integrated Packs"
+metaTitle: "AStand-alone and Integrated Packs"
+metaDescription: "Learn about Palette Stand-Alone Packs and Integrated Packs."
+icon: ""
+hideToC: false
+fullWidth: false
+---
+
+import {Content} from "shared/layouts/Default";
+import Tabs from "shared/components/ui/Tabs";
+import Packs from "shared/components/common/Integrations/Packs"
+import AppTiers from "shared/components/common/Integrations/AppTiers"
+
+# Overview
+
+Palette provides many add-on packs that are stand-alone and do not have dependencies. For more complex configurations, Palette has introduced integrated packs, which have dependencies that are handled internally, giving users convenience over configuration. Integrated packs are available in cluster profiles.
+
+Say you want to add the Kubernetes Dashboard to your cluster profile. Typically, this would require manually adding a dependency proxy pack to enable the use of a reverse proxy with a Kubernetes cluster. It also requires configuring third-party authentication through OIDC.
+
+Palette’s integrated version of the Kubernetes dashboard pack, called Spectro Kubernetes Dashboard, has pre-set defaults and does not require configuration. However, integrated packs offer the flexibility to change defaults if needed. Changing the defaults in an integrated pack would require some configuration. 
+
+<WarningBox>
+Default settings provide best practices for your clusters. Changing the default settings can introduce security issues by exposing your clusters. We recommend using the defaults.
+</WarningBox>
+
+<br />
+
+<br />
+
+

--- a/content/docs/06-integrations/01-standalone-integrated-packs.md
+++ b/content/docs/06-integrations/01-standalone-integrated-packs.md
@@ -21,7 +21,9 @@ Say you want to add the Kubernetes dashboard to your cluster profile. Typically,
 Palette’s integrated version of the Kubernetes dashboard pack, called Spectro Kubernetes Dashboard, has pre-set defaults and does not require configuration. However, integrated packs offer the flexibility to change defaults if needed. Changing the defaults in an integrated pack would require some configuration. 
 
 <WarningBox>
-Default settings provide best practices for your clusters. Changing the default settings can introduce security issues by exposing your clusters. We recommend using the defaults.
+
+We recommend using the Pack defaults. Default settings provide best practices for your clusters. Changing the default settings can introduce misconfigurations. Carefully review the changes you make to a pack. 
+
 </WarningBox>
 
 <br />

--- a/content/docs/06-integrations/01-standalone-integrated-packs.md
+++ b/content/docs/06-integrations/01-standalone-integrated-packs.md
@@ -1,6 +1,6 @@
 ---
 title: "Stand-alone and Integrated Packs"
-metaTitle: "AStand-alone and Integrated Packs"
+metaTitle: "Stand-alone and Integrated Packs"
 metaDescription: "Learn about Palette Stand-Alone Packs and Integrated Packs."
 icon: ""
 hideToC: false

--- a/content/docs/06-integrations/01-standalone-integrated-packs.md
+++ b/content/docs/06-integrations/01-standalone-integrated-packs.md
@@ -16,7 +16,7 @@ import AppTiers from "shared/components/common/Integrations/AppTiers"
 
 Palette provides many add-on packs that are stand-alone and do not have dependencies. For more complex configurations, Palette has introduced integrated packs, which have dependencies that are handled internally, giving users convenience over configuration. Integrated packs are available in cluster profiles.
 
-Say you want to add the Kubernetes Dashboard to your cluster profile. Typically, this would require manually adding a dependency proxy pack to enable the use of a reverse proxy with a Kubernetes cluster. It also requires configuring third-party authentication through OIDC.
+Say you want to add the Kubernetes dashboard to your cluster profile. Typically, this would require manually adding a dependency proxy pack to enable the use of a reverse proxy with a Kubernetes cluster. It also requires configuring third-party authentication through OIDC.
 
 Palette’s integrated version of the Kubernetes dashboard pack, called Spectro Kubernetes Dashboard, has pre-set defaults and does not require configuration. However, integrated packs offer the flexibility to change defaults if needed. Changing the defaults in an integrated pack would require some configuration. 
 


### PR DESCRIPTION
This PR rewrites the Pack Integrations doc and changes the nav pane label from "Pack Integrations" to "Packs List". Alternatively, it can just be "Packs" but labeling it as "Packs List" distinguishes it from "Registries and Packs".

The 06-integrations.mdx file contains  <Content> and </Content> elements. Are these necessary and can they be deleted? Or are they related to the search bar?

Note: This PR doesn't present the Integrations filter button (that's in the spectro K8s dashboard PR).

[Doc Preview](https://deploy-preview-1112--docs-spectrocloud.netlify.app/integrations)
See also the "Stand-Alone and Integrated Packs" doc in the nav pane below Packs List.
