### PR TITLE
Offline Docs

### DIFF
--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -33,6 +33,6 @@ jobs:
         with:
           context: .
           # build-args: 
-          platforms: linux/amd64,linux/arm64, windows/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}:nightly

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -28,7 +28,6 @@ jobs:
 
       - name: Compile
         run: |
-          make versions-ci
           make build
 
 

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -33,6 +33,6 @@ jobs:
         with:
           context: .
           # build-args: 
-          platforms: linux/amd64,linux/arm64, windows/amd64, windows/arm64
+          platforms: linux/amd64,linux/arm64, windows/amd64
           push: true
           tags: ghcr.io/${{ github.repository }}:nightly

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -1,0 +1,31 @@
+name: Nighly Docker Build
+
+on:
+  push:
+    branches-ignore:
+      - "main"
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          # build-args: 
+          platforms: linux/amd64,linux/arm64, windows/amd64, windows/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository }}:nightly

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -7,6 +7,10 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # We cannot use our production values for nightly Docker builds as that would leak our production secrets.
+  ALGOLIA_ADMIN_KEY: "123456789"
+  ALGOLIA_APP_ID: "123456789"
+  ALGOLIA_SEARCH_KEY: "123456789"
 
 jobs:
   build:

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
@@ -26,6 +33,6 @@ jobs:
         with:
           context: .
           # build-args: 
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64, windows/amd64, windows/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}:nightly

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -26,6 +26,6 @@ jobs:
         with:
           context: .
           # build-args: 
-          platforms: linux/amd64,linux/arm64, windows/amd64, windows/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}:nightly

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -1,9 +1,9 @@
 name: Nighly Docker Build
 
 on:
-  push:
-    branches-ignore:
-      - "main"
+  schedule:
+    - cron: '15 22 * * 1-5'  # 22:15 UTC, Monday through Friday
+  workflow_dispatch:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ./Dockerfile-offline
           # build-args: 
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -10,9 +10,22 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Compile
+        run: |
+          make versions-ci
+          make build
 
 
       - name: Set up QEMU

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
 # This is the default workflow that uses the self-hosted runner. The self-hosted runner is slower than the GitHub-hosted large runner, but it does not incurr additional charges.
   build-self-hosted-runner:
     if: ${{ github.event.inputs.useGitHubHostedLargeRunner != 'true' || github.event_name == 'schedule' }}
-    name: Build Website
+    name: Build Website (Self-Hosted Runner)
     runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
     steps:
       - name: Checkout Repository
@@ -67,7 +67,7 @@ jobs:
 #  Use this workflow if you want to use the GitHub-hosted large runner. Useful for scenarios when you need a change to deploy faster than the self-hosted runner can build it.
   build-large-runner:
     if: ${{ github.event.inputs.useGitHubHostedLargeRunner == 'true' && github.event_name != 'schedule' }}
-    name: Build Website
+    name: Build Website (GitHub-Hosted Large Runner)
     runs-on: 
       group: 'Doc Runners'
       labels: docbot

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,4 @@
+:80 {
+	root * /srv
+	file_server
+}

--- a/Dockerfile-offline
+++ b/Dockerfile-offline
@@ -1,0 +1,21 @@
+FROM node:18-alpine as builder
+
+COPY --chown=node . .
+
+ENV ALGOLIA_APP_ID 1234567890
+ENV ALGOLIA_SEARCH_KEY 1234567890
+
+WORKDIR /librarium
+
+RUN npm ci && \
+npm run build
+
+
+FROM caddy:latest
+
+COPY --from=builder build /srv
+COPY --from=builder Caddyfile /etc/caddy/Caddyfile
+
+EXPOSE 80 443 2015 2019
+
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/Dockerfile-offline
+++ b/Dockerfile-offline
@@ -1,16 +1,7 @@
-FROM node:18-alpine as builder
-
-COPY --chown=node . .
-
-ENV ALGOLIA_APP_ID 1234567890
-ENV ALGOLIA_SEARCH_KEY 1234567890
-
-WORKDIR /librarium
-
 FROM caddy:latest
 
-COPY --from=builder build /srv
-COPY --from=builder Caddyfile /etc/caddy/Caddyfile
+COPY build /srv
+COPY Caddyfile /etc/caddy/Caddyfile
 
 EXPOSE 80 443 2015 2019
 

--- a/Dockerfile-offline
+++ b/Dockerfile-offline
@@ -7,10 +7,6 @@ ENV ALGOLIA_SEARCH_KEY 1234567890
 
 WORKDIR /librarium
 
-RUN npm ci && \
-npm run build
-
-
 FROM caddy:latest
 
 COPY --from=builder build /srv

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/airgap.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/airgap.md
@@ -75,3 +75,5 @@ Each platform guide provides detailed instructions on how to complete the pre-in
 - [Checklist](checklist.md)
 
 - [Additional Packs](supplemental-packs.md)
