### PR TITLE
docs: add note that exiting proxy pod must be restarted for vmo

### DIFF
--- a/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
@@ -17,7 +17,7 @@ components, refer to [Virtual Machine Orchestrator Pack](../vm-packs-profiles/vm
 If you are updating the profile of an existing cluster that already has the **Spectro Proxy** pack. You must restart the
 Spectro Proxy pod for the proxy to work as expected.
 
-To restart Spetro Proxy pod, drain the pod and it will restart automatically. You can issue the command
+To restart Spetro Proxy pod, delete the pod and it will restart automatically. You can issue the command
 `kubectl get pods --all-namespaces | grep spectro-proxy` to find the name and namespace of the Spectro Proxy pod, and
 then issue the command `kubectl delete pod --namespace NAMESPACE POD_NAME` to delete the pod. For example:
 

--- a/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
@@ -17,24 +17,11 @@ components, refer to [Virtual Machine Orchestrator Pack](../vm-packs-profiles/vm
 - If you are updating the profile of an existing cluster that already has the **Spectro Proxy** pack. You must restart
   the Spectro Proxy pod for the proxy to work as expected.
 
-  To restart the Spectro Proxy pod, delete the pod and it will restart automatically. You can issue the command
-  `kubectl get pods --all-namespaces | grep spectro-proxy` to find the name and namespace of the Spectro Proxy pod, and
-  then issue the command `kubectl delete pod --namespace NAMESPACE POD_NAME` to delete the pod.
-
-  For example:
+  To restart the Spectro Proxy pod, delete the pod and it will restart automatically. You can issue the following
+  command to delete the pod:
 
   ```shell
-  kubectl get pods --all-namespaces | grep spectro-proxy
-  ```
-
-  ```hideClipboard
-  cluster-65c40969caf2312a4a885570   spectro-proxy-6bff55c7dd-cffx9                                   1/1     Running     0          11m
-  ```
-
-  Then, issue the following command to delete the pod and a new one will automatically be created in its place.
-
-  ```shell hideClipboard
-  kubectl delete pod --namespace cluster-65c40969caf2312a4a885570 spectro-proxy-6bff55c7dd-cffx9
+  kubectl delete pods --selector app=spectro-proxy --all-namespaces
   ```
 
 ## Prerequisites

--- a/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
@@ -14,18 +14,18 @@ components, refer to [Virtual Machine Orchestrator Pack](../vm-packs-profiles/vm
 
 ## Limitations
 
-- If you are updating the profile of an existing cluster that already has the **Spectro Proxy** pack. You must restart
-  the Spectro Proxy pod for the proxy to work as expected.
+If you are updating the profile of an existing cluster that already has the **Spectro Proxy** pack. You must restart the
+Spectro Proxy pod for the proxy to work as expected.
 
-  To restart Spetro Proxy pod, drain the pod and it will restart automatically. You can issue the command
-  `kubectl get pods --all-namespaces | grep spectro-proxy` to find the name and namespace of the Spectro Proxy pod, and
-  then issue the command `kubectl delete pod --namespace NAMESPACE POD_NAME` to delete the pod. For example:
+To restart Spetro Proxy pod, drain the pod and it will restart automatically. You can issue the command
+`kubectl get pods --all-namespaces | grep spectro-proxy` to find the name and namespace of the Spectro Proxy pod, and
+then issue the command `kubectl delete pod --namespace NAMESPACE POD_NAME` to delete the pod. For example:
 
-  ```shell hideClipboard
-  kubectl get pods --all-namespaces | grep spectro-proxy
-  cluster-65c40969caf2312a4a885570   spectro-proxy-6bff55c7dd-cffx9                                   1/1     Running     0          11m
-  kubectl delete pod --namespace cluster-65c40969caf2312a4a885570 spectro-proxy-6bff55c7dd-cffx9
-  ```
+```shell hideClipboard
+kubectl get pods --all-namespaces | grep spectro-proxy
+cluster-65c40969caf2312a4a885570   spectro-proxy-6bff55c7dd-cffx9                                   1/1     Running     0          11m
+kubectl delete pod --namespace cluster-65c40969caf2312a4a885570 spectro-proxy-6bff55c7dd-cffx9
+```
 
 ## Prerequisites
 

--- a/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
@@ -17,7 +17,7 @@ components, refer to [Virtual Machine Orchestrator Pack](../vm-packs-profiles/vm
 If you are updating the profile of an existing cluster that already has the **Spectro Proxy** pack. You must restart the
 Spectro Proxy pod for the proxy to work as expected.
 
-To restart Spetro Proxy pod, delete the pod and it will restart automatically. You can issue the command
+To restart the Spetro Proxy pod, delete the pod and it will restart automatically. You can issue the command
 `kubectl get pods --all-namespaces | grep spectro-proxy` to find the name and namespace of the Spectro Proxy pod, and
 then issue the command `kubectl delete pod --namespace NAMESPACE POD_NAME` to delete the pod. For example:
 

--- a/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
@@ -14,18 +14,28 @@ components, refer to [Virtual Machine Orchestrator Pack](../vm-packs-profiles/vm
 
 ## Limitations
 
-If you are updating the profile of an existing cluster that already has the **Spectro Proxy** pack. You must restart the
-Spectro Proxy pod for the proxy to work as expected.
+- If you are updating the profile of an existing cluster that already has the **Spectro Proxy** pack. You must restart
+  the Spectro Proxy pod for the proxy to work as expected.
 
-To restart the Spetro Proxy pod, delete the pod and it will restart automatically. You can issue the command
-`kubectl get pods --all-namespaces | grep spectro-proxy` to find the name and namespace of the Spectro Proxy pod, and
-then issue the command `kubectl delete pod --namespace NAMESPACE POD_NAME` to delete the pod. For example:
+  To restart the Spetro Proxy pod, delete the pod and it will restart automatically. You can issue the command
+  `kubectl get pods --all-namespaces | grep spectro-proxy` to find the name and namespace of the Spectro Proxy pod, and
+  then issue the command `kubectl delete pod --namespace NAMESPACE POD_NAME` to delete the pod.
 
-```shell hideClipboard
-kubectl get pods --all-namespaces | grep spectro-proxy
-cluster-65c40969caf2312a4a885570   spectro-proxy-6bff55c7dd-cffx9                                   1/1     Running     0          11m
-kubectl delete pod --namespace cluster-65c40969caf2312a4a885570 spectro-proxy-6bff55c7dd-cffx9
-```
+  For example:
+
+  ```shell
+  kubectl get pods --all-namespaces | grep spectro-proxy
+  ```
+
+  ```hideClipboard
+  cluster-65c40969caf2312a4a885570   spectro-proxy-6bff55c7dd-cffx9                                   1/1     Running     0          11m
+  ```
+
+  Then, issue the following command to delete the pod and a new one will automatically be created in its place.
+
+  ```shell hideClipboard
+  kubectl delete pod --namespace cluster-65c40969caf2312a4a885570 spectro-proxy-6bff55c7dd-cffx9
+  ```
 
 ## Prerequisites
 

--- a/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
@@ -12,6 +12,21 @@ The **Virtual Machine Orchestrator** pack conveniently includes several componen
 [Spectro Proxy](../../integrations/frp.md) pack when you use the default profile configuration. To learn about pack
 components, refer to [Virtual Machine Orchestrator Pack](../vm-packs-profiles/vm-packs-profiles.md).
 
+## Limitations
+
+- If you are updating the profile of an existing cluster that already has the **Spectro Proxy** pack. You must restart
+  the Spectro Proxy pod for the proxy to work as expected.
+
+  To restart Spetro Proxy pod, drain the pod and it will restart automatically. You can issue the command
+  `kubectl get pods --all-namespaces | grep spectro-proxy` to find the name and namespace of the Spectro Proxy pod, and
+  then issue the command `kubectl delete pod --namespace NAMESPACE POD_NAME` to delete the pod. For example:
+
+  ```shell hideClipboard
+  kubectl get pods --all-namespaces | grep spectro-proxy
+  cluster-65c40969caf2312a4a885570   spectro-proxy-6bff55c7dd-cffx9                                   1/1     Running     0          11m
+  kubectl delete pod --namespace cluster-65c40969caf2312a4a885570 spectro-proxy-6bff55c7dd-cffx9
+  ```
+
 ## Prerequisites
 
 - A Palette permission key `create` for the resource `clusterProfile`.

--- a/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/vm-packs-profiles/create-vmo-profile.md
@@ -17,7 +17,7 @@ components, refer to [Virtual Machine Orchestrator Pack](../vm-packs-profiles/vm
 - If you are updating the profile of an existing cluster that already has the **Spectro Proxy** pack. You must restart
   the Spectro Proxy pod for the proxy to work as expected.
 
-  To restart the Spetro Proxy pod, delete the pod and it will restart automatically. You can issue the command
+  To restart the Spectro Proxy pod, delete the pod and it will restart automatically. You can issue the command
   `kubectl get pods --all-namespaces | grep spectro-proxy` to find the name and namespace of the Spectro Proxy pod, and
   then issue the command `kubectl delete pod --namespace NAMESPACE POD_NAME` to delete the pod.
 


### PR DESCRIPTION
## Describe the Change

This PR adds. the requirement that an existing spectro proxy pod must be restarted if the user wants to add the vmo to the cluster. 

## Review Changes

💻 [Preview URL](https://deploy-preview-2193--docs-spectrocloud.netlify.app/vm-management/vm-packs-profiles/create-vmo-profile)

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/PEM-4221)
