### PR TITLE
Backport Vale updates to version 4.1

### DIFF
--- a/vale/styles/Vocab/Internal/accept.txt
+++ b/vale/styles/Vocab/Internal/accept.txt
@@ -176,3 +176,10 @@ untrusted
 goroutines
 renegotiation
 renegotiations
+wpa_supplicant
+Podman
+filepath
+Datagram
+PCGs
+vCPU
+vCPUs


### PR DESCRIPTION
## Describe the Change

This PR manually backports changes from [PR#2246](https://github.com/spectrocloud/librarium/pull/2246).