### PR TITLE
Backup and other fix

### DIFF
--- a/docs/docs-content/clusters/cluster-management/backup-restore/create-cluster-backup.md
+++ b/docs/docs-content/clusters/cluster-management/backup-restore/create-cluster-backup.md
@@ -11,7 +11,7 @@ This guide provides instructions for how to create a cluster backup using Palett
 where you created the backup as the _source cluster_.
 
 A backup operation can only back up specified namespaces, cluster-scoped resources, and Persistent Volumes (PVs) from
-the source cluster. The backup operation includes the source cluster profile in Palette's final backup object.
+the source cluster.
 
 :::info
 

--- a/docs/docs-content/clusters/cluster-management/backup-restore/restore-cluster-backup.md
+++ b/docs/docs-content/clusters/cluster-management/backup-restore/restore-cluster-backup.md
@@ -89,7 +89,8 @@ backup. To learn more about the restore operation, refer to the Velero
 
   :::warning
 
-  If the source cluster is unavailable in Palette, you cannot restore its backup.
+  If the source cluster is unavailable in Palette, you cannot restore its backup through the Palette user interface.
+  Reach out to our support team at [support@spectrocloud.com](mailto:support@spectrocloud.com) for additional guidance.
 
   :::
 

--- a/docs/docs-content/integrations/ubuntu.md
+++ b/docs/docs-content/integrations/ubuntu.md
@@ -726,22 +726,6 @@ data "spectrocloud_pack_simple" "ubuntu" {
 ```
 
 </TabItem>
-<TabItem label="Cox Edge" value="cox-edge">
-
-```hcl
-data "spectrocloud_registry" "public_registry" {
-  name = "Public Repo"
-}
-
-data "spectrocloud_pack_simple" "ubuntu" {
-  name    = "ubuntu-coxedge"
-  version = "22.04"
-  type = "helm"
-  registry_uid = data.spectrocloud_registry.public_registry.id
-}
-```
-
-</TabItem>
 <TabItem label="AWS" value="aws">
 
 ```hcl

--- a/docs/docs-content/registries-and-packs/registries/registries.md
+++ b/docs/docs-content/registries-and-packs/registries/registries.md
@@ -40,14 +40,15 @@ synchronization behavior of Helm registries.
 Palette comes with a set of default registries that are available to all SaaS tenants, and non-airgap self-hosted
 Palette environments. The default registries are listed below:
 
-| **Name**                   | **Provider** | **Description**                                                                   | **URL**                                        | **Base Path** |
-| -------------------------- | ------------ | --------------------------------------------------------------------------------- | ---------------------------------------------- | ------------- |
-| Bitnami                    | Helm         | A Helm Chart registry containing Helm Charts maintained and supported by Bitnami. | `https://charts.bitnami.com/bitnami`           | -             |
-| Public Spectro Helm Repo   | Helm         | A Helm Chart registry containing Helm Charts maintained and supported by us.      | `https://spectrocloud.github.io/helm-charts`   | -             |
-| Public Repo                | Legacy Packs | A packs registry containing packs maintained and supported by us.                 | `https://registry.spectrocloud.com`            | -             |
-| Spectro Addon Repo         | Legacy Packs | A packs registry containing add-on packs maintained and supported by us.          | `https://registry-addon.spectrocloud.com`      | -             |
-| Palette Registry           | OCI          | A packs registry containing packs maintained and supported by us.                 | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `production`  |
-| Palette Community Registry | OCI          | A packs registry containing community packs.                                      | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `community`   |
+| **Name**                   | **Provider** | **Description**                                                                   | **URL**                                        | **Base Path**     |
+| -------------------------- | ------------ | --------------------------------------------------------------------------------- | ---------------------------------------------- | ----------------- |
+| Bitnami                    | Helm         | A Helm Chart registry containing Helm Charts maintained and supported by Bitnami. | `https://charts.bitnami.com/bitnami`           | -                 |
+| Public Spectro Helm Repo   | Helm         | A Helm Chart registry containing Helm Charts maintained and supported by us.      | `https://spectrocloud.github.io/helm-charts`   | -                 |
+| Public Repo                | Legacy Packs | A packs registry containing packs maintained and supported by us.                 | `https://registry.spectrocloud.com`            | -                 |
+| Spectro Addon Repo         | Legacy Packs | A packs registry containing add-on packs maintained and supported by us.          | `https://registry-addon.spectrocloud.com`      | -                 |
+| Palette Registry           | OCI          | A packs registry containing packs maintained and supported by us.                 | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `production`      |
+| Palette Registry FIPS      | OCI          | A packs registry containing FIPS packs maintained and supported by us.            | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `production-fips` |
+| Palette Community Registry | OCI          | A packs registry containing community packs.                                      | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `community`       |
 
 :::info
 


### PR DESCRIPTION
## Describe the Change

This PR fixes minor items that were provided through Slack feedback. 

- Removed Cox Edge from Terraform block in [Ubuntu packs page](https://deploy-preview-2194--docs-spectrocloud.netlify.app/integrations/ubuntu#terraform).
- Removed an incorrect sentence from [Backup index page](https://deploy-preview-2194--docs-spectrocloud.netlify.app/clusters/cluster-management/backup-restore/).
- [Added FIPS OCI registry to table](https://deploy-preview-2194--docs-spectrocloud.netlify.app/registries-and-packs/registries/#default-registries).

## Review Changes

💻 [Preview URL](https://deploy-preview-2194--docs-spectrocloud.netlify.app)

