### PR TITLE
DOC-295 - Improve docs custom pack registry

### DIFF
--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -14,7 +14,7 @@ import InfoBox from 'shared/components/InfoBox';
 # Add Custom Registries
 
 Setting up a custom pack registry involves the installation of a registry server and configuring it with the Palette console.
-Once installed, the Spectro Cloud CLI tool can be used to manage the contents of the pack registry.
+Once the registry servier is installed, use the Spectro Cloud CLI tool to manage the contents of the pack registry.
 Pack contents are periodically synchronized with the Palette console.
 
 # Prerequisites
@@ -30,9 +30,11 @@ Pack contents are periodically synchronized with the Palette console.
 
 * Firewall ports 443/80 are required to be opened on the machine to allow traffic from the Palette console and Spectro CLI tool.
 
-<InfoBox>
-Please ensure that the ports 443/80 are exclusively allocated to the registry server and are not in use on any other servers.
-</InfoBox>
+* [OpenSSL](https://www.openssl.org/source/) if creating a self-signed certificate. Refer to the [Self-Signed Certificates](#self-signed-certificates) section for more guidance.
+
+<WarningBox>
+Please ensure that the ports 443 and 80 are exclusively allocated to the registry server and are not in use by other processes.
+</WarningBox>
 
 # Deploying a Pack Registry Server
 
@@ -63,37 +65,7 @@ Palette provides a Docker image for the pack registry server. The following step
     mkdir -p /root/certs
     ```
 
-<InfoBox>
-
-**Self-Signed Certificates**
-
-For self-signed certificates, use the following command to generate certificates.
-
-  ```bash
-  openssl req \
-    -newkey rsa:4096 -nodes -sha256 -keyout tls.key \
-    -x509 -days 1825 -out tls.crt
-  ```
-
-Provide the appropriate values while ensuring that the Common Name matches the registry hostname.
-
-  ```text
-  Country Name (2 letter code) [XX]:
-  State or Province Name (full name) []:
-  Locality Name (eg, city) [Default City]:
-  Organization Name (eg, company) [Default Company Ltd]:
-  Organizational Unit Name (eg, section) []:
-  Common Name (eg, your name or your server's hostname) []:[REGISTRY_HOST_DNS]
-  Email Address []:
-  
-  Example:
-  REGISTRY_HOST_DNS - registry.com
-  ```
-
-</InfoBox>
-
-
-5. Copy the `tls.crt` and `tls.key` files from the Certificate Authority into the `/roots/certs` directory. This directory will be mounted inside the registry Docker container.
+5. Copy the `tls.crt` and `tls.key` files from the Certificate Authority into the `/roots/certs` directory. This directory will be mounted inside the registry Docker container. 
 
 6. Pack contents in a pack registry can be stored locally on the host or an external file system.
 An external file system is recommended so that the pack contents can be mounted on another pack
@@ -129,13 +101,14 @@ Create a directory or mount an external volume to the desired storage location. 
     
 <br />
 
-  <WarningBox>
-      Spectro Cloud CLI registry login command fails with the error message in the case of self-signed certificates created using an IP address, rather than a hostname. <br /> <br /> "x509: cannot validate certificate for <em>ip_address</em>, because it doesn't contain any IP SANs" <br /> <br /> Either the certificate must be recreated to include an IP SAN, or you must use a DNS name as the Common Name, rather than an IP address.
-  </WarningBox>
+  #### Common Issues 
 
-  <WarningBox>
-    Spectro Cloud CLI registry login command fails with the error message in case of self-signed certificates or if the certificate is invalid. <br /> <br /> "x509: certificate signed by unknown authority" <br /> <br />  The host where Spectro Cloud CLI is installed must be configured to trust the certificate.
-  </WarningBox>
+  * Spectro Cloud CLI registry login command fails with the error message in the case of self-signed certificates created using an IP address, rather than a hostname. `x509: cannot validate certificate for ip_address, because it doesn't contain any IP SANs`. Either the certificate must be recreated to include an IP SAN, or you must use a DNS name as the Common Name, rather than an IP address.
+
+
+
+  * Spectro Cloud CLI registry login command fails with the error message in case of self-signed certificates or if the certificate is invalid. `x509: certificate signed by unknown authority`. The host where Spectro Cloud CLI is installed must be configured to trust the certificate.
+
 
   *    **HTTP mode** (*not recommended*)
         ```bash
@@ -210,3 +183,36 @@ use these packs in their cluster profiles.
 **Note:**
 
 To know more about the use of Spectro CLI to push packs to a custom registry and sync it to Palette [click here..](/registries-and-packs/spectro-cli-reference/?cliCommands=cli_push#push)
+
+
+
+# Self-Signed Certificates
+
+For self-signed certificates, use the following command to generate certificates.
+
+<br />
+
+  ```bash
+  openssl req \
+    -newkey rsa:4096 -nodes -sha256 -keyout tls.key \
+    -x509 -days 1825 -out tls.crt
+  ```
+
+Provide the appropriate values while ensuring that the Common Name matches the registry hostname.
+
+<br />
+
+  ```text
+  Country Name (2 letter code) [XX]:
+  State or Province Name (full name) []:
+  Locality Name (eg, city) [Default City]:
+  Organization Name (eg, company) [Default Company Ltd]:
+  Organizational Unit Name (eg, section) []:
+  Common Name (eg, your name or your server's hostname) []:[REGISTRY_HOST_DNS]
+  Email Address []:
+  
+  Example:
+  REGISTRY_HOST_DNS - registry.com
+  ```
+
+  <br />

--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -13,9 +13,9 @@ import InfoBox from 'shared/components/InfoBox';
 
 # Add Custom Registries
 
-Setting up a custom pack registry involves the installation of a registry server and configuring it with the Palette console.
-Once the registry servier is installed, use the Spectro Cloud CLI tool to manage the contents of the pack registry.
-Pack contents are periodically synchronized with the Palette console.
+Setting up a custom pack registry involves the installation of a registry server and configuring it with Palette.
+Once the registry server is installed, use the Spectro Cloud CLI tool to manage the contents of the pack registry.
+Pack contents are periodically synchronized with Palette.
 
 # Prerequisites
 

--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -13,7 +13,9 @@ import InfoBox from 'shared/components/InfoBox';
 
 # Add Custom Registries
 
-Setting up a custom pack registry involves the installation of a registry server and configuring it with the Palette console. Once installed, the Spectro Cloud CLI tool can be used to manage the contents of the pack registry. Pack contents are periodically synchronized with the Palette console.
+Setting up a custom pack registry involves the installation of a registry server and configuring it with the Palette console.
+Once installed, the Spectro Cloud CLI tool can be used to manage the contents of the pack registry.
+Pack contents are periodically synchronized with the Palette console.
 
 # Prerequisites
 
@@ -93,16 +95,16 @@ Provide the appropriate values while ensuring that the Common Name matches the r
 
 5. Copy the `tls.crt` and `tls.key` files from the Certificate Authority into the `/roots/certs` directory. This directory will be mounted inside the registry Docker container.
 
-
-6. Pack contents in a pack registry can be stored locally on the host or an external file system. An external file system is recommended so that the pack contents can be easily mounted on another pack registry instance in the event of restarts and failures. Create a directory or mount an external volume to the desired storage location. Example: `/root/data`
-
+6. Pack contents in a pack registry can be stored locally on the host or an external file system.
+An external file system is recommended so that the pack contents can be mounted on another pack
+registry instance in the event of restarts and failures.
+Create a directory or mount an external volume to the desired storage location. Example: `/root/data`
 
 7. Pull the latest Palette pack registry Docker image using the docker CLI.
 
     ```bash
         docker pull gcr.io/spectro-images-public/release/spectro-registry:3.1.0
     ```
-
 
 8. Create the Docker container using the docker `run` command:
 
@@ -129,8 +131,7 @@ Provide the appropriate values while ensuring that the Common Name matches the r
 
   <WarningBox>
       Spectro Cloud CLI registry login command fails with the error message in the case of self-signed certificates created using an IP address, rather than a hostname. <br /> <br /> "x509: cannot validate certificate for <em>ip_address</em>, because it doesn't contain any IP SANs" <br /> <br /> Either the certificate must be recreated to include an IP SAN, or you must use a DNS name as the Common Name, rather than an IP address.
-    </WarningBox>
-
+  </WarningBox>
 
   <WarningBox>
     Spectro Cloud CLI registry login command fails with the error message in case of self-signed certificates or if the certificate is invalid. <br /> <br /> "x509: certificate signed by unknown authority" <br /> <br />  The host where Spectro Cloud CLI is installed must be configured to trust the certificate.
@@ -153,15 +154,13 @@ Provide the appropriate values while ensuring that the Common Name matches the r
 
 <br />
 
-
 <InfoBox>
-
 Spectro Cloud CLI is required to use the insecure option `-i ( --insecure )` in the registry login command if the pack registry is installed in the HTTP mode.
 </InfoBox>
-
 <br />
 
-9. Expose the container host's port publicly to allow the Palette console to interact with the pack registry. This would be typically done via environment-specific constructs like Security Groups, Firewalls, etc.
+9. Expose the container host's port publicly to allow the console to interact with the pack registry.
+   This would be typically done via environment-specific constructs like Security Groups, Firewalls, etc.
 
 
 10. Verify the installation by invoking the pack registry APIs using the curl command. This should result in a 200 response.
@@ -182,7 +181,7 @@ Spectro Cloud CLI is required to use the insecure option `-i ( --insecure )` in 
 
 # Configure a Custom Pack Registry on the Palette Console
 
-Once the deployment of the pack registry server is complete, configure it with the Palette console as follows:
+Once the deployment of the pack registry server is complete, configure it with the console as follows:
 
 1. As a Tenant Administrator, navigate to **Admin Settings** > **Registries** > **Pack Registries**.
 
@@ -192,8 +191,21 @@ Once the deployment of the pack registry server is complete, configure it with t
 
 3. Click on **Confirm** once the details are filled.
 
+# Upload the CA Certificate to Palette
 
-Upon successful registration, users can build and deploy custom packs on to the custom pack registry and use these packs in their cluster profiles.
+In order to establish a trusted secure connection between Palette and your registry
+you will need to upload your certificate to the console.
+
+1. Click on **Tenant Settings** > **Certificates** > **Add A New Certificate**
+
+   Provide the content of your CA Cert (that will be the content of `tls.crt` if
+   you followed this tutorial.
+
+   After you saved the content of the certificate, it will take a few minutes for your
+   custom packs to appear in the available packs list.
+
+Upon successful registration, users can build and deploy custom packs on to the custom pack registry and
+use these packs in their cluster profiles.
 
 **Note:**
 


### PR DESCRIPTION
The description that we had so far, was not working if the user didn't specify the correct CA certificate.