### PR TITLE
docs: Disable workloads Settting

### DIFF
--- a/content/docs/00-release-notes.md
+++ b/content/docs/00-release-notes.md
@@ -85,7 +85,7 @@ Palette 3.4.0 has various security upgrades, better support for multiple Kuberne
 
 
 
-- You can now configure the behavior of the Palette agent to disable sending workload reports to the Palette control plane. This addresses scenarios where large clusters with many nodes exceed the 1 MB payload threshold resulting in agent failures. Refer to the [Nodes Troubleshooting](/troubleshooting/nodes#paletteagentsworkloadpayloadsizeissue) for guidance on disabling the workload report feature.
+- You can now configure the behavior of the Palette agent to disable sending workload reports to the Palette control plane. This addresses scenarios where large clusters with many nodes exceed the 1 MB payload threshold, resulting in agent failures. Refer to the [Nodes Troubleshooting](/troubleshooting/nodes#paletteagentsworkloadpayloadsizeissue) for guidance on disabling the workload report feature.
 ## Edge
 
 ## Breaking Changes

--- a/content/docs/00-release-notes.md
+++ b/content/docs/00-release-notes.md
@@ -85,7 +85,7 @@ Palette 3.4.0 has various security upgrades, better support for multiple Kuberne
 
 
 
-- You can now configure the behavior of the Palette agent to disable sending workloads to the Palette control plane. This addresses scenarios where large clusters with many nodes exceed the 1 MB payload threshold resulting in agent failures. Refer to the [Nodes Troubleshooting](/troubleshooting/nodes#paletteagentsworkloadpayloadsizeissue) for guidance on disabling the workload feature.
+- You can now configure the behavior of the Palette agent to disable sending workload reports to the Palette control plane. This addresses scenarios where large clusters with many nodes exceed the 1 MB payload threshold resulting in agent failures. Refer to the [Nodes Troubleshooting](/troubleshooting/nodes#paletteagentsworkloadpayloadsizeissue) for guidance on disabling the workload report feature.
 ## Edge
 
 ## Breaking Changes

--- a/content/docs/00-release-notes.md
+++ b/content/docs/00-release-notes.md
@@ -75,6 +75,7 @@ Palette 3.4.0 has various security upgrades, better support for multiple Kuberne
 - The Metal as a Service (MAAS) provider has been updated to improve the node reconciliation behavior. In scenarios where the Machine Intelligent Platform Management Interface (IPMI) is powered off, the machine is powered on instead of provisioning a new node.
 
 
+
 ### Bug Fixes
 
 - A bug that caused issues with the deletion of a cluster's profile manifest has been successfully fixed. Manifests are now correctly deleted when removed from a cluster profile.
@@ -82,6 +83,9 @@ Palette 3.4.0 has various security upgrades, better support for multiple Kuberne
 
 - The problem with Palette not removing namespaces when removing a layer from a cluster profile has been resolved.
 
+
+
+- You can now configure the behavior of the Palette agent to disable sending workloads to the Palette control plane. This addresses scenarios where large clusters with many nodes exceed the 1 MB payload threshold resulting in agent failures. Refer to the [Nodes Troubleshooting](/troubleshooting/nodes#paletteagentsworkloadpayloadsizeissue) for guidance on disabling the workload feature.
 ## Edge
 
 ## Breaking Changes

--- a/content/docs/14-troubleshooting/06-nodes.md
+++ b/content/docs/14-troubleshooting/06-nodes.md
@@ -29,25 +29,49 @@ Logs are provided in Palette for traceability. However, these logs may be lost w
 
 For detailed information, review the cluster upgrades [page](/clusters/#clusterupgradedetails).
 
-
+<br />
 
 # Clusters
 
 ## Scenario -  vSphere Cluster and Stale ARP Table
-Sometimes certain vSphere clusters run into issues where non-VIP nodes are unable to contact the VIP node, primarly because non-VIP nodes' ARP entries became stale.
 
-To minimize this situation, vSphere clusters deployed from Palette now come equiped with a daemonset that cleans the ARP entry cache every 5 minutes. The cleaning process will force the nodes to re-request an ARP entry of the VIP node periodically. This is done automatically without any user action.
+Sometimes vSphere clusters encounter issues where nodes with an assigned Virtual IP Address (VIP) cannot contact the node with a VIP. The problem is caused by non-VIP nodes' Address Resolution Protocol (ARP) entries becoming stale.
 
-You can verify the cleaning process by running the following command on non-VIP nodes and observe that ARP cache is never older than 300 seconds:
+To minimize this situation, vSphere clusters deployed through Palette now have a daemon set that cleans the ARP entry cache every five minutes. The cleaning process will force the nodes to re-request an ARP entry of the VIP node periodically. This is done automatically without any user action.
 
-```
+You can verify the cleaning process by issuing the following command on non-VIP nodes and observing that the ARP cache is never older than 300 seconds.
+
+<br />
+
+```shell
 watch ip -statistics neighbour
 ```
 
 
-## Secnario - EKS Cluster Worker Pool Failures
+## Scenario - EKS Cluster Worker Pool Failures
 
 If your EKS cluster  worker pool ends up in `Failed` or `Create Failed` or `Error nodes failed to join` state, please refer to this [Amazon provided Runbook](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-awssupport-troubleshooteksworkernode.html
 )
+
+<br />
+
+## Palette Agents Workload Payload Size Issue
+
+
+A cluster comprising many nodes can create a situation where the workload data the agent sends to Palette exceeds the 1 MB threshold and fails to deliver the messages. If the agent encounters too many workload deliveries, the agent container may transition into a  *CrashLoopBackOff* state. 
+
+If you encounter this scenario, you can configure the cluster to stop sending workloads to Palette. To disable the workload feature, create a *configMap* with the following configuration. Use a cluster profile manifest layer to make this configMap.
+
+<br />
+
+```shell
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: palette-agent-config
+  namespace: "cluster-{{ .spectro.system.cluster.uid }}"
+data:
+  feature.workloads: disable 
+```
 
 <br />

--- a/content/docs/14-troubleshooting/06-nodes.md
+++ b/content/docs/14-troubleshooting/06-nodes.md
@@ -35,9 +35,9 @@ For detailed information, review the cluster upgrades [page](/clusters/#clusteru
 
 ## Scenario -  vSphere Cluster and Stale ARP Table
 
-Sometimes vSphere clusters encounter issues where nodes with an assigned Virtual IP Address (VIP) cannot contact the node with a VIP. The problem is caused by non-VIP nodes' Address Resolution Protocol (ARP) entries becoming stale.
+Sometimes vSphere clusters encounter issues where nodes with an assigned Virtual IP Address (VIP) cannot contact the node with a VIP. The problem is caused by Address Resolution Protocol (ARP) entries becoming stale on non-VIP nodes.
 
-To minimize this situation, vSphere clusters deployed through Palette now have a daemon set that cleans the ARP entry cache every five minutes. The cleaning process will force the nodes to re-request an ARP entry of the VIP node periodically. This is done automatically without any user action.
+To minimize this situation, vSphere clusters deployed through Palette now have a daemon set that cleans the ARP entry cache every five minutes. The cleaning process forces the nodes to periodically re-request an ARP entry of the VIP node. This is done automatically without any user action.
 
 You can verify the cleaning process by issuing the following command on non-VIP nodes and observing that the ARP cache is never older than 300 seconds.
 
@@ -58,9 +58,9 @@ If your EKS cluster worker pool ends up in `Failed`, `Create Failed` or `Error n
 ## Palette Agents Workload Payload Size Issue
 
 
-A cluster comprising many nodes can create a situation where the workload report data the agent sends to Palette exceeds the 1 MB threshold and fails to deliver the messages. If the agent encounters too many workload report deliveries, the agent container may transition into a  *CrashLoopBackOff* state. 
+A cluster comprised of many nodes can create a situation where the workload report data the agent sends to Palette exceeds the 1 MB threshold and fails to deliver the messages. If the agent encounters too many workload report deliveries, the agent container may transition into a  *CrashLoopBackOff* state. 
 
-If you encounter this scenario, you can configure the cluster to stop sending workload reports to Palette. To disable the workload report feature, create a *configMap* with the following configuration. Use a cluster profile manifest layer to make this configMap.
+If you encounter this scenario, you can configure the cluster to stop sending workload reports to Palette. To disable the workload report feature, create a *configMap* with the following configuration. Use a cluster profile manifest layer to create the configMap.
 
 <br />
 

--- a/content/docs/14-troubleshooting/06-nodes.md
+++ b/content/docs/14-troubleshooting/06-nodes.md
@@ -50,17 +50,17 @@ watch ip -statistics neighbour
 
 ## Scenario - EKS Cluster Worker Pool Failures
 
-If your EKS cluster  worker pool ends up in `Failed` or `Create Failed` or `Error nodes failed to join` state, please refer to this [Amazon provided Runbook](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-awssupport-troubleshooteksworkernode.html
-)
+If your EKS cluster worker pool ends up in `Failed`, `Create Failed` or `Error nodes failed to join` state, refer to the Amazon EKS [Runbook](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-awssupport-troubleshooteksworkernode.html
+) for troubleshooting guidance. 
 
 <br />
 
 ## Palette Agents Workload Payload Size Issue
 
 
-A cluster comprising many nodes can create a situation where the workload data the agent sends to Palette exceeds the 1 MB threshold and fails to deliver the messages. If the agent encounters too many workload deliveries, the agent container may transition into a  *CrashLoopBackOff* state. 
+A cluster comprising many nodes can create a situation where the workload report data the agent sends to Palette exceeds the 1 MB threshold and fails to deliver the messages. If the agent encounters too many workload report deliveries, the agent container may transition into a  *CrashLoopBackOff* state. 
 
-If you encounter this scenario, you can configure the cluster to stop sending workloads to Palette. To disable the workload feature, create a *configMap* with the following configuration. Use a cluster profile manifest layer to make this configMap.
+If you encounter this scenario, you can configure the cluster to stop sending workload reports to Palette. To disable the workload report feature, create a *configMap* with the following configuration. Use a cluster profile manifest layer to make this configMap.
 
 <br />
 


### PR DESCRIPTION
## Describe the Change

This PR explains how to disable the Palette agent from sending workloads to the control plane.

![CleanShot 2023-05-17 at 16 27 05](https://github.com/spectrocloud/librarium/assets/29551334/24c29c34-bff4-4841-aa15-14c6add54bc1)


## Review Changes

💻 [Preview URL](https://deploy-preview-1296--docs-spectrocloud.netlify.app/troubleshooting/nodes#paletteagentsworkloadpayloadsizeissue)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/PE-1530)
