### PR TITLE
chore: updated netlify.sh script

### DIFF
--- a/scripts/netlify.sh
+++ b/scripts/netlify.sh
@@ -5,8 +5,8 @@
 # Release branches get a preview through docs-latest.spectrocloud.com
 
 
-# List of branches to NOT create an automatic Netlify preview
-disallowed_branches=("master" "release-*" "version-*")
+# List of branches to NOT create an automatic Netlify preview. This also includes branch-deploy previews.
+disallowed_branches=("master" "release-*")
 
 # Get current branch name
 current_branch=$(git branch --show-current)


### PR DESCRIPTION
## Describe the Change

This PR removes the `version-*` element from the netlify.sh script. This will enable branch-deploys for our version branches. 

