### PR TITLE
Document addition of namespace labels for pods needing elevated privileges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,14 +108,9 @@ verify-url-links: ## Check for broken URLs in production
 	grep -E '^[^,]*,[[:space:]]*([4-9][0-9]{2}|[0-9]{4,}),' temp_report.csv > link_report.csv && rm temp_report.csv
 
 
-verify-url-links-ci: ## Check for broken URLs in production
+verify-url-links-ci: ## Check for broken URLs in production in a GitHub Actions CI environment
 	rm link_report.json || echo "No report exists. Proceeding to scan step"
-	npx linkinator https://docs.spectrocloud.com/ --recurse --timeout 60000 --retry --retry-errors-count 3 --skip '^http(?!.*software-private.spectrocloud\\.com).*$'' --skip ^http(?!.*spectrocloud\\.com).*$"" --format json > temp_report.json
+	npx linkinator https://docs.spectrocloud.com/ --recurse --timeout 60000 --retry --retry-errors-count 3 --skip '^http(?!.*software-private.spectrocloud\\.com).*$'' --skip '^http(?!.*spectrocloud\\.com).*$'' --format json > temp_report.json
 	jq 'del(.links[] | select(.status <= 200))' temp_report.json > link_report.json
 	rm temp_report.json
 	mv link_report.json scripts/
-
-
-verify-url-links-local: build ## Check for broken URLs locally
-	rm link_report.csv || echo "No report exists. Proceeding to scan step"
-	npm run test-links

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -121,6 +121,7 @@ You can change the Pod Security Standards of the namepace where the pod is being
 The example below shows `"monitoring"` as the namespace key with the key value.
    - If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
    - For example, if you the pack creates a namespace called `monitoring`, add the labels to the `monitoring` namespace:
+   
    ```yaml
    pack:
     namespace: "monitoring"

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -110,14 +110,14 @@ To address this issue, you can change the Pod Security Standards of the namespac
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
-1. Navigate to the left **Main Menu** and click on **Profiles**. 
+2. Navigate to the left **Main Menu** and click on **Profiles**. 
 
-1. Select the profile you are using to deploy the cluster. Palette displays the profile stack and details.
+3. Select the profile you are using to deploy the cluster. Palette displays the profile stack and details.
 Click on the layer in the profile stack that contains the pack configuration.
 
-1. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
+4. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
 
-1. In the `namespaceLabels` section, add a subsection with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+5. In the `namespaceLabels` section, add a subsection with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
    - If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
 
 :::tip

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -117,8 +117,8 @@ To address this issue, you can change the Pod Security Standards of the namespac
 
 5. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
 
-6. In the `namespaceLabels` section, add a line with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes on your cluster. 
-7. If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
+6. In the `namespaceLabels` section, add a line with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes on your cluster and only include the major and minor version following the lowercase letter `v`. For example, `v1.25` and `v1.28`.
+7. If a key matching your namespace already exists, add the labels to the value corresponding to that key. 
 
 :::caution
 

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -102,39 +102,43 @@ Cluster deployment fails with the following message.
 Error creating: pods <name of pod> is forbidden: violates PodSecurity "baseline:v<k8s version>": non-default capabilities …
 ```
 
-This can happen when the cluster profile uses Kubernetes 1.25 or later and also includes packs that create pods requiring elevated privileges . 
+This can happen when the cluster profile uses Kubernetes 1.25 or later and also includes packs that create pods requiring elevated privileges. 
 
 ### Debug Steps
 
-You can change the Pod Security Standards of the namepace where the pod is being created to address this issue. 
+To address this issue, you can change the Pod Security Standards of the namespace where the pod is being created. 
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
 2. Navigate to the left **Main Menu** and click on **Profiles**. 
 
-3. Select the profile you are trying to deploy the cluster with and choose the layer that represents your pack. The name of the Pod that failed to be created should give you a clue about which packs you need to modify. 
+3. Select the profile you are using to deploy the cluster. Palette displays the profile stack and details.
+Click on the layer in the profile stack that contains the pack configuration.
+The name of the pod that failed to be created should give you a clue about which packs you need to modify. 
 
 4. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
 
 5. In the `namespaceLabels` section, add a subsection with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
