### PR TITLE
Azure account gov create

### DIFF
--- a/docs/docs-content/clusters/public-cloud/azure/azure-cloud.md
+++ b/docs/docs-content/clusters/public-cloud/azure/azure-cloud.md
@@ -102,3 +102,8 @@ You can verify your account is added.
 Use the **three-dot Menu** in the row of the cloud account to edit Azure account information in Palette or remove the account from Palette.
 
 :::
+
+
+## Next Steps
+
+After you have added your Azure cloud account to Palette or VerteX, you can start deploying an Azure IaaS cluster by following the  [Create and Manage IaaS Cluster](./create-azure-cluster.md) guide, or if you prefer an Azure Managed Kubernetes Service (AKS) cluster, refer to the [Create and Manage Azure AKS Cluster](./azure.md) guide. We also encourage you to check out the [Deploy a Cluster tutorial](../deploy-k8s-cluster.md) for a detailed walkthrough of the cluster creation process.

--- a/docs/docs-content/clusters/public-cloud/azure/azure-cloud.md
+++ b/docs/docs-content/clusters/public-cloud/azure/azure-cloud.md
@@ -24,8 +24,7 @@ Palette supports integration with Azure and [Azure Government](https://azure.mic
 
 ## Add Azure Cloud Account
 
-<Tabs groupId="account">
-<TabItem label="Azure" value="azure-nongov">
+Use the following steps to add an Azure or Azure Government account in Palette or Palette VerteX.
 
 1. Log in to [Palette](https://console.spectrocloud.com) or Palette VerteX as a tenant admin.
 
@@ -42,22 +41,28 @@ Palette supports integration with Azure and [Azure Government](https://azure.mic
 |**Account Name**| A custom account name.|
 |**Tenant ID**| Unique tenant ID from Azure Management Portal.|
 |**Client ID**| Unique client ID from Azure Management Portal.|
-|**Client Secret**| Azure secret for authentication. Refer to Microsoft's reference guide for creating a [Client Secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#create-an-azure-active-directory-application). After providing the client secret, click the **Validate** button. If the client secret you provided is correct, a *Credentials validated* success message with a green check is displayed. |
+|**Client Secret**| Azure secret for authentication. Refer to Microsoft's reference guide for creating a [Client Secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#create-an-azure-active-directory-application).  |
+| **Cloud** | Select **Azure Public Cloud** or **Azure US Government**. |
 |**Tenant Name**| An optional tenant name.|
 |**Disable Properties**| This option disables Palette importing Azure networking details. Disabling this option requires you to create a Microsoft Entra application and manually obtain account information. To learn more, refer to the [Disable Palette Network Calls to the Account](#disable-palette-network-calls-to-the-account) section below. |
 |**Connect Private Cloud Gateway**| If you will be launching Managed Kubernetes Service (AKS), use the **drop-down Menu** to select a [self-hosted PCG](gateways.md) that you created to link to the cloud account.|
 
+6. After providing the required values, click the **Validate** button. If the client secret you provided is correct, a *Credentials validated* success message with a green check is displayed.
+
+7. Click **Confirm** to complete the registration.
+
 
 #### Disable Palette Network Calls to Azure Account  
 
+<details>
+ <summary>Expand to learn more about disabling properties.</summary>
+
 When you provide your cloud account information, Azure networking details are sent to Palette unless you disable network calls from Palette to the account. To disable network calls, select the **Disable Properties** option.  
 
-Disabling network calls requires that you create a [Microsoft Entra](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#create-an-azure-active-directory-application) application, which can be used with Role-Based Access Control (RBAC). Follow the summary steps below to create a new Microsoft Entra application, assign roles, and create the client secret. 
+Disabling network calls requires that you create a [Microsoft Entra](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#create-an-azure-active-directory-application) application, which can be used with Role-Based Access Control (RBAC). Follow the summary steps below to create a new Microsoft Entra application, assign roles, and create the client secret.  
 
-:::info
-
+:::tip
 Microsoft Entra replaces the Azure Active Directory (AAD) application. For more information, review the [Microsoft Entra](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#create-an-azure-active-directory-application) reference guide.
-
 :::
 
 
@@ -77,10 +82,7 @@ Microsoft Entra replaces the Azure Active Directory (AAD) application. For more 
 
   :::
 
-</TabItem>
-<TabItem label="Azure Gov" value="azure-gov">
-</TabItem>
-</Tabs>
+</details>
 
 ## Validate
 

--- a/docs/docs-content/clusters/public-cloud/azure/azure-cloud.md
+++ b/docs/docs-content/clusters/public-cloud/azure/azure-cloud.md
@@ -8,20 +8,26 @@ sidebar_position: 10
 ---
 
 
-Palette supports integration with Azure cloud accounts. This section explains how to create an Azure cloud account in Palette. You can use any of the following authentication methods to register your cloud account.
+Palette supports integration with Azure and [Azure Government](https://azure.microsoft.com/en-us/explore/global-infrastructure/government) cloud accounts. This section explains how to add an Azure cloud account in Palette or Palette VerteX. You can use any of the following authentication methods to register your cloud account.
+
 
 ## Prerequisites
 
-* A [Palette Account](https://console.spectrocloud.com/).
+* A [Palette](https://console.spectrocloud.com/), or VerteX account. 
 
 * An active [Azure cloud account](https://portal.azure.com/) with sufficient resource limits and permissions to provision compute, network, and security resources in the desired regions.
 
 * An [Azure App](https://learn.microsoft.com/en-us/azure/app-service/overview) with valid credentials.
 
 
+
+
 ## Add Azure Cloud Account
 
-1. Log in to [Palette](https://console.spectrocloud.com) as a tenant admin.
+<Tabs groupId="account">
+<TabItem label="Azure" value="azure-nongov">
+
+1. Log in to [Palette](https://console.spectrocloud.com) or Palette VerteX as a tenant admin.
 
 2. From the left **Main Menu**, select **Tenant Settings**. 
 
@@ -42,7 +48,7 @@ Palette supports integration with Azure cloud accounts. This section explains ho
 |**Connect Private Cloud Gateway**| If you will be launching Managed Kubernetes Service (AKS), use the **drop-down Menu** to select a [self-hosted PCG](gateways.md) that you created to link to the cloud account.|
 
 
-### Disable Palette Network Calls to Azure Account  
+#### Disable Palette Network Calls to Azure Account  
 
 When you provide your cloud account information, Azure networking details are sent to Palette unless you disable network calls from Palette to the account. To disable network calls, select the **Disable Properties** option.  
 
@@ -71,6 +77,10 @@ Microsoft Entra replaces the Azure Active Directory (AAD) application. For more 
 
   :::
 
+</TabItem>
+<TabItem label="Azure Gov" value="azure-gov">
+</TabItem>
+</Tabs>
 
 ## Validate
 

--- a/docs/docs-content/clusters/public-cloud/azure/azure.md
+++ b/docs/docs-content/clusters/public-cloud/azure/azure.md
@@ -8,7 +8,7 @@ tags:
 - azure
 ---
 
-Palette supports integration with [Microsoft Azure](https://azure.microsoft.com/en-us). You can deploy and manage [Host Clusters](../../../glossary-all.md#hostcluster) in Azure. To get  started check out the [Register and Manage Azure Cloud Account](azure-cloud.md#manage-azure-accounts). 
+Palette supports integration with [Microsoft Azure](https://azure.microsoft.com/en-us). You can deploy and manage [Host Clusters](../../../glossary-all.md#hostcluster) in Azure or Azure Government. To get  started check out the [Register and Manage Azure Cloud Account](azure-cloud.md#manage-azure-accounts). 
 
 
 

--- a/vale/styles/Vocab/Internal/accept.txt
+++ b/vale/styles/Vocab/Internal/accept.txt
@@ -169,3 +169,4 @@ Simple Mail Transfer Protocol
 NIC
 autoscale
 initContainer
+Entra


### PR DESCRIPTION
## Describe the Change

This PR updates the Azure account registration steps to include the option of Azure Government. The steps are identical; the only difference is the drop-down option selected for cloud type. 

## Review Changes

💻 [Preview URL](https://6595c4d518a1ba00a1b5ad89--docs-spectrocloud.netlify.app/clusters/public-cloud/azure/azure-cloud)

🎫 [PCP-810](https://spectrocloud.atlassian.net/browse/PCP-810)
