### PR TITLE
Node Repave Configuration

### DIFF
--- a/content/docs/00-release-notes.md
+++ b/content/docs/00-release-notes.md
@@ -84,7 +84,7 @@ Palette 4.0.0 introduces new features and improvements, including [Palette Verte
 - You can now access Palette documentation directly from the Palette UI. This allows you to quickly access the documentation for the page you are currently on. You can find the documentation link in the top right corner of the Palette UI.
 
 
-- Palette now supports configuring the time interval for node repaves. In the scenario of a node repavement, the time interval is the amount of time that Palette waits before it starts the node replacement process on other nodes in the cluster. The default time interval is 15 minutes.
+- Palette now supports configuring the time interval for node repaves. In the scenario of a node repavement, the time interval is the amount of time that Palette waits before it starts the node replacement process on other nodes in the cluster. The default time interval is 15 minutes. Refer to the [Node Pool](/clusters/cluster-management/node-pool/) documentation to learn more.
 
 
 

--- a/content/docs/00-release-notes.md
+++ b/content/docs/00-release-notes.md
@@ -84,7 +84,7 @@ Palette 4.0.0 introduces new features and improvements, including [Palette Verte
 - You can now access Palette documentation directly from the Palette UI. This allows you to quickly access the documentation for the page you are currently on. You can find the documentation link in the top right corner of the Palette UI.
 
 
-- Palette now supports configuring the time interval for node repaves. In the scenario of a node repavement, the time interval is the amount of time that Palette waits before it starts the node replacement process on other nodes in the cluster. The default time interval is 15 minutes. Refer to the [Node Pool](/clusters/cluster-management/node-pool/) documentation to learn more.
+- Palette now supports configuring the time interval for node repavement. The time interval is the amount of time that Palette waits before it starts the node replacement process on nodes in the cluster. The default time interval is 15 minutes. Refer to the [Node Pool](/clusters/cluster-management/node-pool/) documentation to learn more.
 
 
 

--- a/content/docs/04-clusters/06-cluster-management/15-node-pool.md
+++ b/content/docs/04-clusters/06-cluster-management/15-node-pool.md
@@ -98,7 +98,7 @@ Some features may not be available for all infrastructure providers. Review each
 
 You can create a new node pool for an active cluster. To create a new node pool follow the steps below.
 
-1. Ensure you are in the correct scope or project.
+1. Log in to [Palette](https://console.spectrocloud.com).
 
 
 2. Navigate to the left **Main Menu** and click on **Clusters**.

--- a/content/docs/04-clusters/06-cluster-management/15-node-pool.md
+++ b/content/docs/04-clusters/06-cluster-management/15-node-pool.md
@@ -12,11 +12,10 @@ import InfoBox from 'shared/components/InfoBox';
 import PointsOfInterest from 'shared/components/common/PointOfInterest';
 import Tooltip from "shared/components/ui/Tooltip";
 
-# Overview
+# Node Pools
 
-<!-- Update Node Pool Repavement Behavior -->
 
-You have the ability to update node pools for active clusters and the option to create a new node pool for the cluster.
+A node pool is a group of nodes within a cluster that all have the same configuration. Node pools allow you to create pools of nodes that can be used for different workloads. For example, you can create a node pool for your production workloads and another node pool for your development workloads. You can update node pools for active clusters or create a new node pool for the cluster. 
 
 <br />
 
@@ -26,8 +25,76 @@ Ensure you exercise caution when modifying node pools. We recommend creating a [
 
 </WarningBox>
 
+## Repave Behavior and Configuration
 
-# Create a New Node Pool
+In Kubernetes, the term "repave" refers to the process of replacing a node with a new node. [Repaving](/glossary-all#repavement) is a common practice in Kubernetes to ensure that nodes are deployed with the latest version of the operating system and Kubernetes. Repaving is also used to replace nodes that are unhealthy or have failed. You can configure the repave time interval for a node pool. 
+
+The ability to configure the repave time interval for all node pools except the master pool. The repave time interval is set to 900 seconds (15 minutes) by default. You can configure the node repave time interval during the cluster creation process or after the cluster is created. To modify the repave time interval after the cluster is created, follow the [Change a Node Pool](#changeanodepool) instructions below.
+
+
+<br />
+
+## Node Pool Configuration Settings
+
+The following tables contain the configuration settings for node pools. Depending on the type of node pool, some of the settings may not be available.
+
+<br />
+
+### Master Node Pool
+
+| **Property** | **Description** |
+|-----------|-------------|
+| **Node pool name** | A descriptive name for the node pool. |
+| **Number of nodes in the pool** | Number of nodes to be provisioned for the node pool. For the master pool, this number can be 1, 3, or 5. |
+| **Allow worker capability** | Select this option to allow workloads to be provisioned on master nodes. |
+| **Additional Labels** | Optional labels apply placement constraints on a pod. For example, you can add a label to make a node eligible to receive the workload. To learn more, refer to the [Overview on Labels](/clusters/cluster-management/taints#overviewonlabels). |
+| **Taints** | Sets toleration to pods and allows (but does not require) the pods to schedule onto nodes with matching taints. To learn more, refer to the [Overview on Taints](/clusters/cluster-management/taints#overviewontaints).|
+| **Availability Zones** | The Availability Zones from which to select available servers for deployment. If you select multiple zones, Palette will deploy servers evenly across them as long as sufficient servers are available to do so. |
+| **Disk Size** | Give the required storage size. |
+
+
+### Worker Node Pool
+
+| **Property** | **Description** |
+|-----------|-------------|
+| **Node pool name** | A descriptive name for the worker pool. |
+| **Number of nodes in the pool** | Number of nodes to be provisioned for the node pool. |
+| **Node repave interval** | The time interval in seconds between repaves. The default value is 900 seconds (15 minutes). |
+| **Additional Labels** | Optional labels apply placement constraints on a pod. For example, you can add a label to make a node eligible to receive the workload. To learn more, refer to the [Overview on Labels](/clusters/cluster-management/taints#overviewonlabels). |
+| **Taints** | Sets toleration to pods and allows (but does not require) the pods to schedule onto nodes with matching taints. To learn more, refer to the [Overview on Taints](/clusters/cluster-management/taints#overviewontaints).|
+| **Rolling update** |  Apply the update policy. **Expand first** launches new nodes and then terminates old notes. **Contract first** terminates old nodes and then launches new ones. |
+| **Instance Option** | AWS options for compute capacity. **On Demand** gives you full control over the instance lifecycle without long-term commitment. **Spot** allows the use of spare EC2 capacity at a discount but which can be reclaimed if needed. |
+| **Instance Type** |The compute size. |
+| **Availability Zones** | The Availability Zones from which to select available servers for deployment. If you select multiple zones, Palette will deploy servers evenly across them as long as sufficient servers are available to do so. |
+| **Disk Size** | Give the required storage size. |
+ 
+
+<br />
+
+
+<WarningBox>
+
+Some features may not be available for all infrastructure providers. Review each infrastructure provider's node pool configuration settings to learn more.
+
+</WarningBox>
+
+<br />
+
+
+## Create a New Node Pool
+
+
+### Prerequisites
+
+
+* A Palette deployed cluster.
+
+
+* Sufficient permissions to edit the cluster.
+
+
+### Create Node Pool
+
 
 You can create a new node pool for an active cluster. To create a new node pool follow the steps below.
 
@@ -46,48 +113,52 @@ You can create a new node pool for an active cluster. To create a new node pool 
 5. Click on **New Node Pool**. 
 
 
-6. Fill out the input fields in the **Add node pool** page. The following table contains an explanation of the available input parameters.
+6. Fill out the input fields in the **Add node pool** page. Refer to the [Node Pool Configuration Settings](#nodepoolconfigurationsettings) tables for more information on each field.
 
 
-### Master Node Pool
 
-| Property | Description |
-|-----------|-------------|
-| **Node pool name** | A descriptive name for the node pool. |
-| **Number of nodes in the pool** | Number of nodes to be provisioned for the node pool. For the master pool, this number can be 1, 3, or 5. |
-| **Allow worker capability** | Select this option to allow workloads to be provisioned on master nodes. |
-| **Additional Labels** | Optional labels apply placement constraints on a pod. For example, you can add a label to make a node eligible to receive the workload. To learn more, refer to the [Overview on Labels](/clusters/cluster-management/taints#overviewonlabels). |
-| **Taints** | Sets toleration to pods and allows (but does not require) the pods to schedule onto nodes with matching taints. To learn more, refer to the [Overview on Taints](/clusters/cluster-management/taints#overviewontaints).|
-| **Availability Zones** | The Availability Zones from which to select available servers for deployment. If you select multiple zones, Palette will deploy servers evenly across them as long as sufficient servers are available to do so. |
-| **Disk Size** | Give the required storage size. |
-
-
-### Worker Node Pool
-
-| Property | Description |
-|-----------|-------------|
-| **Node pool name** | A descriptive name for the worker pool. |
-| **Number of nodes in the pool** | Number of nodes to be provisioned for the node pool. |
-| **Additional Labels** | Optional labels apply placement constraints on a pod. For example, you can add a label to make a node eligible to receive the workload. To learn more, refer to the [Overview on Labels](/clusters/cluster-management/taints#overviewonlabels). |
-| **Taints** | Sets toleration to pods and allows (but does not require) the pods to schedule onto nodes with matching taints. To learn more, refer to the [Overview on Taints](/clusters/cluster-management/taints#overviewontaints).|
-| **Rolling update** |  Apply the update policy. **Expand first** launches new nodes and then terminates old notes. **Contract first** terminates old nodes and then launches new ones. |
-| **Instance Option** | AWS options for compute capacity. **On Demand** gives you full control over the instance lifecycle without long-term commitment. **Spot** allows the use of spare EC2 capacity at a discount but which can be reclaimed if needed. |
-| **Instance Type** |The compute size. |
-| **Availability Zones** | The Availability Zones from which to select available servers for deployment. If you select multiple zones, Palette will deploy servers evenly across them as long as sufficient servers are available to do so. |
-| **Disk Size** | Give the required storage size. |
- 
-**Note**: Currently Palette does not support Autoscaler for Azure clusters.
 
 <br />
 
 7. Click on **Confirm** to create the new node pool.
 
 
-# Change a Node Pool
+### Validate
 
-Palette allows its users to apply changes to a node pool, including its taints label for a running cluster. To make changes to the an active cluster's node pools, follow the steps below. 
+After you create a new node pool, you can validate the node pool by following the steps below.
 
-1. Ensure you are in the correct scope or project.
+1. Log in to [Palette](https://console.spectrocloud.com).
+
+
+2. Navigate to the left **Main Menu** and click on **Clusters**.
+
+
+3. Click on the row of the cluster you added the new node pool.
+
+
+4. Click on the **Nodes** tab.
+
+
+5. Ensure the new node pool is listed in the **Node Pools** section and that all compute instances are in the healthy status. 
+
+## Change a Node Pool
+
+
+You can apply changes to a node pool after a cluster is created and deployed. You can change the node pool's taints label, node repavement interval, number of compute instances in the node pool and more. To make changes to an active cluster's node pools, follow the steps below. 
+
+### Prerequisites
+
+
+* A Palette deployed cluster.
+
+
+* Sufficient permissions to edit the cluster.
+
+
+### Edit Node Pool
+
+
+1. Log in to [Palette](https://console.spectrocloud.com).
 
 
 2. Navigate to the left **Main Menu** and click on **Clusters**.
@@ -102,8 +173,27 @@ Palette allows its users to apply changes to a node pool, including its taints l
 5. The nodes details page is where you can review the existing node pools and their configuration. You can also add a new node pool from this page. Click on the **Edit** button to make changes to the node pool.
 
 
-6. Make changes as needed.
+6. Make the changes as needed. Refer to the [Node Pool Configuration Settings](#nodepoolconfigurationsettings) tables for more information on each field. 
 
 
 7. Click on **Confirm** to update the node pool.
 
+### Validate
+
+After you have modified a new node pool, you can validate the node pool by following the steps below.
+
+1. Log in to [Palette](https://console.spectrocloud.com).
+
+
+2. Navigate to the left **Main Menu** and click on **Clusters**.
+
+
+3. Click on the row of the cluster you added the new node pool.
+
+
+4. Click on the **Nodes** tab.
+
+
+5. Ensure the new node pool is listed in the **Node Pools** section and that all compute instances are in the healthy status. 
+
+<br />

--- a/content/docs/04-clusters/06-cluster-management/15-node-pool.md
+++ b/content/docs/04-clusters/06-cluster-management/15-node-pool.md
@@ -29,7 +29,7 @@ Ensure you exercise caution when modifying node pools. We recommend creating a [
 
 In Kubernetes, the term "repave" refers to the process of replacing a node with a new node. [Repaving](/glossary-all#repavement) is a common practice in Kubernetes to ensure that nodes are deployed with the latest version of the operating system and Kubernetes. Repaving is also used to replace nodes that are unhealthy or have failed. You can configure the repave time interval for a node pool. 
 
-The ability to configure the repave time interval for all node pools except the master pool. The repave time interval is set to 900 seconds (15 minutes) by default. You can configure the node repave time interval during the cluster creation process or after the cluster is created. To modify the repave time interval after the cluster is created, follow the [Change a Node Pool](#changeanodepool) instructions below.
+The ability to configure the repave time interval for all node pools except the master pool. The default repave time interval is 900 seconds (15 minutes). You can configure the node repave time interval during the cluster creation process or after the cluster is created. To modify the repave time interval after the cluster is created, follow the [Change a Node Pool](#changeanodepool) instructions below.
 
 
 <br />
@@ -87,7 +87,7 @@ Some features may not be available for all infrastructure providers. Review each
 ### Prerequisites
 
 
-* A Palette deployed cluster.
+* A Palette-deployed cluster.
 
 
 * Sufficient permissions to edit the cluster.
@@ -164,7 +164,7 @@ You can apply changes to a node pool after a cluster is created and deployed. Yo
 2. Navigate to the left **Main Menu** and click on **Clusters**.
 
 
-3. Click on the row of the cluster you want to edit the node pool.
+3. Select a cluster to edit the node pool.
 
 
 4. Click on the **Nodes** tab.
@@ -188,7 +188,7 @@ After you have modified a new node pool, you can validate the node pool by follo
 2. Navigate to the left **Main Menu** and click on **Clusters**.
 
 
-3. Click on the row of the cluster you added the new node pool.
+3. Select the cluster with the new node pool.
 
 
 4. Click on the **Nodes** tab.

--- a/content/docs/04-clusters/06-cluster-management/15-node-pool.md
+++ b/content/docs/04-clusters/06-cluster-management/15-node-pool.md
@@ -14,6 +14,8 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 # Overview
 
+<!-- Update Node Pool Repavement Behavior -->
+
 You have the ability to update node pools for active clusters and the option to create a new node pool for the cluster.
 
 <br />
@@ -104,3 +106,4 @@ Palette allows its users to apply changes to a node pool, including its taints l
 
 
 7. Click on **Confirm** to update the node pool.
+

--- a/content/docs/17-glossary-all.md
+++ b/content/docs/17-glossary-all.md
@@ -158,6 +158,12 @@ Projects provide a way for grouping clusters together for logical separation. Ro
 ## Public Pack Registry
 
 Palette maintains a public pack registry containing various [packs](#pack) that can be used in any [cluster profile](#cluster-profile). The pack content in this registry is constantly updated with new integrations.
+
+
+## Repavement
+
+Repavement is the process of replacing a Kubernetes node with a new one. This is typically done when a node is unhealthy or needs to be upgraded. The process involves draining the node, or in other words, migrating active workloads to another healthy node, and removing it from the cluster. A new node is created and configured with the same settings as the old node and added back to the cluster. The process is fully automated and does not require any manual intervention.
+
 ## Role
 
 A Role is a collection of [permissions](#permission). There are two kinds of roles in Palette: *tenant roles* and *project roles*. *Tenant roles* are a collection of tenant-level permissions such as create a new user, add a new project, etc. *Project roles* consist of permissions for various actions within the scope of a project such as create a cluster profile, create a cluster, etc.

--- a/vale/styles/Vocab/Internal/accept.txt
+++ b/vale/styles/Vocab/Internal/accept.txt
@@ -119,4 +119,7 @@ nameserver
 uncomment
 OAuth
 unsecure
-
+repavement
+Repavement
+repave
+Repave


### PR DESCRIPTION
## Describe the Change

This PR adds documentation about the new node repavement configuration.

New Glossary definition

![CleanShot 2023-08-16 at 10 51 27](https://github.com/spectrocloud/librarium/assets/29551334/df8f6653-01a6-46ce-bf1c-962abc4e2d7a)

Moved the Node Settings tables to a dedicated section for easier referencing.
![CleanShot 2023-08-16 at 10 52 28](https://github.com/spectrocloud/librarium/assets/29551334/8c85d44b-1c56-41db-8da1-a57e6786bf2c)


Added a repave section that explains the topic and raises awareness of the ability to configure the time interval.

![CleanShot 2023-08-16 at 10 53 20](https://github.com/spectrocloud/librarium/assets/29551334/e6b32272-cf6e-4b71-9e47-283989d48989)



## Review Changes

💻 [Preview URL](https://deploy-preview-1462--docs-spectrocloud.netlify.app/clusters/cluster-management/node-pool)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/PCP-1511)
