### PR TITLE
docs: fixed url redirect

### DIFF
--- a/content/docs/04-clusters/01-public-cloud/01-aws/08-create-cluster.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws/08-create-cluster.md
@@ -21,7 +21,7 @@ Palette supports creating and managing Kubernetes clusters deployed to an AWS ac
 The following prerequisites must be met before deploying a cluster to AWS:
 
 - Access to an AWS cloud account 
-- Palette integration with AWS account. Review the [Add AWS Account](/clusters/public-cloud/aws/create-gov-accounts) for guidance.
+- Palette integration with AWS account. Review the [Add AWS Account](/clusters/public-cloud/aws/add-aws-accounts) for guidance.
 - An infrastructure cluster profile. Review the [Create Cluster Profiles](/cluster-profiles/task-define-profile) for guidance.
 - An [EC2 Key Pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) in the target region.
 - Palette creates compute, network, and storage resources in AWS during the provisioning of Kubernetes clusters. Ensure there is sufficient capacity in the preferred AWS region for the creation of the following resources:

--- a/content/docs/04-clusters/01-public-cloud/01-aws/09-eks.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws/09-eks.md
@@ -22,7 +22,7 @@ Palette supports creating and managing AWS Elastic Kubernetes Service (EKS) clus
 The following prerequisites must be met before deploying a cluster to AWS:
 
 - Access to an AWS cloud account 
-- Palette integration with AWS account. Review the [Add AWS Account](/clusters/public-cloud/aws/create-gov-accounts) for guidance.
+- Palette integration with AWS account. Review the [Add AWS Account](/clusters/public-cloud/aws/add-aws-accounts) for guidance.
 - An infrastructure cluster profile for AWS EKS. Review the [Create Cluster Profiles](/cluster-profiles/task-define-profile) for guidance.
 - An [EC2 Key Pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) in the target region.
 - Palette creates compute, network, and storage resources in AWS during the provisioning of Kubernetes clusters. Ensure there is sufficient capacity in the preferred AWS region for the creation of the following resources:


### PR DESCRIPTION
This PR fixes an incorrect URL in the AWS Create Cluster how-to page.