### PR TITLE
docs: PEM-1632 added new macro variable

### DIFF
--- a/content/docs/09-registries-and-packs/5-pack-constraints.md
+++ b/content/docs/09-registries-and-packs/5-pack-constraints.md
@@ -574,7 +574,8 @@ user:
 | `{{.spectro.system.project.name}}`  | The name of the project. |
 | `{{.spectro.system.project.uid}}`  | The unique identifier of the project. |
 | `{{.spectro.system.clusterprofile.name}}`| The name of the cluster profile associated with the current project. |
-| `{{.spectro.system.clusterprofile.uid}}` | The unique identifier of the cluster profile associated with the current project. |
+| `{{.spectro.system.clusterprofile.uid}}` | The unique identifier of the cluster profile the pack is part of. |
+| `{{.spectro.system.clusterprofile.version}}`| The current version of the cluster profile the pack is part of.|
 | `{{.spectro.system.cluster.name}}`  | The name of the cluster. |
 | `{{.spectro.system.cluster.uid}}`  | The unique identifier of the cluster. |
 | `{{.spectro.system.cloudaccount.name}}`  | The name of the cloud account associated with the current project. |


### PR DESCRIPTION
## Describe the Change

This PR documents a new Packs macro variable `{{.spectro.system.kubernetes.version}}`.

## Review Changes

💻 [Preview URL](https://deploy-preview-1262--docs-spectrocloud.netlify.app/registries-and-packs/pack-constraints#typesofmacros)

🎫 [PEM-1632](https://spectrocloud.atlassian.net/browse/PEM-1632)
