### PR TITLE
Update Palette CLI download link

### DIFF
--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -25,7 +25,7 @@ the [Palette CLI](/palette-cli/install-palette-cli) document for installation gu
 
 | Version | Operating System                                                                      | Checksum (SHA256)                                                  |
 | ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 4.2.2   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.2.2/linux/cli/palette) | `ea57325f5c741eff080b3fbf29ed69f878e9d1b0f680265fd0e63fe595fa49eb` |
+| 4.2.4   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.2.4/linux/cli/palette) | `3e1cddc25c7c883e6385b9c8365519cef66d1893756e5794947de2cf38d02092` |
 
 ## Palette Edge CLI
 


### PR DESCRIPTION
## Describe the Change

This PR updates the download link for Palette CLI from 4.2.2 to 4.2.4.

## Review Changes

💻 [Downloads](https://deploy-preview-2257--docs-spectrocloud.netlify.app/spectro-downloads)

🎫 [DOC-1077](https://spectrocloud.atlassian.net/browse/DOC-1077)


[DOC-1077]: https://spectrocloud.atlassian.net/browse/DOC-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