### PR TITLE
Virtual clusters use cni csi of host cluster

### DIFF
--- a/content/docs/04-clusters/04-palette-virtual-clusters.md
+++ b/content/docs/04-clusters/04-palette-virtual-clusters.md
@@ -16,12 +16,11 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 # Palette Virtual Clusters Overview
 
-Palette Virtual Clusters are Kubernetes clusters that run as nested clusters within an existing cluster (also known as a Host Cluster) and share the host cluster resources, such as CPU, memory, and storage. By default, Palette Virtual Clusters will use [k3s](https://github.com/k3s-io/k3s) as virtual Kubernetes cluster, which is a highly available, certified Kubernetes distribution designed for production workloads.
+Palette Virtual Clusters run as nested Kubernetes clusters within a Host Cluster. Virtual clusters share the host cluster resources, such as CPU, memory, and storage, container network interface (CNI), and container storage interface (CSI). By default, virtual clusters use [k3s](https://github.com/k3s-io/k3s), a highly available, certified Kubernetes distribution designed for production workloads.
 
+Palette provisions and orchestrates virtual clusters and makes it easy to use the lightweight, Kubernetes technology stack and tools ecosystem. Deploy virtual clusters on both new and imported Host Clusters and attach application profiles.
 
-Palette provisions and orchestrates Palette Virtual Clusters and makes it easy to use the lightweight, Kubernetes technology stack and tools ecosystem. Deploy Palette Virtual Clusters on both new and imported Host Clusters as simple as following the wizard and attaching Add-on profiles.
-
-Palette also supports Day 2 operations such as upgrades, backup/restore and more, to keep Palette Virtual Clusters secure, compliant, and up to date. Additionally, it provides visibility into the workloads running inside your Palette Virtual Clusters and its associated costs.
+Palette also supports Day 2 operations such as upgrades and backup and restore to keep virtual clusters secure, compliant, and up to date. Additionally, it provides visibility into the workloads running inside your virtual clusters and the associated costs.
 
 To get started, refer to [Add Virtual Clusters to a Host Cluster](/clusters/palette-virtual-clusters/add-virtual-cluster-to-host-cluster).
 
@@ -30,16 +29,12 @@ To get started, refer to [Add Virtual Clusters to a Host Cluster](/clusters/pale
 
 ## Accessibility Options
 
-Two Palette Virtual Cluster accessibility options are supported:<p></p><br />
-1. **Load Balancer** <br />
-The Host Cluster must support dynamic provisioning of load balancers, either via a Cloud Controller Manager in the public cloud or a bare metal load balancer provider, such as MetalLB.<p></p><br />
+Two virtual cluster accessibility options are supported:<p></p><br />
+- **Load Balancer**: The Host Cluster must support dynamic provisioning of load balancers, either via a Cloud Controller Manager in the public cloud or a bare metal load balancer provider such as MetalLB.<p></p><br />
 
-1. **Ingress** <br />
-The NGINX Ingress Controller must be deployed on the Host cluster with SSL passthrough enabled. This allows TLS termination to occur at the Palette Virtual Cluster's Kubernetes API server.<br />
+- **Ingress**: The NGINX Ingress Controller must be deployed on the Host Cluster with SSL passthrough enabled. This allows TLS termination to occur at the virtual cluster's Kubernetes API server.<br />
 
-   A wildcard DNS record must be configured that maps to the load balancer associated with the NGINX Ingress Controller.
-
-   For example:
+   A wildcard DNS record must be configured that maps to the load balancer associated with the NGINX Ingress Controller. For example:
 
    `*.myapp.mydomain.com`
 

--- a/content/docs/04-clusters/04-palette-virtual-clusters.md
+++ b/content/docs/04-clusters/04-palette-virtual-clusters.md
@@ -18,16 +18,16 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 Palette Virtual Clusters run as nested Kubernetes clusters within a Host Cluster. Virtual clusters share the host cluster resources, such as CPU, memory, and storage, container network interface (CNI), and container storage interface (CSI). By default, virtual clusters use [k3s](https://github.com/k3s-io/k3s), a highly available, certified Kubernetes distribution designed for production workloads.
 
-Palette provisions and orchestrates virtual clusters and makes it easy to use the lightweight, Kubernetes technology stack and tools ecosystem. Deploy virtual clusters on both new and imported Host Clusters and attach application profiles.
+Palette provisions and orchestrates virtual clusters to make the lightweight Kubernetes technology stack and tools ecosystem available to you. Deploy virtual clusters on both new and imported Host Clusters and attach application profiles.
 
-Palette also supports Day 2 operations such as upgrades and backup and restore to keep virtual clusters secure, compliant, and up to date. Additionally, it provides visibility into the workloads running inside your virtual clusters and the associated costs.
+Palette also supports Day 2 operations such as upgrades, backup, and restore to keep virtual clusters secure, compliant, and up to date. Additionally, Palette provides visibility into the workloads running inside your virtual clusters and the associated costs.
 
 To get started, refer to [Add Virtual Clusters to a Host Cluster](/clusters/palette-virtual-clusters/add-virtual-cluster-to-host-cluster).
 
 
 <br />
 
-## Accessibility Options
+## Network Connectivity
 
 Two virtual cluster accessibility options are supported:<p></p><br />
 - **Load Balancer**: The Host Cluster must support dynamic provisioning of load balancers, either via a Cloud Controller Manager in the public cloud or a bare metal load balancer provider such as MetalLB.<p></p><br />


### PR DESCRIPTION
This PR was going to fix the "Add Virtual Clusters to a Host Cluster" doc to include a policy for ([PPD-969](https://spectrocloud.atlassian.net/browse/PPD-969)). However, as of 3.2 this method is deprecated. Instead, I added mention of CNI and CSI in the "Palette Virtual Clusters" doc. Should we also mention in the Overview that Host Clusters are deprecated in 3.2? Please advise.

Host Cluster also appears in the glossary.

In this PR, I also edited the "Palette Virtual Clusters" doc.