### PR TITLE
Docs:Typos Edit under Architecture section

### DIFF
--- a/content/docs/02.5-architecture/01-architecture-overview.md
+++ b/content/docs/02.5-architecture/01-architecture-overview.md
@@ -52,7 +52,7 @@ For private clouds like VMware, since the Palette SaaS platform does not have di
 ![spectro_cloud](/architecture_architecture-overview_on-prem.png)
 
 
-## Self-hosted Architecture and Data Flow
+## Self-Hosted Architecture and Data Flow
 Although the Palette SaaS platform fully supports both public clouds and data centers, for some customers, especially with regulated industry or air-gapped environments, they may prefer to install Palette in their own environment behind the firewall, so that they can control the platform upgrade cycles and ensure no sensitive data are exposed. For these use cases Palette supports a self-hosted on-premises installation. The platform updates and add-on integration contents can be optionally downloaded from an on-prem private repository instead of pulling from Palette’s hosted public repository.
 
 ![spectro_cloud](/architecture_architecture-on-prem-detailed.png)

--- a/content/docs/02.5-architecture/04-networking-ports.md
+++ b/content/docs/02.5-architecture/04-networking-ports.md
@@ -55,7 +55,7 @@ You can expose inbound port 22 for SSH if you would like to access your cluster 
 
 # Self-Hosted Network Communications and Ports
 
-The following ports must be reachable from a network perspective for Palette Sefl-Hosted to function correctly.
+The following ports must be reachable from a network perspective for Palette self-hosted to function correctly.
 
 
 ![On-prem network diagram](/architecture_networking-ports_network-diagram.png "#title="network diagram")


### PR DESCRIPTION
## This PR fixes typing errors under Architecture section of Spectrocloud Docs.

## Ready for Review

💻 [Preview]()

