### PR TITLE
Fix a command in the Nutanix PCG deployment guide

### DIFF
--- a/docs/docs-content/clusters/data-center/nutanix/add-nutanix-cloud-account.md
+++ b/docs/docs-content/clusters/data-center/nutanix/add-nutanix-cloud-account.md
@@ -31,15 +31,15 @@ Once the Private Cloud Gateway (PCG) is installed, the Nutanix cloud account mus
 
 6. Fill out the following input values and click **Confirm** to continue.
 
-| **Field**                 | **Description**                                                                                             |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Name**                  | A custom name for the account.                                                                              |
-| **Private Cloud Gateway** | Select the PCG from the list of deployed PCGs in your setup.                                                |
-| **NUTANIX_USER**          | The Prism Central user name.                                                                                |
-| **NUTANIX_PASSWORD**      | The Prism Central user password.                                                                            |
-| **NUTANIX_ENDPOINT**      | The Prism Central IP address or the fully qualified domain name (FQDN) assigned to Prism.                   |
-| **NUTANIX_PORT**          | Specify the default port you assigned in the `cloudClusterTemplate.yaml` file. The default value is `9440`. |
-| **NUTANIX_INSECURE**      | Specify the SSL behavior you used in the `cloudClusterTemplate.yaml` file. The default behavior is `false`. |
+   | **Field**                 | **Description**                                                                                             |
+   | ------------------------- | ----------------------------------------------------------------------------------------------------------- |
+   | **Name**                  | A custom name for the account.                                                                              |
+   | **Private Cloud Gateway** | Select the PCG from the list of deployed PCGs in your setup.                                                |
+   | **NUTANIX_USER**          | The Prism Central user name.                                                                                |
+   | **NUTANIX_PASSWORD**      | The Prism Central user password.                                                                            |
+   | **NUTANIX_ENDPOINT**      | The Prism Central IP address or the fully qualified domain name (FQDN) assigned to Prism.                   |
+   | **NUTANIX_PORT**          | Specify the default port you assigned in the `cloudClusterTemplate.yaml` file. The default value is `9440`. |
+   | **NUTANIX_INSECURE**      | Specify the SSL behavior you used in the `cloudClusterTemplate.yaml` file. The default behavior is `false`. |
 
 ## Validate
 

--- a/docs/docs-content/clusters/data-center/nutanix/create-manage-nutanix-cluster.md
+++ b/docs/docs-content/clusters/data-center/nutanix/create-manage-nutanix-cluster.md
@@ -49,12 +49,12 @@ Use the following steps to deploy a Kubernetes cluster in Nutanix.
 
 5. Fill out the following basic information, and click **Next** to continue.
 
-| **Field**         | **Description**                                                                                                          |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| **Cluster Name**  | A custom name for the cluster. Use this cluster name for the `${CLUSTER_NAME}` variable in the YAML configuration files. |
-| **Description**   | Use the description to provide context about the cluster.                                                                |
-| **Tags**          | Assign any desired cluster tags.                                                                                         |
-| **Cloud Account** | Select your Nutanix account from the **drop-down Menu**.                                                                 |
+   | **Field**         | **Description**                                                                                                          |
+   | ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
+   | **Cluster Name**  | A custom name for the cluster. Use this cluster name for the `${CLUSTER_NAME}` variable in the YAML configuration files. |
+   | **Description**   | Use the description to provide context about the cluster.                                                                |
+   | **Tags**          | Assign any desired cluster tags.                                                                                         |
+   | **Cloud Account** | Select your Nutanix account from the **drop-down Menu**.                                                                 |
 
 6. Select the Nutanix cluster profile you created and click **Next**. Palette displays the profile layers.
 
@@ -65,54 +65,55 @@ Use the following steps to deploy a Kubernetes cluster in Nutanix.
    listed in the table below with values that apply to your Nutanix cloud environment, and make any adjustments to
    configure your cluster. Click **Next** when you are done.
 
