### PR TITLE
Update Formatting in 05-backup-restore.md

### DIFF
--- a/content/docs/04-clusters/06-cluster-management/05-backup-restore.md
+++ b/content/docs/04-clusters/06-cluster-management/05-backup-restore.md
@@ -104,66 +104,65 @@ The following details are required to configure a backup location in AWS:
 
 #### AWS S3 Permissions
 
-    ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "ec2:DescribeVolumes",
-                    "ec2:DescribeSnapshots",
-                    "ec2:CreateTags",
-                    "ec2:CreateVolume",
-                    "ec2:CreateSnapshot",
-                    "ec2:DeleteSnapshot"
-                ],
-                "Resource": "*"
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "s3:GetObject",
-                    "s3:DeleteObject",
-                    "s3:PutObject",
-                    "s3:AbortMultipartUpload",
-                    "s3:ListMultipartUploadParts"
-                ],
-                "Resource": [
-                    "arn:aws:s3:::BUCKET-NAME/*"
-                ]
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "s3:ListBucket"
-                ],
-                "Resource": [
-                    "arn:aws:s3:::BUCKET-NAME"
-                ]
-            }
-        ]
-    }
-     
-    ```
+ ```json
+ {
+     "Version": "2012-10-17",
+     "Statement": [
+         {
+             "Effect": "Allow",
+             "Action": [
+                 "ec2:DescribeVolumes",
+                 "ec2:DescribeSnapshots",
+                 "ec2:CreateTags",
+                 "ec2:CreateVolume",
+                 "ec2:CreateSnapshot",
+                 "ec2:DeleteSnapshot"
+             ],
+             "Resource": "*"
+         },
+         {
+             "Effect": "Allow",
+             "Action": [
+                 "s3:GetObject",
+                 "s3:DeleteObject",
+                 "s3:PutObject",
+                 "s3:AbortMultipartUpload",
+                 "s3:ListMultipartUploadParts"
+             ],
+             "Resource": [
+                 "arn:aws:s3:::BUCKET-NAME/*"
+             ]
+         },
+         {
+             "Effect": "Allow",
+             "Action": [
+                 "s3:ListBucket"
+             ],
+             "Resource": [
+                 "arn:aws:s3:::BUCKET-NAME"
+             ]
+         }
+     ]
+ }
+ ```
 
 #### Trust Setup Example
 
-    ```json
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Principal": {
-            "AWS": "arn:aws:iam::141912899XX99:root"
-          },
-          "Action": "sts:AssumeRole",
-          "Condition": {}
-        }
-      ]
-    }
-    ```
+ ```json
+ {
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "arn:aws:iam::141912899XX99:root"
+       },
+       "Action": "sts:AssumeRole",
+       "Condition": {}
+     }
+   ]
+ }
+ ```
 
 ## Configure your Backup in GCP Bucket
 


### PR DESCRIPTION
## Describe the Change

This PR changes the indents of the JSON Code so it formats correctly. 

https://docs.spectrocloud.com/clusters/cluster-management/backup-restore/#configureyourbackupinawss3

## Review Changes


### Current State in Production Docs
<img width="657" alt="Screenshot 2023-08-11 at 10 23 56" src="https://github.com/spectrocloud/librarium/assets/30413278/96542f27-1b48-4e95-b8cd-52e6c28c0b02">

### Changes in this Pull Request
<img width="666" alt="Screenshot 2023-08-11 at 10 28 42" src="https://github.com/spectrocloud/librarium/assets/30413278/3a5ac837-1443-4eb2-a1a3-2e3a58bbc6a9">


Note that this issue also exists in https://github.com/spectrocloud/docs-prototype. @nagesh161007

https://github.com/spectrocloud/docs-prototype/blob/99ad8a10b618893a7b9923dc4be807a422fb6527/docs/docs-content/clusters/cluster-management/backup-restore.md?plain=1#L100-L161


🎫 No open JIRA ticket.
