### PR TITLE
chore: added correct field to display

### DIFF
--- a/src/components/PacksTable/PacksTable.tsx
+++ b/src/components/PacksTable/PacksTable.tsx
@@ -92,9 +92,9 @@ const columns: PacksColumn[] = [
   },
   {
     title: "Status",
-    dataIndex: "status",
-    key: "status",
-    sorter: (a: Pack, b: Pack) => a.status.localeCompare(b.status),
+    dataIndex: "prodStatus",
+    key: "prodStatus",
+    sorter: (a: Pack, b: Pack) => a.prodStatus.localeCompare(b.prodStatus),
     render: (status: string) => {
       const className = statusClassNames[status];
       return <span className={className}>{status}</span>;


### PR DESCRIPTION
## Describe the Change

This PR adds the missing logic to display the `prodStatus` field.
