### PR TITLE
Update 06-air-gap-repo.md

### DIFF
--- a/content/docs/12-enterprise-version/06-air-gap-repo.md
+++ b/content/docs/12-enterprise-version/06-air-gap-repo.md
@@ -171,7 +171,7 @@ If you have any questions or concerns, please feel free to contact support@spect
   <br />
 
   ```shell
-  sudo /bin/airgap-setup.sh X.X.X.X
+  sudo /opt/spectro/airgap-setup.sh X.X.X.X
   ```
 
   Record the output of the setup command as you will use it when deploying the Quick Start appliance later on in the installation process.


### PR DESCRIPTION
Modifies referenced directory from /bin/ to /opt/spectro in latest. Using latest version referenced in the Golden Images confluences `v2.3.0` the `airgap-install.sh` script has moved from `/bin` to `/opt/spectro`.

## Describe the Change

This PR changes a singular line to update the reference install script to `airgap-install.sh`

## Review Changes

💻 [Add Preview URL N/A](#)

🎫 [Jira Ticket N/A](#)
