### PR TITLE
Update tutorial to adhere to the Spectro Cloud style guide

### DIFF
--- a/content/docs/09-registries-and-packs/4.5-deploy-pack.md
+++ b/content/docs/09-registries-and-packs/4.5-deploy-pack.md
@@ -15,7 +15,7 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 
 # Create and Deploy a Custom Add-On Pack
-Custom add-on packs allow you to run Kubernetes applications in clusters and reuse them in multiple deployments. This ensures uniformity across your clusters. The primary use cases for creating custom packs are:
+Custom add-on packs allow you to deploy Kubernetes applications in clusters and reuse them in multiple deployments. This ensures uniformity across your clusters. The primary use cases for creating custom packs are:
 
 - Aggregated configuration and application dependencies simplify deployment and consumption.
 
@@ -56,7 +56,7 @@ To complete the tutorial, you will need the following items:
 You will work in a Docker container pre-configured with the necessary tools for this tutorial. However, you can practice this tutorial in any `linux/amd64` or `x86_64` environment by installing the [necessary tools](https://github.com/spectrocloud/tutorials/blob/main/docs/docker.md#docker) and cloning the [GitHub repository](https://github.com/spectrocloud/tutorials/) that contains the tutorial files. Here are the steps to start the tutorials container. 
 <br />
 
-Start the Docker Desktop on your local machine and ensure the daemon is available by issuing a command to list the running containers.
+Start the Docker Desktop on your local machine and ensure the daemon is available by issuing a command to list the currently active containers.
 
 <br />
 
@@ -314,7 +314,7 @@ Verify the registry server is accessible from outside the tutorials container by
 <br /> 
 
 ## Log in to the Registry Server
-Once the registry server is up and running, the next step is to log in and then push the pack to it. The pack you will push is in the tutorials container. You will need to open another bash session into the tutorials container from your local terminal.  
+Once the registry server `/health` endpoint shows `UP` status, the next step is to log in and push the pack to it. The pack you will push is in the tutorials container. Therefore, you must open another bash session into the tutorials container from your local terminal.  
 <br/>
 
 ```bash


### PR DESCRIPTION
## Describe the Change

This PR removes the word `run` from the tutorial. 

## Review Changes

💻 [Add Preview URL](https://deploy-preview-1269--docs-spectrocloud.netlify.app/registries-and-packs/deploy-pack)

🎫 Jira Ticket: [DOC-724](https://spectrocloud.atlassian.net/browse/DOC-724)
