### PR TITLE
MetalLB Refactor

### DIFF
--- a/.github/workflows/version-branch-update.yaml
+++ b/.github/workflows/version-branch-update.yaml
@@ -1,12 +1,10 @@
 name: Version Branch Update
 
 on:
-  push:
-    branches:
-      - 'version-*'
   pull_request:
     branches:
-      - 'version-*'
+      - 'backport/version-*'
+
 
 concurrency:
   group: version-${{ github.ref }}

--- a/content/docs/06-integrations/00-metallb.md
+++ b/content/docs/06-integrations/00-metallb.md
@@ -17,7 +17,9 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 # MetalLB
 
-MetalLB is a load-balancer implementation for bare metal [Kubernetes](https://kubernetes.io/) clusters using standard routing protocols. This integration is recommended for self-hosted cloud environments to help external services get an IP address when the service type is set as LoadBalancer. You can use a manifest-based pack or a Helm-based pack to configure and manage bare metal Kubernetes clusters. MetalLB deploys a controller and a speaker. The speaker is deployed as a DaemonSet that runs on all nodes.
+MetalLB is a load-balancer implementation for bare metal [Kubernetes](https://kubernetes.io/) clusters using standard routing protocols. This pack is recommended for self-hosted cloud environments to help external services get an IP address when the service type is set as LoadBalancer. You can use a manifest-based pack or a Helm-based pack to configure and manage bare metal Kubernetes clusters.
+
+MetalLB deploys a controller and a speaker. The speaker is deployed as a DaemonSet that runs on all nodes.
 
 
 ## Versions Supported
@@ -45,7 +47,7 @@ MetalLB is a load-balancer implementation for bare metal [Kubernetes](https://ku
 
 ## Parameters
 
-The `addresses` parameter applies to the manifest-based pack. You can provide multiple entries but only one is typically needed.
+The `addresses` parameter applies to the manifest-based MetalLB pack. You can provide multiple entries, but usually only one is needed.
 
 | **Parameter** | **Description** |
 |---------------|-----------------|
@@ -53,13 +55,13 @@ The `addresses` parameter applies to the manifest-based pack. You can provide mu
 
 ## Usage
 
-You can use a manifest-based pack or a Helm-based pack to configure and manage bare metal Kubernetes clusters.
+The *lb-metallb* manifest-based pack supports direct configuration of a Layer 2 (L2) IP address set. The *lb-metallb-helm* Helm-based pack provides an L2 address pool.
 
 <br />
 
 ### Manifest
 
-The manifest-based pack (lb-metallb) supports direct configuration of a Layer 2-based IP address set. You can set either a range of addresses or use CIDR format, such as 192.168.250.48/29. A more advanced MetalLB configuration like Border Gateway Protocol (BGP)-based routing requires you to write your own manifests and add them to the Palette cluster profile.
+Manifest-based MetalLB supports direct configuration of an L2 IP address set. You can set either a range of addresses or use CIDR format, such as `192.168.250.48/29`. A more advanced MetalLB configuration, such as Border Gateway Protocol (BGP) routing requires you to write your own manifests and add them to the Palette cluster profile.
 
 The example shows the syntax used to set an address range.
 
@@ -81,9 +83,9 @@ manifests:
 
 ### Helm Chart
 
-The helm-based pack, *lb-metallb-helm*, has two sections, `charts:metallb-full:configuration` and `charts:metallb-full:metallb`, as shown in the following examples.
+Helm-based MetalLB default gives you an L2 address pool by default. It has two sections, `charts:metallb-full:configuration` and `charts:metallb-full:metallb`, as shown in the following examples.
 
-Use the `charts:metallb-full:configuration` parameter section to set resource types that MetalLB supports. The pack default gives you a Layer 2 address pool. To set up a more advanced scenario, you can use the other resource types provided in the pack. The pack includes a commented-out example for each resource.
+Use the `charts:metallb-full:configuration` parameter section to set resource types that MetalLB supports. The pack default gives you an L2 address pool. To set up a more advanced scenario, you can use the other resource types provided in the pack. The pack includes a commented-out example for each resource.
 
 <br />
 
@@ -113,7 +115,7 @@ charts:
 ```
 <br />
 
-The `charts:metall-full:metallb` parameter section provides access to all the options of the base chart that installs MetalLB. You don’t need to change anything unless you want to install MetalLB in Free Range Routing (FRR) mode. To use FRR mode, set the option to `true`, as the example shows. 
+The `charts:metallb-full:metallb` parameter section provides access to all the options of the base chart that installs MetalLB. You don’t need to change anything unless you want to install MetalLB in Free Range Routing (FRR) mode. To use FRR mode, set the option to `true`, as the example shows. 
 
 <br />
 
@@ -125,6 +127,9 @@ charts:
 				frr:
 					enabled: true
 ```
+
+
+
 
 
 
@@ -152,7 +157,7 @@ charts:
 
 ## Parameters
 
-The `addresses` parameter applies to the manifest-based pack. You can provide multiple entries but only one is typically needed.
+The `addresses` parameter applies to the manifest-based MetalLB pack. You can provide multiple entries but only one is typically needed.
 
 | **Parameter** | **Description** |
 |---------------|-----------------|
@@ -160,13 +165,9 @@ The `addresses` parameter applies to the manifest-based pack. You can provide mu
 
 ## Usage
 
-<!-- You can use a manifest-based pack or a Helm-based pack to configure and manage bare metal Kubernetes clusters.
+The *lb-metallb* manifest-based pack supports direct configuration of a Layer 2 (L2) IP address set.
 
-<br /> 
-
-### Manifest -->
-
-The manifest-based pack, *lb-metallb*, supports direct configuration of a Layer 2-based IP address set. You can set either a range of addresses or use CIDR format, such as 192.168.250.48/29. A more advanced MetalLB configuration like Border Gateway Protocol (BGP)-based routing requires you to write your own manifests and add them to the Palette cluster profile.
+Manifest-based MetalLB supports direct configuration of an L2 IP address set. You can set either a range of addresses or use CIDR format, such as `192.168.250.48/29`. A more advanced MetalLB configuration, such as Border Gateway Protocol (BGP) routing requires you to write your own manifests and add them to the Palette cluster profile.
 
 The example shows the syntax used to set an address range.
 
@@ -184,54 +185,6 @@ manifests:
 		- 192.168.250.48-192.168.250.55
 ```
 
-<br />
-
-### Helm Chart
-
-The helm-based pack, *lb-metallb-helm*, has two sections, `charts:metallb-full:configuration` and `charts:metallb-full:metallb`, as shown in the following examples.
-
-Use the `charts:metallb-full:configuration` parameter section to set resource types that MetalLB supports. The pack default gives you a Layer 2 address pool. To set up a more advanced scenario, you can use the other resource types provided in the pack. The pack includes a commented-out example for each resource.
-
-<br />
-
-
-```yaml
-charts:
-  metallb-full:
-    configuration:
-      ipaddresspools:
-        first-pool:
-          spec:
-            addresses:
-              - 192.168.10.0/24
-            avoidBuggyIPs: true
-            autoAssign: true
-
-      l2advertisements:
-        default:
-          spec:
-            ipAddressPools:
-              - first-pool
-
-      bgpadvertisements: {}
-      bgppeers: {}
-      communities: {}
-      bfdprofiles: {}
-```
-<br />
-
-The `charts:metall-full:metallb` parameter section provides access to all the options of the base chart that installs MetalLB. You don’t need to change anything unless you want to install MetalLB in Free Range Routing (FRR) mode. To use FRR mode, set the option to `true`, as the example shows. 
-
-<br />
-
-```yaml
-charts:
-	metallb-full:
-		metallb:
-			speaker:
-				frr:
-					enabled: true
-```
 
 
 
@@ -254,9 +207,11 @@ All versions of the manifest-based pack less than v0.9.x are considered deprecat
 
 ## Troubleshooting
 
-Addresses specified in the pack values go into a configMap `config` in the `metallb-system` namespace. This configMap is used by the MetalLB controller and speakers as volume mounts.
+If controller and speaker pods are not assigning new IP addresses that you provided in the MetalLB pack, it is likely pods in existing deployments do not have the latest configMap file. 
 
-Any changes to the address will get updated in the configMap. You can confirm this by issuing the following command.
+Addresses you specify in MetalLB pack values go into a configMap called `config` in the `metallb-system` namespace. The MetalLB controller and speakers use the configMap as a volume mount.
+
+Any changed IP addresses will get updated in the configMap. You can confirm this by issuing the following command.
 
 <br />
 
@@ -266,11 +221,15 @@ kubectl describe cm config -n metallb-system
 
 <br />
 	
-Since the controller and speaker pods are already running with a previous copy of the configMap, existing deployments are unaware of the changes made to configMap. To ensure the address change are reflected, you need to restart the controller and speaker pods so they fetch the new configMap and start assigning new addresses correctly. Issue the commands below to restart the controller and speaker.
+Since the controller and speaker pods are using a previous copy of the configMap, existing deployments are unaware of the changes made to configMap. 
+
+<br />
+<br />
+
+To ensure updated addresses are reflected in the configMap, you need to restart the controller and speaker pods so they fetch the new configMap and start assigning new addresses correctly. Issue the commands below to restart the controller and speaker.
 
 <br />
 
-<br />
 
 ```bash
 	kubectl rollout restart deploy controller -n metallb-system

--- a/content/docs/06-integrations/00-metallb.md
+++ b/content/docs/06-integrations/00-metallb.md
@@ -42,7 +42,7 @@ MetalLB deploys a controller and a speaker. The speaker is deployed as a DaemonS
 - When using the Border Gateway Protocol (BGP), one or more BGP-capable routers are required.
 
 
-- When using the L2 operating mode, Transmission Control Protocol (TCP) and User Datagram Protocol (UDP) traffic on port 7946 must be allowed between nodes, as required by the [Hashicorp memberlist](https://github.com/hashicorp/memberlist). You can configure other port as needed. 
+- When using the L2 operating mode, Transmission Control Protocol (TCP) and User Datagram Protocol (UDP) traffic on port 7946 must be allowed between nodes, as required by the [HashiCorp memberlist](https://github.com/hashicorp/memberlist). You can configure other port as needed. 
 
 
 ## Parameters
@@ -152,7 +152,7 @@ charts:
 - When using the Border Gateway Protocol (BGP), one or more BGP-capable routers are required.
 
 
-- When using the L2 operating mode, Transmission Control Protocol (TCP) and User Datagram Protocol (UDP) traffic on port 7946 must be allowed between nodes, as required by the [Hashicorp memberlist](https://github.com/hashicorp/memberlist). You can configure other port as needed. 
+- When using the L2 operating mode, Transmission Control Protocol (TCP) and User Datagram Protocol (UDP) traffic on port 7946 must be allowed between nodes, as required by the [HashiCorp memberlist](https://github.com/hashicorp/memberlist). You can configure other port as needed. 
 
 
 ## Parameters

--- a/content/docs/06-integrations/00-metallb.md
+++ b/content/docs/06-integrations/00-metallb.md
@@ -17,22 +17,8 @@ import Tooltip from "shared/components/ui/Tooltip";
 
 # MetalLB
 
-MetalLB is a load-balancer implementation for bare metal [Kubernetes](https://kubernetes.io/) clusters, using standard routing protocols. This integration is recommended for the on-prem cloud(s) and will help external service(s) get an IP address when the service type is set as LoadBalancer.
+MetalLB is a load-balancer implementation for bare metal [Kubernetes](https://kubernetes.io/) clusters using standard routing protocols. This integration is recommended for self-hosted cloud environments to help external services get an IP address when the service type is set as LoadBalancer. MetalLB deploys a controller and a speaker. The speaker is deployed as a DaemonSet and runs on all nodes.
 
-## MetalLB Pack Working Details:
-
-* The address set in pack values goes into a configMap **`config`** in **`metallb-system`** namespace. This configMap is used by the MetalLB controller and speakers as volume mounts.
-
-* Any changes to the address will get updated in the configMap. Our users may confirm this with this command:
-
-		kubectl describe cm config -n metallb-system.
-
-* However, the controller and speaker pods are already running with a previous copy of the configMap and these deployments are not aware of the new changes made to configMap. To ensure the address change are reflected, we need to restart the controller and speaker pods so that they will fetch the new configMap and start assigning new addresses correctly.
-
-* Run the following commands, which will help restart the controller and speaker:
-
-		  kubectl rollout restart deploy controller -n metallb-system
-		  kubectl rollout restart ds speaker -n metallb-system
 
 ## Versions Supported
 
@@ -40,34 +26,203 @@ MetalLB is a load-balancer implementation for bare metal [Kubernetes](https://ku
 
 <Tabs.TabPane tab="0.13.x" key="0.13.x">
 
-* **0.13.5**
+## Prerequisites
+
+- A Kubernetes cluster running Kubernetes 1.13.0 or later that does not already have network load-balancing functionality.
+
+
+- A cluster network configuration that can co-exist with MetalLB.
+
+
+- Some IPv4 addresses for MetalLB to hand out.
+
+
+- When using the Border Gateway Protocol (BGP), one or more BGP-capable routers are required.
+
+
+- When using the L2 operating mode, Transmission Control Protocol (TCP) and User Datagram Protocol (UDP) traffic on port 7946 must be allowed between nodes, as required by the [Hashicorp memberlist](https://github.com/hashicorp/memberlist). You can configure other port as needed. 
+
+
+## Parameters
+
+
+
+## Usage
+
+You can use a manifest-based pack or a Helm-based pack to configure and manage bare metal Kubernetes clusters.
+
+### Manifest
+
+The manifest-based pack (lb-metallb) supports direct configuration of a Layer 2-based IP address set. You can set either a range of addresses or a CIDR such as 192.168.250.48/29 for the same set of addresses. A more advanced MetalLB configuration like Border Gateway Protocol (BGP)-based routing requires you to write your own manifests and add them to the Palette cluster profile.
+
+The example shows the syntax used to set an address range.
+
+```yaml
+manifests:
+  metallb:
+    images:
+      controller: ""
+      speaker: ""
+    #The namespace to use for deploying MetalLB
+    namespace: "metallb-system"
+
+    #MetalLB will skip setting .0 & .255 IP address when this flag is enabled
+    avoidBuggyIps: true
+
+		# Layer 2 config; The IP address range MetalLB should use while assigning IP's for svc type LoadBalancer
+    # For the supported formats, check https://metallb.universe.tf/configuration/#layer-2-configuration
+    addresses:
+    #- 10.10.184.0-10.10.184.255
+		- 192.168.250.48-192.168.250.55
+```
+
+
+The helm-based pack (lb-metallb-helm) has two sections, `charts:metallb-full:configuration` and `charts:metallb-full:metallb`, as shown in the following examples.
+
+The `charts:metallb-full:configuration` parameter section is where you can set resource types that MetalLB supports. The pack default gives you a Layer 2 pool of IP addresses. If you want to set up a more advanced scenario, you can do so with the other resource types provided in the pack. The pack includes a commented-out example for each resource.
+
+
+```yaml
+charts:
+  metallb-full:
+    configuration:
+      ipaddresspools:
+        first-pool:
+          spec:
+            addresses:
+              - 192.168.10.0/24
+              # - 192.168.100.50-192.168.100.60
+            avoidBuggyIPs: true
+            autoAssign: true
+
+      l2advertisements:
+        default:
+          spec:
+            ipAddressPools:
+              - first-pool
+
+      bgpadvertisements: {}
+        # external:
+        #   spec:
+        #     ipAddressPools:
+        #       - bgp-pool
+        #     # communities:
+        #     #   - vpn-only
+
+      bgppeers: {}
+        # bgp-peer-1:
+        #   spec:
+        #     myASN: 64512
+        #     peerASN: 64512
+        #     peerAddress: 172.30.0.3
+        #     peerPort: 180
+        #     # BFD profiles can only be used in FRR mode
+        #     # bfdProfile: bfd-profile-1
+
+      communities: {}
+        # community-1:
+        #   spec:
+        #     communities:
+        #     - name: vpn-only
+        #       value: 1234:1
+
+      bfdprofiles: {}
+        # bfd-profile-1:
+        #   spec:
+        #     receiveInterval: 380
+        #     transmitInterval: 270
+
+    metallb:
+      # Default values for the metallb chart.
+      # This is a YAML-formatted file.
+      # Declare variables to be passed into your templates.
+```
+
+
+The `charts:metall-full:metallb` parameter section provides access to all the options of the base chart that installs MetalLB. You don’t need to change anything unless you want to install MetalLB in Free Range Routing (FRR) mode. To use FRR mode, you would set the option as shown in the example.
+
+```yaml
+charts:
+	metallb-full:
+		metallb:
+			speaker:
+				frr:
+					enabled: true
+```
+
+
+
+
+
 
 </Tabs.TabPane>
 
 <Tabs.TabPane tab="0.11.x" key="0.11.x">
 
-* **0.11.0**
+
 
 </Tabs.TabPane>
 
 <Tabs.TabPane tab="0.9.x" key="0.9.x">
 
-* **0.9.5**
+
 
 </Tabs.TabPane>
 <Tabs.TabPane tab="0.8.x" key="0.8.x">
 
-  * **0.8.3**
+
 
 </Tabs.TabPane>
 </Tabs>
+
+
+
 
 ## Components
 
 * MetalLB controller.
 * Speaker (runs on all nodes, deployed as DaemonSet).
 
+
+## Troubleshooting
+
+The IP address set in pack values goes into a configMap `config` in the `metallb-system` namespace. This configMap is used by the MetalLB controller and speakers as volume mounts.
+
+Any changes to the address will get updated in the configMap. You can confirm this by issuing the following command:
+
+	```bash
+	kubectl describe cm config -n metallb-system
+	```
+
+	<br />
+	
+	Since the controller and speaker pods are already running with a previous copy of the configMap, existing deployments are unaware of the changes made to configMap. To ensure the address change are reflected, you need to restart the controller and speaker pods so they fetch the new configMap and start assigning new addresses correctly.
+
+Issue the commands below to restart the controller and speaker.
+
+```bash
+	kubectl rollout restart deploy controller -n metallb-system
+	kubectl rollout restart ds speaker -n metallb-system
+```
+
+
+## Terraform
+
+```hcl
+data "spectrocloud_pack" "MetalLB" {
+     name    = "lb-metallb"
+     version = "0.13.5"
+}
+data "spectrocloud_pack" "MetalLB-Helm" {
+     name    = "lb-metallb-helm"
+     version = "0.13.7"
+}
+```
+
+
 ## References
 
-https://metallb.universe.tf/ <br />
-https://github.com/metallb/metallb
+- [MetalLB](https://metallb.universe.tf/) 
+
+
+- [MetalLB-GitHub ](https://github.com/metallb/metallb)

--- a/vale/styles/Vocab/Internal/accept.txt
+++ b/vale/styles/Vocab/Internal/accept.txt
@@ -128,3 +128,4 @@ K3s
 boolean
 Layer 2
 L2
+HashiCorp

--- a/vale/styles/Vocab/Internal/accept.txt
+++ b/vale/styles/Vocab/Internal/accept.txt
@@ -126,3 +126,5 @@ repave
 Repave
 K3s
 boolean
+Layer 2
+L2


### PR DESCRIPTION
## Describe the Change

This PR refactors MetalLB and adds details about the manifest-based and Helm-based versions of the pack. It also adds Layer 2, L2, and HashiCorp to Vale accept.

## Review Changes

💻 [Preview](https://deploy-preview-1505--docs-spectrocloud.netlify.app/integrations/metallb)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-440)
