### PR TITLE
docs: update kubeconfig behavior PEM-4198

### DIFF
--- a/docs/docs-content/clusters/cluster-management/kubeconfig.md
+++ b/docs/docs-content/clusters/cluster-management/kubeconfig.md
@@ -36,7 +36,7 @@ Palette exposes kubeconfig files for each cluster deployed through the platform.
 
 Your assigned [Palette permissions](../../user-management/palette-rbac/project-scope-roles-permissions.md) determine which clusters you can access and what operations you can perform on the cluster. The permissions assigned to you in Palette determine if you can download and access the kubeconfig files for a cluster. 
 
-As a rule of thumb, users with the Palette role [*Cluster Admin*](../../user-management/palette-rbac/project-scope-roles-permissions#cluster) can access the admin kubeconfig files for all clusters in the project. Users with lower-level project roles such as the  *Cluster Editor* or the *Cluster Viewer* may not be able to access the kubeconfig file of the cluster. 
+As a rule, users with the Palette role [*Cluster Admin*](../../user-management/palette-rbac/project-scope-roles-permissions#cluster) can access the admin kubeconfig files for all clusters in the project. Users with lower-level project roles such as the  *Cluster Editor* or the *Cluster Viewer* may not be able to access the kubeconfig file of the cluster. 
 
 
 

--- a/docs/docs-content/clusters/cluster-management/kubeconfig.md
+++ b/docs/docs-content/clusters/cluster-management/kubeconfig.md
@@ -36,7 +36,7 @@ Palette exposes kubeconfig files for each cluster deployed through the platform.
 
 Your assigned [Palette permissions](../../user-management/palette-rbac/project-scope-roles-permissions.md) determine which clusters you can access and what operations you can perform on the cluster. The permissions assigned to you in Palette determine if you can download and access the kubeconfig files for a cluster. 
 
-As a rule of thumb, users with the Palette role [*Cluster Admin*](../../user-management/palette-rbac/project-scope-roles-permissions#cluster) can access both kubeconfig files for all clusters in the project. Users with lower-level project roles such as the  *Cluster Editor* or the *Cluster Viewer* may not be able to access the kubeconfig file of the cluster. 
+As a rule of thumb, users with the Palette role [*Cluster Admin*](../../user-management/palette-rbac/project-scope-roles-permissions#cluster) can access the admin kubeconfig files for all clusters in the project. Users with lower-level project roles such as the  *Cluster Editor* or the *Cluster Viewer* may not be able to access the kubeconfig file of the cluster. 
 
 
 
@@ -75,7 +75,7 @@ The following table shows the *Cluster Admin* role or equivalent provides access
  **Is OIDC Configured?** | **Is Spectro Proxy Enabled?** | **Access to Kubeconfig File** | **Access to Admin Kubeconfig File** |
  --- | --- | --- | --- |
 Yes | Yes | ✅ | ✅ |
-No | Yes| ✅ | ✅ |
+No | Yes| ❌ | ✅ |
 Yes | No | ✅ | ✅ |
 
 ### Non-Cluster Admin


### PR DESCRIPTION
## Describe the Change

This PR updates the Kubeconfig file behavior. For Cluster Admins, if OIDC is enabled, then the regular Kubeconfig file is unavailable. 

## Review Changes

💻 [Preview URL](https://65774118294e941a3fd96824--docs-spectrocloud.netlify.app/clusters/cluster-management/kubeconfig)

🎫 [PEM-4198](https://spectrocloud.atlassian.net/browse/PEM-4198)
