### PR TITLE
Add a Vale rule to check for admonitions of type `:::note`

### DIFF
--- a/vale/styles/spectrocloud/admonitions.yml
+++ b/vale/styles/spectrocloud/admonitions.yml
@@ -1,4 +1,8 @@
-extends: existence
-message:
+extends: substitution
+message: "The ':::note' admonition is not approved under the Spectro Cloud style guide. Consider using ':::info' or another approved admonition."
+link: https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro+Cloud+Internal+Style+Guide#Admonitions/Callouts
 level: error
+nonword: true
 ignorecase: true
+swap:
+  ":::note": ":::info"

--- a/vale/styles/spectrocloud/admonitions.yml
+++ b/vale/styles/spectrocloud/admonitions.yml
@@ -1,0 +1,4 @@
+extends: existence
+message:
+level: error
+ignorecase: true


### PR DESCRIPTION
## Describe the Change

This PR adds a custom Vale rule to check for admonitions of type `:::note` and suggests using `:::info` or another approved admonition.

## Review Changes

💻 [Add Preview URL]()

🎫 [DOC-1001](https://spectrocloud.atlassian.net/browse/DOC-1001)