### PR TITLE
Quick 404 links fix

### DIFF
--- a/content/docs/04-clusters/02-data-center/01-maas.md
+++ b/content/docs/04-clusters/02-data-center/01-maas.md
@@ -26,7 +26,7 @@ Palette supports integration with Canonical MAAS to give a cloud-like experience
 - [MAAS Bare-Metal Architecture](/clusters/data-center/maas/architecture)
 - [Install and Manage MAAS Gateway](/clusters/data-center/maas/install-manage-maas-pcg)
 - [Register and Manage MAAS Cloud Accounts](/clusters/data-center/maas/register-manage-maas-cloud-accounts)
-- [Create and Manage MAAS Cluster](/clusters/data-center/maas/create-manage-maas-cluster)
+- [Create and Manage MAAS Cluster](/clusters/data-center/maas/create-manage-maas-clusters)
 
 
 <br />


### PR DESCRIPTION
## Describe the Change

I noticed a broken link (missing an `s` to `clusters` at the end), here's a quick PR to fix it.