-
-The example below shows `"monitoring"` as the namespace key with the key value.
    - If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
-   - For example, if you the pack creates a namespace called `monitoring`, add the labels to the `monitoring` namespace:
-   
-   ```yaml
-   pack:
-    namespace: "monitoring"
-
-    namespaceLabels:
-        "monitoring": "org=spectro,team=dev,pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v1.28"
-   ```
 
 :::tip
 
 If your pack creates multiple namespaces, and you are not sure which namespaces need the elevated privileges, you can [access the clusteter with the kubectl CLI](https://docs.spectrocloud.com/clusters/cluster-management/palette-webctl/#access-cluster-with-cli) and run [`kubectl get pods`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) to find out which pods are failing at creation in which namespaces. It's recommended that you only apply the labels to namespaces where pods are failing to be created. 
 
 :::
+
+The example below shows `"monitoring"` as the namespace key with the key value.
+
+   
+```yaml
+pack:
+  namespace: "monitoring"
+
+  namespaceLabels:
+    "monitoring": "org=spectro,team=dev,pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v1.28"
+```
+
+
 
 ## Gateway Installer Registration Failures
 

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -110,24 +110,23 @@ To address this issue, you can change the Pod Security Standards of the namespac
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
-2. Navigate to the left **Main Menu** and click on **Profiles**. 
+1. Navigate to the left **Main Menu** and click on **Profiles**. 
 
-3. Select the profile you are using to deploy the cluster. Palette displays the profile stack and details.
+1. Select the profile you are using to deploy the cluster. Palette displays the profile stack and details.
 Click on the layer in the profile stack that contains the pack configuration.
-The name of the pod that failed to be created should give you a clue about which packs you need to modify. 
 
-4. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
+1. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
 
-5. In the `namespaceLabels` section, add a subsection with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+1. In the `namespaceLabels` section, add a subsection with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
    - If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
 
 :::tip
 
-If your pack creates multiple namespaces, and you are not sure which namespaces need the elevated privileges, you can [access the clusteter with the kubectl CLI](https://docs.spectrocloud.com/clusters/cluster-management/palette-webctl/#access-cluster-with-cli) and run [`kubectl get pods`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) to find out which pods are failing at creation in which namespaces. It's recommended that you only apply the labels to namespaces where pods are failing to be created. 
+If your pack creates multiple namespaces, and you are not sure which namespaces need the elevated privileges, you can [access the clusteter with the kubectl CLI](https://docs.spectrocloud.com/clusters/cluster-management/palette-webctl/#access-cluster-with-cli) and run [`kubectl get pods`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) to find out which pods are failing at creation in which namespaces. We recommend that you only apply the labels to namespaces where pods are failing to be created. 
 
 :::
 
-The example below shows `"monitoring"` as the namespace key with the key value.
+The example below shows `"monitoring"` as the namespace key with the key value. In this case, the `monitoring` key already exists under `namespaceLabels`, with its original value being `"org=spectro,team=dev"`. Therefore, we add the labels to the existing value:
 
    
 ```yaml

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -102,22 +102,22 @@ Cluster deployment fails with the following message.
 Error creating: pods <name of pod> is forbidden: violates PodSecurity "baseline:v<k8s version>": non-default capabilities …
 ```
 
-This can happen when the cluster profile uses Kubernetes 1.25 or later and also includes packs that create Pods requiring elevated privileges . 
+This can happen when the cluster profile uses Kubernetes 1.25 or later and also includes packs that create pods requiring elevated privileges . 
 
 ### Debug Steps
 
-You can change the Pod Security Standards of the namepace where the Pod is being created to address this issue. 
+You can change the Pod Security Standards of the namepace where the pod is being created to address this issue. 
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
 2. Navigate to the left **Main Menu** and click on **Profiles**. 
 
-3. Select the profile you are trying to deploy the cluster with and choose the layer that represents your pack. 
+3. Select the profile you are trying to deploy the cluster with and choose the layer that represents your pack. The name of the Pod that failed to be created should give you a clue about which packs you need to modify. 
 
 4. In the YAML file for that pack, under the `pack` field, add a subfield `namespaceLabels` if it doesn't already exist.
 
 5. In the `namespaceLabels` field, add a subfield with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
-   - If a key matching your namespace already exists here, add the labels to the value corresponding to that key.
+   - If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
    - For example, if you the pack creates a namespace called `monitoring`, add the labels to the `monitoring` namespace:
    ```yaml
    pack:
@@ -127,6 +127,11 @@ You can change the Pod Security Standards of the namepace where the Pod is being
         "monitoring": "org=spectro,team=dev,pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v1.28"
    ```
 
+:::tip
+
+If your pack creates multiple namespaces, and you are not sure which namespaces need the elevated privileges, you can [access the clusteter with the kubectl CLI](https://docs.spectrocloud.com/clusters/cluster-management/palette-webctl/#access-cluster-with-cli) and run [`kubectl get pods`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) to find out which pods are failing at creation in which namespaces. It's recommended that you only apply the labels to namespaces where pods are failing to be created. 
+
+:::
 
 ## Gateway Installer Registration Failures
 

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -97,20 +97,27 @@ Common reasons for why a service may fail are:
 
 ## Deployment Violates Pod Security
 Cluster deployment fails with the following message. 
-This can happen when the cluster profile uses Kubernetes 1.25 or later and indicates the pod needs elevated privileges to be created. 
 
 ```
 Error creating: pods <name of pod> is forbidden: violates PodSecurity "baseline:v<k8s version>": non-default capabilities …
 ```
 
+This can happen when the cluster profile uses Kubernetes 1.25 or later and also includes packs that create Pods requiring elevated privileges . 
+
 ### Debug Steps
 
 You can change the Pod Security Standards of the namepace where the Pod is being created to address this issue. 
 
-1. Log in to **Palette** and navigate to the **Profiles** tab. 
-2. Select the profile you are trying to deploy the cluster with and choose the layer that represents your pack. 
-3. In the YAML file for your pack, under the `pack` field, add a subfield `namespaceLabels`.
-4. In the `namespaceLabels` field, add a subfield with the name of your namespace as the key and `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as the value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+1. Log in to [Palette](https://console.spectrocloud.com).
+
+2. Navigate to the left **Main Menu** and click on **Profiles**. 
+
+3. Select the profile you are trying to deploy the cluster with and choose the layer that represents your pack. 
+
+4. In the YAML file for that pack, under the `pack` field, add a subfield `namespaceLabels` if it doesn't already exist.
+
+5. In the `namespaceLabels` field, add a subfield with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+   - If a key matching your namespace already exists here, add the labels to the value corresponding to that key.
    - For example, if you the pack creates a namespace called `monitoring`, add the labels to the `monitoring` namespace:
    ```yaml
    pack:

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -96,7 +96,7 @@ Common reasons for why a service may fail are:
 6. Check stdout for errors. You can also open a support ticket. Visit our [support page](http://support.spectrocloud.io/).
 
 ## Deployment Violates Pod Security
-In cluster profiles running Kubernetes 1.25 or later, some packs contain Pods that need elevated privileges during Pod creation. 
+Cluster deployment fails with the following message. 
 When you try to deploy a cluster with such packs, you get an error message that looks like the following:
 
 ```

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -96,7 +96,7 @@ Common reasons for why a service may fail are:
 6. Check stdout for errors. You can also open a support ticket. Visit our [support page](http://support.spectrocloud.io/).
 
 ## Deployment Violates Pod Security
-In profiles running Kubernetes 1.25 or later, some packs contain pods that need elevated privileges during Pod creation. 
+In cluster profiles running Kubernetes 1.25 or later, some packs contain Pods that need elevated privileges during Pod creation. 
 When you try to deploy a cluster with such packs, you get an error message that looks like the following:
 
 ```

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -117,7 +117,7 @@ To address this issue, you can change the Pod Security Standards of the namespac
 
 5. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
 
-6. In the `namespaceLabels` section, add a line with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+6. In the `namespaceLabels` section, add a line with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes on your cluster. 
 7. If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
 
 :::caution
@@ -133,7 +133,7 @@ For guidance in using the CLI, review [Access Cluster with CLI](./clusters/clust
 ### Examples
 
 The following example shows a pack that creates a namespace called `"monitoring"`. In this example, the `monitoring` namespace does not have any pre-existing labels. 
-We need to add the `namespaceLabels` line as well as the corresponding key-value pair under it to apply the labels to the `monitoring` namespace. 
+You need to add the `namespaceLabels` line as well as the corresponding key-value pair under it to apply the labels to the `monitoring` namespace. 
 
 ```yaml
 pack:
@@ -144,7 +144,7 @@ pack:
 
 ```
 
-This second example is similar to the first one. However, in this example, the `monitoring` key already exists under `namespaceLabels`, with its original value being `"org=spectro,team=dev"`. Therefore, we add the labels to the existing value:
+This second example is similar to the first one. However, in this example, the `monitoring` key already exists under `namespaceLabels`, with its original value being `"org=spectro,team=dev"`. Therefore, you add the labels to the existing value:
    
 ```yaml
 pack:

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -97,7 +97,7 @@ Common reasons for why a service may fail are:
 
 ## Deployment Violates Pod Security
 Cluster deployment fails with the following message. 
-When you try to deploy a cluster with such packs, you get an error message that looks like the following:
+This can happen when the cluster profile uses Kubernetes 1.25 or later and indicates the pod needs elevated privileges to be created. 
 
 ```
 Error creating: pods <name of pod> is forbidden: violates PodSecurity "baseline:v<k8s version>": non-default capabilities …

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -133,7 +133,7 @@ For guidance in using the CLI, review [Access Cluster with CLI](./clusters/clust
 ### Examples
 
 The following example shows a pack that creates a namespace called `"monitoring"`. In this example, the `monitoring` namespace does not have any pre-existing labels. 
-We need to add the `namespaceLabels` line as well as the the corresponding key-value pair under it to apply the labels to the `monitoring` namespace. 
+We need to add the `namespaceLabels` line as well as the corresponding key-value pair under it to apply the labels to the `monitoring` namespace. 
 
 ```yaml
 pack:

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -122,7 +122,7 @@ To address this issue, you can change the Pod Security Standards of the namespac
 
 :::tip
 
-If your pack creates multiple namespaces, and you are not sure which namespaces need the elevated privileges, you can [access the cluster with the kubectl CLI](https://docs.spectrocloud.com/clusters/cluster-management/palette-webctl/#access-cluster-with-cli) and use [`kubectl get pods`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) to find out which pods are failing at creation in which namespaces. We recommend that you only apply the labels to namespaces where pods are failing to be created. 
+If your pack creates multiple namespaces, and you are unsure which ones need the elevated privileges, you can access the cluster with the kubectl CLI and use the `kubectl get pods` command. This command lists pods and their namespaces so you can identify the pods that are failing at creation. We recommend only applying the labels to namespaces where pods fail to be created. For guidance in using the CLI, review [Access Cluster with CLI(./clusters/cluster-management/palette-webctl/#access-cluster-with-cli). To learn more about kubectl pod commands, refer to the [Kubernetes](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) documentation.
 
 :::
 

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -107,10 +107,11 @@ Error creating: pods <name of pod> is forbidden: violates PodSecurity "baseline:
 
 You can change the Pod Security Standards of the namepace where the Pod is being created to address this issue. 
 
-1. Log in to *Palette* and navigate to the *Profiles* tab. 
+1. Log in to **Palette** and navigate to the **Profiles** tab. 
 2. Select the profile you are trying to deploy the cluster with and choose the layer that represents your pack. 
-3. In the YAML file for your pack, under the `pack` field, add a subfield `namespaceLabels`. 4. In the `namespaceLabels` field, add a subfield with the name of your namespace as the key and `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as the value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
-   - For example, if you the pack creates a namespace called "monitoring", add the labels to the monitoring namespace:
+3. In the YAML file for your pack, under the `pack` field, add a subfield `namespaceLabels`.
+4. In the `namespaceLabels` field, add a subfield with the name of your namespace as the key and `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as the value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+   - For example, if you the pack creates a namespace called `monitoring`, add the labels to the `monitoring` namespace:
    ```yaml
    pack:
     namespace: "monitoring"

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -102,7 +102,7 @@ Cluster deployment fails with the following message.
 Error creating: pods <name of pod> is forbidden: violates PodSecurity "baseline:v<k8s version>": non-default capabilities …
 ```
 
-This can happen when the cluster profile uses Kubernetes 1.25 or later and also includes packs that create pods requiring elevated privileges. 
+This can happen when the cluster profile uses Kubernetes 1.25 or later and also includes packs that create pods that require elevated privileges. 
 
 ### Debug Steps
 

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -116,7 +116,9 @@ You can change the Pod Security Standards of the namepace where the pod is being
 
 4. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
 
-5. In the `namespaceLabels` field, add a subfield with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+5. In the `namespaceLabels` section, add a subsection with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+
+The example below shows `"monitoring"` as the namespace key with the key value.
    - If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
    - For example, if you the pack creates a namespace called `monitoring`, add the labels to the `monitoring` namespace:
    ```yaml

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -113,21 +113,38 @@ To address this issue, you can change the Pod Security Standards of the namespac
 2. Navigate to the left **Main Menu** and click on **Profiles**. 
 
 3. Select the profile you are using to deploy the cluster. Palette displays the profile stack and details.
-3. Click on the pack layer in the profile stack that contains the pack configuration.
+4. Click on the pack layer in the profile stack that contains the pack configuration.
 
-4. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
+5. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
 
-5. In the `namespaceLabels` section, add a subsection with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
-   - If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
+6. In the `namespaceLabels` section, add a line with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+7. If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 
 
-:::tip
+:::caution
 
-If your pack creates multiple namespaces, and you are unsure which ones need the elevated privileges, you can access the cluster with the kubectl CLI and use the `kubectl get pods` command. This command lists pods and their namespaces so you can identify the pods that are failing at creation. We recommend only applying the labels to namespaces where pods fail to be created. For guidance in using the CLI, review [Access Cluster with CLI(./clusters/cluster-management/palette-webctl/#access-cluster-with-cli). To learn more about kubectl pod commands, refer to the [Kubernetes](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) documentation.
+We recommend only applying the labels to namespaces where pods fail to be created. 
+If your pack creates multiple namespaces, and you are unsure which ones contain pods that need the elevated privileges, you can access the cluster with the kubectl CLI and use the `kubectl get pods` command. 
+This command lists pods and their namespaces so you can identify the pods that are failing at creation.
+
+For guidance in using the CLI, review [Access Cluster with CLI](./clusters/cluster-management/palette-webctl/#access-cluster-with-cli). To learn more about kubectl pod commands, refer to the [Kubernetes](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) documentation.
 
 :::
 
-The example below shows `"monitoring"` as the namespace key with the key value. In this case, the `monitoring` key already exists under `namespaceLabels`, with its original value being `"org=spectro,team=dev"`. Therefore, we add the labels to the existing value:
+### Examples
 
+The following example shows a pack that creates a namespace called `"monitoring"`. In this example, the `monitoring` namespace does not have any pre-existing labels. 
+We need to add the `namespaceLabels` line as well as the the corresponding key-value pair under it to apply the labels to the `monitoring` namespace. 
+
+```yaml
+pack:
+  namespace: "monitoring"
+
+  namespaceLabels:
+    "monitoring": "pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v1.28"
+
+```
+
+This second example is similar to the first one. However, in this example, the `monitoring` key already exists under `namespaceLabels`, with its original value being `"org=spectro,team=dev"`. Therefore, we add the labels to the existing value:
    
 ```yaml
 pack:

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -122,7 +122,7 @@ Click on the layer in the profile stack that contains the pack configuration.
 
 :::tip
 
-If your pack creates multiple namespaces, and you are not sure which namespaces need the elevated privileges, you can [access the clusteter with the kubectl CLI](https://docs.spectrocloud.com/clusters/cluster-management/palette-webctl/#access-cluster-with-cli) and run [`kubectl get pods`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) to find out which pods are failing at creation in which namespaces. We recommend that you only apply the labels to namespaces where pods are failing to be created. 
+If your pack creates multiple namespaces, and you are not sure which namespaces need the elevated privileges, you can [access the cluster with the kubectl CLI](https://docs.spectrocloud.com/clusters/cluster-management/palette-webctl/#access-cluster-with-cli) and use [`kubectl get pods`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get) to find out which pods are failing at creation in which namespaces. We recommend that you only apply the labels to namespaces where pods are failing to be created. 
 
 :::
 

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -113,7 +113,7 @@ To address this issue, you can change the Pod Security Standards of the namespac
 2. Navigate to the left **Main Menu** and click on **Profiles**. 
 
 3. Select the profile you are using to deploy the cluster. Palette displays the profile stack and details.
-Click on the layer in the profile stack that contains the pack configuration.
+3. Click on the pack layer in the profile stack that contains the pack configuration.
 
 4. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
 

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -114,7 +114,7 @@ You can change the Pod Security Standards of the namepace where the pod is being
 
 3. Select the profile you are trying to deploy the cluster with and choose the layer that represents your pack. The name of the Pod that failed to be created should give you a clue about which packs you need to modify. 
 
-4. In the YAML file for that pack, under the `pack` field, add a subfield `namespaceLabels` if it doesn't already exist.
+4. In the pack's YAML file, add a subfield in the `pack` section called `namespaceLabels` if it does not already exist.
 
 5. In the `namespaceLabels` field, add a subfield with the name of your namespace as the key and add `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as its value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
    - If a key matching your namespace already exists here, add the labels to the value corresponding to that key. 

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -17,7 +17,8 @@ tags: ["troubleshooting", "cluster-deployment"]
 The following steps will help you troubleshoot errors in the event issues arise while deploying a cluster.  
 
 
-## Scenario - Instances Continuously Delete Every 30 Minutes
+## Instances Continuously Delete Every 30 Minutes
+
 
 An instance is launched and terminated every 30 minutes prior to completion of its deployment, and the **Events Tab** lists errors with the following message:
 
@@ -93,6 +94,30 @@ Common reasons for why a service may fail are:
         :::
 
 6. Check stdout for errors. You can also open a support ticket. Visit our [support page](http://support.spectrocloud.io/).
+
+## Deployment Violates Pod Security
+In profiles running Kubernetes 1.25 or later, some packs contain pods that need elevated privileges during Pod creation. 
+When you try to deploy a cluster with such packs, you get an error message that looks like the following:
+
+```
+Error creating: pods <name of pod> is forbidden: violates PodSecurity "baseline:v<k8s version>": non-default capabilities …
+```
+
+### Debug Steps
+
+You can change the Pod Security Standards of the namepace where the Pod is being created to address this issue. 
+
+1. Log in to *Palette* and navigate to the *Profiles* tab. 
+2. Select the profile you are trying to deploy the cluster with and choose the layer that represents your pack. 
+3. In the YAML file for your pack, under the `pack` field, add a subfield `namespaceLabels`. 4. In the `namespaceLabels` field, add a subfield with the name of your namespace as the key and `pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v<k8s_version>` as the value. Replace `<k8s_version>` with the version of Kubernetes that runs on your cluster. 
+   - For example, if you the pack creates a namespace called "monitoring", add the labels to the monitoring namespace:
+   ```yaml
+   pack:
+    namespace: "monitoring"
+
+    namespaceLabels:
+        "monitoring": "org=spectro,team=dev,pod-security.kubernetes.io/enforce=privileged,pod-security.kubernetes.io/enforce-version=v1.28"
+   ```
 
 
 ## Gateway Installer Registration Failures


### PR DESCRIPTION
## Describe the Change

This PR adds the steps to change Pod Security Standards by applying labels to namespaces if users encounter problems during deployment of cluster profiles with Packs that require elevated privileges. 

## Review Changes

💻 [Preview](https://deploy-preview-1706--docs-spectrocloud.netlify.app/troubleshooting/cluster-deployment#deployment-violates-pod-security)

🎫 [PAC-828](https://spectrocloud.atlassian.net/browse/PAC-828)
