### PR TITLE
Image Fix

### DIFF
--- a/docs/docs-content/architecture/networking-ports.md
+++ b/docs/docs-content/architecture/networking-ports.md
@@ -135,13 +135,13 @@ You can expose inbound port 22 for SSH if you would like to access your cluster 
 <TabItem label="gRPC" value="gRPC">
 
 
-![On-prem network diagram](/architecture_networking-ports_on_prem_network-diagram-grpc.png "#title="network diagram")
+![On-prem network diagram](/architecture_networking-ports_on_prem_network-diagram-grpc.png)
 
 </TabItem>
 
 <TabItem label="NATS" value="nats">
 
-![On-prem network diagram](/architecture_networking-ports_on_prem_network-diagram-nats.png "#title="network diagram")
+![On-prem network diagram](/architecture_networking-ports_on_prem_network-diagram-nats.png)
 
 
 </TabItem>


### PR DESCRIPTION
## Describe the Change

This PR fixes a broken image display on the Network Ports page. The image now displays correctly.

![CleanShot 2024-01-16 at 14 18 22](https://github.com/spectrocloud/librarium/assets/29551334/e7b064fd-ec70-4274-b2d1-9820710669e3)


## Review Changes

💻 [Preview URL](https://deploy-preview-2051--docs-spectrocloud.netlify.app/architecture/networking-ports)

