### PR TITLE
Backport Prettier docs to v.4.1

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,8 @@ vale/
 **/*.yaml
 **/*.yml
 
-# Troublesome files!
+docs/api-content/**/*.json
+
+# Troublesome files
 tsconfig.json
 src/components/IconMapper/dynamicFontAwesomeImports.js

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,13 @@ sync-vale: ## Install Vale plugins
 check-writing: ## Run Vale lint checks
 	vale $(CHANGED_FILE) 
 
+##@ Formatting Checks
+
 format: ## Apply Prettier formating to all files.
 	npm run format
+
+format-check: ## Check if all files are formatted with Prettier.
+	npm run format-check
 
 ##@ Clean Server Artifacts
 

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ The content in the `docs/` folder require approval from the documentation team. 
 be found in the [OWNERS_ALIAS](./content/OWNER_ALIASES) file. Only members of the documentation team may modify this
 file.
 
-# Check Writing
+## Check Writing
 
 We leverage [Vale](https://vale.sh/) to help us enforce our writing style programmatically and to avoid common writing
 mistakes. The writing checks are executed upon a pull request. You may also conduct a writing check locally by using the
@@ -566,6 +566,72 @@ words from the list by modifying the file.
 
 Rejected words automatically get flagged by Vale. To modify the list of rejected words, modify the
 [reject.txt](/vale/styles/Vocab/Internal/reject.txt) file.
+
+## Check Formatting
+
+We use [Prettier](https://prettier.io/) to maintain uniform and consistent formatting across the docbase. When you
+commit changes, Prettier formats the staged files automatically. Then, once you create a pull request, it verifies that
+the formatting in all files complies with our Prettier configuration.
+
+> [!NOTE]  
+> The build fails if the Code Formatting check doesn't pass.
+
+To manually check the formatting before pushing your work upstream, execute the following command in your terminal:
+
+```
+make format-check
+```
+
+Console output if all files are formatted:
+
+```
+Checking formatting...
+All matched files use Prettier code style!
+```
+
+Console output if some of the files require re-formatting:
+
+```
+Checking formatting...
+[warn] README.md
+[warn] Code style issues found in the above file. Run Prettier to fix.
+```
+
+To manually format all files, issue the following command:
+
+```
+make format
+```
+
+### Known Caveats
+
+- When using callouts/admonitions,
+  [pay attention to their syntax](https://docusaurus.io/docs/markdown-features/admonitions#usage-with-prettier).
+
+  ```
+  <!-- Prettier doesn't change this -->
+  :::note
+
+  Hello world
+
+  :::
+
+  <!-- Prettier changes this -->
+
+  :::note
+  Hello world
+  :::
+
+  <!-- to this, interfering with the admonition rendering and breaking JSX components -->
+
+  ::: note Hello world:::
+
+  ```
+
+- When you add JSX or HTML syntax, Prettier can introduce empty artifacts around them `{" "}` to ensure that whitespace
+  is preserved in the rendered output – a helpful feature in React development. However, Docusaurus can sometimes parse
+  them as valid HTML, making these artifacts visible to readers. For this reason, check your docs before pushing changes
+  upstream and remove any `{" "}` you find.
 
 ## Release
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint . --ext .js,.ts,.jsx,.tsx",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write \"**/*.{js,jsx,json,ts,tsx,md,mdx,css}\"",
+    "format-check": "prettier . --check",
     "prepare": "husky install"
   },
   "lint-staged": {


### PR DESCRIPTION
## Describe the Change

This PR manually backports the Prettier docs to v.4.1 (PR#2104).

## Review Changes

💻 [Add Preview URL]()

🎫 [Jira Ticket]()
