### PR TITLE
Update cilium-tetragon.md

### DIFF
--- a/docs/docs-content/integrations/cilium-tetragon.md
+++ b/docs/docs-content/integrations/cilium-tetragon.md
@@ -6,7 +6,7 @@ hide_table_of_contents: true
 type: "integration"
 category: ['monitoring', 'amd64']
 sidebar_class_name: "hide-from-sidebar"
-logoUrl: 'https://soak.stage.spectrocloud.com/assets/monitoring_layer.3b14cf5b.svg'
+logoUrl: 'https://registry.spectrocloud.com/v1/tetragon/blobs/sha256:4b14874658de77afc1c966119c156f5a0c28477debc7cb1276f9e1fb63ba9cae?type=image/png'
 tags: ["packs", "cilium-tetragon", "monitoring"]
 ---
 


### PR DESCRIPTION
## Describe the Change

This PR fixes the missing logo to Cilium Tetragon.

![CleanShot 2024-01-02 at 08 45 53](https://github.com/spectrocloud/librarium/assets/29551334/282b235a-94b6-4425-a4b4-72167cd47acc)


## Review Changes

💻 [Preview URL]()
