### PR TITLE
docs: update image file path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ _Components_:
 Example 
 
 
-![Example usage of codeblocks with highlighting.](assets/docs/images/readme_codeblocks_example.png)
+![Example usage of codeblocks with highlighting.](/readme_codeblocks_example.png)
 
 
 


### PR DESCRIPTION

## Describe the Change

This PR updated the image path of the **readme_codeblocks_example.png** file. It should be relative to the **/assets/docs/images** folder and must have a `/` at the beginning.

## Review Changes

💻 Preview URL: n.a

🎫 Jira Ticket: n.a
