### PR TITLE
DOC-836: Update & de-duplicate proxy whitelists

### DIFF
--- a/content/docs/04-clusters.md
+++ b/content/docs/04-clusters.md
@@ -252,24 +252,27 @@ At times, you may be required to work with the Palette Support Team to troublesh
 
 </InfoBox>
 
-# Proxy Whitelists
+# Proxy Whitelist
 
 This table lists the proxy requirements for enabling the Palette management console.
 
-| Top-level Domain          | Port | Description                                 |
-| ------------------------- | ---- | ------------------------------------------- |
-| spectrocloud.com          | 443  | For the Palette SaaS.                       |
-| s3.amazonaws.com          | 443  | To access the Palette VMware OVA files.     |
-| gcr.io                    | 443  | To access the Palette image files.          |
-| ghcr.io                   | 443  | To access kube vip image                    |
-| docker.io                 | 443  | To access the Palette Pack Registries.      |
-| googleapis.com            | 443  | For pulling Palette images.                 |
-| docker.com                | 443  | To access the Palette docker images.        |
-| raw.githubusercontent.com | 443  |                                             |
-| projectcalico.org         | 443  | For egress management.                      |
-| quay.io                   | 443  | Container image registry access.            |
-| grafana.com               | 443  | To provide access to the dashboard metrics. |
-| github.com                | 443  |                                             |
+| Top-level Domain          | Port | Description                                  |
+| ------------------------- | ---- | -------------------------------------------- |
+| docker.io                 | 443  | 3rd party container images                   |
+| docker.com                | 443  | 3rd party container images                   |
+| gcr.io                    | 443  | Spectro Cloud and 3rd party container images |
+| ghcr.io                   | 443  | 3rd party container images                   |
+| github.com                | 443  | 3rd party content                            |
+| googleapis.com            | 443  | Spectro Cloud images                         |
+| grafana.com               | 443  | Grafana container images and manifests       |
+| k8s.gcr.io                | 443  | 3rd party container images                   |
+| projectcalico.org         | 443  | Calico container images                      |
+| registry.k8s.io           | 443  | 3rd party container images                   |
+| raw.githubusercontent.com | 443  | 3rd party content                            |
+| spectrocloud.com          | 443  | Spectro Cloud Palette SaaS                   |
+| s3.amazonaws.com          | 443  | Spectro Cloud VMware OVA files               |
+| quay.io                   | 443  | 3rd party container images                   |
+
 
 # Scope
 

--- a/content/docs/04-clusters.md
+++ b/content/docs/04-clusters.md
@@ -258,20 +258,20 @@ This table lists the proxy requirements for enabling the Palette management cons
 
 | Top-level Domain          | Port | Description                                  |
 | ------------------------- | ---- | -------------------------------------------- |
-| docker.io                 | 443  | 3rd party container images                   |
-| docker.com                | 443  | 3rd party container images                   |
-| gcr.io                    | 443  | Spectro Cloud and 3rd party container images |
-| ghcr.io                   | 443  | 3rd party container images                   |
-| github.com                | 443  | 3rd party content                            |
-| googleapis.com            | 443  | Spectro Cloud images                         |
-| grafana.com               | 443  | Grafana container images and manifests       |
-| k8s.gcr.io                | 443  | 3rd party container images                   |
-| projectcalico.org         | 443  | Calico container images                      |
-| registry.k8s.io           | 443  | 3rd party container images                   |
-| raw.githubusercontent.com | 443  | 3rd party content                            |
-| spectrocloud.com          | 443  | Spectro Cloud Palette SaaS                   |
-| s3.amazonaws.com          | 443  | Spectro Cloud VMware OVA files               |
-| quay.io                   | 443  | 3rd party container images                   |
+| docker.io                 | 443  | Third party container images.                   |
+| docker.com                | 443  | Third party container images.                   |
+| gcr.io                    | 443  | Spectro Cloud and 3rd party container images. |
+| ghcr.io                   | 443  | Third party container images.                   |
+| github.com                | 443  | Third party content.                            |
+| googleapis.com            | 443  | Spectro Cloud images.                         |
+| grafana.com               | 443  | Grafana container images and manifests.       |
+| k8s.gcr.io                | 443  | Third party container images.                   |
+| projectcalico.org         | 443  | Calico container images.                      |
+| registry.k8s.io           | 443  | Third party container images.                   |
+| raw.githubusercontent.com | 443  | Third party content.                           |
+| spectrocloud.com          | 443  | Spectro Cloud Palette SaaS.                   |
+| s3.amazonaws.com          | 443  | Spectro Cloud VMware OVA files.               |
+| quay.io                   | 443  | Third party container images.                   |
 
 
 # Scope

--- a/content/docs/12-enterprise-version/00-on-prem-system-requirements.md
+++ b/content/docs/12-enterprise-version/00-on-prem-system-requirements.md
@@ -796,22 +796,7 @@ Ensure your data center CIDR IP address does not overlap with the Kubernetes Pod
 ##  Proxy Requirements
 *  If a proxy is used for outgoing connections, it must support both HTTPS and HTTP traffic. All Palette components communicate over HTTPS by default. An HTTP proxy can be used when HTTP is the only supported protocol, such as connecting to a private image registry that only supports HTTP.
 
-
-*   Connectivity to the following domains and ports should be allowed:
-
-    | **Top-level Domain**      | **Port** | **Description**                                     |
-    | ------------------------- | -------- | --------------------------------------------------- |
-    | spectrocloud.com          | 443      | Spectro Cloud content repository and pack registry  |
-    | s3.amazonaws.com          | 443      | Spectro Cloud VMware OVA files                      |
-    | gcr.io                    | 443      | Spectro Cloud and common 3rd party container images |
-    | docker.io                 | 443      | Common 3rd party container images                   |
-    | googleapis.com            | 443      | For pulling Spectro Cloud images                    |
-    | docker.com                | 443      | Common 3rd party container images                   |
-    | raw.githubusercontent.com | 443      | Common 3rd party content                            |
-    | projectcalico.org         | 443      | Calico container images                             |
-    | quay.io                   | 443      | Common 3rd party container images                   |
-    | grafana.com               | 443      | Grafana container images and manifests              |
-    | github.com                | 443      | Common 3rd party content                            |
+*   Connectivity to all [Proxy Whitelist](/clusters#proxywhitelist) domains must be allowed
 
 
 ## Hardware Requirements


### PR DESCRIPTION
## Describe the Change

This PR adds `k8s.gcr.io` and `registry.k8s.io` to the proxy whitelist, de-duplicates the two proxy whitelists, and alphabetizes the remaining list.

## Review Changes

💻 [Preview URL](https://deploy-preview-1468--docs-spectrocloud.netlify.app/)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-836)
