### PR TITLE
Helm Chart Deployments

### DIFF
--- a/Charts/Chart.yaml
+++ b/Charts/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: spectrocloud-librarium
+description: A Helm chart for SpectroCloud Docs
+version: 0.1.0

--- a/Charts/Chart.yaml
+++ b/Charts/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: spectrocloud-librarium
-description: A Helm chart for SpectroCloud Docs
+description: A Helm chart for deploying Spectro Cloud documentation offline.
 version: 0.1.0

--- a/Charts/templates/deployment.yaml
+++ b/Charts/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    group: {{ .Chart.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+        group: {{ .Chart.Name }}
+    spec:
+      serviceAccountName: restart-docs
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/Charts/templates/deployment.yaml
+++ b/Charts/templates/deployment.yaml
@@ -20,4 +20,10 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.port }}
+            failureThreshold: 1
+            periodSeconds: 60
+            terminationGracePeriodSeconds: 60

--- a/Charts/templates/job.yaml
+++ b/Charts/templates/job.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: restart-docs
+  namespace: {{ .Chart.Name }}
+spec:
+  concurrencyPolicy: Forbid
+  schedule: '0 0 * * *'
+  jobTemplate:
+    spec:
+      backoffLimit: 2 
+      activeDeadlineSeconds: 600 
+      template:
+        spec:
+          serviceAccountName: restart-docs
+          restartPolicy: Never
+          containers:
+            - name: kubectl
+              image: bitnami/kubectl
+              command:
+                - 'kubectl'
+                - 'rollout'
+                - 'restart'
+                - 'deployment/{{ .Chart.Name }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: restart-docs
+  namespace: {{ .Chart.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: restart-docs
+subjects:
+  - kind: ServiceAccount
+    name: restart-docs
+    namespace: {{ .Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: restart-docs
+  namespace: {{ .Chart.Name }}
+rules:
+  - apiGroups: ["apps", "extensions"]
+    resources: ["deployments"]
+    resourceNames: ["{{ .Chart.Name }}"]
+    verbs: ["get", "patch"]
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: restart-docs
+  namespace: {{ .Chart.Name }}

--- a/Charts/templates/namespace.yaml
+++ b/Charts/templates/namespace.yaml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    name: {{ .Chart.Name }}

--- a/Charts/templates/service.yaml
+++ b/Charts/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+  labels: 
+    group: {{ .Chart.Name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: restart-docs
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80

--- a/Charts/values.yaml
+++ b/Charts/values.yaml
@@ -1,0 +1,10 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/spectrocloud/librarium
+  tag: "nightly"
+  pullPolicy: Always
+
+service:
+  type: ClusterIP
+  port: 8000

--- a/Charts/values.yaml
+++ b/Charts/values.yaml
@@ -7,4 +7,4 @@ image:
 
 service:
   type: ClusterIP
-  port: 8000
+  port: 8080


### PR DESCRIPTION
## Describe the Change

This PR creates a simple helm chart that deploys Spectro Cloud docs. In addition is a CronJob task that will re-deploy the deployment once a day, ensuring docs are up to date with the upstream OCI.

## Review Changes

💻 [Add Preview URL]()

🎫 [Jira Ticket]()