### PR TITLE
docs: PE-1982 added macro to table

### DIFF
--- a/content/docs/09-registries-and-packs/5-pack-constraints.md
+++ b/content/docs/09-registries-and-packs/5-pack-constraints.md
@@ -590,6 +590,7 @@ user:
 | `{{.spectro.system.clusterprofile.infra.name}}`    | The name of the cluster profile. |
 | `{{.spectro.system.clusterprofile.infra.uid}}`   | The unique identifier of the cluster profile. |
 | `{{.spectro.system.clusterprofile.infra.version}}`  | The version of the cluster profile. |
+| `{{.spectro.system.cluster.kubevip}}`| The IP address of the virtual IP assigned to the cluster and load balancer for the control plane. This macro is only available for Edge and vSphere cluster deployments. |
 
 </Tabs.TabPane>
 

--- a/content/docs/09-registries-and-packs/5-pack-constraints.md
+++ b/content/docs/09-registries-and-packs/5-pack-constraints.md
@@ -590,7 +590,7 @@ user:
 | `{{.spectro.system.clusterprofile.infra.name}}`    | The name of the cluster profile. |
 | `{{.spectro.system.clusterprofile.infra.uid}}`   | The unique identifier of the cluster profile. |
 | `{{.spectro.system.clusterprofile.infra.version}}`  | The version of the cluster profile. |
-| `{{.spectro.system.cluster.kubevip}}`| The IP address of the virtual IP assigned to the cluster and load balancer for the control plane. This macro is only available for Edge and vSphere cluster deployments. |
+| `{{.spectro.system.cluster.kubevip}}`| The IP address of the virtual IP (VIP) assigned to the cluster and load balancer for the control plane. This macro is only available for Edge and vSphere cluster deployments. |
 
 </Tabs.TabPane>
 


### PR DESCRIPTION
## Describe the Change

This PR updates the macro table with a new parameter  `{{.spectro.system.cluster.kubevip}}'


![CleanShot 2023-07-07 at 11 13 56](https://github.com/spectrocloud/librarium/assets/29551334/8eebefb0-2950-4e87-b725-b973d6c750f7)


## Review Changes

💻 [Preview URL](https://deploy-preview-1407--docs-spectrocloud.netlify.app/registries-and-packs/pack-constraints#typesofmacros)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/PE-1982)
