### PR TITLE
Update default node repave interval value

### DIFF
--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -20,7 +20,7 @@ Ensure you exercise caution when modifying node pools. We recommend creating a [
 
 In Kubernetes, the term "repave" refers to the process of replacing a node with a new node. [Repaving](/glossary-all#repavement) is a common practice in Kubernetes to ensure that nodes are deployed with the latest version of the operating system and Kubernetes. Repaving is also used to replace nodes that are unhealthy or have failed. You can configure the repave time interval for a node pool. 
 
-The ability to configure the repave time interval for all node pools except the master pool. The default repave time interval is 900 seconds (15 minutes). You can configure the node repave time interval during the cluster creation process or after the cluster is created. To modify the repave time interval after the cluster is created, follow the [Change a Node Pool](#changeanodepool) instructions below.
+The ability to configure the repave time interval for all node pools except the master pool. The default repave time interval is 0 seconds. You can configure the node repave time interval during the cluster creation process or after the cluster is created. To modify the repave time interval after the cluster is created, follow the [Change a Node Pool](#changeanodepool) instructions below.
 
 
 ## Node Pool Configuration Settings


### PR DESCRIPTION
## Describe the Change

This PR fixes the default node repave interval for worker pools, which is 0 seconds and not 900 (implementation changed).

<img width="1153" alt="Screenshot 2023-09-08 at 15 08 18" src="https://github.com/spectrocloud/librarium/assets/10382023/a4771848-0cf6-409b-9e6f-928057f0841a">
