### PR TITLE
docs: set toc_max_heading_level to default value 3 for all docs DOC-938

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ sidebar_custom_props:
 | `sidebar_custom_props:`<br>` icon: "graph"`  | string  | one of icons from https://fontawesome.com/icons?d=gallery                                       |      
 | `hide_table_of_contents`         | boolean | setting this to `false` will hide the page from the navigation                                              |
 | `sidebar_position`               | number  | the position of the page in the navigation sidebar. The pages are sorted ascending by this value            |
-| `toc_min_heading_level`          | number | the minimum heading level to show in the table of contents.                                                  |
-| `toc_max_heading_level`          | number | the maximum heading level to show in the table of contents.                                                  | 
+| `toc_min_heading_level`          | number | the minimum heading level to show in the table of contents. The default value for all documents is `2`.      |
+| `toc_max_heading_level`          | number | the maximum heading level to show in the table of contents. The default value for all documents is `3`.      | 
 | `tags`                           | array  |  A list of string that can be used for additonal categorization of content.                                  | 
 | `keywords`                      | array  |  A list of strings that areused for SEO purposes.                                                             |
 ### Sub pages

--- a/docs/docs-content/clusters/data-center/maas/install-manage-maas-pcg.md
+++ b/docs/docs-content/clusters/data-center/maas/install-manage-maas-pcg.md
@@ -4,8 +4,6 @@ title: "Install and Manage MAAS Private Cloud Gateway"
 description: "Learn how to install and manage the MAAS Private Cloud Gateway in Palette."
 hide_table_of_contents: false
 sidebar_position: 10
-toc_min_heading_level: 2
-toc_max_heading_level: 3
 tags: ["data center", "maas"]
 ---
 

--- a/docs/docs-content/clusters/data-center/openstack.md
+++ b/docs/docs-content/clusters/data-center/openstack.md
@@ -4,8 +4,6 @@ title: "OpenStack"
 description: "The methods of creating clusters for a speedy deployment on any CSP"
 hide_table_of_contents: false
 sidebar_position: 20
-toc_min_heading_level: 2
-toc_max_heading_level: 3
 tags: ["data center", "openstack"]
 ---
 

--- a/docs/docs-content/clusters/data-center/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware.md
@@ -4,8 +4,6 @@ title: "VMware"
 description: "Learn how to configure VMware to create VMware clusters in Palette."
 hide_table_of_contents: false
 sidebar_position: 30
-toc_min_heading_level: 2
-toc_max_heading_level: 3
 tags: ["data center", "vmware"]
 ---
 

--- a/docs/docs-content/clusters/public-cloud/deploy-k8s-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/deploy-k8s-cluster.md
@@ -6,8 +6,6 @@ icon: ""
 category: ["tutorial"]
 hide_table_of_contents: false
 tags: ["public cloud", "aws", "azure", "gcp", "tutorial"]
-toc_min_heading_level: 2
-toc_max_heading_level: 3
 sidebar_position: 50
 ---
 

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -5,7 +5,6 @@ description: "Learn how to install Palette on VMware."
 icon: ""
 sidebar_position: 10
 hide_table_of_contents: false
-toc_max_heading_level: 3
 tags: ["palette", "self-hosted", "vmware"]
 keywords: ["self-hosted", "enterprise"]
 ---

--- a/docs/docs-content/registries-and-packs/spectro-cli-reference.md
+++ b/docs/docs-content/registries-and-packs/spectro-cli-reference.md
@@ -5,7 +5,6 @@ description: "A reference sheet for the Spectro Cloud CLI tool"
 icon: ""
 hide_table_of_contents: false
 sidebar_position: 10
-toc_max_heading_level: 3
 ---
 
 

--- a/docs/docs-content/release-notes.md
+++ b/docs/docs-content/release-notes.md
@@ -3,8 +3,6 @@ sidebar_label: "Release Notes"
 title: "Release Notes"
 description: "Spectro Cloud release notes for Palette and its sub-components."
 hide_table_of_contents: false
-toc_min_heading_level: 2
-toc_max_heading_level: 3
 sidebar_position: 0
 sidebar_custom_props: 
   icon: "audits"

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -5,7 +5,6 @@ description: "Learn how to deploy Palette VerteX on VMware."
 icon: ""
 hide_table_of_contents: false
 sidebar_position: 0
-toc_max_heading_level: 3
 tags: ["vertex", "vmware"]
 keywords: ["self-hosted", "vertex"]
 ---

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -249,7 +249,7 @@ const config = {
       },
       tableOfContents: {
         minHeadingLevel: 2,
-        maxHeadingLevel: 6,
+        maxHeadingLevel: 3,
       },
       // Replace with your project's social card
       image: "img/spectro-cloud-social-card.png",


### PR DESCRIPTION
## Describe the Change

This patch makes the following changes:
- sets the `toc_max_heading_level` to default value 3
- removes redundant frontmatter settings for this level

## Review Changes

💻 [Add Preview URL]()

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-938)
