### PR TITLE
docs: doc-755 added public IP addresses

### DIFF
--- a/content/docs/02.5-architecture/04.5-palette-public-ips.md
+++ b/content/docs/02.5-architecture/04.5-palette-public-ips.md
@@ -9,7 +9,7 @@ fullWidth: false
  
  # Overview
 
- In this section, you can find the public IP addresses that support Spectro Cloud SaaS operations. These IP addresses are essential for ensuring seamless communication between your infrastructure and our platform.
+ In this section, you can find the public IP addresses that support Spectro Cloud SaaS operations. These IP addresses are essential to ensure seamless communication between your infrastructure and our platform.
 
 
 

--- a/content/docs/02.5-architecture/04.5-palette-public-ips.md
+++ b/content/docs/02.5-architecture/04.5-palette-public-ips.md
@@ -1,0 +1,31 @@
+---
+title: "IP Addresses"
+metaTitle: "IP Addresses"
+metaDescription: "Palette's public IP Addresses."
+icon: ""
+hideToC: false
+fullWidth: false
+---
+ 
+ # Overview
+
+ In this section, you can find the public IP addresses that support Spectro Cloud SaaS operations. These IP addresses are essential for ensuring seamless communication between your infrastructure and our platform.
+
+
+
+Allow the following IP address ranges in your network configuration to enable traffic to and from the Spectro Cloud SaaS platform.
+
+| **IP Address**| **Region** | 
+|---|---|
+|44.232.106.120 | North West U.S. |
+|44.233.247.65  | North West U.S. |
+|52.35.163.177  | North West U.S. |
+|13.52.68.206   | South West U.S. |
+|18.144.153.171 | South West U.S. |
+|52.6.49.233 | North East U.S. |
+|54.158.209.13 | North East U.S. |
+|54.80.29.137 | North East U.S. |
+
+
+
+ <br />


### PR DESCRIPTION
## Describe the Change

This PR publishes the Public Palette IP addresses that customers must know when configuring their Firewall rules.

![CleanShot 2023-04-24 at 07 43 31](https://user-images.githubusercontent.com/29551334/234031677-6d22ed21-32ca-45ee-b835-f11c5a21ae0b.png)


## Review Changes

💻 [Preview](https://deploy-preview-1256--docs-spectrocloud.netlify.app/architecture/palette-public-ips)

🎫 [DOC-755](https://spectrocloud.atlassian.net/browse/DOC-755)
