### PR TITLE
Make Algolia search result clickable

### DIFF
--- a/__tests__/hitComps.test.js
+++ b/__tests__/hitComps.test.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { PageHit } from "../src/shared/layouts/Default/search/hitComps";
+import { render, fireEvent } from "@testing-library/react";
+import { InstantSearch } from "react-instantsearch-dom";
+import algoliasearch from "algoliasearch/lite";
+
+describe("Displays hitComps Component", () => {
+  it("renders the link with the correct URL", () => {
+    const mockNavigate = jest.fn();
+    window.___navigate = mockNavigate;
+    const searchClient = algoliasearch("1234", "abcd");
+    const hit = { slug: "/example-slug" };
+    const { getByRole } = render(
+      <InstantSearch searchClient={searchClient} indexName="test">
+        <PageHit hit={hit} />
+      </InstantSearch>
+    );
+    const link = getByRole("link");
+    expect(link.getAttribute("href")).toBe("/example-slug");
+    fireEvent.click(link);
+    expect(window.___navigate.mock.calls[0][0]).toBe("/example-slug");
+  });
+});

--- a/src/shared/layouts/Default/search/hitComps.js
+++ b/src/shared/layouts/Default/search/hitComps.js
@@ -13,9 +13,9 @@ const SearchResultLink = styled.div`
 `;
 
 export const PageHit = ({ hit, onClick }) => (
-  <Wrap>
+  <Wrap onClick={onClick}>
     <div>
-      <SearchResultLink onClick={onClick}>
+      <SearchResultLink>
         <Highlight attribute="title" hit={hit} tagName="mark" />
       </SearchResultLink>
     </div>

--- a/src/shared/layouts/Default/search/hitComps.js
+++ b/src/shared/layouts/Default/search/hitComps.js
@@ -6,6 +6,7 @@ import { Link } from "gatsby";
 const StyledLink = styled(Link)`
   cursor: pointer;
   display: block;
+  font-weight: unset;
   &:hover {
     color: unset;
   }

--- a/src/shared/layouts/Default/search/hitComps.js
+++ b/src/shared/layouts/Default/search/hitComps.js
@@ -3,9 +3,10 @@ import styled from "styled-components";
 import { Highlight, Snippet } from "react-instantsearch-dom";
 import { Link } from "gatsby";
 
-const Wrap = styled.div`
+const StyledLink = styled(Link)`
   cursor: pointer;
-  a:hover {
+  display: block;
+  &:hover {
     color: unset;
   }
 `;
@@ -17,14 +18,12 @@ const SearchResultLink = styled.div`
 `;
 
 export const PageHit = ({ hit, onClick }) => (
-  <Wrap>
-    <Link to={hit.slug}>
-      <div>
-        <SearchResultLink>
-          <Highlight attribute="title" hit={hit} tagName="mark" />
-        </SearchResultLink>
-      </div>
-      <Snippet attribute="excerpt" hit={hit} tagName="mark" />
-    </Link>
-  </Wrap>
+  <StyledLink to={hit.slug} onClick={onClick}>
+    <div>
+      <SearchResultLink>
+        <Highlight attribute="title" hit={hit} tagName="mark" />
+      </SearchResultLink>
+    </div>
+    <Snippet attribute="excerpt" hit={hit} tagName="mark" />
+  </StyledLink>
 );

--- a/src/shared/layouts/Default/search/hitComps.js
+++ b/src/shared/layouts/Default/search/hitComps.js
@@ -1,9 +1,13 @@
 import React from "react";
 import styled from "styled-components";
 import { Highlight, Snippet } from "react-instantsearch-dom";
+import { Link } from "gatsby";
 
 const Wrap = styled.div`
   cursor: pointer;
+  a:hover {
+    color: unset;
+  }
 `;
 
 const SearchResultLink = styled.div`
@@ -13,12 +17,14 @@ const SearchResultLink = styled.div`
 `;
 
 export const PageHit = ({ hit, onClick }) => (
-  <Wrap onClick={onClick}>
-    <div>
-      <SearchResultLink>
-        <Highlight attribute="title" hit={hit} tagName="mark" />
-      </SearchResultLink>
-    </div>
-    <Snippet attribute="excerpt" hit={hit} tagName="mark" />
+  <Wrap>
+    <Link to={hit.slug}>
+      <div>
+        <SearchResultLink>
+          <Highlight attribute="title" hit={hit} tagName="mark" />
+        </SearchResultLink>
+      </div>
+      <Snippet attribute="excerpt" hit={hit} tagName="mark" />
+    </Link>
   </Wrap>
 );

--- a/src/shared/layouts/Default/search/hitComps.js
+++ b/src/shared/layouts/Default/search/hitComps.js
@@ -1,21 +1,23 @@
 import React from "react";
 import styled from "styled-components";
 import { Highlight, Snippet } from "react-instantsearch-dom";
-import { Link } from "gatsby";
 
 const Wrap = styled.div`
-  a {
-    font-size: 18px;
-    color: #206cd1;
-  }
+  cursor: pointer;
+`;
+
+const SearchResultLink = styled.div`
+  color: #206cd1;
+  font-weight: 500;
+  font-size: 18px;
 `;
 
 export const PageHit = ({ hit, onClick }) => (
   <Wrap>
     <div>
-      <Link to={hit.slug} onClick={onClick}>
+      <SearchResultLink onClick={onClick}>
         <Highlight attribute="title" hit={hit} tagName="mark" />
-      </Link>
+      </SearchResultLink>
     </div>
     <Snippet attribute="excerpt" hit={hit} tagName="mark" />
   </Wrap>

--- a/src/shared/layouts/Default/search/index.js
+++ b/src/shared/layouts/Default/search/index.js
@@ -14,7 +14,6 @@ import { PoweredBy } from "./styles";
 import Input from "./input";
 import * as hitComps from "./hitComps";
 import { useLocation } from "@reach/router";
-import { navigate } from "gatsby";
 
 const PoweredByWrapper = styled.div`
   display: flex;
@@ -197,9 +196,6 @@ function SearchBar({ indices = [], collapse, hitsAsGrid, searchClient, focusInpu
                           {...props}
                           onClick={() => {
                             setFocus(false);
-                            if (props?.hit?.slug) {
-                              navigate(props.hit.slug);
-                            }
                           }}
                         />
                       )

--- a/src/shared/layouts/Default/search/index.js
+++ b/src/shared/layouts/Default/search/index.js
@@ -14,6 +14,7 @@ import { PoweredBy } from "./styles";
 import Input from "./input";
 import * as hitComps from "./hitComps";
 import { useLocation } from "@reach/router";
+import { navigate } from "gatsby";
 
 const PoweredByWrapper = styled.div`
   display: flex;
@@ -191,7 +192,17 @@ function SearchBar({ indices = [], collapse, hitsAsGrid, searchClient, focusInpu
               <Hits
                 hitComponent={
                   Component
-                    ? (props) => <Component {...props} onClick={() => setFocus(false)} />
+                    ? (props) => (
+                        <Component
+                          {...props}
+                          onClick={() => {
+                            setFocus(false);
+                            if (props?.hit?.slug) {
+                              navigate(props.hit.slug);
+                            }
+                          }}
+                        />
+                      )
                     : () => null
                 }
               />

--- a/src/shared/layouts/Default/search/index.js
+++ b/src/shared/layouts/Default/search/index.js
@@ -191,14 +191,7 @@ function SearchBar({ indices = [], collapse, hitsAsGrid, searchClient, focusInpu
               <Hits
                 hitComponent={
                   Component
-                    ? (props) => (
-                        <Component
-                          {...props}
-                          onClick={() => {
-                            setFocus(false);
-                          }}
-                        />
-                      )
+                    ? (props) => <Component {...props} onClick={() => setFocus(false)} />
                     : () => null
                 }
               />


### PR DESCRIPTION
## Describe the Change

To make the entire Algolia search result clickable, the <Link> component was removed and the styling was done using CSS. The navigation is now handled programmatically.

## Review Changes

💻 [Add Preview URL]()

🎫 [Jira Ticket]()
