### PR TITLE
chore: add acronym rule to vale DOC-940

### DIFF
--- a/vale/styles/spectrocloud/acronym.yml
+++ b/vale/styles/spectrocloud/acronym.yml
@@ -1,0 +1,54 @@
+extends: conditional
+message: "Use title case to define the acronym '%s'."
+link: 'https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro+Cloud+Internal+Style+Guide#Acronyms'
+level: error
+ignorecase: false
+scope: text
+# Match two to five capital letters surrounded by brackets 
+# to detect an acronym definition.
+first: '[(][A-Z]{2,5}[)]'
+# Match two to five capitalised words separated by any number of dashes 
+# or whitespaces before the acronym definition.
+second: '(\b(([A-Z][a-z]+)[\-\s ]{1,}){2,5})([(][A-Z]{2,5}[)])'
+exceptions:
+  - (API)
+  - (AWS)
+  - (BYOOS)
+  - (CAPI)
+  - (CLI)
+  - (CPU)
+  - (CSS)
+  - (CSV)
+  - (FAQ)
+  - (GCP)
+  - (GET)
+  - (GPU)
+  - (HTML)
+  - (HTTP)
+  - (HTTPS)
+  - (IDE)
+  - (IP)
+  - (ISO)
+  - (JPEG)
+  - (JPG)
+  - (JSON)
+  - (OS)
+  - (OSS)
+  - (PDF)
+  - (PNG)
+  - (POST)
+  - (RAM)
+  - (SDK)
+  - (SQL)
+  - (SSH)
+  - (SSL)
+  - (SVG)
+  - (TCP)
+  - (URI)
+  - (URL)
+  - (USB)
+  - (VIP)
+  - (YAML)
+  - (YML)
+  - (XML)
+  - (ZIP)


### PR DESCRIPTION
## Describe the Change

This PR adds a vale rule that ensures acronyms are defined using title case, as described in our [style guide](https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro+Cloud+Internal+Style+Guide#Acronyms).
This rule applies to acronyms of 2-5 characters length. 

## Review Changes

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-940)
