### PR TITLE
Update link away from deprecated page to the new one

### DIFF
--- a/content/docs/04-clusters/04-palette-virtual-clusters.md
+++ b/content/docs/04-clusters/04-palette-virtual-clusters.md
@@ -22,7 +22,7 @@ Palette provisions and orchestrates virtual clusters to make the lightweight Kub
 
 Palette also supports Day 2 operations such as upgrades, backup, and restore to keep virtual clusters secure, compliant, and up to date. Additionally, Palette provides visibility into the workloads running inside your virtual clusters and the associated costs.
 
-To get started, refer to [Add Virtual Clusters to a Host Cluster](/clusters/palette-virtual-clusters/add-virtual-cluster-to-host-cluster).
+To get started, refer to [Add Virtual Clusters to a Cluster Group](/clusters/palette-virtual-clusters/deploy-virtual-cluster).
 
 
 <br />


### PR DESCRIPTION
## Describe the Change

This PR updates the link (title and URL) to docs that explain how to create a virtual cluster (was on a host, now in a cluster group)

