### PR TITLE
Correct a heading

### DIFF
--- a/docs/docs-content/clusters/edge/edge-configuration/cloud-init.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/cloud-init.md
@@ -219,7 +219,7 @@ stages:
 ```
 
 
-#### Pass a Sensitive Information
+#### Pass Sensitive Information
 
 If you need to transmit sensitive information, such as credentials, during the site installation phase, you can make the Edge installer skip copying specific stages to the edge hosts. The Edge installer will skip copying the stages that follow the `skip-copy-[string]` naming convention. Refer to the [Sensitive Information in the User Data Stages](skip-copying-stages.md) guide to learn more. 
 <br />


### PR DESCRIPTION
Changed "Pass a Sensitive Information" to "Pass Sensitive Information".

![CleanShot 2023-11-14 at 15 27 19](https://github.com/spectrocloud/librarium/assets/117382432/067b995a-8375-48ca-ba88-917147908ff0)


## Describe the Change

This PR corrects a heading to remove the word "a".

## Review Changes

💻 [Preview URL](https://deploy-preview-1805--docs-spectrocloud.netlify.app/clusters/edge/edge-configuration/cloud-init)