-| **Variable**                   | **Description**                                                                              |
-| ------------------------------ | -------------------------------------------------------------------------------------------- |
-| `${CLUSTER_NAME}`              | The name of the Nutanix workload cluster. Use the same cluster name you specified in step 5. |
-| `${CONTROL_PLANE_ENDPOINT_IP}` | The Kubernetes API IP endpoint for the cluster you are creating.                             |
-| `${NUTANIX_ENDPOINT}`          | The Nutanix Prism Central IP address.                                                        |
+   | **Variable**                   | **Description**                                                                              |
+   | ------------------------------ | -------------------------------------------------------------------------------------------- |
+   | `${CLUSTER_NAME}`              | The name of the Nutanix workload cluster. Use the same cluster name you specified in step 5. |
+   | `${CONTROL_PLANE_ENDPOINT_IP}` | The Kubernetes API IP endpoint for the cluster you are creating.                             |
+   | `${NUTANIX_ENDPOINT}`          | The Nutanix Prism Central IP address.                                                        |
 
-:::warning
+   :::warning
 
-The following applies when replacing variables within curly braces in the YAML configuration files.
+   The following applies when replacing variables within curly braces in the YAML configuration files.
 
-    - All the variables must be resolved or have a default value.
+   - All the variables must be resolved or have a default value.
 
-    - Verify default values such as the port.
+   - Verify default values such as the port.
 
-    - Names you provide must match. Any names in the YAML files that do not match your Nutanix cluster configuration will result in unsuccessful cluster deployment.
+   - Names you provide must match. Any names in the YAML files that do not match your Nutanix cluster configuration will
+     result in unsuccessful cluster deployment.
 
-    - Values that are passed as a string, such as names and keys, must be enclosed in quotes, for example `" "`.
+   - Values that are passed as a string, such as names and keys, must be enclosed in quotes, for example `" "`.
 
-    - When replacing values, remove the dollar sign and curly braces.
+   - When replacing values, remove the dollar sign and curly braces.
 
-:::
+   :::
 
 9. In the Node pool configuration YAML files for the control plane and worker pools, edit the files to replace each
    occurrence of the variables within curly braces listed in the tables below with values that apply to your Nutanix
    cloud environment. You can configure scaling in the Palette UI by specifying the number of nodes in the pool. This
    corresponds to `replicas` in the YAML file.
 
-#### Control Plane Pool
+   #### Control Plane Pool
 
-| **Variable**                             | **Description**                                                                                                                                                  |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `${CLUSTER_NAME}`                        | The name of the Nutanix workload cluster. Use the same cluster name you specified in step 5.                                                                     |
-| `${CONTROL_PLANE_ENDPOINT_IP}`           | The Kubernetes API IP endpoint for the cluster you are creating.                                                                                                 |
-| `${NUTANIX_SSH_AUTHORIZED_KEY}`          | Provide your public SSH key.                                                                                                                                     |
-| `${KUBERNETES_VERSION}`                  | Specify the Kubernetes version for your cluster, and precede the version number with `v`. For example `v1.26.3`                                                  |
-| `${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}`  | The name of your Nutanix AHV cluster as defined in Prism.                                                                                                        |
-| `${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}` | The name of your OS image as defined in Prism Central. To locate images, navigate in the Nutanix Prism dashboard to **Compute & Storage** and select **Images**. |
-| `${NUTANIX_SUBNET_NAME}`                 | The name of the subnet as defined in Prism Central that will be assigned to the virtual machines (VMs) deployed in this cluster.                                 |
+   | **Variable**                             | **Description**                                                                                                                                                  |
+   | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `${CLUSTER_NAME}`                        | The name of the Nutanix workload cluster. Use the same cluster name you specified in step 5.                                                                     |
+   | `${CONTROL_PLANE_ENDPOINT_IP}`           | The Kubernetes API IP endpoint for the cluster you are creating.                                                                                                 |
+   | `${NUTANIX_SSH_AUTHORIZED_KEY}`          | Provide your public SSH key.                                                                                                                                     |
+   | `${KUBERNETES_VERSION}`                  | Specify the Kubernetes version for your cluster, and precede the version number with `v`. For example `v1.26.3`                                                  |
+   | `${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}`  | The name of your Nutanix AHV cluster as defined in Prism.                                                                                                        |
+   | `${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}` | The name of your OS image as defined in Prism Central. To locate images, navigate in the Nutanix Prism dashboard to **Compute & Storage** and select **Images**. |
+   | `${NUTANIX_SUBNET_NAME}`                 | The name of the subnet as defined in Prism Central that will be assigned to the virtual machines (VMs) deployed in this cluster.                                 |
 
-#### Worker-Pool
+   #### Worker-Pool
 
