### PR TITLE
Deprecated packs style

### DIFF
--- a/src/components/PacksTable/PackTable.test.tsx
+++ b/src/components/PacksTable/PackTable.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, waitFor, screen, fireEvent } from "@testing-library/react";
 import fetchMock from "jest-fetch-mock";
 import FilteredTable from "./PacksTable";
+import { toTitleCase } from "./PacksTable";
 // Enable fetch mocking
 fetchMock.enableMocks();
 
@@ -102,4 +103,33 @@ describe("FilteredTable Tests", () => {
     expect(screen.getByText("EKS, vSphere")).toBeInTheDocument();
   });
 
+});
+
+
+describe('toTitleCase', () => {
+  it('converts a dasherized string to title case', () => {
+      expect(toTitleCase("my-example-string")).toBe("My Example String");
+  });
+
+  it('converts a camelCase string to title case', () => {
+      expect(toTitleCase("myExampleString")).toBe("My Example String");
+  });
+
+  it('drops CNI from the string', () => {
+      expect(toTitleCase("my-example-CNI-string")).toBe("My Example String");
+  });
+
+  it('drops CSI from the string', () => {
+      expect(toTitleCase("myCSIExampleString")).toBe("My Example String");
+  });
+
+  it('converts aws to AWS in a string', () => {
+      expect(toTitleCase("my-example-aws-string")).toBe("My Example AWS String");
+  });
+
+  it('handles mixed cases with aws, CNI, and CSI correctly', () => {
+      expect(toTitleCase("myAwsExampleCNIStringCSI")).toBe("My AWS Example String");
+  });
+
+  // Add more test cases as necessary
 });

--- a/src/components/PacksTable/PackTable.test.tsx
+++ b/src/components/PacksTable/PackTable.test.tsx
@@ -115,21 +115,9 @@ describe('toTitleCase', () => {
       expect(toTitleCase("myExampleString")).toBe("My Example String");
   });
 
-  it('drops CNI from the string', () => {
-      expect(toTitleCase("my-example-CNI-string")).toBe("My Example String");
-  });
-
-  it('drops CSI from the string', () => {
-      expect(toTitleCase("myCSIExampleString")).toBe("My Example String");
-  });
 
   it('converts aws to AWS in a string', () => {
       expect(toTitleCase("my-example-aws-string")).toBe("My Example AWS String");
   });
 
-  it('handles mixed cases with aws, CNI, and CSI correctly', () => {
-      expect(toTitleCase("myAwsExampleCNIStringCSI")).toBe("My AWS Example String");
-  });
-
-  // Add more test cases as necessary
 });

--- a/src/components/PacksTable/PacksTable.tsx
+++ b/src/components/PacksTable/PacksTable.tsx
@@ -197,17 +197,15 @@ const FilteredTable: React.FC = () => {
 // Convert the pack name to title case
 export function toTitleCase(str:string) {
   return str
-       // Replace 'aws' with 'AWS' and handle camelCase and dashes
-      .replace(/aws/gi, 'AWS')
       .replace(/([a-z])([A-Z])|-/g, '$1 $2')
       // Split, filter, and capitalize words
       .split(/\s+/)
       .map(word => {
         // Words that should be capitalized
-          if (['CNI', 'CSI', 'OSS', 'EBS',].includes(word.toUpperCase())) {
+          if (['CNI', 'CSI', 'OSS', 'EBS', 'AWS'].includes(word.toUpperCase())) {
               return word.toUpperCase();
           }
-          return word === 'AWS' ? 'AWS' : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+          return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
       })
       .filter(word => word)
       .join(' ');

--- a/src/components/PacksTable/PacksTable.tsx
+++ b/src/components/PacksTable/PacksTable.tsx
@@ -142,7 +142,14 @@ const FilteredTable: React.FC = () => {
     fetch("/packs-data/packs_report.json")
       .then((response) => response.json())
       .then((packData: PacksData) => {
-        const deprecatedPackData = packData.Packs.filter((pack) => {  
+        const deprecatedPackData = packData.Packs.filter((pack) => { 
+
+          if (pack.displayName == "") {
+            pack.displayName = toTitleCase(pack.name);
+            pack.timeLastUpdated = "-"
+            pack.packLastModifiedDate = "-"
+          }
+
           return pack.prodStatus !== "active" && pack.prodStatus !== "unknown"
         });
         setDeprecatedPacks(deprecatedPackData);
@@ -183,5 +190,21 @@ const FilteredTable: React.FC = () => {
     </div>
   );
 };
+
+
+export function toTitleCase(str:string) {
+  const words = str.replace(/([A-Z])/g, ' $1').split(/-|\s/);
+  const processedWords = words.map(word => {
+      if (word.toLowerCase() === 'aws') {
+          return 'AWS';
+      } else if (word.toUpperCase() !== 'CNI' && word.toUpperCase() !== 'CSI') {
+          return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+      }
+      return '';
+  }).filter(word => word !== '');
+
+  return processedWords.join(' ');
+}
+
 
 export default FilteredTable;

--- a/src/components/PacksTable/PacksTable.tsx
+++ b/src/components/PacksTable/PacksTable.tsx
@@ -144,6 +144,9 @@ const FilteredTable: React.FC = () => {
       .then((packData: PacksData) => {
         const deprecatedPackData = packData.Packs.filter((pack) => { 
 
+          // Handle the case where the pack name is empty.
+          // This is applicable when the API returns a pack with no name.
+          // The API also does not include the last modified date for these packs.
           if (pack.displayName == "") {
             pack.displayName = toTitleCase(pack.name);
             pack.timeLastUpdated = "-"
@@ -191,19 +194,23 @@ const FilteredTable: React.FC = () => {
   );
 };
 
-
+// Convert the pack name to title case
 export function toTitleCase(str:string) {
-  const words = str.replace(/([A-Z])/g, ' $1').split(/-|\s/);
-  const processedWords = words.map(word => {
-      if (word.toLowerCase() === 'aws') {
-          return 'AWS';
-      } else if (word.toUpperCase() !== 'CNI' && word.toUpperCase() !== 'CSI') {
-          return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-      }
-      return '';
-  }).filter(word => word !== '');
-
-  return processedWords.join(' ');
+  return str
+       // Replace 'aws' with 'AWS' and handle camelCase and dashes
+      .replace(/aws/gi, 'AWS')
+      .replace(/([a-z])([A-Z])|-/g, '$1 $2')
+      // Split, filter, and capitalize words
+      .split(/\s+/)
+      .map(word => {
+        // Words that should be capitalized
+          if (['CNI', 'CSI', 'OSS', 'EBS',].includes(word.toUpperCase())) {
+              return word.toUpperCase();
+          }
+          return word === 'AWS' ? 'AWS' : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+      })
+      .filter(word => word)
+      .join(' ');
 }
 
 


### PR DESCRIPTION
## Describe the Change

This PR fixed the issue when some packs are not in the git packs repository but are available through the API. These packs don't have a DisplayName value, nor do they have modified date information. 

![CleanShot 2023-11-17 at 11 46 24](https://github.com/spectrocloud/librarium/assets/29551334/d42e10c9-4641-417e-abe2-bb073e3b40a9)

## Review Changes

💻 [Preview URL](https://deploy-preview-1819--docs-spectrocloud.netlify.app/integrations/deprecated-packs)

