### PR TITLE
docs: updated oras statement DOC-909

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/airgap/kubernetes-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/airgap/kubernetes-airgap-instructions.md
@@ -66,7 +66,7 @@ Carefully review the [prerequisites](#prerequisites) section before proceeding. 
 
   - [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) - Required for AWS ECR.
 
-  - [Oras](https://oras.land/docs/installation.html) CLI v1.0.0 - Required for the setup script. DO NOT USE a version greater than 1.0.0.
+  - [Oras](https://oras.land/docs/installation.html) CLI v1.0.0 - This version is explicitly required for the setup script.
 
   - [zip](https://linux.die.net/man/3/zip) - Required for the setup script.
 

--- a/docs/docs-content/enterprise-version/install-palette/airgap/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/airgap/vmware-vsphere-airgap-instructions.md
@@ -66,7 +66,7 @@ Carefully review the [prerequisites](#prerequisites) section before proceeding. 
 
   - [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) - Required for AWS ECR.
 
-  - [Oras](https://oras.land/docs/installation.html) CLI v1.0.0 - Required for the setup script. DO NOT USE a version greater than 1.0.0.
+  - [Oras](https://oras.land/docs/installation.html) CLI v1.0.0 - This version is explicitly required for the setup script.
 
   - [zip](https://linux.die.net/man/3/zip) - required for the setup script.
 

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/kubernetes-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/kubernetes-airgap-instructions.md
@@ -66,7 +66,7 @@ Carefully review the [prerequisites](#prerequisites) section before proceeding. 
 
   - [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) - Required for AWS ECR.
 
-  - [Oras](https://oras.land/docs/installation.html) CLI v1.0.0 - Required for the setup script. DO NOT USE a version greater than 1.0.0.
+  - [Oras](https://oras.land/docs/installation.html) CLI v1.0.0 - This version is explicitly required for the setup script.
 
   - [zip](https://linux.die.net/man/3/zip) - Required for the setup script.
 

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/vmware-vsphere-airgap-instructions.md
@@ -66,7 +66,7 @@ Carefully review the [prerequisites](#prerequisites) section before proceeding. 
 
   - [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) - Required for AWS ECR.
 
-  - [Oras](https://oras.land/docs/installation.html) CLI v1.0.0 - Required for the setup script. DO NOT USE a version greater than 1.0.0.
+  - [Oras](https://oras.land/docs/installation.html) CLI v1.0.0 - This version is explicitly required for the setup script.
 
   - [zip](https://linux.die.net/man/3/zip) - required for the setup script.
 


### PR DESCRIPTION
## Describe the Change

This PR updates the Oras version prereqs statement.

- [VerteX Airgap Kubernetes](https://deploy-preview-1759--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/airgap/kubernetes-airgap-instructions)
- [VerteX Airgap VMware](https://deploy-preview-1759--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/airgap/vmware-vsphere-airgap-instructions)
- [Airgap Kubernetes](https://deploy-preview-1759--docs-spectrocloud.netlify.app/enterprise-version/install-palette/airgap/kubernetes-airgap-instructions)
- [AIrgap VMware](https://deploy-preview-1759--docs-spectrocloud.netlify.app/enterprise-version/install-palette/airgap/vmware-vsphere-airgap-instructions)

## Review Changes

💻 [Preview URL](https://deploy-preview-1759--docs-spectrocloud.netlify.app/)

🎫 [DOC-909](https://spectrocloud.atlassian.net/browse/DOC-909)
