### PR TITLE
Remove the 1st occurrence of the OVA PCG video

### DIFF
--- a/content/docs/04-clusters/02-data-center/03-vmware.md
+++ b/content/docs/04-clusters/02-data-center/03-vmware.md
@@ -621,8 +621,6 @@ Palette downloads images and Open Virtual Appliance (OVA) files to the spectro-t
 
 # Create VMware Cloud Gateway
 
-`video: title: "vsphere-pcg-creation": /pcg-creation-video/vmware.mp4`
-
 You can use two different PCG installation methods for VMware vSphere. You can use the Palette CLI, or you can use an OVA/OVF template. Review the prerequisites for each option to help you identify the correct installation method.
 
 <br />


### PR DESCRIPTION
This recording is already present in the `OVA/OVF Template` tab below and is not relevant as introduction of this section

## Describe the Change

Remove the 1st occurrence of the 2 min video recording that describes the PCG deployment using the OVA method.