### PR TITLE
chore: updated Vale rule to standarize on README

### DIFF
--- a/vale/styles/Vocab/Internal/accept.txt
+++ b/vale/styles/Vocab/Internal/accept.txt
@@ -164,3 +164,4 @@ Okta
 Keycloak
 autoscale
 initContainer
+README

--- a/vale/styles/Vocab/Internal/reject.txt
+++ b/vale/styles/Vocab/Internal/reject.txt
@@ -14,3 +14,5 @@ hence
 VSphere
 VMWare
 on-premises
+readme
+Readme


### PR DESCRIPTION
## Describe the Change

This PR updates the Vale rules to enforce README and disallow the usage of readme or Readme. 

