### PR TITLE
Document action needed in Palette if Vcntr pwd changes: doc-866

### DIFF
--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -32,11 +32,7 @@ The following are some architectural highlights of Kubernetes clusters provision
 
 The following prerequisites must be met before deploying a Kubernetes clusters in VMware:
 
-<br />
-
 - vSphere version 7.0 or above. vSphere 6.7 is supported but we do not recommend it, as it reached end of general support in 2022.
-
-  <br />
 
   Palette supports port groups as follows. Opaque networks in vCenter Server are *not* supported.
   
@@ -117,8 +113,6 @@ Zone tagging is required for dynamic storage allocation across fault domains whe
 | cluster-3            | k8s-zone         | az3           |
 
 
-<br />
-
 ## VMware Privileges
 
 The vSphere user account that deploys Palette must have the minimum root-level vSphere privileges listed in the table below. The **Administrator** role provides superuser access to all vSphere objects. For users without the **Administrator** role, one or more custom roles can be created based on tasks the user will perform.
@@ -126,7 +120,7 @@ Permissions and privileges vary depending on the vSphere version you are using.
 
 Select the tab for your vSphere version.
 
-<br />
+
 
 :::caution
 
@@ -134,13 +128,12 @@ If the network is a Distributed Port Group under a vSphere Distributed Switch (V
 
 :::
 
-<br />
+
 
 <Tabs queryString="vm-privileges">
 
 <TabItem label="8.0" value="8.0" >
 
-<br />
 
 ## Root-Level Role Privileges
 
@@ -161,14 +154,11 @@ Root-level role privileges listed in the table are applied only to root objects 
 |**VM Storage Policies**|View VM storage policies|
 |**Storage views**|View|
 
-<br />
 
 ## Spectro Role Privileges
 
-
 The Spectro role privileges listed in the table must be applied to the spectro-template folder, hosts, clusters, virtual machines, templates, datastore, and network objects. 
 
-<br />
 
 :::info
 
@@ -298,7 +288,6 @@ Palette downloads images and Open Virtual Appliance (OVA) files to the spectro-t
 </TabItem>
 <TabItem label="7.0" value="7.0" >
 
-<br />
 
 ## Root-Level Role Privileges
 
@@ -317,14 +306,12 @@ Root-level role privileges listed in the table are applied only to root object a
 |**Profile-driven storage**|Profile-driven storage view|
 |**Storage views**|View|
 
-<br />
 
 ## Spectro Role Privileges
 
 
 The Spectro role privileges listed in the table must be applied to the spectro-template folder, hosts, clusters, virtual machines, templates, datastore, and network objects. 
 
-<br />
 
 :::info
 
@@ -452,7 +439,6 @@ Palette downloads images and Open Virtual Appliance (OVA) files to the spectro-t
 </TabItem>
 <TabItem label="6.7" value="6.7" >
 
-<br />
 
 ## Root-Level Role Privileges
 
@@ -473,13 +459,10 @@ Root-level role privileges listed in the table are applied only to root object a
 |**Profile-driven storage**|Profile-driven storage view|
 |**Storage views**|View|
 
-<br />
 
 ## Spectro Role Privileges
 
 The Spectro role privileges listed in the table must be applied to the spectro-template folder, hosts, clusters, virtual machines, templates, datastore, and network objects. 
-
-<br />
 
 :::info
 
@@ -618,7 +601,6 @@ Palette downloads images and Open Virtual Appliance (OVA) files to the spectro-t
 
 You can use two different PCG installation methods for VMware vSphere. You can use the Palette CLI, or you can use an OVA/OVF template. Review the prerequisites for each option to help you identify the correct installation method.
 
-<br />
 
 <Tabs>
 
@@ -637,8 +619,6 @@ You can use two different PCG installation methods for VMware vSphere. You can u
 - Download the Palette CLI from the [Downloads](/spectro-downloads#palettecli) page and install the CLI. Refer to the [Palette CLI Install](/palette-cli/install-palette-cli) guide to learn more.
 
 - You can set up the PCG as a single or three-node cluster based on your requirements for high availability (HA). The minimum PCG resource requirements are the following.
-
-  <br />
 
   - Single-node cluster: 2 vCPU, 4 GB memory, 60 GB storage.
 
@@ -697,8 +677,6 @@ Self-hosted Palette installations provide a system PCG out-of-the-box and typica
 
 
 4. Next, provide environment configurations for the cluster. Refer to the following table for information about each option.
-
-  <br />
 
   |**Parameter**| **Description**|
   |:-------------|----------------|
@@ -822,7 +800,6 @@ Once installed, the PCG registers itself with Palette. To verify the PCG is regi
 
 To change the PCG install values, restart the installation process using the `palette pcg install` command.  Use the following steps to redeploy the PCG or restart the install process.
 
-<br />
 
 1. Make the necessary changes to the PCG configuration file the CLI created during the installation, if needed. Use a text editor, such as vi or nano to update the PCG install configuration file.
 

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -1051,7 +1051,19 @@ In addition to the default cloud account already associated with the private clo
 
 :::caution
 
-If you change the password for a user account in Vcenter, you must also change it in Palette for the same VMware cloud account. We suggest updating the passwords sequentially to avoid potentially locking Palette out of Vcenter.
+If you change the password for a user account in vCenter, you must also change it in Palette for the same VMware cloud account. We recommend updating the passwords immediately to avoid potentially locking Palette out of vCenter.
+
+:::
+
+
+## Change VMware Cloud Account Password in Palette
+
+
+### Prerequisites
+
+- Access to the vCenter credentials.
+
+### Change the Password in Palette
 
 1. From the **Menu Menu** navigate to **Clusters** > **Add New Cluster** > **Deploy New Cluster** and select **VMware**. 
 2. Click on **Start VMware Configuration**.
@@ -1059,7 +1071,10 @@ If you change the password for a user account in Vcenter, you must also change i
 4. Update the password in the **Password** field and click **Validate**. 
 5. Confirm your changes. 
 
-:::
+### Validation
+
+Palette validates the password. Incorrect credentials will result in an error. As an extra precaution, try deploying a cluster.
+
 
 # Deploy a VMware Cluster
 

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -1051,7 +1051,13 @@ In addition to the default cloud account already associated with the private clo
 
 :::caution
 
-If you change the password for a user account in Vcenter, you must also change it in Palette for the same VMware cloud account. Navigate to Clusters >  
+If you change the password for a user account in Vcenter, you must also change it in Palette for the same VMware cloud account. We suggest updating the passwords sequentially to avoid potentially locking Palette out of Vcenter.
+
+1. From the **Menu Menu** navigate to **Clusters** > **Add New Cluster** > **Deploy New Cluster** and select **VMware**. 
+2. Click on **Start VMware Configuration**.
+3. In the **Cloud Account** field, use the drop-down menu to choose the account with the changed password.
+4. Update the password in the **Password** field and click **Validate**. 
+5. Confirm your changes. 
 
 :::
 

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -1066,10 +1066,14 @@ The user account password in vCenter must match the password for the correspondi
 
 ### Change the Password in Palette
 
-1. From the **Menu Menu** navigate to **Clusters** > **Add New Cluster** > **Deploy New Cluster** and select **VMware**. 
+1. From the **Menu Menu** navigate to **Clusters** > **Add New Cluster** > **Deploy New Cluster**,  and select **VMware**.
+
 2. Click on **Start VMware Configuration**.
+
 3. In the **Cloud Account** field, use the drop-down menu to choose the account with the changed password.
-4. Update the password in the **Password** field and click **Validate**. 
+
+4. Update the password in the **Password** field and click the **Validate** button. 
+
 5. Confirm your changes. 
 
 ### Validation

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -1051,13 +1051,14 @@ In addition to the default cloud account already associated with the private clo
 
 :::caution
 
-If you change the password for a user account in vCenter, you must also change it in Palette for the same VMware cloud account. We recommend updating the passwords immediately to avoid potentially locking Palette out of vCenter.
+If you change the password for a user account in vCenter, you must also change it in Palette for the same VMware cloud account. We recommend updating the passwords immediately to avoid potentially locking Palette out of vCenter. For guidance, refer to [Change VMware Cloud Account Password in Palette](/clusters/data-center/vmware#change-vmware-cloud-account-password-in-palette).
 
 :::
 
 
 ## Change VMware Cloud Account Password in Palette
 
+The user account password in vCenter must match the password for the same VMware cloud account in Palette. This section provides steps to change the password in Palette in the event the vCenter password changes.
 
 ### Prerequisites
 

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -1072,6 +1072,12 @@ In addition to the default cloud account already associated with the private clo
 | **Username** | vCenter username|
 | **Password** | vCenter password|
 
+:::caution
+
+If you change the password for a user account in Vcenter, you must also change it in Palette for the same VMware cloud account. Navigate to Clusters >  
+
+:::
+
 # Deploy a VMware Cluster
 
 <video title="vmware-cluster-creation" src="/videos/clusters/data-center/cluster-creation-videos/vmware.mp4"></video>

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -1058,7 +1058,7 @@ If you change the password for a user account in vCenter, you must also change i
 
 ## Change VMware Cloud Account Password in Palette
 
-The user account password in vCenter must match the password for the same VMware cloud account in Palette. This section provides steps to change the password in Palette in the event the vCenter password changes.
+The user account password in vCenter must match the password for the corresponding VMware cloud account in Palette. This section provides steps to change the password in Palette in the event the vCenter password changes.
 
 ### Prerequisites
 

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -1081,6 +1081,10 @@ The user account password in vCenter must match the password for the correspondi
 
 Palette validates the password. Incorrect credentials will result in an error. As an extra precaution, try scaling a cluster up or down.
 
+:::info
+In addition to changing the password for a VMware account, Palette provides a way for you to also change the user associated with an account by entering a new username in the **Username** field. Ensure the new user account has the same permissions as the previous user account in vCenter.
+:::
+
 
 # Deploy a VMware Cluster
 

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -1056,7 +1056,7 @@ If you change the password for a user account in vCenter, you must also change i
 :::
 
 
-## Change VMware Cloud Account Password in Palette
+## Change VMware Cloud Account Password
 
 The user account password in vCenter must match the password for the corresponding VMware cloud account in Palette. This section provides steps to change the password in Palette in the event the vCenter password changes.
 
@@ -1066,15 +1066,17 @@ The user account password in vCenter must match the password for the correspondi
 
 ### Change the Password in Palette
 
-1. From the **Menu Menu** navigate to **Clusters** > **Add New Cluster** > **Deploy New Cluster**,  and select **VMware**.
+1. Log in to [Palette](https://console.spectrocloud.com/).
 
-2. Click on **Start VMware Configuration**.
+2. From the **Menu Menu** navigate to **Clusters** > **Add New Cluster** > **Deploy New Cluster**,  and select **VMware**.
 
-3. In the **Cloud Account** field, use the drop-down menu to choose the account with the changed password.
+3. Click on **Start VMware Configuration**.
 
-4. Update the password in the **Password** field and click the **Validate** button. 
+4. In the **Cloud Account** field, use the drop-down menu to choose the account with the changed password.
 
-5. Confirm your changes. 
+5. Update the password in the **Password** field and click the **Validate** button. 
+
+6. Confirm your changes. 
 
 ### Validation
 

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -1050,9 +1050,7 @@ In addition to the default cloud account already associated with the private clo
 | **Password** | vCenter password|
 
 :::caution
-
 If you change the password for a user account in vCenter, you must also change it in Palette for the same VMware cloud account. We recommend updating the passwords immediately to avoid potentially locking Palette out of vCenter. For guidance, refer to [Change VMware Cloud Account Password in Palette](/clusters/data-center/vmware#change-vmware-cloud-account-password-in-palette).
-
 :::
 
 
@@ -1068,19 +1066,20 @@ The user account password in vCenter must match the password for the correspondi
 
 1. Log in to [Palette](https://console.spectrocloud.com/).
 
-2. From the **Menu Menu** navigate to **Clusters** > **Add New Cluster** > **Deploy New Cluster**,  and select **VMware**.
+2. From the **Menu Menu** navigate to **Tenant Settings** > **Cloud Accounts**.
 
-3. Click on **Start VMware Configuration**.
+3. Click the **three-dot Menu** for the VMware account you want to update, and select **Edit**.
+ 
 
-4. In the **Cloud Account** field, use the drop-down menu to choose the account with the changed password.
+<!-- 4. In the **Cloud Account** field, use the drop-down menu to choose the account with the changed password. -->
 
-5. Update the password in the **Password** field and click the **Validate** button. 
+4. In the window that opens, update the password in the **Password** field and click the **Validate** button. 
 
-6. Confirm your changes. 
+5. Confirm your changes. 
 
 ### Validation
 
-Palette validates the password. Incorrect credentials will result in an error. As an extra precaution, try deploying a cluster.
+Palette validates the password. Incorrect credentials will result in an error. As an extra precaution, try scaling a cluster up or down.
 
 
 # Deploy a VMware Cluster


### PR DESCRIPTION
## Describe the Change

This PR adds a caution that explains when the password for a user account changes in Vcenter, the password in Palette for the same VMware cloud account must also be changed. PR also removes unneeded breaks.

![CleanShot 2023-09-14 at 16 41 25](https://github.com/spectrocloud/librarium/assets/117382432/2420ffe6-aa01-479a-93b1-c07d06c55a3d)

## Review Changes

💻 [Preview](https://deploy-preview-1547--docs-spectrocloud.netlify.app/clusters/data-center/vmware#create-a-vmware-cloud-account)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-866)
