### PR TITLE
Update NotFound.module.scss

### DIFF
--- a/src/theme/NotFound/NotFound.module.scss
+++ b/src/theme/NotFound/NotFound.module.scss
@@ -36,5 +36,5 @@
 }
 
 .title {
-  color: --ifm-navbar-link-color;
+  color: #515e71;
 }


### PR DESCRIPTION
## Describe the Change

This PR statically defines the color of the `h1` tag in the NotFound page. This is required because the dark mode value of the title is too light and the background image does not change.

## Review Changes

Current Dark Mode NotFound Page

![image](https://github.com/spectrocloud/librarium/assets/30413278/71576e1b-2d6d-4fdf-92ee-5e0aa221366c)

Updated Dark Mode NotFound Page
![Screenshot 2023-09-19 at 12 38 32](https://github.com/spectrocloud/librarium/assets/30413278/15711ae7-872b-4b42-91a2-79cd5e680edd)

🎫 [Jira Ticket]()
