### PR TITLE
docs: updated airgap binaries and ova list DOC-925

### DIFF
--- a/docs/docs-content/vertex/install-palette-vertex/airgap/supplemental-packs.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/supplemental-packs.md
@@ -113,13 +113,13 @@ The following table lists additional OVAs that may be required depending on the 
 
 ### Usage Instructions
 
-Use the provided download URL to download the OVA and upload it to your vSphere environment. The OVA must be uploaded to the `spectro-templates ` older VerteX can access it. One additional note about uploaded OVAs, the OVA name must be prefixed with `r_` to be recognized by VerteX. You can rename the OVA before you upload it or after you upload it to vSphere. 
+Use the provided download URL to download the OVA and upload it to your vSphere environment. The OVA must be uploaded to the `spectro-templates ` so VerteX can access it. One additional note about uploaded OVAs, the OVA name must be prefixed with `r_` to be recognized by VerteX. You can rename the OVA before you upload it or after you upload it to vSphere. 
 
 
 <Tabs>
 <TabItem label="curl" value="curl">
 
-The following example shows how to download the `u-2004-0-k-1259-fips.ova` OVA and rename it to `r_u-2004-0-k-1259-fips.ova` by using `curl` and the `--output` flag. 
+The following example shows how to download the `u-2004-0-k-1259-fips.ova` OVA and rename it to `r_u-2004-0-k-1259-fips.ova` using `curl` and the `--output` flag. 
 
 ```shell
 curl --output r_u-2004-0-k-1259-fips.ova \
@@ -130,7 +130,7 @@ https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-1259-fip
 
 <TabItem label="wget" value="wget">
 
-The following example shows how to download the `u-2004-0-k-1259-fips.ova` OVA and rename it to `r_u-2004-0-k-1259-fips.ova` by using `wget` and the `--output-document` flag. 
+The following example shows how to download the `u-2004-0-k-1259-fips.ova` OVA and rename it to `r_u-2004-0-k-1259-fips.ova` using `wget` and the `--output-document` flag. 
 
 ```shell
 wget --quiet --show-progress \

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/supplemental-packs.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/supplemental-packs.md
@@ -51,17 +51,92 @@ Review the following table to determine which pack binaries you need to download
 | `airgap-fips-pack-ubuntu-vsphere-20.04.bin`                 | https://software-private.spectrocloud.com/airgap-fips/packs/airgap-fips-pack-ubuntu-vsphere-20.04.bin   |
 
 
-## Download Instructions
+### Usage Instructions
 
-To download a binary you must provide the username and password for the support team's private repository. Reach out to our support team to [obtain the credentials](../../vertex.md#access-palette-vertex). The following example shows how to download the `airgap-fips-pack-amazon-linux-eks-1.0.0.bin` binary.
+To download a binary you must provide the username and password for the support team's private repository. Reach out to our support team to [obtain the credentials](../../vertex.md#access-palette-vertex).
+
+
+
+ The following example shows how to download the `airgap-fips-pack-amazon-linux-eks-1.0.0.bin` binary. Replace `XXXX` with your username and `YYYY` with your password.
+
+
+<Tabs>
+<TabItem label="curl" value="curl">
+
 
 ```bash
-$ curl --user XXXXX:YYYYY https://software-private.spectrocloud.com/airgap-fips/packs/airgap-fips-pack-amazon-linux-eks-1.0.0.bin \
- --output airgap-fips-pack-amazon-linux-eks-1.0.0.bin
+curl --user 'XXXX:YYYY' \
+https://software-private.spectrocloud.com/airgap-fips/packs/airgap-fips-pack-amazon-linux-eks-1.0.0.bin \
+--output airgap-fips-pack-amazon-linux-eks-1.0.0.bin
 ```
+
+</TabItem> 
+
+<TabItem label="wget" value="wget">
+
+
+
+```shell
+wget --user='XXXX' --password='YYYY' \
+--output-document=airgap-fips-pack-amazon-linux-eks-1.0.0.bin \
+https://software-private.spectrocloud.com/airgap-fips/packs/airgap-fips-pack-amazon-linux-eks-1.0.0.bin
+```
+
+</TabItem> 
+</Tabs>
+
+
 
 :::info
 
 All binaries require the OCI environment variables to be set and for the registry credentials to be available.
 
 :::
