### PR TITLE
add menu details to add new certificate

### DIFF
--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -266,7 +266,7 @@ Once the deployment of the pack registry server is complete, configure it with t
 In order to establish a trusted secure connection between Palette and your registry
 you will need to upload your certificate to the console.
 
-1. Click on **Tenant Settings** > **Certificates** > **Add A New Certificate**
+1. From the **Tenant Admin** view, click on **Tenant Settings** > **Certificates** > **Add A New Certificate**
 
    Provide the content of your CA Cert (that will be the content of `tls.crt` if
    you followed this tutorial.

--- a/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
+++ b/content/docs/09-registries-and-packs/1-adding-a-custom-registry.md
@@ -266,7 +266,7 @@ Once the deployment of the pack registry server is complete, configure it with t
 In order to establish a trusted secure connection between Palette and your registry
 you will need to upload your certificate to the console.
 
-1. From the **Tenant Admin** view, click on **Tenant Settings** > **Certificates** > **Add A New Certificate**
+1. From the left **Main Menu**,  click on **Tenant Settings** > **Certificates** > **Add A New Certificate**
 
    Provide the content of your CA Cert (that will be the content of `tls.crt` if
    you followed this tutorial.


### PR DESCRIPTION
Add the full path to the tenant settings option (ie. from the tenant admin view, as opposed to a project view, that can be confusing).

