### PR TITLE
chore: fixed broken urls and reported typo

### DIFF
--- a/content/docs/12-enterprise-version/03-deploying-palette-with-helm.md
+++ b/content/docs/12-enterprise-version/03-deploying-palette-with-helm.md
@@ -37,7 +37,7 @@ This installation method is common in secure environments with restricted networ
 - A custom domain and the ability to update Domain Name System (DNS) records.
 
 
-- Access to the Palette Helm Chart. Contact suppport@spectrocloud.com to gain access to the Helm Chart.
+- Access to the Palette Helm Chart. Contact support@spectrocloud.com to gain access to the Helm Chart.
 
 
 - For AWS EKS, ensure you have the [AWS CLI](https://aws.amazon.com/cli/) and the [kubectl CLI](https://github.com/weaveworks/eksctl#installation) installed. 

--- a/content/docs/19-kubernetes-knowlege-hub/00-how-to/02-how-to-retrieve-images-from-private-registry.md
+++ b/content/docs/19-kubernetes-knowlege-hub/00-how-to/02-how-to-retrieve-images-from-private-registry.md
@@ -32,7 +32,7 @@ In this tutorial, you will log into a private docker registry to pull existing i
 
 - The kubectl [command-line tool](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/). Kubectl allows you to connect to, configure and work with your clusters through the command line.
 - Access to a private registry.  [DockerHub](https://hub.docker.com/) offers a single private registry on the free tier. If you do not have a personal registry account, you can use DockerHub.
-- Access to a running Kubernetes cluster. To learn how to create clusters in different environments using Palette, review guides listed under [clusters](/clusters) or visit the [Palette Onboarding Workflow](/getting-started/onboarding-workflow#paletteonboardingworkflow) guide. To learn how to create a Kubernetes cluster from scratch, check out the [Create a Cluster](https://kubernetes.io/docs/tutorials/kubernetes-basics/create-cluster/) Kubernetes resource.
+- Access to a running Kubernetes cluster. To learn how to create clusters in different environments using Palette, review guides listed under [Clusters](/clusters) or visit the [Palette Onboarding Workflow](/getting-started/onboarding-workflow#paletteonboardingworkflow) guide. To learn how to create a Kubernetes cluster from scratch, check out the [Create a Cluster](https://kubernetes.io/docs/tutorials/kubernetes-basics/create-cluster/) Kubernetes resource.
 
 The following example explains how you can create a secret and use it in a Kubernetes deployment:
 

--- a/content/docs/19-kubernetes-knowlege-hub/00-how-to/02-how-to-retrieve-images-from-private-registry.md
+++ b/content/docs/19-kubernetes-knowlege-hub/00-how-to/02-how-to-retrieve-images-from-private-registry.md
@@ -32,7 +32,7 @@ In this tutorial, you will log into a private docker registry to pull existing i
 
 - The kubectl [command-line tool](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/). Kubectl allows you to connect to, configure and work with your clusters through the command line.
 - Access to a private registry.  [DockerHub](https://hub.docker.com/) offers a single private registry on the free tier. If you do not have a personal registry account, you can use DockerHub.
-- Access to a running Kubernetes cluster. To learn how to create clusters in different environments using Palette, review guides listed under [Clusters](docs.spectrocloud.com/clusters) or visit the [Palette Onboarding Workflow](docs.spectrocloud.com/getting-started/onboarding-workflow#paletteonboardingworkflow) guide. To learn how to create a Kubernetes cluster from scratch, check out the [Create a Cluster](https://kubernetes.io/docs/tutorials/kubernetes-basics/create-cluster/) Kubernetes resource.
+- Access to a running Kubernetes cluster. To learn how to create clusters in different environments using Palette, review guides listed under [clusters](/clusters) or visit the [Palette Onboarding Workflow](/getting-started/onboarding-workflow#paletteonboardingworkflow) guide. To learn how to create a Kubernetes cluster from scratch, check out the [Create a Cluster](https://kubernetes.io/docs/tutorials/kubernetes-basics/create-cluster/) Kubernetes resource.
 
 The following example explains how you can create a secret and use it in a Kubernetes deployment:
 


### PR DESCRIPTION
## Describe the Change

This PR fixes two identified broken URLs and a typo in the Helm Install page.

## Review Changes

💻 [Preview](https://deploy-preview-1244--docs-spectrocloud.netlify.app/kubernetes-knowlege-hub/how-to/how-to-retrieve-images-from-private-registry)

