### PR TITLE
Helm update

### DIFF
--- a/docs/docs-content/clusters/cluster-management/backup-restore/add-backup-location-dynamic.md
+++ b/docs/docs-content/clusters/cluster-management/backup-restore/add-backup-location-dynamic.md
@@ -97,11 +97,11 @@ Use the following steps to add an S3 bucket as the backup location using the STS
 	}
 	```
 
-* If the S3 bucket is using a customer managed AWS Key Management Service (KMS) key for server-side encryption, ensure the Palette IAM role has the necessary permissions to access the KMS key. Otherwise, Palette will be unable to put objects in the S3 bucket and result in backup or restore failure. Check out the [Troubleshooting key access](https://docs.aws.amazon.com/kms/latest/developerguide/policy-evaluation.html) guide to learn more about common KMS issues.
+* If the S3 bucket is using a customer managed AWS Key Management Service (KMS) key for server-side encryption, ensure the Palette IAM role has the necessary permissions to access the KMS key. Otherwise, Palette will be unable to put objects in the S3 bucket, resulting in backup or restore failure. Check out the [Troubleshooting key access](https://docs.aws.amazon.com/kms/latest/developerguide/policy-evaluation.html) guide to learn more about common KMS issues.
 
 	:::tip
 
-	Use the IAM Policy Simulator to verify the IAM role has the necessary permissions to access a customer managed KMS key. Refer to the [Testing IAM policies with the IAM policy simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) guide to learn more about the IAM Policy Simulator.
+	Use the IAM Policy Simulator to verify the IAM role has the necessary permissions to access a customer managed KMS key. Refer to the [Testing IAM policies with the IAM policy simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) guide to learn more.
 
 	:::
 

--- a/docs/docs-content/clusters/cluster-management/backup-restore/add-backup-location-dynamic.md
+++ b/docs/docs-content/clusters/cluster-management/backup-restore/add-backup-location-dynamic.md
@@ -97,6 +97,14 @@ Use the following steps to add an S3 bucket as the backup location using the STS
 	}
 	```
 
