### PR TITLE
Update Portworx /w Operator docs

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -96,3 +96,4 @@ eecf731008b962d7f5aefbeb6cfee251147b92b9:docs/docs-content/enterprise-version-bk
 eecf731008b962d7f5aefbeb6cfee251147b92b9:docs/docs-content/enterprise-version/system-management/reverse-proxy.md:private-key:150
 07088abdfe1d1bb713baf745b76f19f8842a2392:docs/docs-content/integrations/kubernetes.md:generic-api-key:634
 fd60bdc4fdfe8b66925db07865cb530eab4978df:docs/docs-content/integrations/kubernetes.md:generic-api-key:634
+51708449cbb201c91a91d3cf7ff7cbbe2e4a6c40:docs/docs-content/integrations/portworx_operator.md:private-key:186

--- a/docs/docs-content/integrations/ngrok.md
+++ b/docs/docs-content/integrations/ngrok.md
@@ -100,7 +100,7 @@ Once you have defined the ngrok Ingress Controller pack, you can add it to an ex
 
 You can reference the ngrok Ingress Controller pack in Terraform with a data resource.
 
-```
+```hcl
 data "spectrocloud_registry" "public_registry" {
   name = "Public Repo"
 }

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -750,23 +750,17 @@ These are the three types of Presets that can be selected and modified. The pack
       # The CA cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
       cacert: |-
         -----BEGIN CERTIFICATE-----
-        MIIC3DCCAcQCCQCr1j968rOV3zANBgkqhkiG9w0BAQsFADAwMQswCQYDVQQGEwJV
-        < .. >
-        i9CNyx+CcwUCkWQzhrHBQA==
+        < KEY DATA >
         -----END CERTIFICATE-----
       # The cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
       cert: |-
         -----BEGIN CERTIFICATE-----
-        MIIDaTCCAlGgAwIBAgIJAPLC+6M3EezhMA0GCSqGSIb3DQEBCwUAMDAxCzAJBgNV
-        < .. >
-        ptWD/oDFCiCjlffyzg==
+        < KEY DATA >
         -----END CERTIFICATE-----
       # The key to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
       key: |-
         -----BEGIN RSA PRIVATE KEY-----
-        MIIEogIBAAKCAQEAsnJghz619GDZO+XLtx+UkL/w9ajQ9vtqxr79GcdvAPfCkfwX
-        < .. >
-        WsqUCBt5+DnOaDyvMkokP+T5tj/2LXemuIi4Q5nrOmw/WwVGGGs=
+       < KEY DATA >
         -----END RSA PRIVATE KEY-----
 ```
 

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -15,181 +15,92 @@ tags: ['packs', 'portworx', 'storage']
 ## Versions Supported
 
 
-<Tabs queryString="versions">
-<TabItem label="2.x" value="2.x">
+<Tabs groupId="versions">
+<TabItem label="3.0.x" value="3.x">
 
-* **2.11.x**
-* **2.12.x**
-* **2.13.x**
 
-</TabItem>
-<TabItem label="3.x" value="3.x">
-
-* **3.0.x**
-
-</TabItem>
-</Tabs>
-
-<br />
 
 ## Prerequisites
 
-For deploying Portworx with Operator for Kubernetes, make sure to configure the properties in the pack:
+Portworx /w Operator has the following prerequisites for installation. You can learn more about all the required Portworx requirements in the [Portworx documentation](https://docs.portworx.com/install-portworx/prerequisites).
 
-* Have at least three nodes with the proper [hardware, software, and network requirements](https://docs.portworx.com/install-portworx/prerequisites).
+* The Kubernetes cluster must have at least three nodes of the type bare metal or virtual machine.
+
+* Storage drives must be unmounted block storage. You can use either, raw disks, drive partitions, LVM, or cloud block storage.
+
+* The backing drive must be at least 8 GB in size.
+
+* The following disk folder require enough space to store Portworx metadata:
+
+  * **/var** - 2 GB
+
+  * **/opt/** - 3 GB
+
+* The operating system root partition must be at least 64 GB is the minimum.
+
+* The minimum hardware requirements for each node are:
+
+  * 4 CPU cores
+
+  * 8 GB RAM
+
+  * 50 GB disk space
+
+  * 1 Gbps network connectivity
+
+
+* A Linux kernel version of 3.10 or higher is required.
+
+
+- Docker version 1.13.1 or higher is required.
 
 * Ensure you use a [supported Kubernetes version](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions).
 
 * Identify and set up the type of storage you want to use.
 
-<br />
 
-## Contents
+:::caution
+
+Starting with Portworx version 3.x.x and greater. Lighthouse is no longer available in the pack itself. Instead you can install [Portworx Central](https://docs.portworx.com/portworx-central-on-prem/install/px-central.html), which provides monitoring capabilities.
+
+:::
+
+
+## Parameters
+
+The following parameters are highlighed for this version of the pack and provide a preset option when configured through the UI. These parameters are not exhaustive and you can configure additional parameters as needed.
+
+
+| Parameter | Description | Default |
+|:----------|:------------|:--------|
+| `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select the "enterprise" type and set "activateLicense" to false. | `essentials` |
+| `portworx-generic.Storagecluster.spec` |  Define the storage type and behavior for Portworx.Refer to the Storage Specification section below to learn more.| `{}`|
+| `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External Etcd section below to learn more.| `{}`|
+| `portworx-generic.storageCluster.env` | Specify environment variables, such as HTTP Proxy settings, for Portworx. | `{}`| 
+
+
+
+## Usage
 
 The default installation of Portworx /w Operator will deploy the following components in the Kubernetes cluster:
 
 * Portworx Operator
 
-* `StorageCluster` resource that tells the Operator how to deploy & configure Portworx
+* `StorageCluster` resource that tells the Operator how to deploy and configure Portworx.
 
-* `StorageClass` resource for dynamic provisioning of PersistentVolumes using the `pxd.portworx.com` provisioner
+* `StorageClass` resource for dynamic provisioning of `PersistentVolumes`` using the `pxd.portworx.com` provisioner.
 
-* [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html), Portworx's storage scheduler for Kubernetes
+* [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html). Portworx's storage scheduler for Kubernetes.
 
 
-Optionally for Portworx 2.x, you can enable Lighthouse for basic monitoring of the Portworx cluster. From Portworx 3.x onwards, Lighthouse is no longer available in the pack itself. Instead you can install [Portworx Central](https://docs.portworx.com/portworx-central-on-prem/install/px-central.html), which provides monitoring capabilities.
 
-<br />
-
-## Parameters
-
-### Charts - Portworx 3.x:
-
-```yaml
-charts:
-  px-operator:
-    namespace: portworx-operator
-
-  portworx-generic:
-    license:
-      # Valid options for "type" are: essentials, saas, enterprise
-      # If you want to deploy the PX Enterprise Trial version, or need manual offline activation,
-      # select the "enterprise" type and set "activateLicense" to false.
-      type: enterprise
-      # The next block only gets used if the type is set to "essentials"
-      essentials:
-        # Base64-decoded value of the px-essen-user-id value in the px-essential secret
-        # Find your Essentials Entitlement ID at https://central.portworx.com/profile
-        userId: 1234abcd-12ab-12ab-12ab-123456abcdef
-        # Base64-decoded value of the px-osb-endpoint value in the px-essential secret
-        # Leave at the default value unless there are special circumstances
-        endpoint: https://pxessentials.portworx.com/osb/billing/v1/register
-      # The next block only gets used if the type is set to "saas"
-      saas:
-        key: <PAY-AS-YOU-GO-KEY>
-      # The next block only gets used if the type is set to "enterprise"
-      enterprise:
-        activateLicense: true
-        activationId: <Activation ID>
-        # customLicenseServer:
-        #   url: http://hostname:7070/fne/bin/capability
-        #   importUnknownCa: true
-        #   licenseBorrowInterval: 1w15m
-        #   addFeatures:
-        #   - feature1
-        #   - feature2
-
-    storageCluster:
-      # When autoGenerateName is true, a name of type "px-cluster-1234abcd-12ab-12ab-12ab-123456abcdef" is generated and the "name" field is ignored
-      autoGenerateName: false
-      name: "px-{{.spectro.system.cluster.name}}"
-      namespace: portworx
-      # annotations:
-      #   If you need additional annotations, specify them here
-      spec: {}
-        # Select a preset from the pane on the right, or use the Portworx Spec Builder to define a custom configuration and
-        # then paste that spec section here. (Spec Builder: https://central.portworx.com/specGen/wizard)
-        # ### Example spec
-        # image: portworx/oci-monitor:3.0.0
-        # imagePullPolicy: Always
-        # deleteStrategy:
-        #   type: UninstallAndWipe
-        # kvdb:
-        #   internal: true
-        #   # endpoints:
-        #   # - etcd:https://etcd.company.domain:2379
-        #   # authSecret: px-kvdb-auth
-        # storage:
-        #   useAll: true
-        #   journalDevice: auto
-        #   kvdbDevice: /dev/sdb
-        # network:
-        #   dataInterface: eth0
-        #   mgmtInterface: eth1
-        # secretsProvider: k8s
-        # stork:
-        #   enabled: true
-        #   args:
-        #     webhook-controller: "true"
-        # autopilot:
-        #   enabled: true
-        #   providers:
-        #   - name: default
-        #     params:
-        #       url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-        #     type: prometheus
-        # runtimeOptions:
-        #   default-io-profile: "6"
-        # csi:
-        #   enabled: true
-        # monitoring:
-        #   telemetry:
-        #       enabled: true
-        #   prometheus:
-        #     enabled: false
-        #     exportMetrics: true
-
-    # To automatically create the px-vsphere-secret for VMware, uncomment this section
-    # vsphereSecret:
-    #   user: ""
-    #   password: ""
-
-    # To automatically create the px-azure secret for Azure, uncomment this section
-    # azureSecret:
-    #   tenantId:
-    #   clientId:
-    #   clientSecret: 
-
-    storageClass:
-      name: spectro-storage-class
-      isDefaultStorageClass: true
-      annotations: {}
-      #   If you need additional annotations, specify them here
-      allowVolumeExpansion: true
-      reclaimPolicy: Delete # Delete or Retain
-      volumeBindingMode: WaitForFirstConsumer # WaitForFirstConsumer or Immediate
-      parameters:
-        repl: "2"
-        # priority_io: "high"
-        # sharedv4: true
-        # sharedv4_svc_type: "ClusterIP"
-        # stork.libopenstorage.org/preferRemoteNodeOnly: "false"
-        # Add additional parameters as needed (https://docs.portworx.com/portworx-install-with-kubernetes/storage-operations/create-pvcs/dynamic-provisioning/)
-
-    # External kvdb related config, only used if storageCluster.spec.kvdb.internal = false
-    externalKvdb:
-      useCertsForSSL: false
-      # cacert: |
-      #   < PEM KEY DATA >
-      # key: |
-      #   < PEM KEY DATA >
-      # cert: |
-      #   < PEM KEY DATA >
-```
+<!-- Optionally for Portworx 2.x, you can enable Lighthouse for basic monitoring of the Portworx cluster. -->
 
 <br />
 
-# License Model
+
+
+### License Model
 
 This pack can install Portworx in three different licensing modes:
 
@@ -253,19 +164,19 @@ Use the presets in the pack user interface to select which license model you wan
 </TabItem>
 </Tabs>
 
-<br />
-
-## Storage Specification
-
-This pack can install Portworx in various different storage environment:
-
-* **Using existing disks (generic)**: This mode does not integrate with any particular storage solution, it just uses existing disks available on the nodes.
 
 
-* **AWS Cloud Storage**: This mode integrates with Amazon EBS block volumes and allows EKS and EC2 kubernetes clusters to dynamically attach EBS volumes to worker nodes for Portworx.
+### Storage Specification
+
+You can install Portworx in a variety of storage configurations.
+
+* **Existing disks (generic)**: This mode does not integrate with any particular storage solution, it uses existing disks available on the nodes.
 
 
-* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows AKS and regular Azure kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
+* **AWS Cloud Storage**: This mode integrates with Amazon EBS block volumes and allows AWS EKS and EC2 based Kubernetes clusters to dynamically attach EBS volumes to worker nodes for Portworx.
+
+
+* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows Azure AKS and regular Azure kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
 
 
 * **Google Cloud Storage**: This mode integrates with Google persistent disks and allows GKE and regular Google kubernetes clusters to dynamically attach persistent disks to worker nodes for Portworx.
@@ -277,7 +188,14 @@ This pack can install Portworx in various different storage environment:
 * **Pure Storage Flash Array**: This mode integrates with Pure Storage Flash Arrays and allows kubernetes clusters to dynamically attach Flash Array disks over iSCSI to worker nodes for Portworx.
 
 
+:::tip
+
 Use the presets in the pack user interface to select which storage specification you want to use, then update the `charts.portworx-generic.storageCluster` section to your specific needs.
+
+:::
+
+Select the tab below for the storage specification you want to use. Use the example YAML as a starting point for your configuration.
+
 
 <br />
 
@@ -331,6 +249,52 @@ Use the presets in the pack user interface to select which storage specification
 </TabItem>
 <TabItem label="AWS" value="AWS">
 
+
+To deploy Portworx in an AWS environment, ensure the following IAM policy is created in AWS and attached to the `nodes.cluster-api-provider-aws.sigs.k8s.io` IAM role.
+<br/>
+
+```yaml
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:ModifyVolume",
+        "ec2:DetachVolume",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteTags",
+        "ec2:DeleteVolume",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumeAttribute",
+        "ec2:DescribeVolumesModifications",
+        "ec2:DescribeVolumeStatus",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeInstances",
+        "autoscaling:DescribeAutoScalingGroups"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+```
+
+* When deploying a regular Kubernetes cluster on an AWS EC2 using Palette, attach the policy to the `nodes.cluster-api-provider-aws.sigs.k8s.io` IAM role. Or alternatively, edit the AWS cloud account in Palette, enable the `Add IAM Policies` option, and select the Portworx IAM policy described above. This will automatically attach the IAM policy to the correct IAM role..
+
+* When deploying an AWS EKS cluster, use the `managedMachinePool.roleAdditionalPolicies` option in the Kubernetes pack layer YAML to automatically attach the Portworx IAM policy to the EKS worker pool IAM role . The example below shows how to attach the Portworx IAM policy to the EKS worker pool IAM role.
+
+```yaml
+managedMachinePool:
+  roleAdditionalPolicies:
+    - "arn:aws:iam::012345678901:policy/my-portworx-policy"
+```
+
+
+
 ```yaml
     storageCluster:
       annotations:
@@ -375,52 +339,6 @@ Use the presets in the pack user interface to select which storage specification
             enabled: false
             exportMetrics: true
 ```
-### Prerequisites
-
-To deploy Portworx in an AWS environment, ensure the following IAM Policy is created in AWS and attached to the correct IAM Role:
-<br/>
-
-```yaml
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AttachVolume",
-                "ec2:ModifyVolume",
-                "ec2:DetachVolume",
-                "ec2:CreateTags",
-                "ec2:CreateVolume",
-                "ec2:DeleteTags",
-                "ec2:DeleteVolume",
-                "ec2:DescribeTags",
-                "ec2:DescribeVolumeAttribute",
-                "ec2:DescribeVolumesModifications",
-                "ec2:DescribeVolumeStatus",
-                "ec2:DescribeVolumes",
-                "ec2:DescribeInstances",
-                "autoscaling:DescribeAutoScalingGroups"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
-```
-
-* When deploying a regular Kubernetes cluster on AWS EC2 using Palette, attach the policy to the `nodes.cluster-api-provider-aws.sigs.k8s.io` IAM Role. Or alternatively, edit the AWS cloud account in Palette, enable the `Add IAM Policies` option, and select the Portworx IAM Policy described above. This will automatically attach the IAM Policy to the correct IAM Role.
-
-* When deploying an EKS cluster, use the `managedMachinePool.roleAdditionalPolicies` option in the `kubernetes-eks` pack to automatically attach the Portworx IAM Policy to the EKS worker pool IAM role that Palette will manage for you. For example:
-
-```yaml
-managedMachinePool:
-  roleAdditionalPolicies:
-    - "arn:aws:iam::012345678901:policy/my-portworx-policy"
-```
-
-<br />
 
 
 </TabItem>
@@ -612,6 +530,17 @@ managedMachinePool:
 </TabItem>
 <TabItem label="Pure Flash Array" value="Pure Flash Array">
 
+
+To activate the Pure Flash Array integration, you will need to create a Kubernetes secret named `px-pure-secret` on your cluster containing your [Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/cloud-references/auto-disk-provisioning/pure-flash-array.html#deploy-portworx). The secret must be created in the namespace that contains the `StorageCluster` resource.  The namespace is `portworx` by default.
+
+Use the following command to create the secret:
+
+```
+kubectl create secret generic px-pure-secret --namespace portworx --from-file=pure.json=<file path>
+```
+
+Alternatively, you can attach a manifest to the Portworx /w Operator pack that contains the YAML for the secret.
+
 ```yaml
     storageCluster:
       spec:
@@ -661,54 +590,31 @@ managedMachinePool:
             value: ISCSI # or "FC"
 ```
 
-To activate the Pure Flash Array integration, you will need to create a `secret` named `px-pure-secret` on your cluster containing your [Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/cloud-references/auto-disk-provisioning/pure-flash-array.html#deploy-portworx). The secret must be created in the namespace that contains the StorageCluster resource. For version 2.x of the pack, the namespace is `kube-system`. For version 3.x and higher of the pack, the namespace is `portworx` by default.
 
-You can do this by running the below kubectl command:
 
-```
-kubectl create secret generic px-pure-secret --namespace portworx --from-file=pure.json=<file path>
-```
+<!-- For version 2.x of the pack, the namespace is `kube-system`. For version 3.x and higher of the pack, the namespace is `portworx` by default. -->
 
-Alternatively, you can attach a manifest to the Portworx /w Operator pack that contains the YAML for the secret.
+
 
 </TabItem>
 </Tabs>
 
 <br />
 
-## Integration With External Etcd
-
-Portworx Enterprise supports multiple Etcd scenarios.
-
-Portworx will default use its internal key-value store (KVDB). However, you can integrate Portworx to an external Etcd server by following the steps below.
-
-1. Select the `Use External Kvdb over HTTP` or `Use External Kvdb over SSL` preset in the pack user interface. If your external Etcd server requires certificate authentication, you need the `Use External Kvdb over SSL` preset.
+### Etcd
 
 
-2. Configure the external Etcd endpoint(s) in `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
 
 
-3. When using the `Use External Kvdb over SSL` preset, leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth` since that is the name of the secret that will be created by this pack.
-
-<br />
-
-When using the `Use External Kvdb over SSL` preset, you additionally need to configure the `charts.portworx-generic.externalKvdb` section:
-
-1. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication.
 
 
-2. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates.
+Portworx Enterprise supports multiple Etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
 
+#### Kvdb and Etcd Presets
 
-:::caution
-Make sure to follow the provided indentation style; otherwise, certs will not be imported correctly and will result in Portworx deployment failure.
-:::
+The following pack presets are available for configuring Etcd.
 
-<br />
-
-## Kvdb and Etcd Presets
-
-These are the three types of Presets that can be selected and modified. The pack defaults to the `Use Internal Kvdb` option. Change to a different preset if you need to connect to an external Etcd server.
+The pack defaults to the **Use Internal Kvdb** option. You can change to a different preset if you need to connect to an external Etcd server. 
 
 <Tabs queryString="keyvalue">
 <TabItem label="Use Internal Kvdb" value="Use Internal Kvdb">
@@ -760,13 +666,746 @@ These are the three types of Presets that can be selected and modified. The pack
 </TabItem>
 </Tabs>
 
+
+
+#### Integration With External Etcd
+
+Use the folllowing steps to integrate Portworx to an external Etcd server by following the steps below.
+
+
+1. During the cluster profile creation, select the Portworx pack and click on the **Presets** button in the top right corner of the pack user interface.
+
+
+2. Select the **Use External Kvdb over HTTP** or **Use External Kvdb over SSL** preset in the pack UI. If your external Etcd server requires certificate authentication, select **Use External Kvdb over SSL** preset.
+
+
+3. Configure the external Etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
+
+
+4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automtically get created by this pack.
+
+  :::caution
+
+    When inserting SSL certificate values into the YAML. Ensure you follow the provided indentation style. Otherwise, SSL certificates will not be imported correctly and will result in Portworx deployment failure.
+  :::
+
 <br />
+
+
+</TabItem>
+
+
+<TabItem label="2.13.X" value="2.13.x">
+
+## Prerequisites
+
+## Prerequisites
+
+Portworx /w Operator has the following prerequisites for installation. You can learn more about all the required Portworx requirements in the [Portworx documentation](https://docs.portworx.com/install-portworx/prerequisites).
+
+* The Kubernetes cluster must have at least three nodes of the type bare metal or virtual machine.
+
+* Storage drives must be unmounted block storage. You can use either, raw disks, drive partitions, LVM, or cloud block storage.
+
+* The backing drive must be at least 8 GB in size.
+
+* The following disk folder require enough space to store Portworx metadata:
+
+  * **/var** - 2 GB
+
+  * **/opt/** - 3 GB
+
+* The operating system root partition must be at least 64 GB is the minimum.
+
+* The minimum hardware requirements for each node are:
+
+  * 4 CPU cores
+
+  * 8 GB RAM
+
+  * 50 GB disk space
+
+  * 1 Gbps network connectivity
+
+
+* A Linux kernel version of 3.10 or higher is required.
+
+
+- Docker version 1.13.1 or higher is required.
+
+* Ensure you use a [supported Kubernetes version](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions).
+
+* Identify and set up the type of storage you want to use.
+
+
+:::caution
+
+Starting with Portworx version 3.x.x and greater. Lighthouse is no longer available in the pack itself. Instead you can install [Portworx Central](https://docs.portworx.com/portworx-central-on-prem/install/px-central.html), which provides monitoring capabilities.
+
+:::
+
+
+## Parameters
+
+The following parameters are highlighed for this version of the pack and provide a preset option when configured through the UI. These parameters are not exhaustive and you can configure additional parameters as needed.
+
+
+| Parameter | Description | Default |
+|:----------|:------------|:--------|
+| `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select the "enterprise" type and set "activateLicense" to false. | `essentials` |
+| `portworx-generic.Storagecluster.spec` |  Define the storage type and behavior for Portworx.Refer to the Storage Specification section below to learn more.| `{}`|
+| `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External Etcd section below to learn more.| `{}`|
+| `portworx-generic.storageCluster.env` | Specify environment variables, such as HTTP Proxy settings, for Portworx. | `{}`| 
+
+
+
+## Usage
+
+The default installation of Portworx /w Operator will deploy the following components in the Kubernetes cluster:
+
+* Portworx Operator
+
+* `StorageCluster` resource that tells the Operator how to deploy and configure Portworx.
+
+* `StorageClass` resource for dynamic provisioning of `PersistentVolumes`` using the `pxd.portworx.com` provisioner.
+
+* [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html). Portworx's storage scheduler for Kubernetes.
+
+
+
+<!-- Optionally for Portworx 2.x, you can enable Lighthouse for basic monitoring of the Portworx cluster. -->
+
+<br />
+
+
+
+### License Model
+
+This pack can install Portworx in three different licensing modes:
+
+* **Essentials**: a free Portworx license with limited functionality that allows you to run small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully-featured Portworx Enterprise version of Portworx.
+
+
+* **Enterprise**: the fully featured version of Portworx. If you install this model without a valid key, Portworx will automatically enter a 30-day trial mode.
+
+
+* **Enterprise SaaS PAYG**: the fully featured version of Portworx but using a SaaS license key that allows unlimited use and in-arrears billing. If you install this model without a valid key, Portworx will automatically enter a 30-day trial mode.
+
+
+Use the presets in the pack user interface to select which license model you want to use, then update the `charts.portworx-generic.license` section for your chosen license model.
+
+<br />
+
+<Tabs queryString="license">
+<TabItem label="PX Essentials" value="PX Essentials">
+
+```yaml
+    license:
+      type: essentials
+      essentials:
+        # Base64-decoded value of the px-essen-user-id value in the px-essential secret
+        # Find your Essentials Entitlement ID at https://central.portworx.com/profile
+        userId: 1234abcd-12ab-12ab-12ab-123456abcdef
+        # Base64-decoded value of the px-osb-endpoint value in the px-essential secret
+        # Leave at the default value unless there are special circumstances
+        endpoint: https://pxessentials.portworx.com/osb/billing/v1/register
+```
+
+</TabItem>
+<TabItem label="PX Enterprise" value="PX Enterprise">
+
+```yaml
+    license:
+      type: saas
+      saas:
+        key: <PAY-AS-YOU-GO-KEY>
+```
+
+</TabItem>
+
+<TabItem label="PX Enterprise SaaS PAYG" value="PX Enterprise SaaS PAYG">
+
+```yaml
+    license:
+      type: enterprise
+      enterprise:
+        activateLicense: true
+        activationId: <Activation ID>
+        # customLicenseServer:
+        #   url: http://hostname:7070/fne/bin/capability
+        #   importUnknownCa: true
+        #   licenseBorrowInterval: 1w15m
+        #   addFeatures:
+        #   - feature1
+        #   - feature2
+```
+
+</TabItem>
+</Tabs>
+
+
+
+### Storage Specification
+
+You can install Portworx in a variety of storage configurations.
+
+* **Existing disks (generic)**: This mode does not integrate with any particular storage solution, it uses existing disks available on the nodes.
+
+
+* **AWS Cloud Storage**: This mode integrates with Amazon EBS block volumes and allows AWS EKS and EC2 based Kubernetes clusters to dynamically attach EBS volumes to worker nodes for Portworx.
+
+
+* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows Azure AKS and regular Azure kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
+
+
+* **Google Cloud Storage**: This mode integrates with Google persistent disks and allows GKE and regular Google kubernetes clusters to dynamically attach persistent disks to worker nodes for Portworx.
+
+
+* **VMware vSphere Datastores**: This mode integrates with VMware vSphere storage and allows kubernetes clusters on vSphere to dynamically attach vSAN and regular Datastore disks to worker nodes for Portworx.
+
+
+* **Pure Storage Flash Array**: This mode integrates with Pure Storage Flash Arrays and allows kubernetes clusters to dynamically attach Flash Array disks over iSCSI to worker nodes for Portworx.
+
+
+:::tip
+
+Use the presets in the pack user interface to select which storage specification you want to use, then update the `charts.portworx-generic.storageCluster` section to your specific needs.
+
+:::
+
+Select the tab below for the storage specification you want to use. Use the example YAML as a starting point for your configuration.
+
+
+<br />
+
+<Tabs queryString="storage">
+<TabItem label="Generic" value="Generic">
+
+```yaml
+    storageCluster:
+      spec:
+        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+        image: portworx/oci-monitor:3.0.0
+        imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
+        kvdb:
+          internal: true
+          # endpoints:
+          # - etcd:https://etcd.company.domain:2379
+          # authSecret: px-kvdb-auth
+        storage:
+          useAll: true
+          # kvdbDevice: /dev/sdb
+          journalDevice: auto
+        # network:
+        #   dataInterface: eth0
+        #   mgmtInterface: eth1
+        secretsProvider: k8s
+        stork:
+          enabled: true
+          args:
+            webhook-controller: "true"
+        autopilot:
+          enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
+        csi:
+          enabled: true
+        monitoring:
+          telemetry:
+            enabled: true
+          prometheus:
+            enabled: false
+            exportMetrics: true
+```
+
+</TabItem>
+<TabItem label="AWS" value="AWS">
+
+
+To deploy Portworx in an AWS environment, ensure the following IAM policy is created in AWS and attached to the `nodes.cluster-api-provider-aws.sigs.k8s.io` IAM role.
+<br/>
+
+```yaml
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:ModifyVolume",
+        "ec2:DetachVolume",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteTags",
+        "ec2:DeleteVolume",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumeAttribute",
+        "ec2:DescribeVolumesModifications",
+        "ec2:DescribeVolumeStatus",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeInstances",
+        "autoscaling:DescribeAutoScalingGroups"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+```
+
+* When deploying a regular Kubernetes cluster on an AWS EC2 using Palette, attach the policy to the `nodes.cluster-api-provider-aws.sigs.k8s.io` IAM role. Or alternatively, edit the AWS cloud account in Palette, enable the `Add IAM Policies` option, and select the Portworx IAM policy described above. This will automatically attach the IAM policy to the correct IAM role..
+
+* When deploying an AWS EKS cluster, use the `managedMachinePool.roleAdditionalPolicies` option in the Kubernetes pack layer YAML to automatically attach the Portworx IAM policy to the EKS worker pool IAM role . The example below shows how to attach the Portworx IAM policy to the EKS worker pool IAM role.
+
+```yaml
+managedMachinePool:
+  roleAdditionalPolicies:
+    - "arn:aws:iam::012345678901:policy/my-portworx-policy"
+```
+
+
+
+```yaml
+    storageCluster:
+      annotations:
+        portworx.io/is-eks: "true"
+      spec:
+        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+        image: portworx/oci-monitor:3.0.0
+        imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
+        kvdb:
+          internal: true
+          # endpoints:
+          # - etcd:https://etcd.company.domain:2379
+          # authSecret: px-kvdb-auth
+        cloudStorage:
+          maxStorageNodesPerZone: 0
+          deviceSpecs:
+            - type=gp3,size=150
+          kvdbDeviceSpec: type=gp3,size=150
+          journalDeviceSpec: auto
+        secretsProvider: k8s
+        stork:
+          enabled: true
+          args:
+            webhook-controller: "true"
+        autopilot:
+          enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
+        csi:
+          enabled: true
+        monitoring:
+          telemetry:
+            enabled: true
+          prometheus:
+            enabled: false
+            exportMetrics: true
+```
+
+
+</TabItem>
+<TabItem label="Azure" value="Azure">
+
+```yaml
+    storageCluster:
+      annotations:
+        portworx.io/is-aks: "true"
+      spec:
+        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+        image: portworx/oci-monitor:3.0.0
+        imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
+        kvdb:
+          internal: true
+          # endpoints:
+          # - etcd:https://etcd.company.domain:2379
+          # authSecret: px-kvdb-auth
+        cloudStorage:
+          maxStorageNodesPerZone: 0
+          deviceSpecs:
+            - type=Premium_LRS,size=150
+          kvdbDeviceSpec: type=Premium_LRS,size=150
+          journalDeviceSpec: auto
+        secretsProvider: k8s
+        stork:
+          enabled: true
+          args:
+            webhook-controller: "true"
+        autopilot:
+          enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
+        csi:
+          enabled: true
+        monitoring:
+          telemetry:
+            enabled: true
+          prometheus:
+            enabled: false
+            exportMetrics: true
+        env:
+          - name: AZURE_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: px-azure
+                key: AZURE_CLIENT_SECRET
+          - name: AZURE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: px-azure
+                key: AZURE_CLIENT_ID
+          - name: AZURE_TENANT_ID
+            valueFrom:
+              secretKeyRef:
+                name: px-azure
+                key: AZURE_TENANT_ID
+    azureSecret:
+      tenantId: "your_azure_tenant_id"
+      clientId: "your_azure_client_id"
+      clientSecret: "your_client_secret"
+```
+
+</TabItem>
+<TabItem label="Google" value="Google">
+
+```yaml
+    storageCluster:
+      annotations:
+        portworx.io/is-gke: "true"
+      spec:
+        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+        image: portworx/oci-monitor:3.0.0
+        imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
+        kvdb:
+          internal: true
+          # endpoints:
+          # - etcd:https://etcd.company.domain:2379
+          # authSecret: px-kvdb-auth
+        cloudStorage:
+          maxStorageNodesPerZone: 0
+          deviceSpecs:
+            - type=pd-standard,size=150
+          kvdbDeviceSpec: type=pd-standard,size=150
+          journalDeviceSpec: auto
+        secretsProvider: k8s
+        stork:
+          enabled: true
+          args:
+            webhook-controller: "true"
+        autopilot:
+          enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
+        csi:
+          enabled: true
+        monitoring:
+          telemetry:
+            enabled: true
+          prometheus:
+            enabled: false
+            exportMetrics: true
+```
+
+</TabItem>
+<TabItem label="VMware vSphere" value="VMware vSphere">
+
+```yaml
+    storageCluster:
+      spec:
+        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+        image: portworx/oci-monitor:3.0.0
+        imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
+        kvdb:
+          internal: true
+          # endpoints:
+          # - etcd:https://etcd.company.domain:2379
+          # authSecret: px-kvdb-auth
+        cloudStorage:
+          maxStorageNodesPerZone: 0
+          deviceSpecs:
+            - type=lazyzeroedthick,size=150
+          kvdbDeviceSpec: type=lazyzeroedthick,size=32
+          journalDeviceSpec: auto
+        secretsProvider: k8s
+        stork:
+          enabled: true
+          args:
+            webhook-controller: "true"
+        autopilot:
+          enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
+        csi:
+          enabled: true
+        monitoring:
+          telemetry:
+            enabled: true
+          prometheus:
+            enabled: false
+            exportMetrics: true
+        env:
+          - name: VSPHERE_INSECURE
+            value: "true"
+          - name: VSPHERE_USER
+            valueFrom:
+              secretKeyRef:
+                name: px-vsphere-secret
+                key: VSPHERE_USER
+          - name: VSPHERE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: px-vsphere-secret
+                key: VSPHERE_PASSWORD
+          - name: VSPHERE_VCENTER
+            value: my-vcenter.company.local
+          - name: VSPHERE_VCENTER_PORT
+            value: "443"
+          - name: VSPHERE_DATASTORE_PREFIX
+            value: Datastore
+          - name: VSPHERE_INSTALL_MODE
+            value: shared
+    vsphereSecret:
+      user: "username_for_vCenter_here"
+      password: "your_password"
+```
+
+</TabItem>
+<TabItem label="Pure Flash Array" value="Pure Flash Array">
+
+
+To activate the Pure Flash Array integration, you will need to create a Kubernetes secret named `px-pure-secret` on your cluster containing your [Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/cloud-references/auto-disk-provisioning/pure-flash-array.html#deploy-portworx). The secret must be created in the namespace that contains the `StorageCluster` resource.  The namespace is `kube-system` by default.
+
+Use the following command to create the secret:
+
+```
+kubectl create secret generic px-pure-secret --namespace portworx --from-file=pure.json=<file path>
+```
+
+Alternatively, you can attach a manifest to the Portworx /w Operator pack that contains the YAML for the secret.
+
+```yaml
+    storageCluster:
+      spec:
+        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+        image: portworx/oci-monitor:3.0.0
+        imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
+        kvdb:
+          internal: true
+          # endpoints:
+          # - etcd:https://etcd.company.domain:2379
+          # authSecret: px-kvdb-auth
+        cloudStorage:
+          maxStorageNodesPerZone: 0
+          deviceSpecs:
+            - size=150
+          kvdbDeviceSpec: size=32
+          journalDeviceSpec: auto
+        # network:
+        #  dataInterface: eth0
+        #  mgmtInterface: eth1
+        secretsProvider: k8s
+        stork:
+          enabled: true
+          args:
+            webhook-controller: "true"
+        autopilot:
+          enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
+        csi:
+          enabled: true
+        monitoring:
+          telemetry:
+            enabled: true
+          prometheus:
+            enabled: false
+            exportMetrics: true
+        env:
+          - name: PURE_FLASHARRAY_SAN_TYPE
+            value: ISCSI # or "FC"
+```
+
+
+
+
+</TabItem>
+</Tabs>
+
+<br />
+
+### Etcd
+
+
+
+
+
+
+Portworx Enterprise supports multiple Etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
+
+#### Kvdb and Etcd Presets
+
+The following pack presets are available for configuring Etcd.
+
+The pack defaults to the **Use Internal Kvdb** option. You can change to a different preset if you need to connect to an external Etcd server. 
+
+<Tabs queryString="keyvalue">
+<TabItem label="Use Internal Kvdb" value="Use Internal Kvdb">
+
+```yaml
+    storageCluster:
+      spec:
+        kvdb:
+          internal: true
+```
+
+</TabItem>
+<TabItem label="Use External Kvdb over HTTP" value="Use External Kvdb over HTTP">
+
+```yaml
+    storageCluster:
+      spec:
+        kvdb:
+          endpoints:
+            - etcd:http://etcd.company.domain:2379
+```
+
+</TabItem>
+
+<TabItem label="Use External Kvdb over SSL" value="Use External Kvdb over SSL">
+
+```yaml
+    storageCluster:
+      spec:
+        kvdb:
+          endpoints:
+            - etcd:http://etcd.company.domain:2379
+          authSecret: px-kvdb-auth
+
+    # External kvdb related config, only used if storageCluster.spec.kvdb.internal != true
+    externalKvdb:
+      useCertsForSSL: true
+      # The CA cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
+      cacert: |
+        < PEM KEY DATA >
+      # The cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
+      cert: |
+        < PEM KEY DATA >
+      # The key to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
+      key: |
+        < PEM KEY DATA >
+```
+
+</TabItem>
+</Tabs>
+
+
+
+#### Integration With External Etcd
+
+Use the folllowing steps to integrate Portworx to an external Etcd server by following the steps below.
+
+
+1. During the cluster profile creation, select the Portworx pack and click on the **Presets** button in the top right corner of the pack user interface.
+
+
+2. Select the **Use External Kvdb over HTTP** or **Use External Kvdb over SSL** preset in the pack UI. If your external Etcd server requires certificate authentication, select **Use External Kvdb over SSL** preset.
+
+
+3. Configure the external Etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
+
+
+4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automtically get created by this pack.
+
+  :::caution
+
+    When inserting SSL certificate values into the YAML. Ensure you follow the provided indentation style. Otherwise, SSL certificates will not be imported correctly and will result in Portworx deployment failure.
+  :::
+
+<br />
+
+</TabItem>
+
+<TabItem label="2.12.X" value="2.12.x">
+
+## Prerequisites
+
+For deploying Portworx with Operator for Kubernetes, make sure to configure the properties in the pack:
+
+* Have at least three nodes with the proper [hardware, software, and network requirements](https://docs.portworx.com/install-portworx/prerequisites).
+
+* Ensure you use a [supported Kubernetes version](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions).
+
+* Identify and set up the type of storage you want to use.
+
+</TabItem>
+
+<TabItem label="Deprecated" value="deprecated">
+
+:::caution
+
+All versions less than v2.12.x are considered deprecated. Upgrade to a newer version to take advantage of new features.
+:::
+
+</TabItem>
+
+</Tabs>
+
+
 
 ## References
 
 - [Portworx Install with Kubernetes](https://docs.portworx.com/portworx-install-with-kubernetes/)
+
 - [Installation Prerequisites](https://docs.portworx.com/install-portworx/prerequisites/)
+
 - [Supported Kubernetes versions](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions)
+
 - [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html)
+
 - [Portworx Central](https://docs.portworx.com/portworx-central-on-prem/install/px-central.html)
+
 - [Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/cloud-references/auto-disk-provisioning/pure-flash-array.html#deploy-portworx)

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -10,7 +10,7 @@ logoUrl: 'https://registry.spectrocloud.com/v1/csi-portworx/blobs/sha256:e27bc9a
 tags: ['packs', 'portworx', 'storage']
 ---
 
-[Portworx](https://portworx.com/) is a software-defined persistent storage solution designed and purpose-built for applications deployed as containers via container orchestrators such as Kubernetes. You can use Palette to install Portworx on a cloud platform, on-premises, or at the edge.
+[Portworx](https://portworx.com/) is a software-defined persistent storage solution designed and purpose-built for applications deployed as containers via container orchestrators such as Kubernetes. You can include Portworx in your Kubernetes cluster by using the Portworx Operator pack.
 
 ## Versions Supported
 
@@ -22,7 +22,7 @@ tags: ['packs', 'portworx', 'storage']
 
 ## Prerequisites
 
-Portworx /w Operator has the following prerequisites for installation. You can learn more about all the required Portworx requirements in the [Portworx documentation](https://docs.portworx.com/install-portworx/prerequisites).
+Portworx Operator has the following prerequisites for installation. You can learn more about all the required Portworx requirements in the [Portworx documentation](https://docs.portworx.com/install-portworx/prerequisites).
 
 * The Kubernetes cluster must have at least three nodes of the type bare metal or virtual machine.
 
@@ -34,7 +34,7 @@ Portworx /w Operator has the following prerequisites for installation. You can l
 
   * **/var** - 2 GB
 
-  * **/opt/** - 3 GB
+  * **/opt** - 3 GB
 
 * The operating system root partition must be at least 64 GB is the minimum.
 
@@ -121,25 +121,25 @@ Use the presets in the pack user interface to select which license model you wan
 <TabItem label="PX Essentials" value="PX Essentials">
 
 ```yaml
-    license:
-      type: essentials
-      essentials:
-        # Base64-decoded value of the px-essen-user-id value in the px-essential secret
-        # Find your Essentials Entitlement ID at https://central.portworx.com/profile
-        userId: 1234abcd-12ab-12ab-12ab-123456abcdef
-        # Base64-decoded value of the px-osb-endpoint value in the px-essential secret
-        # Leave at the default value unless there are special circumstances
-        endpoint: https://pxessentials.portworx.com/osb/billing/v1/register
+license:
+  type: essentials
+  essentials:
+    # Base64-decoded value of the px-essen-user-id value in the px-essential secret
+    # Find your Essentials Entitlement ID at https://central.portworx.com/profile
+    userId: 1234abcd-12ab-12ab-12ab-123456abcdef
+    # Base64-decoded value of the px-osb-endpoint value in the px-essential secret
+    # Leave at the default value unless there are special circumstances
+    endpoint: https://pxessentials.portworx.com/osb/billing/v1/register
 ```
 
 </TabItem>
 <TabItem label="PX Enterprise" value="PX Enterprise">
 
 ```yaml
-    license:
-      type: saas
-      saas:
-        key: <PAY-AS-YOU-GO-KEY>
+license:
+  type: saas
+  saas:
+    key: <PAY-AS-YOU-GO-KEY>
 ```
 
 </TabItem>
@@ -147,18 +147,18 @@ Use the presets in the pack user interface to select which license model you wan
 <TabItem label="PX Enterprise SaaS PAYG" value="PX Enterprise SaaS PAYG">
 
 ```yaml
-    license:
-      type: enterprise
-      enterprise:
-        activateLicense: true
-        activationId: <Activation ID>
-        # customLicenseServer:
-        #   url: http://hostname:7070/fne/bin/capability
-        #   importUnknownCa: true
-        #   licenseBorrowInterval: 1w15m
-        #   addFeatures:
-        #   - feature1
-        #   - feature2
+license:
+  type: enterprise
+  enterprise:
+    activateLicense: true
+    activationId: <Activation ID>
+    # customLicenseServer:
+    #   url: http://hostname:7070/fne/bin/capability
+    #   importUnknownCa: true
+    #   licenseBorrowInterval: 1w15m
+    #   addFeatures:
+    #   - feature1
+    #   - feature2
 ```
 
 </TabItem>
@@ -203,47 +203,47 @@ Select the tab below for the storage specification you want to use. Use the exam
 <TabItem label="Generic" value="Generic">
 
 ```yaml
-    storageCluster:
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        storage:
-          useAll: true
-          # kvdbDevice: /dev/sdb
-          journalDevice: auto
-        # network:
-        #   dataInterface: eth0
-        #   mgmtInterface: eth1
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
+storageCluster:
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:3.0.0
+    imagePullPolicy: Always
+    deleteStrategy:
+      type: UninstallAndWipe
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    storage:
+      useAll: true
+      # kvdbDevice: /dev/sdb
+      journalDevice: auto
+    # network:
+    #   dataInterface: eth0
+    #   mgmtInterface: eth1
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+      providers:
+        - name: default
+          params:
+            url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+          type: prometheus
+    runtimeOptions:
+      default-io-profile: "6"
+    csi:
+      enabled: true
+    monitoring:
+      telemetry:
+        enabled: true
+      prometheus:
+        enabled: false
+        exportMetrics: true
 ```
 
 </TabItem>
@@ -296,48 +296,48 @@ managedMachinePool:
 
 
 ```yaml
-    storageCluster:
-      annotations:
-        portworx.io/is-eks: "true"
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - type=gp3,size=150
-          kvdbDeviceSpec: type=gp3,size=150
-          journalDeviceSpec: auto
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
+storageCluster:
+  annotations:
+    portworx.io/is-eks: "true"
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:3.0.0
+    imagePullPolicy: Always
+    deleteStrategy:
+      type: UninstallAndWipe
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      maxStorageNodesPerZone: 0
+      deviceSpecs:
+        - type=gp3,size=150
+      kvdbDeviceSpec: type=gp3,size=150
+      journalDeviceSpec: auto
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+      providers:
+        - name: default
+          params:
+            url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+          type: prometheus
+    runtimeOptions:
+      default-io-profile: "6"
+    csi:
+      enabled: true
+    monitoring:
+      telemetry:
+        enabled: true
+      prometheus:
+        enabled: false
+        exportMetrics: true
 ```
 
 
@@ -345,186 +345,186 @@ managedMachinePool:
 <TabItem label="Azure" value="Azure">
 
 ```yaml
-    storageCluster:
-      annotations:
-        portworx.io/is-aks: "true"
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - type=Premium_LRS,size=150
-          kvdbDeviceSpec: type=Premium_LRS,size=150
-          journalDeviceSpec: auto
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
-        env:
-          - name: AZURE_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: px-azure
-                key: AZURE_CLIENT_SECRET
-          - name: AZURE_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: px-azure
-                key: AZURE_CLIENT_ID
-          - name: AZURE_TENANT_ID
-            valueFrom:
-              secretKeyRef:
-                name: px-azure
-                key: AZURE_TENANT_ID
-    azureSecret:
-      tenantId: "your_azure_tenant_id"
-      clientId: "your_azure_client_id"
-      clientSecret: "your_client_secret"
+storageCluster:
+  annotations:
+    portworx.io/is-aks: "true"
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:3.0.0
+    imagePullPolicy: Always
+    deleteStrategy:
+      type: UninstallAndWipe
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      maxStorageNodesPerZone: 0
+      deviceSpecs:
+        - type=Premium_LRS,size=150
+      kvdbDeviceSpec: type=Premium_LRS,size=150
+      journalDeviceSpec: auto
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+      providers:
+        - name: default
+          params:
+            url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+          type: prometheus
+    runtimeOptions:
+      default-io-profile: "6"
+    csi:
+      enabled: true
+    monitoring:
+      telemetry:
+        enabled: true
+      prometheus:
+        enabled: false
+        exportMetrics: true
+    env:
+      - name: AZURE_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: px-azure
+            key: AZURE_CLIENT_SECRET
+      - name: AZURE_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: px-azure
+            key: AZURE_CLIENT_ID
+      - name: AZURE_TENANT_ID
+        valueFrom:
+          secretKeyRef:
+            name: px-azure
+            key: AZURE_TENANT_ID
+azureSecret:
+  tenantId: "your_azure_tenant_id"
+  clientId: "your_azure_client_id"
+  clientSecret: "your_client_secret"
 ```
 
 </TabItem>
 <TabItem label="Google" value="Google">
 
 ```yaml
-    storageCluster:
-      annotations:
-        portworx.io/is-gke: "true"
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - type=pd-standard,size=150
-          kvdbDeviceSpec: type=pd-standard,size=150
-          journalDeviceSpec: auto
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
+storageCluster:
+  annotations:
+    portworx.io/is-gke: "true"
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:3.0.0
+    imagePullPolicy: Always
+    deleteStrategy:
+      type: UninstallAndWipe
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      maxStorageNodesPerZone: 0
+      deviceSpecs:
+        - type=pd-standard,size=150
+      kvdbDeviceSpec: type=pd-standard,size=150
+      journalDeviceSpec: auto
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+      providers:
+        - name: default
+          params:
+            url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+          type: prometheus
+    runtimeOptions:
+      default-io-profile: "6"
+    csi:
+      enabled: true
+    monitoring:
+      telemetry:
+        enabled: true
+      prometheus:
+        enabled: false
+        exportMetrics: true
 ```
 
 </TabItem>
 <TabItem label="VMware vSphere" value="VMware vSphere">
 
 ```yaml
-    storageCluster:
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - type=lazyzeroedthick,size=150
-          kvdbDeviceSpec: type=lazyzeroedthick,size=32
-          journalDeviceSpec: auto
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
-        env:
-          - name: VSPHERE_INSECURE
-            value: "true"
-          - name: VSPHERE_USER
-            valueFrom:
-              secretKeyRef:
-                name: px-vsphere-secret
-                key: VSPHERE_USER
-          - name: VSPHERE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: px-vsphere-secret
-                key: VSPHERE_PASSWORD
-          - name: VSPHERE_VCENTER
-            value: my-vcenter.company.local
-          - name: VSPHERE_VCENTER_PORT
-            value: "443"
-          - name: VSPHERE_DATASTORE_PREFIX
-            value: Datastore
-          - name: VSPHERE_INSTALL_MODE
-            value: shared
-    vsphereSecret:
-      user: "username_for_vCenter_here"
-      password: "your_password"
+storageCluster:
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:3.0.0
+    imagePullPolicy: Always
+    deleteStrategy:
+      type: UninstallAndWipe
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      maxStorageNodesPerZone: 0
+      deviceSpecs:
+        - type=lazyzeroedthick,size=150
+      kvdbDeviceSpec: type=lazyzeroedthick,size=32
+      journalDeviceSpec: auto
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+      providers:
+        - name: default
+          params:
+            url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+          type: prometheus
+    runtimeOptions:
+      default-io-profile: "6"
+    csi:
+      enabled: true
+    monitoring:
+      telemetry:
+        enabled: true
+      prometheus:
+        enabled: false
+        exportMetrics: true
+    env:
+      - name: VSPHERE_INSECURE
+        value: "true"
+      - name: VSPHERE_USER
+        valueFrom:
+          secretKeyRef:
+            name: px-vsphere-secret
+            key: VSPHERE_USER
+      - name: VSPHERE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: px-vsphere-secret
+            key: VSPHERE_PASSWORD
+      - name: VSPHERE_VCENTER
+        value: my-vcenter.company.local
+      - name: VSPHERE_VCENTER_PORT
+        value: "443"
+      - name: VSPHERE_DATASTORE_PREFIX
+        value: Datastore
+      - name: VSPHERE_INSTALL_MODE
+        value: shared
+vsphereSecret:
+  user: "username_for_vCenter_here"
+  password: "your_password"
 ```
 
 </TabItem>
@@ -542,52 +542,52 @@ kubectl create secret generic px-pure-secret --namespace portworx --from-file=pu
 Alternatively, you can attach a manifest to the Portworx /w Operator pack that contains the YAML for the secret.
 
 ```yaml
-    storageCluster:
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - size=150
-          kvdbDeviceSpec: size=32
-          journalDeviceSpec: auto
-        # network:
-        #  dataInterface: eth0
-        #  mgmtInterface: eth1
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
-        env:
-          - name: PURE_FLASHARRAY_SAN_TYPE
-            value: ISCSI # or "FC"
+storageCluster:
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:3.0.0
+    imagePullPolicy: Always
+    deleteStrategy:
+      type: UninstallAndWipe
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      maxStorageNodesPerZone: 0
+      deviceSpecs:
+        - size=150
+      kvdbDeviceSpec: size=32
+      journalDeviceSpec: auto
+    # network:
+    #  dataInterface: eth0
+    #  mgmtInterface: eth1
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+      providers:
+        - name: default
+          params:
+            url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+          type: prometheus
+    runtimeOptions:
+      default-io-profile: "6"
+    csi:
+      enabled: true
+    monitoring:
+      telemetry:
+        enabled: true
+      prometheus:
+        enabled: false
+        exportMetrics: true
+    env:
+      - name: PURE_FLASHARRAY_SAN_TYPE
+        value: ISCSI # or "FC"
 ```
 
 
@@ -603,11 +603,6 @@ Alternatively, you can attach a manifest to the Portworx /w Operator pack that c
 
 ### Etcd
 
-
-
-
-
-
 Portworx Enterprise supports multiple Etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
 
 #### Kvdb and Etcd Presets
@@ -620,21 +615,21 @@ The pack defaults to the **Use Internal Kvdb** option. You can change to a diffe
 <TabItem label="Use Internal Kvdb" value="Use Internal Kvdb">
 
 ```yaml
-    storageCluster:
-      spec:
-        kvdb:
-          internal: true
+storageCluster:
+  spec:
+    kvdb:
+      internal: true
 ```
 
 </TabItem>
 <TabItem label="Use External Kvdb over HTTP" value="Use External Kvdb over HTTP">
 
 ```yaml
-    storageCluster:
-      spec:
-        kvdb:
-          endpoints:
-            - etcd:http://etcd.company.domain:2379
+storageCluster:
+  spec:
+    kvdb:
+      endpoints:
+        - etcd:http://etcd.company.domain:2379
 ```
 
 </TabItem>
@@ -642,25 +637,25 @@ The pack defaults to the **Use Internal Kvdb** option. You can change to a diffe
 <TabItem label="Use External Kvdb over SSL" value="Use External Kvdb over SSL">
 
 ```yaml
-    storageCluster:
-      spec:
-        kvdb:
-          endpoints:
-            - etcd:http://etcd.company.domain:2379
-          authSecret: px-kvdb-auth
+storageCluster:
+  spec:
+    kvdb:
+      endpoints:
+        - etcd:http://etcd.company.domain:2379
+      authSecret: px-kvdb-auth
 
-    # External kvdb related config, only used if storageCluster.spec.kvdb.internal != true
-    externalKvdb:
-      useCertsForSSL: true
-      # The CA cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
-      cacert: |
-        < PEM KEY DATA >
-      # The cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
-      cert: |
-        < PEM KEY DATA >
-      # The key to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
-      key: |
-        < PEM KEY DATA >
+# External kvdb related config, only used if storageCluster.spec.kvdb.internal != true
+externalKvdb:
+  useCertsForSSL: true
+  # The CA cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
+  cacert: |
+    < PEM KEY DATA >
+  # The cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
+  cert: |
+    < PEM KEY DATA >
+  # The key to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
+  key: |
+    < PEM KEY DATA >
 ```
 
 </TabItem>
@@ -699,9 +694,7 @@ Use the folllowing steps to integrate Portworx to an external Etcd server by fol
 
 ## Prerequisites
 
-## Prerequisites
-
-Portworx /w Operator has the following prerequisites for installation. You can learn more about all the required Portworx requirements in the [Portworx documentation](https://docs.portworx.com/install-portworx/prerequisites).
+Portworx Operator has the following prerequisites for installation. You can learn more about all the required Portworx requirements in the [Portworx documentation](https://docs.portworx.com/install-portworx/prerequisites).
 
 * The Kubernetes cluster must have at least three nodes of the type bare metal or virtual machine.
 
@@ -713,7 +706,7 @@ Portworx /w Operator has the following prerequisites for installation. You can l
 
   * **/var** - 2 GB
 
-  * **/opt/** - 3 GB
+  * **/opt** - 3 GB
 
 * The operating system root partition must be at least 64 GB is the minimum.
 
@@ -771,9 +764,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 * [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html). Portworx's storage scheduler for Kubernetes.
 
-
-
-<!-- Optionally for Portworx 2.x, you can enable Lighthouse for basic monitoring of the Portworx cluster. -->
+* [Lighthouse](https://portworx.com/blog/manage-portworx-clusters-using-lighthouse/). Portworx's monitoring and alerting solution for Kubernetes.
 
 <br />
 
@@ -800,25 +791,25 @@ Use the presets in the pack user interface to select which license model you wan
 <TabItem label="PX Essentials" value="PX Essentials">
 
 ```yaml
-    license:
-      type: essentials
-      essentials:
-        # Base64-decoded value of the px-essen-user-id value in the px-essential secret
-        # Find your Essentials Entitlement ID at https://central.portworx.com/profile
-        userId: 1234abcd-12ab-12ab-12ab-123456abcdef
-        # Base64-decoded value of the px-osb-endpoint value in the px-essential secret
-        # Leave at the default value unless there are special circumstances
-        endpoint: https://pxessentials.portworx.com/osb/billing/v1/register
+license:
+  type: essentials
+  essentials:
+    # Base64-decoded value of the px-essen-user-id value in the px-essential secret
+    # Find your Essentials Entitlement ID at https://central.portworx.com/profile
+    userId: 1234abcd-12ab-12ab-12ab-123456abcdef
+    # Base64-decoded value of the px-osb-endpoint value in the px-essential secret
+    # Leave at the default value unless there are special circumstances
+    endpoint: https://pxessentials.portworx.com/osb/billing/v1/register
 ```
 
 </TabItem>
 <TabItem label="PX Enterprise" value="PX Enterprise">
 
 ```yaml
-    license:
-      type: saas
-      saas:
-        key: <PAY-AS-YOU-GO-KEY>
+license:
+  type: saas
+  saas:
+    key: <PAY-AS-YOU-GO-KEY>
 ```
 
 </TabItem>
@@ -826,18 +817,18 @@ Use the presets in the pack user interface to select which license model you wan
 <TabItem label="PX Enterprise SaaS PAYG" value="PX Enterprise SaaS PAYG">
 
 ```yaml
-    license:
-      type: enterprise
-      enterprise:
-        activateLicense: true
-        activationId: <Activation ID>
-        # customLicenseServer:
-        #   url: http://hostname:7070/fne/bin/capability
-        #   importUnknownCa: true
-        #   licenseBorrowInterval: 1w15m
-        #   addFeatures:
-        #   - feature1
-        #   - feature2
+license:
+  type: enterprise
+  enterprise:
+    activateLicense: true
+    activationId: <Activation ID>
+    # customLicenseServer:
+    #   url: http://hostname:7070/fne/bin/capability
+    #   importUnknownCa: true
+    #   licenseBorrowInterval: 1w15m
+    #   addFeatures:
+    #   - feature1
+    #   - feature2
 ```
 
 </TabItem>
@@ -882,47 +873,32 @@ Select the tab below for the storage specification you want to use. Use the exam
 <TabItem label="Generic" value="Generic">
 
 ```yaml
-    storageCluster:
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        storage:
-          useAll: true
-          # kvdbDevice: /dev/sdb
-          journalDevice: auto
-        # network:
-        #   dataInterface: eth0
-        #   mgmtInterface: eth1
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
+storageCluster:
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    storage:
+      useAll: true
+      journalDevice: auto
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
 ```
 
 </TabItem>
@@ -975,48 +951,35 @@ managedMachinePool:
 
 
 ```yaml
-    storageCluster:
-      annotations:
-        portworx.io/is-eks: "true"
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - type=gp3,size=150
-          kvdbDeviceSpec: type=gp3,size=150
-          journalDeviceSpec: auto
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
+storageCluster:
+  annotations:
+    portworx.io/is-eks: "true"
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - type=gp2,size=150
+      kvdbDeviceSpec: type=gp2,size=150
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
 ```
 
 
@@ -1024,186 +987,147 @@ managedMachinePool:
 <TabItem label="Azure" value="Azure">
 
 ```yaml
-    storageCluster:
-      annotations:
-        portworx.io/is-aks: "true"
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - type=Premium_LRS,size=150
-          kvdbDeviceSpec: type=Premium_LRS,size=150
-          journalDeviceSpec: auto
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
-        env:
-          - name: AZURE_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: px-azure
-                key: AZURE_CLIENT_SECRET
-          - name: AZURE_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: px-azure
-                key: AZURE_CLIENT_ID
-          - name: AZURE_TENANT_ID
-            valueFrom:
-              secretKeyRef:
-                name: px-azure
-                key: AZURE_TENANT_ID
-    azureSecret:
-      tenantId: "your_azure_tenant_id"
-      clientId: "your_azure_client_id"
-      clientSecret: "your_client_secret"
+storageCluster:
+  annotations:
+    portworx.io/is-aks: "true"
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - type=Premium_LRS,size=150
+      kvdbDeviceSpec: type=Premium_LRS,size=150
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
+    env:
+    - name: AZURE_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: px-azure
+          key: AZURE_CLIENT_SECRET
+    - name: AZURE_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: px-azure
+          key: AZURE_CLIENT_ID
+    - name: AZURE_TENANT_ID
+      valueFrom:
+        secretKeyRef:
+          name: px-azure
+          key: AZURE_TENANT_ID
+  azureSecret:
+    tenantId: "your_azure_tenant_id"
+    clientId: "your_azure_client_id"
+    clientSecret: "your_client_secret"
 ```
 
 </TabItem>
 <TabItem label="Google" value="Google">
 
 ```yaml
-    storageCluster:
-      annotations:
-        portworx.io/is-gke: "true"
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - type=pd-standard,size=150
-          kvdbDeviceSpec: type=pd-standard,size=150
-          journalDeviceSpec: auto
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
+storageCluster:
+  annotations:
+    portworx.io/is-gke: "true"
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - type=pd-standard,size=150
+      kvdbDeviceSpec: type=pd-standard,size=150
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
 ```
 
 </TabItem>
 <TabItem label="VMware vSphere" value="VMware vSphere">
 
 ```yaml
-    storageCluster:
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - type=lazyzeroedthick,size=150
-          kvdbDeviceSpec: type=lazyzeroedthick,size=32
-          journalDeviceSpec: auto
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
-        env:
-          - name: VSPHERE_INSECURE
-            value: "true"
-          - name: VSPHERE_USER
-            valueFrom:
-              secretKeyRef:
-                name: px-vsphere-secret
-                key: VSPHERE_USER
-          - name: VSPHERE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: px-vsphere-secret
-                key: VSPHERE_PASSWORD
-          - name: VSPHERE_VCENTER
-            value: my-vcenter.company.local
-          - name: VSPHERE_VCENTER_PORT
-            value: "443"
-          - name: VSPHERE_DATASTORE_PREFIX
-            value: Datastore
-          - name: VSPHERE_INSTALL_MODE
-            value: shared
-    vsphereSecret:
-      user: "username_for_vCenter_here"
-      password: "your_password"
+storageCluster:
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - type=lazyzeroedthick,size=150
+      kvdbDeviceSpec: type=lazyzeroedthick,size=32
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
+    env:
+    - name: VSPHERE_INSECURE
+      value: "true"
+    - name: VSPHERE_USER
+      valueFrom:
+        secretKeyRef:
+          name: px-vsphere-secret
+          key: VSPHERE_USER
+    - name: VSPHERE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: px-vsphere-secret
+          key: VSPHERE_PASSWORD
+    - name: VSPHERE_VCENTER
+      value: "my-vcenter.company.local"
+    - name: VSPHERE_VCENTER_PORT
+      value: "443"
+    - name: VSPHERE_DATASTORE_PREFIX
+      value: "datastore"
+    - name: VSPHERE_INSTALL_MODE
+      value: "shared"
+vsphereSecret:
+  user: "username_for_vCenter_here"
+  password: "your_password"
 ```
 
 </TabItem>
@@ -1221,52 +1145,36 @@ kubectl create secret generic px-pure-secret --namespace portworx --from-file=pu
 Alternatively, you can attach a manifest to the Portworx /w Operator pack that contains the YAML for the secret.
 
 ```yaml
-    storageCluster:
-      spec:
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:3.0.0
-        imagePullPolicy: Always
-        deleteStrategy:
-          type: UninstallAndWipe
-        kvdb:
-          internal: true
-          # endpoints:
-          # - etcd:https://etcd.company.domain:2379
-          # authSecret: px-kvdb-auth
-        cloudStorage:
-          maxStorageNodesPerZone: 0
-          deviceSpecs:
-            - size=150
-          kvdbDeviceSpec: size=32
-          journalDeviceSpec: auto
-        # network:
-        #  dataInterface: eth0
-        #  mgmtInterface: eth1
-        secretsProvider: k8s
-        stork:
-          enabled: true
-          args:
-            webhook-controller: "true"
-        autopilot:
-          enabled: true
-          providers:
-            - name: default
-              params:
-                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
-              type: prometheus
-        runtimeOptions:
-          default-io-profile: "6"
-        csi:
-          enabled: true
-        monitoring:
-          telemetry:
-            enabled: true
-          prometheus:
-            enabled: false
-            exportMetrics: true
-        env:
-          - name: PURE_FLASHARRAY_SAN_TYPE
-            value: ISCSI # or "FC"
+storageCluster:
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - size=150
+      kvdbDeviceSpec: size=32
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
+    env:
+    - name: PURE_FLASHARRAY_SAN_TYPE
+      value: "ISCSI"
 ```
 
 
@@ -1278,11 +1186,6 @@ Alternatively, you can attach a manifest to the Portworx /w Operator pack that c
 <br />
 
 ### Etcd
-
-
-
-
-
 
 Portworx Enterprise supports multiple Etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
 
@@ -1373,13 +1276,580 @@ Use the folllowing steps to integrate Portworx to an external Etcd server by fol
 
 ## Prerequisites
 
-For deploying Portworx with Operator for Kubernetes, make sure to configure the properties in the pack:
+Portworx Operator has the following prerequisites for installation. You can learn more about all the required Portworx requirements in the [Portworx documentation](https://docs.portworx.com/install-portworx/prerequisites).
 
-* Have at least three nodes with the proper [hardware, software, and network requirements](https://docs.portworx.com/install-portworx/prerequisites).
+* The Kubernetes cluster must have at least three nodes of the type bare metal or virtual machine.
+
+* Storage drives must be unmounted block storage. You can use either, raw disks, drive partitions, LVM, or cloud block storage.
+
+* The backing drive must be at least 8 GB in size.
+
+* The following disk folder require enough space to store Portworx metadata:
+
+  * **/var** - 2 GB
+
+  * **/opt** - 3 GB
+
+* The operating system root partition must be at least 64 GB is the minimum.
+
+* The minimum hardware requirements for each node are:
+
+  * 4 CPU cores
+
+  * 8 GB RAM
+
+  * 50 GB disk space
+
+  * 1 Gbps network connectivity
+
+
+* A Linux kernel version of 3.10 or higher is required.
+
+
+- Docker version 1.13.1 or higher is required.
 
 * Ensure you use a [supported Kubernetes version](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions).
 
 * Identify and set up the type of storage you want to use.
+
+
+:::caution
+
+Starting with Portworx version 3.x.x and greater. Lighthouse is no longer available in the pack itself. Instead you can install [Portworx Central](https://docs.portworx.com/portworx-central-on-prem/install/px-central.html), which provides monitoring capabilities.
+
+:::
+
+
+## Parameters
+
+The following parameters are highlighed for this version of the pack and provide a preset option when configured through the UI. These parameters are not exhaustive and you can configure additional parameters as needed.
+
+
+| Parameter | Description | Default |
+|:----------|:------------|:--------|
+| `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select the "enterprise" type and set "activateLicense" to false. | `essentials` |
+| `portworx-generic.Storagecluster.spec` |  Define the storage type and behavior for Portworx.Refer to the Storage Specification section below to learn more.| `{}`|
+| `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External Etcd section below to learn more.| `{}`|
+| `portworx-generic.storageCluster.env` | Specify environment variables, such as HTTP Proxy settings, for Portworx. | `{}`| 
+
+
+
+## Usage
+
+The default installation of Portworx /w Operator will deploy the following components in the Kubernetes cluster:
+
+* Portworx Operator
+
+* `StorageCluster` resource that tells the Operator how to deploy and configure Portworx.
+
+* `StorageClass` resource for dynamic provisioning of `PersistentVolumes`` using the `pxd.portworx.com` provisioner.
+
+* [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html). Portworx's storage scheduler for Kubernetes.
+
+* [Lighthouse](https://portworx.com/blog/manage-portworx-clusters-using-lighthouse/). Portworx's monitoring and alerting solution for Kubernetes.
+
+<br />
+
+
+
+### License Model
+
+This pack can install Portworx in three different licensing modes:
+
+* **Essentials**: a free Portworx license with limited functionality that allows you to run small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully-featured Portworx Enterprise version of Portworx.
+
+
+* **Enterprise**: the fully featured version of Portworx. If you install this model without a valid key, Portworx will automatically enter a 30-day trial mode.
+
+
+* **Enterprise SaaS PAYG**: the fully featured version of Portworx but using a SaaS license key that allows unlimited use and in-arrears billing. If you install this model without a valid key, Portworx will automatically enter a 30-day trial mode.
+
+
+Use the presets in the pack user interface to select which license model you want to use, then update the `charts.portworx-generic.license` section for your chosen license model.
+
+<br />
+
+<Tabs queryString="license">
+<TabItem label="PX Essentials" value="PX Essentials">
+
+```yaml
+license:
+  type: essentials
+  essentials:
+    # Base64-decoded value of the px-essen-user-id value in the px-essential secret
+    # Find your Essentials Entitlement ID at https://central.portworx.com/profile
+    userId: 1234abcd-12ab-12ab-12ab-123456abcdef
+    # Base64-decoded value of the px-osb-endpoint value in the px-essential secret
+    # Leave at the default value unless there are special circumstances
+    endpoint: https://pxessentials.portworx.com/osb/billing/v1/register
+```
+
+</TabItem>
+<TabItem label="PX Enterprise" value="PX Enterprise">
+
+```yaml
+license:
+  type: saas
+  saas:
+    key: <PAY-AS-YOU-GO-KEY>
+```
+
+</TabItem>
+
+<TabItem label="PX Enterprise SaaS PAYG" value="PX Enterprise SaaS PAYG">
+
+```yaml
+license:
+  type: enterprise
+  enterprise:
+    activateLicense: true
+    activationId: <Activation ID>
+    # customLicenseServer:
+    #   url: http://hostname:7070/fne/bin/capability
+    #   importUnknownCa: true
+    #   licenseBorrowInterval: 1w15m
+    #   addFeatures:
+    #   - feature1
+    #   - feature2
+```
+
+</TabItem>
+</Tabs>
+
+
+
+### Storage Specification
+
+You can install Portworx in a variety of storage configurations.
+
+* **Existing disks (generic)**: This mode does not integrate with any particular storage solution, it uses existing disks available on the nodes.
+
+
+* **AWS Cloud Storage**: This mode integrates with Amazon EBS block volumes and allows AWS EKS and EC2 based Kubernetes clusters to dynamically attach EBS volumes to worker nodes for Portworx.
+
+
+* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows Azure AKS and regular Azure kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
+
+
+* **Google Cloud Storage**: This mode integrates with Google persistent disks and allows GKE and regular Google kubernetes clusters to dynamically attach persistent disks to worker nodes for Portworx.
+
+
+* **VMware vSphere Datastores**: This mode integrates with VMware vSphere storage and allows kubernetes clusters on vSphere to dynamically attach vSAN and regular Datastore disks to worker nodes for Portworx.
+
+
+* **Pure Storage Flash Array**: This mode integrates with Pure Storage Flash Arrays and allows kubernetes clusters to dynamically attach Flash Array disks over iSCSI to worker nodes for Portworx.
+
+
+:::tip
+
+Use the presets in the pack user interface to select which storage specification you want to use, then update the `charts.portworx-generic.storageCluster` section to your specific needs.
+
+:::
+
+Select the tab below for the storage specification you want to use. Use the example YAML as a starting point for your configuration.
+
+
+<br />
+
+<Tabs queryString="storage">
+<TabItem label="Generic" value="Generic">
+
+```yaml
+storageCluster:
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    storage:
+      useAll: true
+      journalDevice: auto
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
+```
+
+</TabItem>
+<TabItem label="AWS" value="AWS">
+
+
+To deploy Portworx in an AWS environment, ensure the following IAM policy is created in AWS and attached to the `nodes.cluster-api-provider-aws.sigs.k8s.io` IAM role.
+<br/>
+
+```yaml
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:ModifyVolume",
+        "ec2:DetachVolume",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteTags",
+        "ec2:DeleteVolume",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumeAttribute",
+        "ec2:DescribeVolumesModifications",
+        "ec2:DescribeVolumeStatus",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeInstances",
+        "autoscaling:DescribeAutoScalingGroups"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+```
+
+* When deploying a regular Kubernetes cluster on an AWS EC2 using Palette, attach the policy to the `nodes.cluster-api-provider-aws.sigs.k8s.io` IAM role. Or alternatively, edit the AWS cloud account in Palette, enable the `Add IAM Policies` option, and select the Portworx IAM policy described above. This will automatically attach the IAM policy to the correct IAM role..
+
+* When deploying an AWS EKS cluster, use the `managedMachinePool.roleAdditionalPolicies` option in the Kubernetes pack layer YAML to automatically attach the Portworx IAM policy to the EKS worker pool IAM role . The example below shows how to attach the Portworx IAM policy to the EKS worker pool IAM role.
+
+```yaml
+managedMachinePool:
+  roleAdditionalPolicies:
+    - "arn:aws:iam::012345678901:policy/my-portworx-policy"
+```
+
+
+
+```yaml
+storageCluster:
+  annotations:
+    portworx.io/is-eks: "true"
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - type=gp2,size=150
+      kvdbDeviceSpec: type=gp2,size=150
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
+```
+
+
+</TabItem>
+<TabItem label="Azure" value="Azure">
+
+```yaml
+storageCluster:
+  annotations:
+    portworx.io/is-aks: "true"
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - type=Premium_LRS,size=150
+      kvdbDeviceSpec: type=Premium_LRS,size=150
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
+    env:
+    - name: AZURE_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: px-azure
+          key: AZURE_CLIENT_SECRET
+    - name: AZURE_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: px-azure
+          key: AZURE_CLIENT_ID
+    - name: AZURE_TENANT_ID
+      valueFrom:
+        secretKeyRef:
+          name: px-azure
+          key: AZURE_TENANT_ID
+  azureSecret:
+    tenantId: "your_azure_tenant_id"
+    clientId: "your_azure_client_id"
+    clientSecret: "your_client_secret"
+```
+
+</TabItem>
+<TabItem label="Google" value="Google">
+
+```yaml
+storageCluster:
+  annotations:
+    portworx.io/is-gke: "true"
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - type=pd-standard,size=150
+      kvdbDeviceSpec: type=pd-standard,size=150
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
+```
+
+</TabItem>
+<TabItem label="VMware vSphere" value="VMware vSphere">
+
+```yaml
+storageCluster:
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - type=lazyzeroedthick,size=150
+      kvdbDeviceSpec: type=lazyzeroedthick,size=32
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
+    env:
+    - name: VSPHERE_INSECURE
+      value: "true"
+    - name: VSPHERE_USER
+      valueFrom:
+        secretKeyRef:
+          name: px-vsphere-secret
+          key: VSPHERE_USER
+    - name: VSPHERE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: px-vsphere-secret
+          key: VSPHERE_PASSWORD
+    - name: VSPHERE_VCENTER
+      value: "my-vcenter.company.local"
+    - name: VSPHERE_VCENTER_PORT
+      value: "443"
+    - name: VSPHERE_DATASTORE_PREFIX
+      value: "datastore"
+    - name: VSPHERE_INSTALL_MODE
+      value: "shared"
+vsphereSecret:
+  user: "username_for_vCenter_here"
+  password: "your_password"
+```
+
+</TabItem>
+<TabItem label="Pure Flash Array" value="Pure Flash Array">
+
+
+To activate the Pure Flash Array integration, you will need to create a Kubernetes secret named `px-pure-secret` on your cluster containing your [Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/cloud-references/auto-disk-provisioning/pure-flash-array.html#deploy-portworx). The secret must be created in the namespace that contains the `StorageCluster` resource.  The namespace is `kube-system` by default.
+
+Use the following command to create the secret:
+
+```
+kubectl create secret generic px-pure-secret --namespace portworx --from-file=pure.json=<file path>
+```
+
+Alternatively, you can attach a manifest to the Portworx /w Operator pack that contains the YAML for the secret.
+
+```yaml
+storageCluster:
+  spec:
+    # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+    image: portworx/oci-monitor:2.11.2
+    imagePullPolicy: Always
+    kvdb:
+      internal: true
+      # endpoints:
+      # - etcd:https://etcd.company.domain:2379
+      # authSecret: px-kvdb-auth
+    cloudStorage:
+      deviceSpecs:
+      - size=150
+      kvdbDeviceSpec: size=32
+    secretsProvider: k8s
+    stork:
+      enabled: true
+      args:
+        webhook-controller: "true"
+    autopilot:
+      enabled: true
+    csi:
+      enabled: true
+    monitoring:
+      prometheus:
+        enabled: false
+        exportMetrics: false
+    env:
+    - name: PURE_FLASHARRAY_SAN_TYPE
+      value: "ISCSI"
+```
+</TabItem>
+</Tabs>
+
+<br />
+
+### Etcd
+
+
+
+
+
+
+Portworx Enterprise supports multiple Etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
+
+#### Kvdb and Etcd Presets
+
+The following pack presets are available for configuring Etcd.
+
+The pack defaults to the **Use Internal Kvdb** option. You can change to a different preset if you need to connect to an external Etcd server. 
+
+<Tabs queryString="keyvalue">
+<TabItem label="Use Internal Kvdb" value="Use Internal Kvdb">
+
+```yaml
+    storageCluster:
+      spec:
+        kvdb:
+          internal: true
+```
+
+</TabItem>
+<TabItem label="Use External Kvdb over HTTP" value="Use External Kvdb over HTTP">
+
+```yaml
+    storageCluster:
+      spec:
+        kvdb:
+          endpoints:
+            - etcd:http://etcd.company.domain:2379
+```
+
+</TabItem>
+
+<TabItem label="Use External Kvdb over SSL" value="Use External Kvdb over SSL">
+
+```yaml
+    storageCluster:
+      spec:
+        kvdb:
+          endpoints:
+            - etcd:http://etcd.company.domain:2379
+          authSecret: px-kvdb-auth
+
+    # External kvdb related config, only used if storageCluster.spec.kvdb.internal != true
+    externalKvdb:
+      useCertsForSSL: true
+      # The CA cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
+      cacert: |
+        < PEM KEY DATA >
+      # The cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
+      cert: |
+        < PEM KEY DATA >
+      # The key to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
+      key: |
+        < PEM KEY DATA >
+```
+
+</TabItem>
+</Tabs>
+
+
+
+#### Integration With External Etcd
+
+Use the folllowing steps to integrate Portworx to an external Etcd server by following the steps below.
+
+
+1. During the cluster profile creation, select the Portworx pack and click on the **Presets** button in the top right corner of the pack user interface.
+
+
+2. Select the **Use External Kvdb over HTTP** or **Use External Kvdb over SSL** preset in the pack UI. If your external Etcd server requires certificate authentication, select **Use External Kvdb over SSL** preset.
+
+
+3. Configure the external Etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
+
+
+4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automtically get created by this pack.
+
+  :::caution
+
+  When inserting SSL certificate values into the YAML. Ensure you follow the provided indentation style. Otherwise, SSL certificates will not be imported correctly and will result in Portworx deployment failure.
+  :::
 
 </TabItem>
 
@@ -1387,25 +1857,46 @@ For deploying Portworx with Operator for Kubernetes, make sure to configure the 
 
 :::caution
 
-All versions less than v2.12.x are considered deprecated. Upgrade to a newer version to take advantage of new features.
+All versions less than 2.12.x are considered deprecated. Upgrade to a newer version to take advantage of new features.
+
 :::
+
+
+<br />
 
 </TabItem>
 
 </Tabs>
 
 
+## Terraform
 
+Use the following Terraform code to interact with the Portworx Operator pack in your Terraform scripts.
+
+```hcl
+data "spectrocloud_registry" "public_registry" {
+  name = "Public Repo"
+}
+
+data "spectrocloud_pack_simple" "portworx-operator" {
+  name    = "csi-portworx-generic"
+  version = "3.0.0"
+  type = "operator-instance"
+  registry_uid = data.spectrocloud_registry.public_registry.id
+}
+```
+
+  
 ## References
 
 - [Portworx Install with Kubernetes](https://docs.portworx.com/portworx-install-with-kubernetes/)
 
 - [Installation Prerequisites](https://docs.portworx.com/install-portworx/prerequisites/)
 
-- [Supported Kubernetes versions](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions)
+- [Portworx Supported Kubernetes versions](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions)
 
 - [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html)
 
 - [Portworx Central](https://docs.portworx.com/portworx-central-on-prem/install/px-central.html)
 
-- [Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/cloud-references/auto-disk-provisioning/pure-flash-array.html#deploy-portworx)
+- [Flash Array License JSON](https://docs.portworx.com/portworx-enterprise/cloud-references/auto-disk-provisioning/pure-flash-array.html#deploy-portworx)

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -105,7 +105,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 This pack can install Portworx in three different licensing modes:
 
-* **Essentials**: a free Portworx license with limited functionality that allows you to run small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully-featured Portworx Enterprise version of Portworx.
+* **Essentials**: a free Portworx license with limited functionality that allows you to deploy a small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully featured Portworx Enterprise version of Portworx.
 
 
 * **Enterprise**: the fully featured version of Portworx. If you install this model without a valid key, Portworx will automatically enter a 30-day trial mode.
@@ -177,16 +177,16 @@ You can install Portworx in a variety of storage configurations.
 * **AWS Cloud Storage**: This mode integrates with Amazon EBS block volumes and allows AWS EKS and EC2 based Kubernetes clusters to dynamically attach EBS volumes to worker nodes for Portworx.
 
 
-* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows Azure AKS and regular Azure kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
+* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows Azure AKS and regular Azure Kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
 
 
-* **Google Cloud Storage**: This mode integrates with Google persistent disks and allows GKE and regular Google kubernetes clusters to dynamically attach persistent disks to worker nodes for Portworx.
+* **Google Cloud Storage**: This mode integrates with Google persistent disks and allows GKE and regular Google Kubernetes clusters to dynamically attach persistent disks to worker nodes for Portworx.
 
 
-* **VMware vSphere Datastores**: This mode integrates with VMware vSphere storage and allows kubernetes clusters on vSphere to dynamically attach vSAN and regular Datastore disks to worker nodes for Portworx.
+* **VMware vSphere Datastores**: This mode integrates with VMware vSphere storage and allows Kubernetes clusters on vSphere to dynamically attach vSAN and regular Datastore disks to worker nodes for Portworx.
 
 
-* **Pure Storage Flash Array**: This mode integrates with Pure Storage Flash Arrays and allows kubernetes clusters to dynamically attach Flash Array disks over iSCSI to worker nodes for Portworx.
+* **Pure Storage Flash Array**: This mode integrates with Pure Storage Flash Arrays and allows Kubernetes clusters to dynamically attach Flash Array disks over iSCSI to worker nodes for Portworx.
 
 
 :::tip
@@ -776,7 +776,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 This pack can install Portworx in three different licensing modes:
 
-* **Essentials**: a free Portworx license with limited functionality that allows you to run small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully-featured Portworx Enterprise version of Portworx.
+* **Essentials**: a free Portworx license with limited functionality that allows you to deploy a small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully featured Portworx Enterprise version of Portworx.
 
 
 * **Enterprise**: the fully featured version of Portworx. If you install this model without a valid key, Portworx will automatically enter a 30-day trial mode.
@@ -848,16 +848,16 @@ You can install Portworx in a variety of storage configurations.
 * **AWS Cloud Storage**: This mode integrates with Amazon EBS block volumes and allows AWS EKS and EC2 based Kubernetes clusters to dynamically attach EBS volumes to worker nodes for Portworx.
 
 
-* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows Azure AKS and regular Azure kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
+* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows Azure AKS and regular Azure Kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
 
 
-* **Google Cloud Storage**: This mode integrates with Google persistent disks and allows GKE and regular Google kubernetes clusters to dynamically attach persistent disks to worker nodes for Portworx.
+* **Google Cloud Storage**: This mode integrates with Google persistent disks and allows GKE and regular Google Kubernetes clusters to dynamically attach persistent disks to worker nodes for Portworx.
 
 
-* **VMware vSphere Datastores**: This mode integrates with VMware vSphere storage and allows kubernetes clusters on vSphere to dynamically attach vSAN and regular Datastore disks to worker nodes for Portworx.
+* **VMware vSphere Datastores**: This mode integrates with VMware vSphere storage and allows Kubernetes clusters on vSphere to dynamically attach vSAN and regular Datastore disks to worker nodes for Portworx.
 
 
-* **Pure Storage Flash Array**: This mode integrates with Pure Storage Flash Arrays and allows kubernetes clusters to dynamically attach Flash Array disks over iSCSI to worker nodes for Portworx.
+* **Pure Storage Flash Array**: This mode integrates with Pure Storage Flash Arrays and allows Kubernetes clusters to dynamically attach Flash Array disks over iSCSI to worker nodes for Portworx.
 
 
 :::tip
@@ -1359,7 +1359,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 This pack can install Portworx in three different licensing modes:
 
-* **Essentials**: a free Portworx license with limited functionality that allows you to run small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully-featured Portworx Enterprise version of Portworx.
+* **Essentials**: a free Portworx license with limited functionality that allows you to deploy a small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully featured Portworx Enterprise version of Portworx.
 
 
 * **Enterprise**: the fully featured version of Portworx. If you install this model without a valid key, Portworx will automatically enter a 30-day trial mode.
@@ -1431,16 +1431,16 @@ You can install Portworx in a variety of storage configurations.
 * **AWS Cloud Storage**: This mode integrates with Amazon EBS block volumes and allows AWS EKS and EC2 based Kubernetes clusters to dynamically attach EBS volumes to worker nodes for Portworx.
 
 
-* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows Azure AKS and regular Azure kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
+* **Azure Cloud Storage**: This mode integrates with Azure block storage and allows Azure AKS and regular Azure Kubernetes clusters to dynamically attach Azure block storage to worker nodes for Portworx.
 
 
-* **Google Cloud Storage**: This mode integrates with Google persistent disks and allows GKE and regular Google kubernetes clusters to dynamically attach persistent disks to worker nodes for Portworx.
+* **Google Cloud Storage**: This mode integrates with Google persistent disks and allows GKE and regular Google Kubernetes clusters to dynamically attach persistent disks to worker nodes for Portworx.
 
 
-* **VMware vSphere Datastores**: This mode integrates with VMware vSphere storage and allows kubernetes clusters on vSphere to dynamically attach vSAN and regular Datastore disks to worker nodes for Portworx.
+* **VMware vSphere Datastores**: This mode integrates with VMware vSphere storage and allows Kubernetes clusters on vSphere to dynamically attach vSAN and regular Datastore disks to worker nodes for Portworx.
 
 
-* **Pure Storage Flash Array**: This mode integrates with Pure Storage Flash Arrays and allows kubernetes clusters to dynamically attach Flash Array disks over iSCSI to worker nodes for Portworx.
+* **Pure Storage Flash Array**: This mode integrates with Pure Storage Flash Arrays and allows Kubernetes clusters to dynamically attach Flash Array disks over iSCSI to worker nodes for Portworx.
 
 
 :::tip

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -68,12 +68,13 @@ Starting with Portworx version 3.x.x and greater. Lighthouse is no longer availa
 
 ## Parameters
 
-The following parameters are highlighed for this version of the pack and provide a preset option when configured through the UI. These parameters are not exhaustive and you can configure additional parameters as needed.
+The following parameters are highlighted for this version of the pack and provide a preset option when configured through the UI. These parameters are not exhaustive and you can configure additional parameters as needed.
 
 
 | Parameter | Description | Default |
 |:----------|:------------|:--------|
-| `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select the "enterprise" type and set "activateLicense" to false. | `essentials` |
+| `portworx-generic.activateLicense`| Set to `true` to activate the Portworx license. | `true` |
+| `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select the **PX Enterprise** type and set `activateLicense` to `false`. | `essentials` |
 | `portworx-generic.Storagecluster.spec` |  Define the storage type and behavior for Portworx.Refer to the Storage Specification section below to learn more.| `{}`|
 | `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External Etcd section below to learn more.| `{}`|
 | `portworx-generic.storageCluster.env` | Specify environment variables, such as HTTP Proxy settings, for Portworx. | `{}`| 
@@ -665,7 +666,7 @@ externalKvdb:
 
 #### Integration With External Etcd
 
-Use the folllowing steps to integrate Portworx to an external Etcd server by following the steps below.
+Use the following steps to integrate Portworx to an external Etcd server by following the steps below.
 
 
 1. During the cluster profile creation, select the Portworx pack and click on the **Presets** button in the top right corner of the pack user interface.
@@ -677,7 +678,7 @@ Use the folllowing steps to integrate Portworx to an external Etcd server by fol
 3. Configure the external Etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
 
 
-4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automtically get created by this pack.
+4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automatically get created by this pack.
 
   :::caution
 
@@ -740,12 +741,13 @@ Starting with Portworx version 3.x.x and greater. Lighthouse is no longer availa
 
 ## Parameters
 
-The following parameters are highlighed for this version of the pack and provide a preset option when configured through the UI. These parameters are not exhaustive and you can configure additional parameters as needed.
+The following parameters are highlighted for this version of the pack and provide a preset option when configured through the UI. These parameters are not exhaustive and you can configure additional parameters as needed.
 
 
 | Parameter | Description | Default |
 |:----------|:------------|:--------|
-| `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select the "enterprise" type and set "activateLicense" to false. | `essentials` |
+| `portworx-generic.activateLicense`| Set to `true` to activate the Portworx license. | `true` |
+| `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select **PX Enterprise** type and set `activateLicense` to `false`. | `essentials` |
 | `portworx-generic.Storagecluster.spec` |  Define the storage type and behavior for Portworx.Refer to the Storage Specification section below to learn more.| `{}`|
 | `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External Etcd section below to learn more.| `{}`|
 | `portworx-generic.storageCluster.env` | Specify environment variables, such as HTTP Proxy settings, for Portworx. | `{}`| 
@@ -1249,7 +1251,7 @@ The pack defaults to the **Use Internal Kvdb** option. You can change to a diffe
 
 #### Integration With External Etcd
 
-Use the folllowing steps to integrate Portworx to an external Etcd server by following the steps below.
+Use the following steps to integrate Portworx to an external Etcd server by following the steps below.
 
 
 1. During the cluster profile creation, select the Portworx pack and click on the **Presets** button in the top right corner of the pack user interface.
@@ -1261,7 +1263,7 @@ Use the folllowing steps to integrate Portworx to an external Etcd server by fol
 3. Configure the external Etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
 
 
-4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automtically get created by this pack.
+4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automatically get created by this pack.
 
   :::caution
 
@@ -1322,12 +1324,13 @@ Starting with Portworx version 3.x.x and greater. Lighthouse is no longer availa
 
 ## Parameters
 
-The following parameters are highlighed for this version of the pack and provide a preset option when configured through the UI. These parameters are not exhaustive and you can configure additional parameters as needed.
+The following parameters are highlighted for this version of the pack and provide a preset option when configured through the UI. These parameters are not exhaustive and you can configure additional parameters as needed.
 
 
 | Parameter | Description | Default |
 |:----------|:------------|:--------|
-| `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select the "enterprise" type and set "activateLicense" to false. | `essentials` |
+| `portworx-generic.activateLicense`| Set to `true` to activate the Portworx license. | `true` |
+| `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select **PX Enterprise** and set `activateLicense` to `false`. | `essentials` |
 | `portworx-generic.Storagecluster.spec` |  Define the storage type and behavior for Portworx.Refer to the Storage Specification section below to learn more.| `{}`|
 | `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External Etcd section below to learn more.| `{}`|
 | `portworx-generic.storageCluster.env` | Specify environment variables, such as HTTP Proxy settings, for Portworx. | `{}`| 
@@ -1832,7 +1835,7 @@ The pack defaults to the **Use Internal Kvdb** option. You can change to a diffe
 
 #### Integration With External Etcd
 
-Use the folllowing steps to integrate Portworx to an external Etcd server by following the steps below.
+Use the following steps to integrate Portworx to an external Etcd server by following the steps below.
 
 
 1. During the cluster profile creation, select the Portworx pack and click on the **Presets** button in the top right corner of the pack user interface.
@@ -1844,7 +1847,7 @@ Use the folllowing steps to integrate Portworx to an external Etcd server by fol
 3. Configure the external Etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
 
 
-4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automtically get created by this pack.
+4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automatically get created by this pack.
 
   :::caution
 

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -20,6 +20,7 @@ tags: ['packs', 'portworx', 'storage']
 
 * **2.11.x**
 * **2.12.x**
+* **2.13.x**
 
 </TabItem>
 <TabItem label="3.x" value="3.x">
@@ -29,10 +30,11 @@ tags: ['packs', 'portworx', 'storage']
 </TabItem>
 </Tabs>
 
+<br />
+
 ## Prerequisites
 
 For deploying Portworx with Operator for Kubernetes, make sure to configure the properties in the pack:
-<br />
 
 * Have at least three nodes with the proper [hardware, software, and network requirements](https://docs.portworx.com/install-portworx/prerequisites).
 
@@ -45,7 +47,6 @@ For deploying Portworx with Operator for Kubernetes, make sure to configure the 
 ## Contents
 
 The default installation of Portworx /w Operator will deploy the following components in the Kubernetes cluster:
-<br />
 
 * Portworx Operator
 
@@ -185,6 +186,9 @@ charts:
       # cert: |
       #   < PEM KEY DATA >
 ```
+
+<br />
+
 # License Model
 
 This pack can install Portworx in three different licensing modes:
@@ -249,6 +253,7 @@ Use the presets in the pack user interface to select which license model you wan
 </TabItem>
 </Tabs>
 
+<br />
 
 ## Storage Specification
 
@@ -669,12 +674,13 @@ Alternatively, you can attach a manifest to the Portworx /w Operator pack that c
 </TabItem>
 </Tabs>
 
+<br />
+
 ## Integration With External Etcd
 
 Portworx Enterprise supports multiple Etcd scenarios.
 
 Portworx will default use its internal key-value store (KVDB). However, you can integrate Portworx to an external Etcd server by following the steps below.
-<br />
 
 1. Select the `Use External Kvdb over HTTP` or `Use External Kvdb over SSL` preset in the pack user interface. If your external Etcd server requires certificate authentication, you need the `Use External Kvdb over SSL` preset.
 
@@ -684,9 +690,9 @@ Portworx will default use its internal key-value store (KVDB). However, you can 
 
 3. When using the `Use External Kvdb over SSL` preset, leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth` since that is the name of the secret that will be created by this pack.
 
+<br />
 
 When using the `Use External Kvdb over SSL` preset, you additionally need to configure the `charts.portworx-generic.externalKvdb` section:
-<br />
 
 1. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication.
 
@@ -698,12 +704,11 @@ When using the `Use External Kvdb over SSL` preset, you additionally need to con
 Make sure to follow the provided indentation style; otherwise, certs will not be imported correctly and will result in Portworx deployment failure.
 :::
 
+<br />
 
 ## Kvdb and Etcd Presets
 
 These are the three types of Presets that can be selected and modified. The pack defaults to the `Use Internal Kvdb` option. Change to a different preset if you need to connect to an external Etcd server.
-
-<br />
 
 <Tabs queryString="keyvalue">
 <TabItem label="Use Internal Kvdb" value="Use Internal Kvdb">

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -179,17 +179,11 @@ charts:
     externalKvdb:
       useCertsForSSL: false
       # cacert: |
-      #   -----BEGIN CERTIFICATE-----
-      #   < KEY DATA >
-      #   -----END CERTIFICATE-----
+      #   < PEM KEY DATA >
       # key: |
-      #   -----BEGIN RSA PRIVATE KEY-----
-      #   < KEY DATA >
-      #   -----END RSA PRIVATE KEY-----
+      #   < PEM KEY DATA >
       # cert: |
-      #   -----BEGIN CERTIFICATE-----
-      #   < KEY DATA >
-      #   -----END CERTIFICATE-----
+      #   < PEM KEY DATA >
 ```
 # License Model
 
@@ -748,20 +742,14 @@ These are the three types of Presets that can be selected and modified. The pack
     externalKvdb:
       useCertsForSSL: true
       # The CA cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
-      cacert: |-
-        -----BEGIN CERTIFICATE-----
-        < KEY DATA >
-        -----END CERTIFICATE-----
+      cacert: |
+        < PEM KEY DATA >
       # The cert to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
-      cert: |-
-        -----BEGIN CERTIFICATE-----
-        < KEY DATA >
-        -----END CERTIFICATE-----
+      cert: |
+        < PEM KEY DATA >
       # The key to use for etcd authentication. Make sure to follow the same indentation style as given in the example below
-      key: |-
-        -----BEGIN RSA PRIVATE KEY-----
-       < KEY DATA >
-        -----END RSA PRIVATE KEY-----
+      key: |
+        < PEM KEY DATA >
 ```
 
 </TabItem>

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -16,10 +16,15 @@ tags: ['packs', 'portworx', 'storage']
 
 
 <Tabs queryString="versions">
-<TabItem label="2.11.x" value="2.11.x">
+<TabItem label="2.x" value="2.x">
 
 * **2.11.x**
+* **2.12.x**
 
+</TabItem>
+<TabItem label="3.x" value="3.x">
+
+* **3.0.x**
 
 </TabItem>
 </Tabs>
@@ -31,9 +36,9 @@ For deploying Portworx with Operator for Kubernetes, make sure to configure the 
 
 * Have at least three nodes with the proper [hardware, software, and network requirements](https://docs.portworx.com/install-portworx/prerequisites).
 
-* Ensure you use a supported Kubernetes version (1.19 or above).
+* Ensure you use a [supported Kubernetes version](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions).
 
-* Identify and set up the storageType.
+* Identify and set up the type of storage you want to use.
 
 <br />
 
@@ -46,28 +51,30 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 * `StorageCluster` resource that tells the Operator how to deploy & configure Portworx
 
-* `StorageClass` resource for dynamic provisioning of PersistentVolumes using the portworx-volume provisioner
+* `StorageClass` resource for dynamic provisioning of PersistentVolumes using the `pxd.portworx.com` provisioner
 
-* [Stork](https://github.com/libopenstorage/stork) and [Stork on Portworx](https://docs.portworx.com/portworx-install-with-kubernetes/storage-operations/stork/)
+* [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html), Portworx's storage scheduler for Kubernetes
 
 
-Optionally, you can enable [Lighthouse](https://legacy-docs.portworx.com/enterprise/lighthouse-new) for essential monitoring of the Portworx cluster.
+Optionally for Portworx 2.x, you can enable Lighthouse for basic monitoring of the Portworx cluster. From Portworx 3.x onwards, Lighthouse is no longer available in the pack itself. Instead you can install [Portworx Central](https://docs.portworx.com/portworx-central-on-prem/install/px-central.html), which provides monitoring capabilities.
 
 <br />
 
 ## Parameters
 
-### Charts - Portworx:
+### Charts - Portworx 3.x:
 
 ```yaml
 charts:
-  portworx-generic:
+  px-operator:
+    namespace: portworx-operator
 
+  portworx-generic:
     license:
       # Valid options for "type" are: essentials, saas, enterprise
       # If you want to deploy the PX Enterprise Trial version, or need manual offline activation,
       # select the "enterprise" type and set "activateLicense" to false.
-      type: essentials
+      type: enterprise
       # The next block only gets used if the type is set to "essentials"
       essentials:
         # Base64-decoded value of the px-essen-user-id value in the px-essential secret
@@ -95,26 +102,94 @@ charts:
       # When autoGenerateName is true, a name of type "px-cluster-1234abcd-12ab-12ab-12ab-123456abcdef" is generated and the "name" field is ignored
       autoGenerateName: false
       name: "px-{{.spectro.system.cluster.name}}"
+      namespace: portworx
       # annotations:
       #   If you need additional annotations, specify them here
       spec: {}
-        # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
+        # Select a preset from the pane on the right, or use the Portworx Spec Builder to define a custom configuration and
+        # then paste that spec section here. (Spec Builder: https://central.portworx.com/specGen/wizard)
+        # ### Example spec
+        # image: portworx/oci-monitor:3.0.0
+        # imagePullPolicy: Always
+        # deleteStrategy:
+        #   type: UninstallAndWipe
+        # kvdb:
+        #   internal: true
+        #   # endpoints:
+        #   # - etcd:https://etcd.company.domain:2379
+        #   # authSecret: px-kvdb-auth
+        # storage:
+        #   useAll: true
+        #   journalDevice: auto
+        #   kvdbDevice: /dev/sdb
+        # network:
+        #   dataInterface: eth0
+        #   mgmtInterface: eth1
+        # secretsProvider: k8s
+        # stork:
+        #   enabled: true
+        #   args:
+        #     webhook-controller: "true"
+        # autopilot:
+        #   enabled: true
+        #   providers:
+        #   - name: default
+        #     params:
+        #       url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+        #     type: prometheus
+        # runtimeOptions:
+        #   default-io-profile: "6"
+        # csi:
+        #   enabled: true
+        # monitoring:
+        #   telemetry:
+        #       enabled: true
+        #   prometheus:
+        #     enabled: false
+        #     exportMetrics: true
+
+    # To automatically create the px-vsphere-secret for VMware, uncomment this section
+    # vsphereSecret:
+    #   user: ""
+    #   password: ""
+
+    # To automatically create the px-azure secret for Azure, uncomment this section
+    # azureSecret:
+    #   tenantId:
+    #   clientId:
+    #   clientSecret: 
 
     storageClass:
       name: spectro-storage-class
       isDefaultStorageClass: true
-      # annotations:
+      annotations: {}
       #   If you need additional annotations, specify them here
       allowVolumeExpansion: true
-      # Delete or Retain
-      reclaimPolicy: Delete
-      # WaitForFirstConsumer or Immediate
-      volumeBindingMode: WaitForFirstConsumer
+      reclaimPolicy: Delete # Delete or Retain
+      volumeBindingMode: WaitForFirstConsumer # WaitForFirstConsumer or Immediate
       parameters:
-        repl: "3"
-        priority_io: "high"
+        repl: "2"
+        # priority_io: "high"
         # sharedv4: true
+        # sharedv4_svc_type: "ClusterIP"
+        # stork.libopenstorage.org/preferRemoteNodeOnly: "false"
         # Add additional parameters as needed (https://docs.portworx.com/portworx-install-with-kubernetes/storage-operations/create-pvcs/dynamic-provisioning/)
+
+    # External kvdb related config, only used if storageCluster.spec.kvdb.internal = false
+    externalKvdb:
+      useCertsForSSL: false
+      # cacert: |
+      #   -----BEGIN CERTIFICATE-----
+      #   < KEY DATA >
+      #   -----END CERTIFICATE-----
+      # key: |
+      #   -----BEGIN RSA PRIVATE KEY-----
+      #   < KEY DATA >
+      #   -----END RSA PRIVATE KEY-----
+      # cert: |
+      #   -----BEGIN CERTIFICATE-----
+      #   < KEY DATA >
+      #   -----END CERTIFICATE-----
 ```
 # License Model
 
@@ -214,8 +289,10 @@ Use the presets in the pack user interface to select which storage specification
     storageCluster:
       spec:
         # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:2.11.2
+        image: portworx/oci-monitor:3.0.0
         imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
         kvdb:
           internal: true
           # endpoints:
@@ -223,7 +300,11 @@ Use the presets in the pack user interface to select which storage specification
           # authSecret: px-kvdb-auth
         storage:
           useAll: true
+          # kvdbDevice: /dev/sdb
           journalDevice: auto
+        # network:
+        #   dataInterface: eth0
+        #   mgmtInterface: eth1
         secretsProvider: k8s
         stork:
           enabled: true
@@ -231,12 +312,21 @@ Use the presets in the pack user interface to select which storage specification
             webhook-controller: "true"
         autopilot:
           enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
         csi:
           enabled: true
         monitoring:
+          telemetry:
+            enabled: true
           prometheus:
             enabled: false
-            exportMetrics: false
+            exportMetrics: true
 ```
 
 </TabItem>
@@ -248,17 +338,21 @@ Use the presets in the pack user interface to select which storage specification
         portworx.io/is-eks: "true"
       spec:
         # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:2.11.2
+        image: portworx/oci-monitor:3.0.0
         imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
         kvdb:
           internal: true
           # endpoints:
           # - etcd:https://etcd.company.domain:2379
           # authSecret: px-kvdb-auth
         cloudStorage:
+          maxStorageNodesPerZone: 0
           deviceSpecs:
-          - type=gp2,size=150
-          kvdbDeviceSpec: type=gp2,size=150
+            - type=gp3,size=150
+          kvdbDeviceSpec: type=gp3,size=150
+          journalDeviceSpec: auto
         secretsProvider: k8s
         stork:
           enabled: true
@@ -266,12 +360,21 @@ Use the presets in the pack user interface to select which storage specification
             webhook-controller: "true"
         autopilot:
           enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
         csi:
           enabled: true
         monitoring:
+          telemetry:
+            enabled: true
           prometheus:
             enabled: false
-            exportMetrics: false
+            exportMetrics: true
 ```
 ### Prerequisites
 
@@ -330,17 +433,21 @@ managedMachinePool:
         portworx.io/is-aks: "true"
       spec:
         # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:2.11.2
+        image: portworx/oci-monitor:3.0.0
         imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
         kvdb:
           internal: true
           # endpoints:
           # - etcd:https://etcd.company.domain:2379
           # authSecret: px-kvdb-auth
         cloudStorage:
+          maxStorageNodesPerZone: 0
           deviceSpecs:
-          - type=Premium_LRS,size=150
+            - type=Premium_LRS,size=150
           kvdbDeviceSpec: type=Premium_LRS,size=150
+          journalDeviceSpec: auto
         secretsProvider: k8s
         stork:
           enabled: true
@@ -348,28 +455,37 @@ managedMachinePool:
             webhook-controller: "true"
         autopilot:
           enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
         csi:
           enabled: true
         monitoring:
+          telemetry:
+            enabled: true
           prometheus:
             enabled: false
-            exportMetrics: false
+            exportMetrics: true
         env:
-        - name: AZURE_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: px-azure
-              key: AZURE_CLIENT_SECRET
-        - name: AZURE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name: px-azure
-              key: AZURE_CLIENT_ID
-        - name: AZURE_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              name: px-azure
-              key: AZURE_TENANT_ID
+          - name: AZURE_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: px-azure
+                key: AZURE_CLIENT_SECRET
+          - name: AZURE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: px-azure
+                key: AZURE_CLIENT_ID
+          - name: AZURE_TENANT_ID
+            valueFrom:
+              secretKeyRef:
+                name: px-azure
+                key: AZURE_TENANT_ID
     azureSecret:
       tenantId: "your_azure_tenant_id"
       clientId: "your_azure_client_id"
@@ -385,17 +501,21 @@ managedMachinePool:
         portworx.io/is-gke: "true"
       spec:
         # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:2.11.2
+        image: portworx/oci-monitor:3.0.0
         imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
         kvdb:
           internal: true
           # endpoints:
           # - etcd:https://etcd.company.domain:2379
           # authSecret: px-kvdb-auth
         cloudStorage:
+          maxStorageNodesPerZone: 0
           deviceSpecs:
-          - type=pd-standard,size=150
+            - type=pd-standard,size=150
           kvdbDeviceSpec: type=pd-standard,size=150
+          journalDeviceSpec: auto
         secretsProvider: k8s
         stork:
           enabled: true
@@ -403,12 +523,21 @@ managedMachinePool:
             webhook-controller: "true"
         autopilot:
           enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
         csi:
           enabled: true
         monitoring:
+          telemetry:
+            enabled: true
           prometheus:
             enabled: false
-            exportMetrics: false
+            exportMetrics: true
 ```
 
 </TabItem>
@@ -418,17 +547,21 @@ managedMachinePool:
     storageCluster:
       spec:
         # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:2.11.2
+        image: portworx/oci-monitor:3.0.0
         imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
         kvdb:
           internal: true
           # endpoints:
           # - etcd:https://etcd.company.domain:2379
           # authSecret: px-kvdb-auth
         cloudStorage:
+          maxStorageNodesPerZone: 0
           deviceSpecs:
-          - type=lazyzeroedthick,size=150
+            - type=lazyzeroedthick,size=150
           kvdbDeviceSpec: type=lazyzeroedthick,size=32
+          journalDeviceSpec: auto
         secretsProvider: k8s
         stork:
           enabled: true
@@ -436,33 +569,42 @@ managedMachinePool:
             webhook-controller: "true"
         autopilot:
           enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
         csi:
           enabled: true
         monitoring:
+          telemetry:
+            enabled: true
           prometheus:
             enabled: false
-            exportMetrics: false
+            exportMetrics: true
         env:
-        - name: VSPHERE_INSECURE
-          value: "true"
-        - name: VSPHERE_USER
-          valueFrom:
-            secretKeyRef:
-              name: px-vsphere-secret
-              key: VSPHERE_USER
-        - name: VSPHERE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: px-vsphere-secret
-              key: VSPHERE_PASSWORD
-        - name: VSPHERE_VCENTER
-          value: "my-vcenter.company.local"
-        - name: VSPHERE_VCENTER_PORT
-          value: "443"
-        - name: VSPHERE_DATASTORE_PREFIX
-          value: "datastore"
-        - name: VSPHERE_INSTALL_MODE
-          value: "shared"
+          - name: VSPHERE_INSECURE
+            value: "true"
+          - name: VSPHERE_USER
+            valueFrom:
+              secretKeyRef:
+                name: px-vsphere-secret
+                key: VSPHERE_USER
+          - name: VSPHERE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: px-vsphere-secret
+                key: VSPHERE_PASSWORD
+          - name: VSPHERE_VCENTER
+            value: my-vcenter.company.local
+          - name: VSPHERE_VCENTER_PORT
+            value: "443"
+          - name: VSPHERE_DATASTORE_PREFIX
+            value: Datastore
+          - name: VSPHERE_INSTALL_MODE
+            value: shared
     vsphereSecret:
       user: "username_for_vCenter_here"
       password: "your_password"
@@ -475,17 +617,24 @@ managedMachinePool:
     storageCluster:
       spec:
         # Use the Portworx Spec Builder at https://central.portworx.com/landing/login to define custom configurations, then paste the spec section here
-        image: portworx/oci-monitor:2.11.2
+        image: portworx/oci-monitor:3.0.0
         imagePullPolicy: Always
+        deleteStrategy:
+          type: UninstallAndWipe
         kvdb:
           internal: true
           # endpoints:
           # - etcd:https://etcd.company.domain:2379
           # authSecret: px-kvdb-auth
         cloudStorage:
+          maxStorageNodesPerZone: 0
           deviceSpecs:
-          - size=150
+            - size=150
           kvdbDeviceSpec: size=32
+          journalDeviceSpec: auto
+        # network:
+        #  dataInterface: eth0
+        #  mgmtInterface: eth1
         secretsProvider: k8s
         stork:
           enabled: true
@@ -493,23 +642,35 @@ managedMachinePool:
             webhook-controller: "true"
         autopilot:
           enabled: true
+          providers:
+            - name: default
+              params:
+                url: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+              type: prometheus
+        runtimeOptions:
+          default-io-profile: "6"
         csi:
           enabled: true
         monitoring:
+          telemetry:
+            enabled: true
           prometheus:
             enabled: false
-            exportMetrics: false
+            exportMetrics: true
         env:
-        - name: PURE_FLASHARRAY_SAN_TYPE
-          value: "ISCSI"
+          - name: PURE_FLASHARRAY_SAN_TYPE
+            value: ISCSI # or "FC"
 ```
 
-To activate the Pure Flash Array integration, you will need to create a `secret` on your cluster named `px-pure-secret` that contains your Flash Array license. You can do this by running the below kubectl command:
+To activate the Pure Flash Array integration, you will need to create a `secret` named `px-pure-secret` on your cluster containing your [Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/cloud-references/auto-disk-provisioning/pure-flash-array.html#deploy-portworx). The secret must be created in the namespace that contains the StorageCluster resource. For version 2.x of the pack, the namespace is `kube-system`. For version 3.x and higher of the pack, the namespace is `portworx` by default.
+
+You can do this by running the below kubectl command:
 
 ```
-kubectl create secret generic px-pure-secret --namespace kube-system --from-file=pure.json=<file path>
+kubectl create secret generic px-pure-secret --namespace portworx --from-file=pure.json=<file path>
 ```
 
+Alternatively, you can attach a manifest to the Portworx /w Operator pack that contains the YAML for the secret.
 
 </TabItem>
 </Tabs>
@@ -617,5 +778,8 @@ These are the three types of Presets that can be selected and modified. The pack
 ## References
 
 - [Portworx Install with Kubernetes](https://docs.portworx.com/portworx-install-with-kubernetes/)
-- [Lighthouse](https://docs.portworx.com/reference/lighthouse/)
 - [Installation Prerequisites](https://docs.portworx.com/install-portworx/prerequisites/)
+- [Supported Kubernetes versions](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions)
+- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html)
+- [Portworx Central](https://docs.portworx.com/portworx-central-on-prem/install/px-central.html)
+- [Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/cloud-references/auto-disk-provisioning/pure-flash-array.html#deploy-portworx)

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -76,7 +76,7 @@ The following parameters are highlighted for this version of the pack and provid
 | `portworx-generic.activateLicense`| Set to `true` to activate the Portworx license. | `true` |
 | `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select the **PX Enterprise** type and set `activateLicense` to `false`. | `essentials` |
 | `portworx-generic.Storagecluster.spec` |  Define the storage type and behavior for Portworx.Refer to the Storage Specification section below to learn more.| `{}`|
-| `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External Etcd section below to learn more.| `{}`|
+| `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External etcd section below to learn more.| `{}`|
 | `portworx-generic.storageCluster.env` | Specify environment variables, such as HTTP Proxy settings, for Portworx. | `{}`| 
 
 
@@ -604,13 +604,13 @@ storageCluster:
 
 ### Etcd
 
-Portworx Enterprise supports multiple Etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
+Portworx Enterprise supports multiple etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
 
 #### Kvdb and Etcd Presets
 
-The following pack presets are available for configuring Etcd.
+The following pack presets are available for configuring etcd.
 
-The pack defaults to the **Use Internal Kvdb** option. You can change to a different preset if you need to connect to an external Etcd server. 
+The pack defaults to the **Use Internal Kvdb** option. You can change to a different preset if you need to connect to an external etcd server. 
 
 <Tabs queryString="keyvalue">
 <TabItem label="Use Internal Kvdb" value="Use Internal Kvdb">
@@ -666,16 +666,16 @@ externalKvdb:
 
 #### Integration With External Etcd
 
-Use the following steps to integrate Portworx to an external Etcd server by following the steps below.
+Use the following steps to integrate Portworx to an external etcd server by following the steps below.
 
 
 1. During the cluster profile creation, select the Portworx pack and click on the **Presets** button in the top right corner of the pack user interface.
 
 
-2. Select the **Use External Kvdb over HTTP** or **Use External Kvdb over SSL** preset in the pack UI. If your external Etcd server requires certificate authentication, select **Use External Kvdb over SSL** preset.
+2. Select the **Use External Kvdb over HTTP** or **Use External Kvdb over SSL** preset in the pack UI. If your external etcd server requires certificate authentication, select **Use External Kvdb over SSL** preset.
 
 
-3. Configure the external Etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
+3. Configure the external etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
 
 
 4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automatically get created by this pack.
@@ -749,7 +749,7 @@ The following parameters are highlighted for this version of the pack and provid
 | `portworx-generic.activateLicense`| Set to `true` to activate the Portworx license. | `true` |
 | `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select **PX Enterprise** type and set `activateLicense` to `false`. | `essentials` |
 | `portworx-generic.Storagecluster.spec` |  Define the storage type and behavior for Portworx.Refer to the Storage Specification section below to learn more.| `{}`|
-| `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External Etcd section below to learn more.| `{}`|
+| `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External etcd section below to learn more.| `{}`|
 | `portworx-generic.storageCluster.env` | Specify environment variables, such as HTTP Proxy settings, for Portworx. | `{}`| 
 
 
@@ -1189,13 +1189,13 @@ storageCluster:
 
 ### Etcd
 
-Portworx Enterprise supports multiple Etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
+Portworx Enterprise supports multiple etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
 
 #### Kvdb and Etcd Presets
 
-The following pack presets are available for configuring Etcd.
+The following pack presets are available for configuring etcd.
 
-The pack defaults to the **Use Internal Kvdb** option. You can change to a different preset if you need to connect to an external Etcd server. 
+The pack defaults to the **Use Internal Kvdb** option. You can change to a different preset if you need to connect to an external etcd server. 
 
 <Tabs queryString="keyvalue">
 <TabItem label="Use Internal Kvdb" value="Use Internal Kvdb">
@@ -1251,16 +1251,16 @@ The pack defaults to the **Use Internal Kvdb** option. You can change to a diffe
 
 #### Integration With External Etcd
 
-Use the following steps to integrate Portworx to an external Etcd server by following the steps below.
+Use the following steps to integrate Portworx to an external etcd server by following the steps below.
 
 
 1. During the cluster profile creation, select the Portworx pack and click on the **Presets** button in the top right corner of the pack user interface.
 
 
-2. Select the **Use External Kvdb over HTTP** or **Use External Kvdb over SSL** preset in the pack UI. If your external Etcd server requires certificate authentication, select **Use External Kvdb over SSL** preset.
+2. Select the **Use External Kvdb over HTTP** or **Use External Kvdb over SSL** preset in the pack UI. If your external etcd server requires certificate authentication, select **Use External Kvdb over SSL** preset.
 
 
-3. Configure the external Etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
+3. Configure the external etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
 
 
 4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automatically get created by this pack.
@@ -1332,7 +1332,7 @@ The following parameters are highlighted for this version of the pack and provid
 | `portworx-generic.activateLicense`| Set to `true` to activate the Portworx license. | `true` |
 | `portworx-generic.license.type` | Allowed values are: `essentials`, `saas`, `enterprise`. If you want to deploy the PX Enterprise Trial version, or need manual offline activation, select **PX Enterprise** and set `activateLicense` to `false`. | `essentials` |
 | `portworx-generic.Storagecluster.spec` |  Define the storage type and behavior for Portworx.Refer to the Storage Specification section below to learn more.| `{}`|
-| `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External Etcd section below to learn more.| `{}`|
+| `portworx-generic.externalKvdb` |  Define the external Key Value Database (KVDB) configuration for Portworx. Refer to the Integration With External etcd section below to learn more.| `{}`|
 | `portworx-generic.storageCluster.env` | Specify environment variables, such as HTTP Proxy settings, for Portworx. | `{}`| 
 
 
@@ -1768,18 +1768,13 @@ storageCluster:
 
 ### Etcd
 
-
-
-
-
-
-Portworx Enterprise supports multiple Etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
+Portworx Enterprise supports multiple etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
 
 #### Kvdb and Etcd Presets
 
-The following pack presets are available for configuring Etcd.
+The following pack presets are available for configuring etcd.
 
-The pack defaults to the **Use Internal Kvdb** option. You can change to a different preset if you need to connect to an external Etcd server. 
+The pack defaults to the **Use Internal Kvdb** option. You can change to a different preset if you need to connect to an external etcd server. 
 
 <Tabs queryString="keyvalue">
 <TabItem label="Use Internal Kvdb" value="Use Internal Kvdb">
@@ -1835,16 +1830,16 @@ The pack defaults to the **Use Internal Kvdb** option. You can change to a diffe
 
 #### Integration With External Etcd
 
-Use the following steps to integrate Portworx to an external Etcd server by following the steps below.
+Use the following steps to integrate Portworx to an external etcd server by following the steps below.
 
 
 1. During the cluster profile creation, select the Portworx pack and click on the **Presets** button in the top right corner of the pack user interface.
 
 
-2. Select the **Use External Kvdb over HTTP** or **Use External Kvdb over SSL** preset in the pack UI. If your external Etcd server requires certificate authentication, select **Use External Kvdb over SSL** preset.
+2. Select the **Use External Kvdb over HTTP** or **Use External Kvdb over SSL** preset in the pack UI. If your external etcd server requires certificate authentication, select **Use External Kvdb over SSL** preset.
 
 
-3. Configure the external Etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
+3. Configure the external etcd endpoints in the YAML parameter block named `charts.portworx-generic.storageCluster.spec.kvdb.endpoints`.
 
 
 4. If you selected the **Use External Kvdb over SSL** preset, you will also need to configure the `charts.portworx-generic.externalKvdb` section. Set `charts.portworx-generic.externalKvdb.useCertsForSSL` to `true` to enable certificate authentication. Input your SSL certificates in the `cacert`, `cert`, and `key` sections of `charts.portworx-generic.externalKvdb`. The preset will give you cropped example values that you can overwrite with your actual PEM certificates. Leave the `charts.portworx-generic.storageCluster.spec.kvdb.endpoints` option to its default of `px-kvdb-auth`. The name of the Kubernetes secret will automatically get created by this pack.

--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -604,7 +604,7 @@ storageCluster:
 
 ### Etcd
 
-Portworx Enterprise supports multiple etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
+Portworx Enterprise supports multiple etcd scenarios. Portworx will default to an internal key-value store (KVDB). 
 
 #### Kvdb and Etcd Presets
 
@@ -1189,7 +1189,7 @@ storageCluster:
 
 ### Etcd
 
-Portworx Enterprise supports multiple etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
+Portworx Enterprise supports multiple etcd scenarios. Portworx will default to an internal key-value store (KVDB). 
 
 #### Kvdb and Etcd Presets
 
@@ -1768,7 +1768,7 @@ storageCluster:
 
 ### Etcd
 
-Portworx Enterprise supports multiple etcd scenarios. Portworx will default to an internal internal key-value store (KVDB). 
+Portworx Enterprise supports multiple etcd scenarios. Portworx will default to an internal key-value store (KVDB). 
 
 #### Kvdb and Etcd Presets
 


### PR DESCRIPTION
## Describe the Change

This PR refreshes the Portworx /w Operator documentation to the latest 3.x version.

## Review Changes

💻 [Preview URL](https://deploy-preview-1917--docs-spectrocloud.netlify.app/integrations/portworx_operator)

🎫 [DOC-594](https://spectrocloud.atlassian.net/browse/DOC-594)
