### PR TITLE
Update App Mode Table

### DIFF
--- a/docs/docs-content/devx/devx.md
+++ b/docs/docs-content/devx/devx.md
@@ -29,8 +29,8 @@ App Mode is available for the following Palette platforms.
 | Platform | Supported | Palette Version |
 |---|----|---|
 | SaaS | ✅| `v3.0.0` or greater. |
-| Self-hosted | ✅ | `3.4.0` or greater. |
-| Airgap Self-hosted | ❌| N/A.
+| Self-hosted | ✅ | `v3.4.0` or greater. |
+| Airgap Self-hosted | ✅ |`v4.0.0` or greater. |
 
 
 ## Manage Resources


### PR DESCRIPTION
## Describe the Change

This PR updates the App mode table that explains what modes of Palette users can use app mode. 

![CleanShot 2023-11-02 at 07 16 26](https://github.com/spectrocloud/librarium/assets/29551334/2c7ebd63-4ea8-4c82-a2e7-be2a0d3281b0)


## Review Changes

💻 [Preview URL](https://deploy-preview-1750--docs-spectrocloud.netlify.app/devx/#supported-platforms)

