### PR TITLE
chore: added .vscode file to set standard editor config for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ vale/styles/Google/
 vale/styles/write-good/
 .idea/
 link_report.*
-.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "[markdown]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true,
+    },
+    "[mdx]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true,
+    }
+}


### PR DESCRIPTION
## Describe the Change

This PR adds a default settings file for vscode. 

```json
{
    "[markdown]": {
        "editor.tabSize": 2,
        "editor.insertSpaces": true,
    },
    "[mdx]": {
        "editor.tabSize": 2,
        "editor.insertSpaces": true,
    }
}
```