-    | **Variable** | **Description** |
-    |--------------|-----------------|
-    | `${NUTANIX_SSH_AUTHORIZED_KEY}`| Provide your public SSH key. |
-    | `${KUBERNETES_VERSION}`| Specify the Kubernetes version for your cluster, and precede the version number with `v`. For example `v1.26.3` |
-    | `${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}`| The name of your Nutanix AHV cluster as defined in Prism. |
-    | `${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}` | The name of your OS image as defined in Prism Central. To locate images, navigate in the Nutanix Prism dashboard to **Compute & Storage** and select **Images**. |
-    | `${NUTANIX_SUBNET_NAME}` | The name of the subnet as defined in Prism Central that will be assigned to the VMs deployed in this cluster. |
+   | **Variable**                             | **Description**                                                                                                                                                  |
+   | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `${NUTANIX_SSH_AUTHORIZED_KEY}`          | Provide your public SSH key.                                                                                                                                     |
+   | `${KUBERNETES_VERSION}`                  | Specify the Kubernetes version for your cluster, and precede the version number with `v`. For example `v1.26.3`                                                  |
+   | `${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}`  | The name of your Nutanix AHV cluster as defined in Prism.                                                                                                        |
+   | `${NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME}` | The name of your OS image as defined in Prism Central. To locate images, navigate in the Nutanix Prism dashboard to **Compute & Storage** and select **Images**. |
+   | `${NUTANIX_SUBNET_NAME}`                 | The name of the subnet as defined in Prism Central that will be assigned to the VMs deployed in this cluster.                                                    |
 
 10. Click **Next** when you are done.
 

--- a/docs/docs-content/clusters/data-center/nutanix/install-pcg/deploy-kubernetes-cluster-pcg.md
+++ b/docs/docs-content/clusters/data-center/nutanix/install-pcg/deploy-kubernetes-cluster-pcg.md
@@ -96,9 +96,16 @@ following command for each variable.
 
 4. Instantiate Nutanix Cluster API.
 
-```bash
-clusterctl init --infrastructure nutanix
-```
+   :::info
+
+   To prevent conflicts with the recent Nutanix CAPI provider updates, you need to install this exact version of the
+   Nutanix infrastructure.
+
+   :::
+
+   ```bash
+   clusterctl init --infrastructure nutanix:v1.2.4
+   ```
 
 5. Deploy a workload cluster in Nutanix by issuing the following command. Replace `mytestcluster` with the cluster name
    that you assigned to your workload cluster and `mytestnamespace` and with your namespace name. Provide the Nutanix

--- a/docs/docs-content/clusters/data-center/nutanix/install-pcg/deploy-kubernetes-cluster-pcg.md
+++ b/docs/docs-content/clusters/data-center/nutanix/install-pcg/deploy-kubernetes-cluster-pcg.md
@@ -38,9 +38,9 @@ following the process described in the
 2. Create a local kind cluster. This cluster will bootstrap Cluster API and provision the target workload cluster in the
    Nutanix account. The workload cluster is then used to deploy the PCG.
 
-```bash
-kind create cluster --name pcg-pilot
-```
+   ```bash
+   kind create cluster --name pcg-pilot
+   ```
 
 ## Deploy Workload Cluster
 
