### PR TITLE
docs: updated IAM policies page with a warning

### DIFF
--- a/content/docs/04-clusters/01-public-cloud/01-aws/10-required-iam-policies.md
+++ b/content/docs/04-clusters/01-public-cloud/01-aws/10-required-iam-policies.md
@@ -13,10 +13,17 @@ import PointsOfInterest from 'shared/components/common/PointOfInterest';
 
 # Required IAM Policies
 
-Palette requires proper Amazon Web Services (AWS) permissions in order to operate and perform actions on your behalf.
-The following four policies include all the required permissions for provisioning clusters through Palette:
+Palette requires proper Amazon Web Services (AWS) permissions to operate and perform actions on your behalf.
+The following four policies include all the required permissions for provisioning clusters through Palette.
 
 <br />
+
+<WarningBox>
+
+You can attach a maximum of ten managed policies to an IAM User or role. Exceeding this limit will result in cluster deployment failures. If you find yourself in a scenario where you are exceeding the limit, consider combining policies into a custom-managed policy.
+You can learn more about AWS IAM limits in the [IAM Quotas](https://docs.aws.amazon.com/us_en/IAM/latest/UserGuide/reference_iam-quotas.html) reference guide.
+
+</WarningBox>
 
 <Tabs>
 


### PR DESCRIPTION
## Describe the Change

This PR adds a warning to the AWS IAM policies page. Users that exceed the policy attachment limit will result in cluster creation failures.

![CleanShot 2023-04-14 at 07 24 52](https://user-images.githubusercontent.com/29551334/232072086-015b91e3-e522-4960-9bff-99ee7e40ccde.png)


## Review Changes

💻 [Preview](https://deploy-preview-1240--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/required-iam-policies)

