### PR TITLE
Replace referenced repository

### DIFF
--- a/content/docs/19-kubernetes-knowlege-hub/01-tutorials/06-deploy-stateless-frontend-app.md
+++ b/content/docs/19-kubernetes-knowlege-hub/01-tutorials/06-deploy-stateless-frontend-app.md
@@ -53,7 +53,7 @@ Use the command shown below to clone the application from GitHub.
 <br />
 
 ```bash
-git clone https://github.com/spectrocloud/date-buddy
+git clone https://github.com/Princesso/date-buddy
 ```
 
 If you prefer to use a different stateless frontend app, you can do so. You may, however, get different results than in this tutorial. This tutorial only serves as a guide.


### PR DESCRIPTION
## Describe the Change

This PR updates the reference to the example repository. In the current state it references a non-existing repository in the SpectroCloud organization, this could cause issues for individuals following the tutorial.

## Review Changes

💻 No Preview URL

🎫 No JIRA Ticket
