### PR TITLE
Backport Vale updates to version 4.2

### DIFF
--- a/vale/styles/Vocab/Internal/accept.txt
+++ b/vale/styles/Vocab/Internal/accept.txt
@@ -187,3 +187,6 @@ wpa_supplicant
 Podman
 filepath
 Datagram
+PCGs
+vCPU
+vCPUs


### PR DESCRIPTION
## Describe the Change

This PR manually backports changes from [PR#2246](https://github.com/spectrocloud/librarium/pull/2246).