### PR TITLE
Docker prune

### DIFF
--- a/.github/workflows/container-prune.yaml
+++ b/.github/workflows/container-prune.yaml
@@ -24,5 +24,6 @@ jobs:
         with:
           owner: spectrocloud
           name: librarium
-          token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
+          # token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           untagged-keep-latest: 2

--- a/.github/workflows/container-prune.yaml
+++ b/.github/workflows/container-prune.yaml
@@ -1,8 +1,10 @@
 name: Container Image Cleanup
 
 on:
-  push:
-    branches-ignore: [ main ]
+  workflow_run:
+    workflows: ["Nighly Docker Build"]
+    types: [completed]
+  workflow_dispatch:
 
 
 jobs:
@@ -10,20 +12,19 @@ jobs:
     name: Prune Container Images
     runs-on: ubuntu-latest
     steps:
-      - name: Retrieve Credentials
-        id: import-secrets
-        uses: hashicorp/vault-action@v2.7.3
-        with:
-          url: https://vault.prism.spectrocloud.com
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
-
       - uses: bots-house/ghcr-delete-image-action@v1.1.0
         with:
           owner: spectrocloud
           name: librarium
-          # token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           untagged-keep-latest: 2
+
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: "spectromate"
+          SLACK_ICON_EMOJI: ":robot_panic:"
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: 'The nightly docs container prune workflow failed. Review the GitHub Actions logs for more details.'

--- a/.github/workflows/container-prune.yaml
+++ b/.github/workflows/container-prune.yaml
@@ -1,0 +1,28 @@
+name: Container Image Cleanup
+
+on:
+  push:
+    branches-ignore: [ main ]
+
+
+jobs:
+  prune:
+    name: Prune Container Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve Credentials
+        id: import-secrets
+        uses: hashicorp/vault-action@v2.7.3
+        with:
+          url: https://vault.prism.spectrocloud.com
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
+
+      - uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          owner: spectrocloud
+          name: librarium
+          token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
+          untagged-keep-latest: 2


### PR DESCRIPTION
## Describe the Change

This PR introduces a running job that removes outdated instances of the nightly docs container. The image repository will continue to occupy space unless these images are pruned.  The new  GitHub Actions workflow introduced will be triggered upon completion of the Nighly Docker image creation. 

## Review Changes


Before:
![CleanShot 2023-12-13 at 15 15 36](https://github.com/spectrocloud/librarium/assets/29551334/264346b2-6ee7-4a1e-a67f-aae007cb7826)



🎫 [DOC-957](https://spectrocloud.atlassian.net/browse/DOC-957)
