### PR TITLE
Doc 472/custom pack registry updates

### DIFF
--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -96,7 +96,7 @@ Create a directory or mount an external volume to the desired storage location. 
             -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd-basic \
             -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/tls.crt \
             -e REGISTRY_HTTP_TLS_KEY=/certs/tls.key \
-            spectro-registry:3.1.0
+            gcr.io/spectro-images-public/release/spectro-registry:3.1.0
           ```
     
 <br />

--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -85,14 +85,14 @@ auth:
     path: /etc/spectropaxconfig/htpasswd-basic
 ```
 
-3. Start the container image with the following flags
+3. Start the container image with the following flags.
 
 ```
 docker run  \
     --rm \
-    -p 443:5000 \
+    --port 443:5000 \
     --name spectro-registry \
-    -v $(pwd)/spectropaxconfig/:/etc/spectropaxconfig/ \
+    --volume $(pwd)/spectropaxconfig/:/etc/spectropaxconfig/ \
     gcr.io/spectro-images-public/release/spectro-registry:3.3.0  \
     serve /etc/spectropaxconfig/myconfig.yml
 ```

--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -38,7 +38,10 @@ Please ensure that the ports 443 and 80 are exclusively allocated to the registr
 
 # Deploying a Pack Registry Server
 
-Palette provides a Docker image for the pack registry server. The following steps need to be performed to deploy the pack registry server using this docker image:
+The following section demonstrates how you can deploy a registry server secured with a TLS certificate issued by [Let's Encrypt](https://letsencrypt.org/).
+For more advanced configuration and deployment with self-signed certificates see [advanced configuration.](/registries-and-packs/advanced-configuration)
+Palette provides a Docker image for the pack registry server.
+The following steps need to be performed to deploy the pack registry server using this docker image:
 
 
 1. Configure the user credentials by using the `htpasswd` utility and store the credentials in a file locally. This file will be mounted inside the pack registry docker container.

--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -78,7 +78,7 @@ Create a directory or mount an external volume to the desired storage location. 
 7. Pull the latest Palette pack registry Docker image using the docker CLI.
 
     ```bash
-        docker pull gcr.io/spectro-images-public/release/spectro-registry:3.2.0
+        docker pull gcr.io/spectro-images-public/release/spectro-registry:3.3.0
     ```
 
 8. Create the Docker container using the docker `run` command:
@@ -99,7 +99,7 @@ Create a directory or mount an external volume to the desired storage location. 
             -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd-basic \
             -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/tls.crt \
             -e REGISTRY_HTTP_TLS_KEY=/certs/tls.key \
-            gcr.io/spectro-images-public/release/spectro-registry:3.2.0
+            gcr.io/spectro-images-public/release/spectro-registry:3.3.0
           ```
     
 <br />
@@ -125,7 +125,7 @@ Create a directory or mount an external volume to the desired storage location. 
                 -e  REGISTRY_AUTH=htpasswd \
                 -e  REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
                 -e  REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd-basic \
-                spectro-registry:3.2.0
+                spectro-registry:3.3.0
         ```
 
 <br />

--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -36,23 +36,29 @@ Pack contents are periodically synchronized with Palette.
 Please ensure that the ports 443 and 80 are exclusively allocated to the registry server and are not in use by other processes.
 </WarningBox>
 
-# Deploying a Pack Registry Server with letsencrypt certificates
+# Deploy Pack Registry Server with Letsencrypt
 
 The following section demonstrates how you can deploy a registry server secured with a TLS certificate issued by [Let's Encrypt](https://letsencrypt.org/).
-For more advanced configuration and deployment with self-signed certificates see [advanced configuration.](/registries-and-packs/advanced-configuration)
+
+Check out the [advanced configuration](/registries-and-packs/adding-a-custom-registry#self-signedcertificates) section
+for more advanced configuration and deployment with self-signed certificates.
+
 Palette provides a Docker image for the pack registry server.
+
 The following steps need to be performed to deploy the pack registry server using this docker image:
 
-
-1. Create an httppasswd file 
+1. Create a folder that contains an httppasswd file.
 
 ```
 mkdir spectropaxconfig
+```
+
+2. Create the htpasswd file:
+
+```
 htpasswd -Bbn admin {enter your secure password choice} > spectropaxconfig/htpasswd-basic
 ```
-2. Create a pax registry configuration
-
-Edit and save in `spectropaxconfig/myconfig.yml`
+3. Create a pax registry configuration file titled **myconfig.yml**. This file should be in the **spectropaxconfig** directory.
 
 ```yaml
 version: 0.1

--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -75,7 +75,7 @@ Create a directory or mount an external volume to the desired storage location. 
 7. Pull the latest Palette pack registry Docker image using the docker CLI.
 
     ```bash
-        docker pull gcr.io/spectro-images-public/release/spectro-registry:3.1.0
+        docker pull gcr.io/spectro-images-public/release/spectro-registry:3.2.0
     ```
 
 8. Create the Docker container using the docker `run` command:
@@ -96,7 +96,7 @@ Create a directory or mount an external volume to the desired storage location. 
             -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd-basic \
             -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/tls.crt \
             -e REGISTRY_HTTP_TLS_KEY=/certs/tls.key \
-            gcr.io/spectro-images-public/release/spectro-registry:3.1.0
+            gcr.io/spectro-images-public/release/spectro-registry:3.2.0
           ```
     
 <br />
@@ -122,7 +122,7 @@ Create a directory or mount an external volume to the desired storage location. 
                 -e  REGISTRY_AUTH=htpasswd \
                 -e  REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
                 -e  REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd-basic \
-                spectro-registry:3.1.0
+                spectro-registry:3.2.0
         ```
 
 <br />

--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -33,7 +33,9 @@ Pack contents are periodically synchronized with Palette.
 * [OpenSSL](https://www.openssl.org/source/) if creating a self-signed certificate. Refer to the [Self-Signed Certificates](#self-signed-certificates) section for more guidance.
 
 <WarningBox>
+
 Please ensure that the ports 443 and 80 are exclusively allocated to the registry server and are not in use by other processes.
+
 </WarningBox>
 
 # Deploy Pack Registry Server with Letsencrypt
@@ -47,6 +49,8 @@ Palette provides a Docker image for the pack registry server.
 
 The following steps need to be performed to deploy the pack registry server using this docker image:
 
+<br />
+
 1. Create a folder that contains an httppasswd file.
 
 ```
@@ -55,9 +59,11 @@ mkdir spectropaxconfig
 
 2. Create the htpasswd file:
 
+```shell
+htpasswd -Bbn admin "yourPasswordHere" > spectropaxconfig/htpasswd-basic
 ```
-htpasswd -Bbn admin {enter your secure password choice} > spectropaxconfig/htpasswd-basic
-```
+
+
 3. Create a pax registry configuration file titled **myconfig.yml**. This file should be in the **spectropaxconfig** directory.
 
 ```yaml
@@ -79,7 +85,7 @@ auth:
     path: /etc/spectropaxconfig/htpasswd-basic
 ```
 
-3. Run the container image with the following flags
+3. Start the container image with the following flags
 
 ```
 docker run  \

--- a/content/docs/09-registries-and-packs/7-advanced-configuration.md
+++ b/content/docs/09-registries-and-packs/7-advanced-configuration.md
@@ -1,0 +1,86 @@
+---
+title: 'Advanced Registry configuration'
+metaTitle: 'Advanced Registry configuration'
+metaDescription: 'Customizing deployments of Spectro Registry'
+icon: ''
+hideToC: true
+fullWidth: false
+---
+
+import Tabs from 'shared/components/ui/Tabs';
+import WarningBox from 'shared/components/WarningBox';
+import InfoBox from 'shared/components/InfoBox';
+import PointsOfInterest from 'shared/components/common/PointOfInterest';
+import Tooltip from "shared/components/ui/Tooltip";
+
+
+# Advanced Configuration of Spectro Registry
+
+You can modify a few deployment options of the Spectro Registy.
+Configuration is done by a YAML file, however you can override 
+many options using environment variables.
+
+The YAML file is divided into keys and values, which can have
+embedded keys and values, such as:
+
+```
+version: 0.1
+log:
+  level: info
+  fields:
+    environment: test
+```
+
+
+The key `version` has number value. The `log` key has value with multiple keys (`level`,
+`fields`), which in turn have more keys.
+
+To override the value of `log.level` you can specify an environment variable named
+`REGISTRY_LOG_LEVEL`.
+
+## The default configuration
+
+The docker image for the registy contains the following configuration:
+
+```yaml
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /data/.spectro-server
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [ nosniff ]
+    Strict-Transport-Security: [ max-age=63072000; includeSubdomains; preload ]
+    Content-Security-Policy: [ img-src 'self'; script-src 'self';  style-src 'self ]
+    X-Frame-Options: [ DENY ]
+    X-XSS-Protection: [ 1; mode=block ]
+    Referrer-Policy: [ same-origin ]
+auth:
+  htpasswd:
+    realm: basic-realm
+    path: /auth/htpasswd-basic
+```
+
+The server is started with the command `registy serve /etc/spectro/config.yml`.
+You can override this configuration by overriding specific values via environment
+variables or you can pass your own configuration file.
+
+## Storage Backend
+
+## Authentication
+
+## TLS
+
+## HTTP
+
+## Logging
+
+## Alerting
+
+

--- a/content/docs/09-registries-and-packs/7-advanced-configuration.md
+++ b/content/docs/09-registries-and-packs/7-advanced-configuration.md
@@ -209,9 +209,3 @@ http:
     clientcas: /path/to/file/with one or more/CA certificates encoded as PEM
     minimumtls: minimum tls version to use
 ```
-
-## Logging
-
-## Alerting
-
-

--- a/content/docs/09-registries-and-packs/7-advanced-configuration.md
+++ b/content/docs/09-registries-and-packs/7-advanced-configuration.md
@@ -139,7 +139,7 @@ storage: inmemory
 
 Basic HTTP Auth is supported:
 
-```
+```yaml
 auth:
   htpasswd:
     realm: basic-realm
@@ -154,20 +154,20 @@ The following options are available for modifying HTTP transport:
 
 For serving content on all interfaces on port 5000:
 
-```
+```yaml
 http:
     addr: :5000
 ```
-Alternatively one can bind to a single IP and different port:
+Alternatively, the server can bind to a single IP and different port:
 
-```
+```yaml
 http:
     addr: 192.168.122.77:25000
 ```
 ### HTTP Headers
 
 The following headers are the default, and can be overriden:
-```
+```yaml
 http:
   headers:
     X-Content-Type-Options: [ nosniff ]
@@ -176,15 +176,15 @@ http:
     X-Frame-Options: [ DENY ]
     X-XSS-Protection: [ 1; mode=block ]
     Referrer-Policy: [ same-origin ]
-
+```
 ### TLS
 
 TLS can be configured using [letsencrypt](https://letsencrypt.org) or custom TLS certificates:
 
 For letsencrypt, your registry has to have a public IP address accessible for HTTP based
-validation by letsencrypt services.
+validation by the letsencrypt services.
 
-```
+```yaml
 http:
   addr: :5000
   tls:

--- a/content/docs/09-registries-and-packs/7-advanced-configuration.md
+++ b/content/docs/09-registries-and-packs/7-advanced-configuration.md
@@ -158,7 +158,7 @@ For serving content on all interfaces on port 5000:
 http:
     addr: :5000
 ```
-Alternatively one can bing to a single IP and different port:
+Alternatively one can bind to a single IP and different port:
 
 ```
 http:

--- a/content/docs/09-registries-and-packs/7-advanced-configuration.md
+++ b/content/docs/09-registries-and-packs/7-advanced-configuration.md
@@ -130,11 +130,85 @@ storage:
     port: OPTIONAL_MINIO_PORT_IF_USING
 ```
 
+Ephemeral storage for testing purposes is also available:
+```
+storage: inmemory
+```
+
 ## Authentication
 
-## TLS
+Basic HTTP Auth is supported:
+
+```
+auth:
+  htpasswd:
+    realm: basic-realm
+    path: /auth/htpasswd-basic
+```
 
 ## HTTP
+
+The following options are available for modifying HTTP transport:
+
+### Server and Port
+
+For serving content on all interfaces on port 5000:
+
+```
+http:
+    addr: :5000
+```
+Alternatively one can bing to a single IP and different port:
+
+```
+http:
+    addr: 192.168.122.77:25000
+```
+### HTTP Headers
+
+The following headers are the default, and can be overriden:
+```
+http:
+  headers:
+    X-Content-Type-Options: [ nosniff ]
+    Strict-Transport-Security: [ max-age=63072000; includeSubdomains; preload ]
+    Content-Security-Policy: [ img-src 'self'; script-src 'self';  style-src 'self ]
+    X-Frame-Options: [ DENY ]
+    X-XSS-Protection: [ 1; mode=block ]
+    Referrer-Policy: [ same-origin ]
+
+### TLS
+
+TLS can be configured using [letsencrypt](https://letsencrypt.org) or custom TLS certificates:
+
+For letsencrypt, your registry has to have a public IP address accessible for HTTP based
+validation by letsencrypt services.
+
+```
+http:
+  addr: :5000
+  tls:
+    letsencrypt:
+      cachefile: le-cache
+      email: oz@spectrocloud.com
+      hosts:
+      - pax-registry.spectrocloud.com
+```
+
+Note, letsencrypt limits the amount of free certificates issued per domain per amount of time.
+It is therefore, recommended to mount a volume where the certificates are permanently stored.
+This option is `cachefile` which is actually a directory, despite the name.
+
+Custom certificates can be specified with:
+
+```
+http:
+  tls:
+    certificate: /path/to/x509/certificate/file
+    key: /pat/to/x509/key/file/which contains/private key/for x509 certificate above
+    clientcas: /path/to/file/with one or more/CA certificates encoded as PEM
+    minimumtls: minimum tls version to use
+```
 
 ## Logging
 

--- a/content/docs/09-registries-and-packs/7-advanced-configuration.md
+++ b/content/docs/09-registries-and-packs/7-advanced-configuration.md
@@ -16,11 +16,11 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 # Advanced Configuration
 
-You can modify a few deployment options of the pack registry.
-The configuration is applied through a YAML file. However, you can override 
-many options using environment variables.
+You can modify the deployment of the pack registry by providing a YAML configuration file. You can also override default configuration options through the usage of environment variables.
 
-The configuration file is divided into keys and values. The following is an example YAML configuration.
+The configuration file is divided into keys and values. The following is an example of a YAML configuration.
+
+<br />
 
 ```yaml
 version: 0.1
@@ -36,8 +36,13 @@ The key `version` has a number value. The `log` key has a value with multiple ke
 To override the value of `log.level` you can specify an environment variable named
 `REGISTRY_LOG_LEVEL`.
 
+<br />
+
 ```shell
 export REGISTRY_LOG_LEVEL=debug
+```
+
+<br />
 
 ## Default Configuration
 
@@ -74,30 +79,35 @@ The server is started with the command `registy serve /etc/spectro/config.yml`.
 You can override the default values with specific values through environment
 variables, or you can use your own configuration file.
 
-For example, you can start the docker container image with the following environment
-variables to override the basic auth realm and logging level:
+For example, you can start the docker container image with the following environment by using the
+variables to override the basic auth realm and logging level. In the following example, the `-e` flag is used to provide environment variables to the container.
+
+<br />
 
 ```bash
 docker run -d \
-    -p 443:5000 \
-    ...
+    --rm \
+    --port 443:5000 \
+    --name spectro-registry\
+    --volume $(pwd)/spectropaxconfig/:/etc/spectropaxconfig/
     -e REGISTRY_LOG_LEVEL=debug \
     -e REGISTRY_AUTH=htpasswd \
     -e REGISTRY_AUTH_HTPASSWD_REALM="My Enterprise Realm" \
-    ...
     gcr.io/spectro-images-public/release/spectro-registry:3.2.0
 ```
 
 Alternatively, you can start the container by mounting a directory with a new configuration file and pointing the server command to the configuration file.
 
-```
+<br />
+
+```shell
 docker run -d \
-    -p 443:5000 \
-    ...
-    -v $(pwd)/myconfig.yml:/etc/myconfig.yml
-    ...
-    gcr.io/spectro-images-public/release/spectro-registry:3.3.0
-    /registry serve /etc/myconfig.yml
+    --rm \
+    --port 443:5000 \
+    --name spectro-registry \
+    --volume $(pwd)/myconfig.yml:/etc/myconfig.yml \
+    gcr.io/spectro-images-public/release/spectro-registry:3.3.0 \
+    serve /etc/spectropaxconfig/myconfig.yml
 ```
 ## Storage Backend
 
@@ -111,12 +121,14 @@ storage:
   cache:
     blobdescriptor: inmemory
   filesystem:
-    rootdirectory: /tmp/registry//data/.spectro-server
+    rootdirectory: /tmp/registry/data/.spectro-server
 ```
 
 If you are using S3 Storage, ensure you specify the required S3 parameters.
 
-```
+<br />
+
+```yaml
 storage:
   cache:
     blobdescriptor: inmemory
@@ -133,6 +145,9 @@ storage:
 ```
 
 You can also use ephemeral storage. We recommend using ephemeral storage for testing purposes. Production environments should use object storage or a file system.
+
+<br />
+
 ```yaml
 storage: inmemory
 ```
@@ -140,6 +155,8 @@ storage: inmemory
 ## Authentication
 
 You can configure basic HTTP Auth. Basic Auth requires providing the pack registry server with an httppasswd file containing the credentials.
+
+<br />
 
 ```yaml
 auth:
@@ -156,11 +173,15 @@ The following options are available for modifying HTTP transport:
 
 For serving content on all interfaces on port 5000:
 
+<br />
+
 ```yaml
 http:
     addr: :5000
 ```
 Alternatively, the server can bind to a single IP and different port:
+
+<br />
 
 ```yaml
 http:
@@ -168,7 +189,10 @@ http:
 ```
 ### HTTP Headers
 
-The following headers are the default, and can be overriden:
+The following headers are the default, and can be overridden:
+
+<br />
+
 ```yaml
 http:
   headers:
@@ -181,10 +205,11 @@ http:
 ```
 ### TLS
 
-TLS can be configured using [letsencrypt](https://letsencrypt.org) or custom TLS certificates:
+TLS can be configured using [Let's Encrypt](https://letsencrypt.org) or custom TLS certificates:
 
-For letsencrypt, your registry has to have a public IP address accessible for HTTP based
-validation by the letsencrypt services.
+When using Let's Encrypt, your registry server must be assigned to a public IP address accessible for HTTP-based validation by the Let's Encrypt services.
+
+<br />
 
 ```yaml
 http:
@@ -197,13 +222,15 @@ http:
       - pax-registry.spectrocloud.com
 ```
 
-Note, letsencrypt limits the amount of free certificates issued per domain per amount of time.
-It is therefore, recommended to mount a volume where the certificates are permanently stored.
-This option is `cachefile` which is actually a directory, despite the name.
+Let's Encrypt limits the number of free certificates issued for each domain for a set time.
+We recommend you mount a volume where the certificates are permanently stored. Use the
+option `cachefile` to enable this behavior.
 
-Custom certificates can be specified with:
+You can specify custom certificates by providing the file path to the certificate files.
 
-```
+<br />
+
+```yaml
 http:
   tls:
     certificate: /path/to/x509/certificate/file

--- a/content/docs/09-registries-and-packs/7-advanced-configuration.md
+++ b/content/docs/09-registries-and-packs/7-advanced-configuration.md
@@ -71,6 +71,32 @@ The server is started with the command `registy serve /etc/spectro/config.yml`.
 You can override this configuration by overriding specific values via environment
 variables or you can pass your own configuration file.
 
+For example you can run the docker container image with the following environment
+variables to override the basic auth realm and logging level:
+
+```bash
+docker run -d \
+    -p 443:5000 \
+    ...
+    -e REGISTRY_LOG_LEVEL=debug \
+    -e REGISTRY_AUTH=htpasswd \
+    -e REGISTRY_AUTH_HTPASSWD_REALM="My Enterprise Realm" \
+    ...
+    gcr.io/spectro-images-public/release/spectro-registry:3.2.0
+```
+
+Alternatively, you can run the image mounting a directory with a new configuration
+file and pointing the server command to it:
+
+```
+docker run -d \
+    -p 443:5000 \
+    ...
+    -v $(pwd)/myconfig.yml:/etc/myconfig.yml
+    ...
+    gcr.io/spectro-images-public/release/spectro-registry:3.2.0
+    /registry serve /etc/myconfig.yml
+```
 ## Storage Backend
 
 ## Authentication

--- a/content/docs/09-registries-and-packs/7-advanced-configuration.md
+++ b/content/docs/09-registries-and-packs/7-advanced-configuration.md
@@ -99,6 +99,37 @@ docker run -d \
 ```
 ## Storage Backend
 
+The pax registry can store data on a file system through a mounted
+volume or it can use S3 storage (AWS or similar).
+
+The following shows a file system backend:
+
+```
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /tmp/registry//data/.spectro-server
+```
+
+S3 Storage needs to know how to connect to S3:
+
+```
+storage:
+  cache:
+    blobdescriptor: inmemory
+  s3:
+    region: us-east-1
+    bucket: my-bucket
+    rootdirectory: /registry
+    encrypt: true|false
+    secure: false|true
+    accesskey: SAMPLEACCESSKEY
+    secretkey: SUPERSECRET
+    host: OPTIONAL_MINIO_HOST_IF_USING
+    port: OPTIONAL_MINIO_PORT_IF_USING
+```
+
 ## Authentication
 
 ## TLS

--- a/vale/styles/Vocab/Internal/accept.txt
+++ b/vale/styles/Vocab/Internal/accept.txt
@@ -99,3 +99,4 @@ Repo
 datastore
 uxp
 wodim
+Letsencrypt


### PR DESCRIPTION
## Describe the Change

This PR extends the documentation of the PAX registry. It adds information on previously
undocumented features and shows how to deploy the registry with letsencrypt, which was added in v3.2.

## Review Changes

🎫 [Jira ticket](https://spectrocloud.atlassian.net/browse/DOC-295)