+* If the S3 bucket is using a customer managed AWS Key Management Service (KMS) key for server-side encryption, ensure the Palette IAM role has the necessary permissions to access the KMS key. Otherwise, Palette will be unable to put objects in the S3 bucket and result in backup or restore failure. Check out the [Troubleshooting key access](https://docs.aws.amazon.com/kms/latest/developerguide/policy-evaluation.html) guide to learn more about common KMS issues.
+
+	:::tip
+
+	Use the IAM Policy Simulator to verify the IAM role has the necessary permissions to access a customer managed KMS key. Refer to the [Testing IAM policies with the IAM policy simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) guide to learn more about the IAM Policy Simulator.
+
+	:::
+
 <br /> 	
 
 

--- a/docs/docs-content/clusters/cluster-management/backup-restore/add-backup-location-static.md
+++ b/docs/docs-content/clusters/cluster-management/backup-restore/add-backup-location-static.md
@@ -97,6 +97,15 @@ The following sections provide detailed instructions. Select the environment whe
 	If you skip copying the secret access key, refer to the [Managing access keys for IAM users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) guide to learn how to create a new access key.
 
 
+* If the S3 bucket is using a customer managed AWS Key Management Service (KMS) key for server-side encryption, ensure the Palette IAM user has the necessary permissions to access the KMS key. Otherwise, Palette will be unable to put objects in the S3 bucket and result in backup or restore failure. Check out the [Troubleshooting key access](https://docs.aws.amazon.com/kms/latest/developerguide/policy-evaluation.html) guide to learn more about common KMS issues.
+
+	:::tip
+
+	Use the IAM Policy Simulator to verify the IAM user has the necessary permissions to access a customer managed KMS key. Refer to the [Testing IAM policies with the IAM policy simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) guide to learn more about the IAM Policy Simulator.
+
+	:::
+
+
 
 ### Add an AWS S3 Bucket 
 

--- a/docs/docs-content/clusters/cluster-management/backup-restore/add-backup-location-static.md
+++ b/docs/docs-content/clusters/cluster-management/backup-restore/add-backup-location-static.md
@@ -101,7 +101,7 @@ The following sections provide detailed instructions. Select the environment whe
 
 	:::tip
 
-	Use the IAM Policy Simulator to verify the IAM user has the necessary permissions to access a customer managed KMS key. Refer to the [Testing IAM policies with the IAM policy simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) guide to learn more about the IAM Policy Simulator.
+Use the IAM Policy Simulator to verify the IAM role has the necessary permissions to access a customer managed KMS key. Refer to the [Testing IAM policies with the IAM policy simulator](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html) guide to learn more.
 
 	:::
 

--- a/docs/docs-content/enterprise-version/air-gap-repo.md
+++ b/docs/docs-content/enterprise-version/air-gap-repo.md
@@ -223,11 +223,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-k8s-v3.3.15.bin
   ```
 
-  :::info
+:::tip
 
-   If you receive a certificate error, use the `-k` or `--insecure` flag.
-  
-  :::
+  If you receive a certificate error, use the `-k` or `--insecure` flag.
+
+:::
 
   Assign the proper permissions and start the download script.
 
@@ -268,11 +268,12 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-k8s-v3.3.15.bin
   ```
 
-  :::info
 
-   If you receive a certificate error, use the `-k` or `--insecure` flag.
-  
-  :::
+:::tip
+
+  If you receive a certificate error, use the `-k` or `--insecure` flag.
+
+:::
 
    Assign the proper permissions and start the download script.
 
@@ -311,11 +312,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-kubeadm.bin
   ```
 
-  :::info
+:::tip
 
-   If you receive a certificate error, use the `-k` or `--insecure` flag.
-  
-  :::
+  If you receive a certificate error, use the `-k` or `--insecure` flag.
+
+:::
 
    Assign the proper permissions and start the download script.
 
@@ -365,11 +366,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-ubuntu22-k3s.bin
   ```
 
-  :::info
+:::tip
 
-   If you receive a certificate error, use the `-k` or `--insecure` flag.
-  
-  :::
+  If you receive a certificate error, use the `-k` or `--insecure` flag.
+
+:::
 
  Assign the proper permissions and start the download script.
 
@@ -394,11 +395,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-ubuntu22-rke.bin
   ```
 
-  :::info
+:::tip
 
-   If you receive a certificate error, use the `-k` or `--insecure` flag.
-  
-  :::
+  If you receive a certificate error, use the `-k` or `--insecure` flag.
+
+:::
 
    Assign the proper permissions and start the download script.
 
@@ -421,11 +422,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-ubuntu22-kubeadm.bin
   ```
 
-  :::info
+:::tip
 
-  If you receive a certificate error, use the `-k` or `--insecure` flag.
+If you receive a certificate error, use the `-k` or `--insecure` flag.
 
-  :::
+:::
 
    Assign the proper permissions and start the download script.
   
@@ -448,11 +449,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-ubuntu20-k3s.bin
   ```
 
-  :::info
+:::tip
 
-  If you receive a certificate error, use the `-k` or `--insecure` flag.
+If you receive a certificate error, use the `-k` or `--insecure` flag.
 
-  :::
+:::
 
    Assign the proper permissions and start the download script.
   
@@ -475,11 +476,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-ubuntu20-rke.bin
   ```
 
-  :::info
+:::tip
 
-  If you receive a certificate error, use the `-k` or `--insecure` flag.
+If you receive a certificate error, use the `-k` or `--insecure` flag.
 
-  :::
+:::
 
    Assign the proper permissions and start the download script.
   
@@ -503,11 +504,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-ubuntu20-kubeadm.bin
   ```
 
-  :::info
+:::tip
 
-  If you receive a certificate error, use the `-k` or `--insecure` flag.
+If you receive a certificate error, use the `-k` or `--insecure` flag.
 
-  :::
+:::
 
    Assign the proper permissions and start the download script.
   
@@ -530,11 +531,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-opensuse-k3s.bin
   ```
 
-  :::info
+:::tip
 
-  If you receive a certificate error, use the `-k` or `--insecure` flag.
+If you receive a certificate error, use the `-k` or `--insecure` flag.
 
-  :::
+:::
 
    Assign the proper permissions and start the download script.
   
@@ -557,11 +558,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-opensuse-rke.bin
   ```
 
-  :::info
+:::tip
 
-  If you receive a certificate error, use the `-k` or `--insecure` flag.
+If you receive a certificate error, use the `-k` or `--insecure` flag.
 
-  :::
+:::
 
    Assign the proper permissions and start the download script.
   
@@ -584,11 +585,11 @@ If you have any questions or concerns, please feel free to contact support@spect
    --output airgap-edge-opensuse-kubeadm.bin
   ```
 
-  :::info
+:::tip
 
-  If you receive a certificate error, use the `-k` or `--insecure` flag.
+If you receive a certificate error, use the `-k` or `--insecure` flag.
 
-  :::
+:::
 
    Assign the proper permissions and start the download script.
   

--- a/docs/docs-content/enterprise-version/helm-chart-install-reference.md
+++ b/docs/docs-content/enterprise-version/helm-chart-install-reference.md
@@ -90,7 +90,7 @@ You can install Palette in connected or air-gapped mode. The table lists the par
 
 | **Parameters** | **Description** | **Type** | **Default value** |
 | --- | --- | --- | --- |
-| `installMode` | Specifies the installation mode. Allowed values are `connected` or `airgap`. Set the value to `airgap` when conducting an install in an air gap environment. | String | `connected` |
+| `installMode` | Specifies the installation mode. Allowed values are `connected` or `airgap`. Set the value to `airgap` when installing in an air-gapped environment. | String | `connected` |
 
 ```yaml
 config:

--- a/docs/docs-content/enterprise-version/helm-chart-install-reference.md
+++ b/docs/docs-content/enterprise-version/helm-chart-install-reference.md
@@ -83,6 +83,20 @@ mongo:
 
 Review the following parameters to configure Palette for your environment. The `config` section contains the following subsections:
 
+
+#### Install Mode
+
+You can install Palette in connected or air-gapped mode. The table lists the parameters to configure the installation mode.
+
+| **Parameters** | **Description** | **Type** | **Default value** |
+| --- | --- | --- | --- |
+| `installMode` | Specifies the installation mode. Allowed values are `connected` or `airgap`. Set the value to `airgap` when conducting an install in an air gap environment. | String | `connected` |
+
+```yaml
+config:
+  installationMode: "connected"
+```
+
 #### SSO 
 
 You can configure Palette to use Single Sign-On (SSO) for user authentication. Configure the SSO parameters to enable SSO for Palette. You can also configure different SSO providers for each tenant post-install, check out the [SAML & SSO Setup](/user-management/saml-sso) documentation for additional guidance.

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/vertex-helm-ref.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/vertex-helm-ref.md
@@ -72,6 +72,20 @@ mongo:
 
 Review the following parameters to configure Palette VerteX for your environment. The `config` section contains the following subsections:
 
+
+#### Install Mode
+
+You can install Palette in connected or air-gapped mode. The table lists the parameters to configure the installation mode.
+
+| **Parameters** | **Description** | **Type** | **Default value** |
+| --- | --- | --- | --- |
+| `installMode` | Specifies the installation mode. Allowed values are `connected` or `airgap`. Set the value to `airgap` when conducting an install in an air gap environment. | String | `connected` |
+
+```yaml
+config:
+  installationMode: "connected"
+```
+
 ### SSO 
 
 You can configure Palette VerteX to use Single Sign-On (SSO) for user authentication. Configure the SSO parameters to enable SSO for Palette VerteX. You can also configure different SSO providers for each tenant post-install, check out the [SAML & SSO Setup](/user-management/saml-sso) documentation for additional guidance.

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/vertex-helm-ref.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/vertex-helm-ref.md
@@ -79,7 +79,7 @@ You can install Palette in connected or air-gapped mode. The table lists the par
 
 | **Parameters** | **Description** | **Type** | **Default value** |
 | --- | --- | --- | --- |
-| `installMode` | Specifies the installation mode. Allowed values are `connected` or `airgap`. Set the value to `airgap` when conducting an install in an air gap environment. | String | `connected` |
+| `installMode` | Specifies the installation mode. Allowed values are `connected` or `airgap`. Set the value to `airgap` when installing in an air-gapped environment. | String | `connected` |
 
 ```yaml
 config:


### PR DESCRIPTION
## Describe the Change

- This PR updates the Helm reference page with a new attribute for Palette 4.0+. 
  - [Palette](https://deploy-preview-1536--docs-spectrocloud.netlify.app/enterprise-version/helm-chart-install-reference#config)
  - [Vertex](https://deploy-preview-1536--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-kubernetes/vertex-helm-ref#install-mode)
- Minor fixes to callout boxes not displaying in the [Airgap document](https://deploy-preview-1536--docs-spectrocloud.netlify.app/enterprise-version/air-gap-repo?install-method=palette-installer).
- Updated the backup instructions to reflect field feedback. 
![CleanShot 2023-09-11 at 15 34 16](https://github.com/spectrocloud/librarium/assets/29551334/d8a0ff1b-e69f-4689-9cb4-0e6c78c0c5a4)
  - [Static Credentials](https://deploy-preview-1536--docs-spectrocloud.netlify.app/clusters/cluster-management/backup-restore/add-backup-location-static#prerequisites)
  - [Dynamic Credentials](https://deploy-preview-1536--docs-spectrocloud.netlify.app/clusters/cluster-management/backup-restore/add-backup-location-dynamic#prerequisites)


## Review Changes

💻 [Preview URL](https://deploy-preview-1536--docs-spectrocloud.netlify.app/enterprise-version/helm-chart-install-reference#config)

🎫 [DOC-869](https://spectrocloud.atlassian.net/browse/DOC-869)
