### PR TITLE
chore: update approvers readme section and move CODEOWNERS (DOC-913)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Docs & Tutorials
-content/ @spectrocloud/docs-education
+docs/docs-content/ @spectrocloud/docs-education
 # Images
-assets/docs/images/ @spectrocloud/docs-education
+static/assets/docs/images/ @spectrocloud/docs-education
 # Writing Checks
 vale/  @spectrocloud/docs-education
 # CI/CD Related

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ To add a Service to the Service List complete the following actions:
 
 ### Images or other assets
 
-All images must reside in the [`assets/docs/images`](./assets/docs/images/) folder.
+All images must reside in the [`static/assets/docs/images`](./static/assets/docs/images/) folder.
 
 ```md
 ![alt text](/clusterprofiles.png "cluster profiles example")
@@ -486,7 +486,7 @@ By default Netlify previews are enabled for pull requests. However, some branche
 
 ## Approvers/Reviewers
 
-The content in the `docs/` folder require approval from the documentation team. The list of approvers and reviewers can be found in the [OWNERS_ALIAS](./content/OWNER_ALIASES) file. Only members of the documentation team may modify this file.
+The content in this repository requires approval from the documentation team. The approval rules can be found in the [CODEOWNERS](./CODEOWNERS) file. Only members of the documentation team may modify this file.
 
 # Check Writing
 


### PR DESCRIPTION


## Describe the Change

This PR makes the following changes:
- Updates `Approvers/Reviewers`README section
- Update `Images` assets path
- Moves `CODEOWNERS` file from `/docs` to root for a more standard layout

## Review Changes

🎫 [DOC-913](https://spectrocloud.atlassian.net/browse/DOC-913)