@@ -48,51 +48,51 @@ kind create cluster --name pcg-pilot
    and export the variables. The table describes the environment variables. For more information, review the
    [Nutanix Getting Started](https://opendocs.nutanix.com/capx/v1.1.x/getting_started/) guide.
 
-| **Variable**                          | **Description**                                                                                     |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `NUTANIX_ENDPOINT`                    | The Prism Central IP address or FQDN.                                                               |
-| `NUTANIX_USER`                        | The Prism Central user name.                                                                        |
-| `NUTANIX_PASSWORD`                    | The Prism Central user password.                                                                    |
-| `NUTANIX_INSECURE`                    | The SSL behavior you used in the `cloudClusterTemplate.yaml` file. The default behavior is `false`. |
-| `NUTANIX_SSH_AUTHORIZED_KEY`          | Provide your public SSH key.                                                                        |
-| `NUTANIX_PRISM_ELEMENT_CLUSTER_NAME`  | The Nutanix Prism Element cluster name.                                                             |
-| `NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME` | The Nutanix CAPI OS Image                                                                           |
-| `NUTANIX_SUBNET_NAME`                 | The subnet of the Nutanix workload cluster.                                                         |
-| `KUBERNETES_VERSION`                  | The Kubernetes version the workload cluster uses. Precede the version with `v`.                     |
-| `WORKER_MACHINE_COUNT`                | The number of nodes in the workload cluster.                                                        |
+   | **Variable**                          | **Description**                                                                                     |
+   | ------------------------------------- | --------------------------------------------------------------------------------------------------- |
+   | `NUTANIX_ENDPOINT`                    | The Prism Central IP address or FQDN.                                                               |
+   | `NUTANIX_USER`                        | The Prism Central user name.                                                                        |
+   | `NUTANIX_PASSWORD`                    | The Prism Central user password.                                                                    |
+   | `NUTANIX_INSECURE`                    | The SSL behavior you used in the `cloudClusterTemplate.yaml` file. The default behavior is `false`. |
+   | `NUTANIX_SSH_AUTHORIZED_KEY`          | Provide your public SSH key.                                                                        |
+   | `NUTANIX_PRISM_ELEMENT_CLUSTER_NAME`  | The Nutanix Prism Element cluster name.                                                             |
+   | `NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME` | The Nutanix CAPI OS Image                                                                           |
+   | `NUTANIX_SUBNET_NAME`                 | The subnet of the Nutanix workload cluster.                                                         |
+   | `KUBERNETES_VERSION`                  | The Kubernetes version the workload cluster uses. Precede the version with `v`.                     |
+   | `WORKER_MACHINE_COUNT`                | The number of nodes in the workload cluster.                                                        |
 
-Copy the following Nutanix environment variables to your terminal, provide values, and export the variables.
+   Copy the following Nutanix environment variables to your terminal, provide values, and export the variables.
 
-    ```bash
-    export NUTANIX_ENDPOINT=""
-    export NUTANIX_USER=""
-    export NUTANIX_PASSWORD=""
-    export NUTANIX_INSECURE=false
-    export NUTANIX_SSH_AUTHORIZED_KEY=""
-    export NUTANIX_PRISM_ELEMENT_CLUSTER_NAME=""
-    export NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME=""
-    export NUTANIX_SUBNET_NAME=""
-    ```
+   ```bash
+   export NUTANIX_ENDPOINT=""
+   export NUTANIX_USER=""
+   export NUTANIX_PASSWORD=""
+   export NUTANIX_INSECURE=false
+   export NUTANIX_SSH_AUTHORIZED_KEY=""
+   export NUTANIX_PRISM_ELEMENT_CLUSTER_NAME=""
+   export NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME=""
+   export NUTANIX_SUBNET_NAME=""
+   ```
 
-You can ensure the Nutanix variables were successfully exported by issuing the following command in your terminal.
+   You can ensure the Nutanix variables were successfully exported by issuing the following command in your terminal.
 
-    ```bash
-    env | grep "NUTANIX"
-    ```
+   ```bash
+   env | grep "NUTANIX"
+   ```
 
-Copy the following environment variables to your terminal, provide values, and export the variables.
+   Copy the following environment variables to your terminal, provide values, and export the variables.
 
-    ```bash
-    export KUBERNETES_VERSION="v1.22.9"
-    export WORKER_MACHINE_COUNT=1
-    ```
+   ```bash
+   export KUBERNETES_VERSION="v1.22.9"
+   export WORKER_MACHINE_COUNT=1
+   ```
 
-To verify the KUBERNETES_VERSION and WORKER_MACHINE_COUNT variables were successfully exported, you can issue the
-following command for each variable.
+   To verify the KUBERNETES_VERSION and WORKER_MACHINE_COUNT variables were successfully exported, you can issue the
+   following command for each variable.
 
-    ```bash
-    echo $variable_name
-    ```
+   ```bash
+   echo $variable_name
+   ```
 
 4. Instantiate Nutanix Cluster API.
 
@@ -111,39 +111,39 @@ following command for each variable.
    that you assigned to your workload cluster and `mytestnamespace` and with your namespace name. Provide the Nutanix
    Prism Central IP address for CONTROL_PLANE_ENDPOINT_IP.
 
-```bash
-export TEST_CLUSTER_NAME=mytestcluster
-export TEST_NAMESPACE=mytestnamespace
-CONTROL_PLANE_ENDPOINT_IP=x.x.x.x clusterctl generate cluster ${TEST_CLUSTER_NAME} \
-  -i nutanix \
-  --target-namespace ${TEST_NAMESPACE}  \
-  > ./cluster.yaml
-kubectl create namespace ${TEST_NAMESPACE}
-kubectl apply -filename ./cluster.yaml -namespace ${TEST_NAMESPACE}
-```
+   ```bash
+   export TEST_CLUSTER_NAME=mytestcluster
+   export TEST_NAMESPACE=mytestnamespace
+   CONTROL_PLANE_ENDPOINT_IP=x.x.x.x clusterctl generate cluster ${TEST_CLUSTER_NAME} \
+     -i nutanix \
+     --target-namespace ${TEST_NAMESPACE}  \
+     > ./cluster.yaml
+   kubectl create namespace ${TEST_NAMESPACE}
+   kubectl apply -filename ./cluster.yaml -namespace ${TEST_NAMESPACE}
+   ```
 
-The snippet below displays the output of the command.
+   The snippet below displays the output of the command.
 
-```bash hideClipBoard
-namespace/mytestnamespace created
-configmap/user-ca-bundle created
-secret/mytestcluster created
-kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/mytestcluster-kcfg-0 created
-cluster.cluster.x-k8s.io/mytestcluster created
-machinedeployment.cluster.x-k8s.io/mytestcluster-wmd created
-machinehealthcheck.cluster.x-k8s.io/mytestcluster-mhc created
-kubeadmcontrolplane.controlplane.cluster.x-k8s.io/mytestcluster-kcp created
-nutanixcluster.infrastructure.cluster.x-k8s.io/mytestcluster created
-nutanixmachinetemplate.infrastructure.cluster.x-k8s.io/mytestcluster-mt-0 created
-```
+   ```bash hideClipBoard
+   namespace/mytestnamespace created
+   configmap/user-ca-bundle created
+   secret/mytestcluster created
+   kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/mytestcluster-kcfg-0 created
+   cluster.cluster.x-k8s.io/mytestcluster created
+   machinedeployment.cluster.x-k8s.io/mytestcluster-wmd created
+   machinehealthcheck.cluster.x-k8s.io/mytestcluster-mhc created
+   kubeadmcontrolplane.controlplane.cluster.x-k8s.io/mytestcluster-kcp created
+   nutanixcluster.infrastructure.cluster.x-k8s.io/mytestcluster created
+   nutanixmachinetemplate.infrastructure.cluster.x-k8s.io/mytestcluster-mt-0 created
+   ```
 
 ## Install CNI on Workload Cluster
 
 6. After your Nutanix workload cluster is deployed, retrieve its kubeconfig file with the command described below.
 
-```bash
-clusterctl get kubeconfig $TEST_CLUSTER_NAME > $TEST_CLUSTER_NAME.kubeconfig -namespace $TEST_NAMESPACE
-```
+   ```bash
+   clusterctl get kubeconfig $TEST_CLUSTER_NAME > $TEST_CLUSTER_NAME.kubeconfig -namespace $TEST_NAMESPACE
+   ```
 
 7. Deploy a Container Network Interface (CNI) pod in the workload cluster to enable pod-to-pod communication. For more
    information, refer to
@@ -151,23 +151,23 @@ clusterctl get kubeconfig $TEST_CLUSTER_NAME > $TEST_CLUSTER_NAME.kubeconfig -na
    [Nutanix Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.htm) reference.
    [Calico](https://docs.tigera.io/calico/latest/about/) is used as the CNI solution in this example.
 
-```bash
-kubectl apply --filename https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/calico.yaml
-```
+   ```bash
+   kubectl apply --filename https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/calico.yaml
+   ```
 
 8. To verify that the CNI was deployed successfully, issue the following command.
 
-```bash
-kubectl --kubeconfig=./$TEST_CLUSTER_NAME.kubeconfig get nodes
-```
+   ```bash
+   kubectl --kubeconfig=./$TEST_CLUSTER_NAME.kubeconfig get nodes
+   ```
 
-The output should display your nodes with a **Ready** status.
+   The output should display your nodes with a **Ready** status.
 
-    ```bash hideClipBoard
-    NAME                           STATUS   ROLES           AGE   VERSION
-    test-cluster-kcp-qhb5h         Ready    control-plane   26h   v1.26.7
-    test-cluster-wmd-gdjps-gx267   Ready    <none>          26h   v1.26.7
-    ```
+   ```bash hideClipBoard
+   NAME                           STATUS   ROLES           AGE   VERSION
+   test-cluster-kcp-qhb5h         Ready    control-plane   26h   v1.26.7
+   test-cluster-wmd-gdjps-gx267   Ready    <none>          26h   v1.26.7
+   ```
 
 ## Validate
 

--- a/docs/docs-content/clusters/data-center/nutanix/install-pcg/deploy-kubernetes-cluster-pcg.md
+++ b/docs/docs-content/clusters/data-center/nutanix/install-pcg/deploy-kubernetes-cluster-pcg.md
@@ -98,8 +98,8 @@ following the process described in the
 
    :::info
 
-   To prevent conflicts with the recent Nutanix CAPI provider updates, you need to install this exact version of the
-   Nutanix infrastructure.
+   To prevent conflicts with the recent Nutanix CAPI provider updates, you need to instantiate Cluster API with this
+   exact version of the Nutanix infrastructure.
 
    :::
 

--- a/docs/docs-content/clusters/data-center/nutanix/nutanix.md
+++ b/docs/docs-content/clusters/data-center/nutanix/nutanix.md
@@ -44,26 +44,26 @@ steps in Palette and their local environment.
    commands provided in the Palette UI. For guidance, review
    [Install Private Cloud Gateway](./install-pcg/install-pcg.md).
 
-When the PCG status displays the state **Running**, the PCG cluster is integrated with Palette.
+   When the PCG status displays the state **Running**, the PCG cluster is integrated with Palette.
 
-:::info
+   :::info
 
-Nutanix cloud requires the deployment of a PCG, which enables Palette to monitor clusters in the infrastructure provider
-environment. The PCG instance is installed on an existing Kubernetes cluster that must remain operational.
+   Nutanix cloud requires the deployment of a PCG, which enables Palette to monitor clusters in the infrastructure
+   provider environment. The PCG instance is installed on an existing Kubernetes cluster that must remain operational.
 
-:::
+   :::
 
 3. Next, add the Nutanix cloud account to Palette. Use the **drop-down Menu** to select the PCG name you provided when
    you configured it in the previous step. You must fill out the account name and account details.
 
 4. Create a cluster profile by selecting Nutanix as the cloud type.
 
-When creating a Nutanix profile, you do not have to specify anything for the OS or Kubernetes layers. Palette provides
-out-of-the-box packs for the network and storage profile layers, including the
-[**Nutanix CSI**](../../../integrations/nutanix-csi.md) storage pack. The **Nutanix CSI** pack is available when the
-cloud is registered using the name `nutanix`. If you have custom packs, you can add them to Palette by adding your
-registry. To learn how to add a pack registry, review
-[Add a Custom Registry](/docs/docs-content/registries-and-packs/adding-a-custom-registry.md).
+   When creating a Nutanix profile, you do not have to specify anything for the OS or Kubernetes layers. Palette
+   provides out-of-the-box packs for the network and storage profile layers, including the
+   [**Nutanix CSI**](../../../integrations/nutanix-csi.md) storage pack. The **Nutanix CSI** pack is available when the
+   cloud is registered using the name `nutanix`. If you have custom packs, you can add them to Palette by adding your
+   registry. To learn how to add a pack registry, review
+   [Add a Custom Registry](/docs/docs-content/registries-and-packs/adding-a-custom-registry.md).
 
 5. Deploy a cluster by specifying Nutanix, listed under **Tech Preview**, as the cluster type. Select the cloud account
    you added and make any needed changes to the profile layers by using the YAML editor. At the **Cluster Config** step,


### PR DESCRIPTION
## Describe the Change

This PR fixes a command in the Nutanix PCG deployment guide to avoid issues stemming from the updates to the Nutanix CAPI provider.

## Review Changes

💻 [Deploy a Kubernetes Cluster to Host the PCG](https://65d8f3f0b791cd450cda368b--docs-spectrocloud.netlify.app/clusters/data-center/nutanix/install-pcg/deploy-kubernetes-cluster-pcg)

🎫 [DOC-1058](https://spectrocloud.atlassian.net/browse/DOC-1058)