+
+
+## Additional OVAs
+
+The following table lists additional OVAs that may be required depending on the Kubernetes version and distribution you want to use for your workload clusters.
+
+|**Kubernetes Version**| **OVA Name**  | **Download URL**   |
+|----------------------|---------------|--------------------|
+| Kubernetes 1.25.9    | u-2004-0-k-1259-fips.ova  | `https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-1259-fips.ova`	|
+| Kubernetes 1.25.10   | u-2004-0-k-12510-fips.ova | `https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-12510-fips.ova`	|
+| Kubernetes 1.26.4    | u-2004-0-k-1264-fips.ova  | `https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-1264-fips.ova`	|
+| Kubernetes 1.26.5    | u-2004-0-k-1265-fips.ova  | `https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-1265-fips.ova`	|
+| Kubernetes 1.27.1    | u-2004-0-k-1271-fips.ova  | `https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-1271-fips.ova`	|
+| Kubernetes 1.27.2    | u-2004-0-k-1272-fips.ova  | `https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-1272-fips.ova`	|
+| RKE2 1.25.10          | u-2004-0-k-rke2-1250-fips.ova  | `https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-rke2-1250-fips.ova`	|
+| RKE2 1.26.5          | u-2004-0-k-rke2-1265-fips.ova  | `https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-rke2-1265-fips.ova`	|
+
+
+
+### Usage Instructions
+
+Use the provided download URL to download the OVA and upload it to your vSphere environment. The OVA must be uploaded to the `spectro-templates ` older VerteX can access it. One additional note about uploaded OVAs, the OVA name must be prefixed with `r_` to be recognized by VerteX. You can rename the OVA before you upload it or after you upload it to vSphere. 
+
+
+<Tabs>
+<TabItem label="curl" value="curl">
+
+The following example shows how to download the `u-2004-0-k-1259-fips.ova` OVA and rename it to `r_u-2004-0-k-1259-fips.ova` by using `curl` and the `--output` flag. 
+
+```shell
+curl --output r_u-2004-0-k-1259-fips.ova \
+https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-1259-fips.ova
+```
+
+</TabItem> 
+
+<TabItem label="wget" value="wget">
+
+The following example shows how to download the `u-2004-0-k-1259-fips.ova` OVA and rename it to `r_u-2004-0-k-1259-fips.ova` by using `wget` and the `--output-document` flag. 
+
+```shell
+wget --quiet --show-progress \
+--output-document=r_u-2004-0-k-1259-fips.ova \
+https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-1259-fips.ova
+```
+
+</TabItem> 
+</Tabs>

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/vmware-vsphere-airgap-instructions.md
@@ -106,7 +106,7 @@ Complete the following steps before deploying the airgap VerteX installation.
   https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2004-0-k-12510-fips.ova
   ```
 
-4. Append an `r_` prefix to the OVA name after the import. For example, `r_u-2004-0-k-12510-fips.ova`. This prefix is required for the install process to identify the OVA.
+4. Append an `r_` prefix to the OVA name after the import. For example, `r_u-2004-0-k-12510-fips.ova`. This prefix is required for the install process to identify the OVA. Refer to the [Supplement Packs](./supplemental-packs.md#additional-ovas) page for a list of additional OVAs you can download and upload to your vCenter environment.
 
 
 5. In your OCI registry, create a repository with the name `spectro-packs` and ensure the repository is private. This repository will host the VerteX Packs. 


### PR DESCRIPTION
## Describe the Change

This PR adds a list of OVAs that customer may need for their VerteX airgap install.

![CleanShot 2023-11-28 at 13 51 02](https://github.com/spectrocloud/librarium/assets/29551334/f89a15a5-304e-42cd-8070-ba2d49c50b44)


## Review Changes

💻 [Preview URL](https://deploy-preview-1848--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/airgap/supplemental-packs#additional-ovas)

🎫 [DOC-925](https://spectrocloud.atlassian.net/browse/DOC-925)
