### PR TITLE
docs: fixed incorrect name for edge hosts

### DIFF
--- a/content/api/v1/12-edgehosts.md
+++ b/content/api/v1/12-edgehosts.md
@@ -1,9 +1,9 @@
 ---
-title: 'Appliances'
-metaTitle: 'Appliances'
-metaDescription: 'List of API endpoints that can be used to list, create or update appliances (Edge Hosts)'
+title: 'Edge Hosts'
+metaTitle: 'Edge Hosts'
+metaDescription: 'List of API endpoints that can be used to list, create or update Edge Hosts.'
 api: true
 paths: ['/v1/edgehosts']
 ---
 
-# Appliances (Edge Hosts)
+# Edge Hosts


### PR DESCRIPTION
This PR fixes a rename bug related to Edge hosts. 