### PR TITLE
docs: remove an Infobox

### DIFF
--- a/content/api/3-postman-collection.md
+++ b/content/api/3-postman-collection.md
@@ -34,11 +34,6 @@ To interact with the API, you will need the following:
 
 * An authentication credential. 
 
-<InfoBox>
-
-If you're running Palette on a self-hosted server instead of the SaaS version, use your server URL as the base URL in the API request.
-
-</InfoBox>
 
 ## Authentication
 


### PR DESCRIPTION
## Describe the Change

This PR removes an InfoBox outlining a tip to find the Palette API endpoint for self-hosted Palette

## Review Changes

💻 [Preview URL]()