+
+- [Offline Documentation](offline-docs.md)

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/offline-docs.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/offline-docs.md
@@ -46,7 +46,7 @@ The following software must be installed on your system:
     docker run --publish 8080:80 --publish 2019:2019 --rm ghcr.io/spectrocloud/librarium:nightly
     ```
 
-    :::note
+    :::info
 
     If another process is using port `8080`, you can change the port mapping to use a different port. For example, to use port `8081`, use the following command:
 

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/offline-docs.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/offline-docs.md
@@ -1,0 +1,91 @@
+---
+sidebar_label: "Offline Documentation"
+title: "Offline Documentation"
+description: "Learn how to use the Palette Vertex documentation offline."
+icon: ""
+hide_table_of_contents: false
+sidebar_position: 60
+tags: ["vertex", "enterprise", "airgap", "kubernetes", "offline"]
+keywords: ["self-hosted", "vertex"]
+---
+
+
+If you are in an environment that requires the Palette Vertex documentation to be available offline, you can use our offline Docker image to serve the documentation locally. The image is updated nightly to ensure that the latest documentation is available. When you start the container, the documentation is available at `http://localhost:8080` and you can access it using your browser.
+
+### Limitations
+
+The following limitations apply when using the offline documentation:
+
+- Only the latest version of the documentation is available.
+
+- The search functionality is not available.
+
+- The documentation AI helper is not available.
+
+
+### Prerequisites
+
+The following software must be installed on your system:
+
+- [Docker](https://docs.docker.com/get-docker/) - The offline documentation is provided as a Docker image.
+
+- A web browser.
+
+- [tar](https://www.gnu.org/software/tar/) - This is only required if you need to deploy the offline documentation to a device without internet access.
+
+
+## Deploy the Offline Documentation
+
+1. Download and start the offline documentation container. Use the following command to start the container.
+
+    ```shell
+    docker run --publish 8080:80 --publish 2019:2019 --rm ghcr.io/spectrocloud/librarium:nightly
+    ```
+
+    :::note
+
+    If another process is using port `8080`, you can change the port mapping to use a different port. For example, to use port `8081`, use the following command:
+
+    ```shell
+    docker run --publish 8081:80 --publish 2019:2019 --rm ghcr.io/spectrocloud/librarium:nightly
+    ```
+
+    :::
+
+2. Open a browser and navigate to `http://localhost:8080` to view the documentation.
+
+
+3. If you need to deploy the offline documentation to a device without internet access, you can use the following command to save the container image to a tar file.
+
+    ```shell
+    docker save ghcr.io/spectrocloud/librarium:nightly > docs.tar
+    ```
+
+4. Copy the **docs.tar** file to the device without internet access.
+
+
+5. Once the **docs.tar** file is on the target device, you can load the container image using the following command.
+
+    ```shell
+    docker load < docs.tar
+    ```
+
+    ```shell hideClipboard
+    5f4d9fc4d98d: Loading layer [==================================================>]  7.949MB/7.949MB
+    1a76f1c3e1ac: Loading layer [==================================================>]  1.369MB/1.369MB
+    810693419710: Loading layer [==================================================>]  28.67kB/28.67kB
+    ba48f3160731: Loading layer [==================================================>]  39.59MB/39.59MB
+    9097de2c1f3e: Loading layer [==================================================>]  523.2MB/523.2MB
+    0ca22615467b: Loading layer [==================================================>]  3.072kB/3.072kB
+    Loaded image: ghcr.io/spectrocloud/librarium:nightly
+    ```
+
+6. You can then start the container using the same command from step 1.
+
+  ```shell
+  docker run --publish 8080:80 --publish 2019:2019 --rm ghcr.io/spectrocloud/librarium:nightly
+  ```
+
+## Validation
+
+To validate that the offline documentation is working, open a browser and navigate to `http://localhost:8080`. The documentation should be displayed in the browser.

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/offline-docs.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/offline-docs.md
@@ -27,6 +27,10 @@ The following limitations apply when using the offline documentation:
 
 The following software must be installed on your system:
 
+
+- A Linux environment in an AMD64 or ARM64 architecture. The Docker image is only available for Linux AMD64 and ARM64 architectures.
+
+
 - [Docker](https://docs.docker.com/get-docker/) - The offline documentation is provided as a Docker image.
 
 - A web browser.


### PR DESCRIPTION
## Describe the Change

This PR adds documentation and logic for how to access the offline documentation.

## Review Changes

💻 [Preview URL](https://deploy-preview-1830--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/airgap/offline-docs)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-922)
