### PR TITLE
docs: added CLI download URL

### DIFF
--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -62,6 +62,7 @@ The Palette Command Line Interface (CLI) is a tool that you can use to interact 
 
 |Version| Operating System |  Checksum (SHA256) |
 |---|---|---|
+|4.0.5| [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.0.5/linux/cli/palette)    | `6762a77c33045b05325a69cd8bcc19d233982441cacd76ebebff143b232a5fe9` | 
 |4.0.4| [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.0.4/linux/cli/palette)    | `4c3885b6498a1d0015afca3d1a1761bca9ec8811caae6047bf3d0790f2aa5b5a` | 
 |4.0.3| [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.0.3/linux/cli/palette)    | `55c8a0b181857e824e12d08ab9786c7b8b171a018c23228a1abd0167cb3788ca` | 
 |4.0.2| [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.0.2/linux/cli/palette)| `01e6b9c73368319fe2855aedcf073526ab73b4ff635997257f8c10a11efd8f0c` |


### PR DESCRIPTION
## Describe the Change

This PR adds a new CLI version to the downloads page. 

## Review Changes

💻 [Preview URL](https://deploy-preview-1658--docs-spectrocloud.netlify.app/spectro-downloads)
