### PR TITLE
chore: add vale rule to avoid master and slave

### DIFF
--- a/vale/styles/spectrocloud/inclusive.yml
+++ b/vale/styles/spectrocloud/inclusive.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: "Consider avoiding '%s' in favor of more inclusive language."
+link: "http://example.com/inclusivity-guidelines"
+ignorecase: true
+level: error
+tokens:
+  - master
+  - slave
+nonword: true
+exceptions:
+  - master node


### PR DESCRIPTION
## Describe the Change

This PR adds a vale rule to avoid terms master and slave. Makes an exception for master node, as we have an in-product name master node pool. 

## Review Changes

💻 [Add Preview URL]()

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-1034)
