### PR TITLE
Remove warning about active development - Update edge.md

### DIFF
--- a/docs/docs-content/clusters/edge/edge.md
+++ b/docs/docs-content/clusters/edge/edge.md
@@ -63,14 +63,6 @@ Edge is built on top of the open-source project [Kairos](https://kairos.io), whi
 Palette manages the installation and all the Day-2 activities, such as scaling, upgrades, and reconfiguration.
 
 
-:::caution
-
-Edge is still in active development and is subject to change. Review the Palette [release notes](../../release-notes.md) for updates and changes.
-
-
-:::
-
-
 
 ## Get Started With Edge
 


### PR DESCRIPTION
Although edge is under active development, so is the rest of palette. the warning was written earlier in the year when edge was indeed under greater change, however now as it is maturing it isn't a good message for us to show while we are working on customer opportunities. This commit simply removes the warning box.

## Describe the Change

This PR .....

## Review Changes

💻 [Add Preview URL]()

🎫 [Jira Ticket]()
