### PR TITLE
docs: removed version PEM-4239

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/airgap/kubernetes-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/airgap/kubernetes-airgap-instructions.md
@@ -206,7 +206,7 @@ Complete the following steps before deploying the airgap Palette installation.
 7. Download the airgap setup binary. Our support team will provide you with the proper version and the necessary credentials. Replace the commands below with the recommended version and credentials provided by our support team.
 
   ```shell
-  VERSION=4.1.6
+  VERSION=X.X.X
   ```
 
   ```shell

--- a/docs/docs-content/enterprise-version/install-palette/airgap/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/airgap/vmware-vsphere-airgap-instructions.md
@@ -232,7 +232,7 @@ Complete the following steps before deploying the airgap Palette installation.
 10. Download the airgap setup binary. Our support team will provide you with the proper version and the necessary credentials. Replace the placeholder values in the commands below with the recommended version and credentials that our support team provides.
 
   ```shell
-  VERSION=4.1.6
+  VERSION=X.X.X
   ```
 
   ```shell

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/kubernetes-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/kubernetes-airgap-instructions.md
@@ -208,7 +208,7 @@ Complete the following steps before deploying the airgap VerteX installation.
 8. Download the airgap setup binary. Our support team will provide you with the proper version and credentials. Replace the values in the commands below with our support team's recommended version and credentials.
 
   ```shell
-  VERSION=4.1.6
+  VERSION=X.X.X
   ```
 
   ```shell

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/vmware-vsphere-airgap-instructions.md
@@ -235,7 +235,7 @@ Complete the following steps before deploying the airgap VerteX installation.
 11. Download the airgap setup binary. Replace the placeholder values in the commands below with the recommended version and credentials that our support team provides.
 
   ```shell
-  VERSION=4.1.6
+  VERSION=X.X.X
   ```
 
   ```shell


### PR DESCRIPTION
## Describe the Change

This PR removes the airgap binary version. Support wants customers to explicitly ask what version to use. 

## Review Changes

💻 [Preview URL]()

🎫 [PEM-4239](https://spectrocloud.atlassian.net/browse/PEM-4239)
