### PR TITLE
Fix cluster page broken urls

### DIFF
--- a/content/docs/04-clusters/06-cluster-management/16-cluster-tag-filter.md
+++ b/content/docs/04-clusters/06-cluster-management/16-cluster-tag-filter.md
@@ -29,7 +29,7 @@ To get started with an attribute access control through tags, check out the [Cre
   * [Add Resource Role](/clusters/cluster-management/cluster-tag-filter/create-add-filter#addresourcerole)
 
 
-* [Palette Resource Roles](http://localhost:9000/user-management/palette-rbac/resource-scope-roles-permissions)
+* [Palette Resource Roles](/user-management/palette-rbac/resource-scope-roles-permissions)
 
   * [Palette Global Resource Roles](/user-management/palette-rbac/resource-scope-roles-permissions#paletteglobalresourceroles)
 
@@ -38,7 +38,7 @@ To get started with an attribute access control through tags, check out the [Cre
     * [Create Custom Role](/user-management/new-user#createcustomrole)
 
 
-* [Create New User in Palette](http://localhost:9000/user-management/new-user#createanewuser)
+* [Create New User in Palette](/user-management/new-user#createanewuser)
 
 
 <br />

--- a/content/docs/04-clusters/06-cluster-management/16-cluster-tag-filter.md
+++ b/content/docs/04-clusters/06-cluster-management/16-cluster-tag-filter.md
@@ -33,7 +33,7 @@ To get started with an attribute access control through tags, check out the [Cre
 
   * [Palette Global Resource Roles](/user-management/palette-rbac/resource-scope-roles-permissions#paletteglobalresourceroles)
 
-  * [Palette Resource Custom Roles](/user-management/palette-rbac/resource-scope-roles-permissions#palettecustomresourceroles)
+  * [Palette Custom Resource Roles](/user-management/palette-rbac/resource-scope-roles-permissions#palettecustomresourceroles)
 
     * [Create Custom Role](/user-management/new-user#createcustomrole)
 

--- a/src/shared/utils/redirects.js
+++ b/src/shared/utils/redirects.js
@@ -163,8 +163,8 @@ const redirects = [
     isPermanent: true,
   },
   {
-    fromPath: `/clusters/edge/installer-image`,
-    toPath: `/clusters/edge/install/installer-image`,
+    fromPath: `/clusters/edge/install/installer-image`,
+    toPath: `/clusters/edge/site-deployment/site-installation`,
     redirectInBrowser: true,
     isPermanent: true,
   },
@@ -176,6 +176,12 @@ const redirects = [
   },
   {
     fromPath: `/clusters/edge/installer-image`,
+    toPath: `/clusters/edge/site-deployment/site-installation`,
+    redirectInBrowser: true,
+    isPermanent: true,
+  },
+  {
+    fromPath: `/clusters/edge/site-deployment/installer`,
     toPath: `/clusters/edge/site-deployment/site-installation`,
     redirectInBrowser: true,
     isPermanent: true,

--- a/src/shared/utils/redirects.js
+++ b/src/shared/utils/redirects.js
@@ -176,16 +176,11 @@ const redirects = [
   },
   {
     fromPath: `/clusters/edge/installer-image`,
-    toPath: `/clusters/edge/site-deployment/installer`,
+    toPath: `/clusters/edge/site-deployment/site-installation`,
     redirectInBrowser: true,
     isPermanent: true,
   },
   {
-    fromPath: `/clusters/edge/native`,
-    toPath: `/clusters/edge/site-deployment/installer`,
-    redirectInBrowser: true,
-    isPermanent: true,
-  },{
     fromPath: `/knowledgebase/tutorials/terraform-tutorial`,
     toPath: `/terraform`,
     redirectInBrowser: true,


### PR DESCRIPTION
## Describe the Change

### 1. Fix the broken links
[Cluster ](https://docs.spectrocloud.com/clusters/cluster-management/cluster-tag-filter/) page has some broken urls with localhost. removed localhost from urls


### 2. Update the redirects
Made the following changes to the **redirects.js** file.

Removed this redundant block. We already have a separate rule available for the `/clusters/edge/native` source. 
```
{
    fromPath: `/clusters/edge/native`,
    toPath: `/clusters/edge/site-deployment/installer`,
    redirectInBrowser: true,
    isPermanent: true,
  },
```
Added a new rule:
```
  {
    fromPath: `/clusters/edge/install/installer-image`,
    toPath: `/clusters/edge/site-deployment/site-installation`,
    redirectInBrowser: true,
    isPermanent: true,
  },
```

Changed the following destination 
```
toPath: `/clusters/edge/site-deployment/installer`,
```

to
```
toPath: `/clusters/edge/site-deployment/site-installation`,
```

 
## Review Changes

Redirects Preview
💻 [Preview URL](https://deploy-preview-1388--docs-spectrocloud.netlify.app/clusters/edge/site-deployment)

Cluster Broken links preview
💻 [Preview URL](https://deploy-preview-1388--docs-spectrocloud.netlify.app/clusters/cluster-management/cluster-tag-filter)
