### PR TITLE
docs: fix virtual cluster text that used double infobox

### DIFF
--- a/docs/api-content/api-docs/1-introduction.md
+++ b/docs/api-content/api-docs/1-introduction.md
@@ -144,7 +144,7 @@ The API rate limits are as follows:
 
 
 
-* API request limits are categorized by the parent resources, such as `/v1/cloudconfig/:uid` and `/v1/roles`. You can find a list of all resource types in the [API documentation](v1/palette-apis-4-0.info.mdx). The requests are counted together if you make multiple requests to the same resource type but use different sub-resources. For example, if you make five requests to `/v1/clusterprofiles` and five requests to `/v1/clusterprofiles/macros`, the requests are counted together as ten requests to the resource `clusterprofiles`.
+* API request limits are categorized by the parent resources, such as `/v1/cloudconfig/:uid` and `/v1/roles`. You can find a list of all resource types in the [API documentation](/api/category/palette-api-v1). The requests are counted together if you make multiple requests to the same resource type but use different sub-resources. For example, if you make five requests to `/v1/clusterprofiles` and five requests to `/v1/clusterprofiles/macros`, the requests are counted together as ten requests to the resource `clusterprofiles`.
 
 
 * If too many requests are issued, you may receive an error with HTTP code `429` - `TooManyRequests.` We recommend retrying the API call after a few moments. 

--- a/docs/docs-content/clusters/cluster-groups/create-cluster-group.md
+++ b/docs/docs-content/clusters/cluster-groups/create-cluster-group.md
@@ -8,7 +8,7 @@ tags: ["clusters", "cluster groups"]
 ---
 
 
-Use a cluster group to organize your host clusters into a single logical group. A cluster group is a collection of one or more host clusters that together form a computing platform for you and your users to deploy Palette virtual clusters. Downstream consumers can use the cluster group when using Palette in [App Mode](../../introduction/palette-modes.md#what-is-app-mode).
+Use a cluster group to organize your host clusters into a single logical group. A cluster group is a collection of one or more host clusters that together form a computing platform for you and your users to deploy Palette Virtual Clusters. Downstream consumers can use the cluster group when using Palette in [App Mode](../../introduction/palette-modes.md#what-is-app-mode).
 
 :::info
 

--- a/docs/docs-content/clusters/cluster-groups/create-cluster-group.md
+++ b/docs/docs-content/clusters/cluster-groups/create-cluster-group.md
@@ -8,9 +8,18 @@ tags: ["clusters", "cluster groups"]
 ---
 
 
+Use a cluster group to organize your host clusters into a single logical group. A cluster group is a collection of one or more host clusters that together form a computing platform for you and your users to deploy Palette virtual clusters. Downstream consumers can use the cluster group when using Palette in [App Mode](../../introduction/palette-modes.md#what-is-app-mode).
+
+:::info
+
+Palette does not offer support for host clusters of these types within a cluster group: 
+- Edge clusters 
+- Virtual clusters 
+- Private Cloud Gateway (PCG) cluster
+- Imported clusters with read-only access
+:::
+
 Use the instructions below to create a cluster group.
-
-
 
 ## Prerequisites
 
@@ -42,7 +51,7 @@ Use the instructions below to create a cluster group.
 
 3. Select **Next** to continue.
 
-s
+
 
 4. Use the **Select clusters** drop-down menu to add available host clusters. 
  
@@ -53,11 +62,6 @@ s
 
 :::
 
-:::info
-
- Palette does not offer support for host clusters of these types within a cluster group: edge clusters, virtual clusters, Private Cloud Gateway (PCG) clusters, and imported clusters with read-only access.
-
-:::
 
 5. Click **Next** once you have added all the host clusters you wish to include.
 


### PR DESCRIPTION
## Describe the Change

This PR removes the double infobox introduced by PR #1598 .  @cloudmaniac in the future, avoid creating back-to-back info boxes. This is an anti-pattern due to how distracting they can be, and the text appears a bit too busy when info boxes are stacked. In your defense, we should have caught this before merging. 

![CleanShot 2023-09-27 at 16 52 50](https://github.com/spectrocloud/librarium/assets/29551334/c07535af-9a02-4b6f-ae51-e2173d6c0b81)


## Review Changes

💻 [Add Preview URL]()

