### PR TITLE
docs: PFT-414 updated limits page

### DIFF
--- a/content/api/1-introduction.md
+++ b/content/api/1-introduction.md
@@ -153,10 +153,81 @@ curl --location 'https://api.spectrocloud.com/v1/packs?continue=eyJvZmZzZXQiOjUw
 
 The API rate limits are as follows:
 
-* There is a limit of ten API requests per second for each source IP address.
+* There is a limit of ten API requests per second for each source IP address. The API supports additional bursts through the usage of a burst queue. The default burst queue size is set to five. You could make 50 (10 * 5) requests in seconds before the API returns a `429 - TooManyRequests` error. Refer to the [Endpoint Prefix Rate](#endpointprefixrate) for additional information.
 
 
-* The API request limits are categorized by the parent resources such as `/v1/cloudconfig/:uid` and `/v1/roles`. You can find a list of all resource types in the [API documentation](/api/introduction). If you make multiple requests to the same resource type, but use different sub-resources, the requests are counted together. For example, if you make five requests to `/v1/clusterprofiles` and five requests to `/v1/clusterprofiles/macros`, the requests are counted together as ten requests to the resource `clusterprofiles`.
+
+* The API request limits are categorized by the parent resources, such as `/v1/cloudconfig/:uid` and `/v1/roles`. You can find a list of all resource types in the [API documentation](/api/introduction). The requests are counted together if you make multiple requests to the same resource type but use different sub-resources. For example, if you make five requests to `/v1/clusterprofiles` and five requests to `/v1/clusterprofiles/macros`, the requests are counted together as ten requests to the resource `clusterprofiles`.
 
 
-* In case of too many requests, the user will receive an error with HTTP code `429` - `TooManyRequests.` In that event, we recommended retrying the API call after a few moments.
+* In case of too many requests, the user will receive an error with HTTP code `429` - `TooManyRequests.` In that event, we recommended retrying the API call after a few moments. 
+
+## Endpoint Prefix Rate
+
+| Endpoint Prefix | Request Per Second | Burst Size | Max w/ Burst |
+|-----------------|--------------------|------------|--------------|
+| /v1/auth | 10 | 5 | 50 |
+| /v1/nats | 10 | 5 | 50 |
+| /v1/users | 10 | 5 | 50 |
+| /v1/userprofiles | 10 | 5 | 50 |
+| /v1/permissions | 10 | 5 | 50 |
+| /v1/roles | 10 | 5 | 50 |
+| /v1/teams | 10 | 5 | 50 |
+| /v1/tenants | 10 | 5 | 50 |
+| /v1/projects | 10 | 5 | 50 |
+| /v1/plans | 10 | 5 | 50 |
+| /v1/payments | 10 | 5 | 50 |
+| /v1/audits | 10 | 5 | 50 |
+| /v1/apiKeys | 10 | 5 | 50 |
+| /v1/datasinks | 10 | 5 | 50 |
+| /v1/notifications | 10 | 5 | 50 |
+| /v1/events | 10 | 5 | 50 |
+| /v1/crypto | 10 | 5 | 50 |
+| /v1/async | 10 | 5 | 50 |
+| /v1/errlogs | 10 | 5 | 50 |
+| /v1/jobs | 10 | 5 | 50 |
+| /v1/health | 10 | 5 | 50 |
+| /v1/cache | 10 | 5 | 50 |
+| /v1/cloudaccounts | 10 | 5 | 50 |
+| /v1/packs | 10 | 5 | 50 |
+| /v1/workspaces | 10 | 5 | 50 |
+| /v1/installers | 10 | 5 | 50 |
+| /v1/git/webhook | 10 | 5 | 50 |
+| /v1/registries | 10 | 5 | 50 |
+| /v1/services | 10 | 5 | 50 |
+| /v1/overlords | 10 | 5 | 50 |
+| /cluster | 10 | 5 | 50 |
+| /v1/cloudconfigs | 10 | 5 | 50 |
+| /v1/cloudconfigs/{cloudType}/{uid}/machinePools | 10 | 5 | 50 |
+| /v1/edgehosts | 10 | 5 | 50 |
+| /v1/metrics | 10 | 5 | 50 |
+| /v1/system | 10 | 5 | 50 |
+| /v1/mgmt | 10 | 5 | 50 |
+| /v1/oidc | 10 | 5 | 50 |
+| /v1/clouds | 10 | 5 | 50 |
+| /v1/events/components | 10 | 5 | 50 |
+| /v1/dashboard | 10 | 5 | 50 |
+| /v1/cloudconfigs/{cloudType}/{uid}/machinePools/{machinePoolName}/machines | 10 | 5 | 50 |
+| /v1/cloudconfigs/{cloudType}/{uid}/machinePools/{machinePoolName}/machines/{machineUid} | 10 | 5 | 50 |
+| /v1/auth/authenticate | 10 | 5 | 50 |
+| /v1/auth/services/login | 10 | 5 | 50 |
+| /v1/auth/services/edge/login | 10 | 5 | 50 |
+| /v1/files | 10 | 5 | 50 |
+| /v1/edgehosts/registers | 10 | 5 | 50 |
+| /v1/edgehosts/:uid/health | 10 | 5 | 50 |
+| /v1/edgehosts/:uid/spc/download | 10 | 5 | 50 |
+| /v1/spectroclusters/features/logFetcher | 10 | 5 | 50 |
+| /v1/spectroclusters/:uid/assets | 10 | 5 | 50 |
+| /v1/spectroclusters/cost | 10 | 5 | 50 |
+| /v1/spectroclusters/usage | 10 | 5 | 50 |
+| /v1/spectroclusters/:uid/download | 10 | 5 | 50 |
+| /v1/spectroclusters/acquire | 10 | 5 | 50 |
+| /v1/auth/user/password/reset | 2 | 5 | 10 |
+| /v1/spectroclusters | 50 | 5 | 250 |
+| /v1/clusterprofiles | 50 | 5 | 250 |
+| /v1/clusterprofiles/:uid/packs | 50 | 5 | 250 |
+| /v1/clusterprofiles/:uid/packs/manifests | 50 | 5 | 250 |
+| /v1/clusterprofiles/:uid/packs/{packName}/manifests | 50 | 5 | 250 |
+| /v1/clusterprofiles/validate/packs | 50 | 5 | 250 |
+| /v1/clusterprofiles/:uid/validate/packs | 50 | 5 | 250 |
+| /v1/spectroclusters/:uid/profiles | 50 | 5 | 250 |

--- a/content/api/1-introduction.md
+++ b/content/api/1-introduction.md
@@ -116,7 +116,7 @@ Example:
 
 <WarningBox>
 
-If you do not provide the `ProjectUid` header, then the assumed scope is of the tenant.
+If you do not provide the `ProjectUid` header, then tenant is the assumed scope.
 
 </WarningBox>
 
@@ -153,6 +153,7 @@ curl --location 'https://api.spectrocloud.com/v1/packs?continue=eyJvZmZzZXQiOjUw
 
 The API rate limits are as follows:
 
+<br />
 * There is a limit of ten API requests per second for each source IP address. The API supports additional bursts through the usage of a burst queue. The default burst queue size is set to five. You could make 50 (10 * 5) requests in seconds before the API returns a `429 - TooManyRequests` error. Refer to the [Endpoint Prefix Rate](#endpointprefixrate) for additional information.
 
 
@@ -160,11 +161,11 @@ The API rate limits are as follows:
 * The API request limits are categorized by the parent resources, such as `/v1/cloudconfig/:uid` and `/v1/roles`. You can find a list of all resource types in the [API documentation](/api/introduction). The requests are counted together if you make multiple requests to the same resource type but use different sub-resources. For example, if you make five requests to `/v1/clusterprofiles` and five requests to `/v1/clusterprofiles/macros`, the requests are counted together as ten requests to the resource `clusterprofiles`.
 
 
-* In case of too many requests, the user will receive an error with HTTP code `429` - `TooManyRequests.` In that event, we recommended retrying the API call after a few moments. 
+* In case of too many requests, the user will receive an error with HTTP code `429` - `TooManyRequests.` In that event, we recommend retrying the API call after a few moments. 
 
 ## Endpoint Prefix Rate
 
-| Endpoint Prefix | Request Per Second | Burst Size | Max w/ Burst |
+| **Endpoint Prefix** | **Request Per Second** | **Burst Size** | **Max with Burst** |
 |-----------------|--------------------|------------|--------------|
 | /v1/auth | 10 | 5 | 50 |
 | /v1/nats | 10 | 5 | 50 |
@@ -196,7 +197,7 @@ The API rate limits are as follows:
 | /v1/registries | 10 | 5 | 50 |
 | /v1/services | 10 | 5 | 50 |
 | /v1/overlords | 10 | 5 | 50 |
-| /cluster | 10 | 5 | 50 |
+| v1/cluster | 10 | 5 | 50 |
 | /v1/cloudconfigs | 10 | 5 | 50 |
 | /v1/cloudconfigs/{cloudType}/{uid}/machinePools | 10 | 5 | 50 |
 | /v1/edgehosts | 10 | 5 | 50 |
@@ -207,8 +208,8 @@ The API rate limits are as follows:
 | /v1/clouds | 10 | 5 | 50 |
 | /v1/events/components | 10 | 5 | 50 |
 | /v1/dashboard | 10 | 5 | 50 |
-| /v1/cloudconfigs/{cloudType}/{uid}/machinePools/{machinePoolName}/machines | 10 | 5 | 50 |
-| /v1/cloudconfigs/{cloudType}/{uid}/machinePools/{machinePoolName}/machines/{machineUid} | 10 | 5 | 50 |
+| /v1/cloudconfigs/{cloudType}/:uid/machinePools/{machinePoolName}/machines | 10 | 5 | 50 |
+| /v1/cloudconfigs/{cloudType}/:uid/machinePools/{machinePoolName}/machines/:machineUid | 10 | 5 | 50 |
 | /v1/auth/authenticate | 10 | 5 | 50 |
 | /v1/auth/services/login | 10 | 5 | 50 |
 | /v1/auth/services/edge/login | 10 | 5 | 50 |

--- a/content/api/1-introduction.md
+++ b/content/api/1-introduction.md
@@ -11,6 +11,8 @@ hideToCSidebar: false
 import {Intro, IntroButtons} from "shared/components"
 import {Layout} from "shared"
 import InfoBox from "shared/components/InfoBox"
+import WarningBox from "shared/components/WarningBox"
+
 
 <Intro>
 
@@ -102,21 +104,59 @@ The version information is included in the API URI, such as `v1alpha1` or `v1`. 
 
 Palette groups resources under either a Tenant or Project scope. When making API requests targeting resources belonging to a project, the project scope should be specified. To specify the project scope, use the HTTP header key `ProjectUid` with the value `<Project Uid>` in the API request. The `ProjectUid` needs to be specified for a request to be applied under a specific project scope.
 
-**Example**:
+Example:
 
-```shell
+```shell hideClipboard
  curl --location --request \
  GET 'https://api.spectrocloud.com/v1/edgehosts/ad3d90ab-de6e-3e48-800f-4d663cec3060?resolvePackValues=false' \
  --header 'Accept: application/json' \
- --header 'ProjectUid: ad3d90ab-de6e-3e48-800f-4d663cec3060'
+ --header 'ProjectUid: yourProjectUid'
 ```
+<br />
 
-<InfoBox>
+<WarningBox>
 
-If you do not provide the ProjectUid header, then the assumed scope is of the tenant.
+If you do not provide the `ProjectUid` header, then the assumed scope is of the tenant.
 
-</InfoBox>
+</WarningBox>
 
 # Pagination
 
-The resources list APIs are limited to 50 items, and therefore pagination is required to retrieve the complete resources list. The list API response includes listMeta with the continue token. To perform pagination, check the presence of the continue token value in the API response. For subsequent requests, use the continue token as a query parameter to paginate the remaining resource items.
+API endpoints that return a list have a limit of 50 items per return payload. Pagination is necessary for this purpose. The API response for the list includes the listMeta resource that contains the continue token. To perform pagination, you need to check whether the continue token value is present in the API response. For subsequent requests, use the continue token as a query parameter to paginate the remaining resource items.
+
+<br />
+
+```json hideClipboard
+    "listmeta": {
+        "continue": "eyJvZmZzZXQiOjUwLCJjb3VudCI6MTE3LCJ0b2tlbiI6IiJ9",
+        "count": 117,
+        "limit": 50,
+        "offset": 50
+    }
+```
+
+<br />
+
+Example of a subsequent request using the continue token.
+
+<br />
+
+```shell hideClipboard
+curl --location 'https://api.spectrocloud.com/v1/packs?continue=eyJvZmZzZXQiOjUwLCJjb3VudCI6MTE3LCJ0b2tlbiI6IiJ9' \
+ --header 'Accept: application/json' \
+ --header 'ProjectUid: yourProjectUid' \
+ --header 'apiKey: yourAPIKey'
+```
+
+
+# Rate Limits
+
+The API rate limits are as follows:
+
+* There is a limit of ten API requests per second for each source IP address.
+
+
+* The API request limits are categorized by the parent resources such as `/v1/cloudconfig/:uid` and `/v1/roles`. You can find a list of all resource types in the [API documentation](/api/introduction). If you make multiple requests to the same resource type, but use different sub-resources, the requests are counted together. For example, if you make five requests to `/v1/clusterprofiles` and five requests to `/v1/clusterprofiles/macros`, the requests are counted together as ten requests to the resource `clusterprofiles`.
+
+
+* In case of too many requests, the user will receive an error with HTTP code `429` - `TooManyRequests.` In that event, we recommended retrying the API call after a few moments.

--- a/content/api/1-introduction.md
+++ b/content/api/1-introduction.md
@@ -122,7 +122,7 @@ If you do not provide the `ProjectUid` header, then tenant is the assumed scope.
 
 # Pagination
 
-API endpoints that return a list have a limit of 50 items per return payload. Pagination is necessary for this purpose. The API response for the list includes the listMeta resource that contains the continue token. To perform pagination, you need to check whether the continue token value is present in the API response. For subsequent requests, use the continue token as a query parameter to paginate the remaining resource items.
+API endpoints that return a list have a limit of 50 items per return payload. Pagination is necessary for this purpose. The API response for the list includes the listMeta resource that contains the continue token. To perform pagination, you need to check whether the continue token value is present in the API response. For subsequent requests, use the `continue` token as a query parameter to paginate the remaining resource items.
 
 <br />
 
@@ -137,7 +137,7 @@ API endpoints that return a list have a limit of 50 items per return payload. Pa
 
 <br />
 
-Example of a subsequent request using the continue token.
+Example of a subsequent request using the `continue` token.
 
 <br />
 

--- a/content/docs/08-user-management/3-palette-resource-limits.md
+++ b/content/docs/08-user-management/3-palette-resource-limits.md
@@ -11,25 +11,25 @@ import InfoBox from 'shared/components/InfoBox';
 
 # Default Palette Resource Limits Per Tenant 
 
-|Resources           |  Max Limit Per Tenant|
-|--------------------|----------------------|
-|Users               |     300              |
-|Teams               |     100              |
-|Projects            |      50              |
-|Workspaces          |      50              |
-|Roles               |     100              |
-|CloudAccounts       |     200              |
-|Cluster profiles    |     200              |
-|Registries          |      50              |
-|Private Gateway     |      50              |
-|Api Keys            |   20 keys per user   |
-|Locations(Backup)   |      100             |
-|Certificates        |       20             |
-|Macros              |      200 (Per Project)|
-|SSH Keys            |      300              |
-|Alerts or Webhook   |   100 (Per Project)   |
-|Clusters.           |      200              |
-|Appliances (Edge hosts)|      200              |  
+|Resources           |  Max Limit | Scope | 
+|--------------------|----------------------|  ---- |
+|Users               |     300              | Tenant|
+|Teams               |     100              | Tenant| 
+|Projects            |      50              | Tenant | 
+|Workspaces          |      50              | Tenant |
+|Roles               |     100              | Tenant |
+|Cloud Accounts       |     200              | Tenant |
+|Cluster Profiles    |     200              | Tenant |
+|Registries          |      50              | Tenant |
+|Private Gateway     |      50              | Tenant |
+|API Keys            |       20             |  User |
+|Backup Locations    |      100             | Tenant |
+|Certificates        |       20             | Tenant |
+|Macros              |      200              | Project|
+|SSH Keys            |      300              | Tenant |
+|Alerts or Webhook   |       100            | Project|
+|Clusters            |      12,000          | Tenant |
+|Edge Hosts          |      200            |  Tenant |
 
 # Set Resource Limit 
 

--- a/content/docs/08-user-management/3-palette-resource-limits.md
+++ b/content/docs/08-user-management/3-palette-resource-limits.md
@@ -1,7 +1,7 @@
 ---
 title: "Palette Resource Limits"
 metaTitle: "Default Palette Resource Limits"
-metaDescription: "This topic describes the default resource limits for Palette and how to set resource limits for your Palette tenant."
+metaDescription: "Understand the default resource limits for Palette and learn how to set resource limits for your Palette tenant."
 icon: ""
 hideToC: false
 fullWidth: false
@@ -16,7 +16,7 @@ Tenant admins can set and update resource limits for Palette. The resource limit
 
 The following table lists the default resource limits for Palette:
 
-|Resources           |  Max Limit | Scope | 
+|**Resources**           |  **Max Limit** | **Scope** | 
 |--------------------|----------------------|  ---- |
 |Users               |     300              | Tenant|
 |Teams               |     100              | Tenant| 
@@ -47,7 +47,7 @@ Use the following steps to set or update resource limits for your Palette tenant
 
 ## Update Limits
 
-1. Login to [Palette](https://console.spectrocloud.com) as a tenant admin.
+1. Log in to [Palette](https://console.spectrocloud.com) as a tenant admin.
 
 
 2. Navigate to the left **Main Menu** and select **Tenant Settings**.
@@ -56,15 +56,15 @@ Use the following steps to set or update resource limits for your Palette tenant
 3. Select **Resource Limits** from the **Tenant Settings Menu**.
 
 
-4. Set the values for the different Palette resources. Ensure you do not 
+4. Set the values for the different Palette resources. 
 
 
-5. Click **Save changes**.
+5. Save your changes.
 
 
 ## Validate
 
-You can validate the updated resource limits by attempting to create a resource of the resource type you updated. For example, if you updated the **API Key** to five, you can create five API keys. If you attempt to create a sixth API key, you will receive an error message.
+You can validate the updated resource limits by creating a resource of the same type you updated. For example, you can create five API keys if you updated the **API Key** to five. If you attempt to create a sixth API key, you will receive an error message.
 
 
 

--- a/content/docs/08-user-management/3-palette-resource-limits.md
+++ b/content/docs/08-user-management/3-palette-resource-limits.md
@@ -1,7 +1,7 @@
 ---
 title: "Palette Resource Limits"
 metaTitle: "Default Palette Resource Limits"
-metaDescription: "Palette Resource Limit table "
+metaDescription: "This topic describes the default resource limits for Palette and how to set resource limits for your Palette tenant."
 icon: ""
 hideToC: false
 fullWidth: false
@@ -9,7 +9,9 @@ fullWidth: false
 
 import InfoBox from 'shared/components/InfoBox';
 
-# Default Palette Resource Limits Per Tenant 
+# Default Palette Resource Limits
+
+The following table lists the default resource limits for Palette:
 
 |Resources           |  Max Limit | Scope | 
 |--------------------|----------------------|  ---- |
@@ -33,31 +35,35 @@ import InfoBox from 'shared/components/InfoBox';
 
 # Set Resource Limit 
 
-To set resource limit:
+Use the following steps to set or update resource limits for your Palette tenant.
 
-<br />
+## Prerequisites
 
-* Login to Palette console as `Tenant Admin`.
-
-
-* Select `Tenant Settings` from the left ribbon menu.
+* You must have access to the Tenant Admin role.
 
 
-* Select `Resource Limits` tab and set the values for different Palette resources as per tenant resource requirements.
- 
-<InfoBox>
-The resource limit can be customized according to per tenant resource requirements 
-</InfoBox>
+## Update Limits
 
-# Palette API Rate Limits
-
-* API operations are limited to 10 requests per second for an IP Address.
+1. Login to [Palette](https://console.spectrocloud.com) as a Tenant Admin.
 
 
-* The API request limits are categorized by resources such as /v1/cloudconfig/:uid and /v1/cloudconfig/:uid/machinepools. Both API requests are counted for the same rate limits as both belong to the same cluster's cloud config resource.
+2. Navigate to the left **Main Menu** and select **Tenant Settings**.
 
 
-* In case of too many requests, the user will receive an error with HTTP code 429 - `TooManyRequests.` In that event, it is recommended to retry the API call after a specific interval.
+3. Select **Resource Limits** from the **Tenant Settings Menu**.
+
+
+4. Set the values for the different Palette resources. Ensure you do not 
+
+
+5. Click **Save changes**.
+
+
+## Validate
+
+You can validate the updated resource limits by attempting to create a resource of the resource type you updated. For example, if you updated the **API Key** to five, you can create five API keys. If you attempt to create a sixth API key, you will receive an error message.
+
+
 
 <br />
 <br />

--- a/content/docs/08-user-management/3-palette-resource-limits.md
+++ b/content/docs/08-user-management/3-palette-resource-limits.md
@@ -11,6 +11,9 @@ import InfoBox from 'shared/components/InfoBox';
 
 # Default Palette Resource Limits
 
+
+Tenant admins can set and update resource limits for Palette. The resource limits determine the maximum number of resources that can be created in Palette. The resource limits are set at the tenant level and apply to all projects in the tenant.
+
 The following table lists the default resource limits for Palette:
 
 |Resources           |  Max Limit | Scope | 
@@ -30,7 +33,7 @@ The following table lists the default resource limits for Palette:
 |Macros              |      200              | Project|
 |SSH Keys            |      300              | Tenant |
 |Alerts or Webhook   |       100            | Project|
-|Clusters            |      12,000          | Tenant |
+|Clusters            |      10,000          | Tenant |
 |Edge Hosts          |      200            |  Tenant |
 
 # Set Resource Limit 
@@ -39,12 +42,12 @@ Use the following steps to set or update resource limits for your Palette tenant
 
 ## Prerequisites
 
-* You must have access to the Tenant Admin role.
+* You must have access to the *tenant admin* role.
 
 
 ## Update Limits
 
-1. Login to [Palette](https://console.spectrocloud.com) as a Tenant Admin.
+1. Login to [Palette](https://console.spectrocloud.com) as a tenant admin.
 
 
 2. Navigate to the left **Main Menu** and select **Tenant Settings**.


### PR DESCRIPTION
## Describe the Change

This PR updates the Palette resource limits page and moves the API Rate limit to the API index page.

**[API Rate](https://deploy-preview-1431--docs-spectrocloud.netlify.app/api/introduction#ratelimits)**

![CleanShot 2023-07-21 at 12 03 15](https://github.com/spectrocloud/librarium/assets/29551334/4bcfb137-1a6b-4f44-a837-c3fde1bc2d7a)


**[Resource Limits Table](https://deploy-preview-1431--docs-spectrocloud.netlify.app/user-management/palette-resource-limits)**

![image](https://github.com/spectrocloud/librarium/assets/29551334/65faec6c-a4ec-4534-bf04-f40959784fd4)


## Review Changes

💻 [Preview URL](https://deploy-preview-1431--docs-spectrocloud.netlify.app/user-management/palette-resource-limits)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/PFR-414)
