### PR TITLE
docs: removing link

### DIFF
--- a/docs/docs-content/clusters/edge/edge.md
+++ b/docs/docs-content/clusters/edge/edge.md
@@ -44,7 +44,7 @@ The following are some highlights of the comprehensive Palette Edge Solution:
 
 - Support for pre-provisioned and on-site device registration
 
-Palette's Edge solution is designed for sites that typically have one or more small devices, such as Intel NUC. An
+Palette's Edge solution is designed for sites that typically have one or more small devices, such as [Asus NUC](https://www.asus.com/us/displays-desktops/nucs/nuc-mini-pcs). An
 instance of Palette optimized for edge computing is installed in the device along with the operating system and
 Kubernetes.
 

--- a/docs/docs-content/clusters/edge/edge.md
+++ b/docs/docs-content/clusters/edge/edge.md
@@ -44,8 +44,7 @@ The following are some highlights of the comprehensive Palette Edge Solution:
 
 - Support for pre-provisioned and on-site device registration
 
-Palette's Edge solution is designed for sites that typically have one or more small devices, such as
-[Intel NUC](https://www.intel.com/content/www/us/en/products/docs/boards-kits/nuc/what-is-nuc-article.html). An instance
+Palette's Edge solution is designed for sites that typically have one or more small devices, such as Intel NUC. An instance
 of Palette optimized for edge computing is installed in the device along with the operating system and Kubernetes.
 
 :::info

--- a/docs/docs-content/clusters/edge/edge.md
+++ b/docs/docs-content/clusters/edge/edge.md
@@ -44,8 +44,9 @@ The following are some highlights of the comprehensive Palette Edge Solution:
 
 - Support for pre-provisioned and on-site device registration
 
-Palette's Edge solution is designed for sites that typically have one or more small devices, such as Intel NUC. An instance
-of Palette optimized for edge computing is installed in the device along with the operating system and Kubernetes.
+Palette's Edge solution is designed for sites that typically have one or more small devices, such as Intel NUC. An
+instance of Palette optimized for edge computing is installed in the device along with the operating system and
+Kubernetes.
 
 :::info
 

--- a/docs/docs-content/clusters/edge/edge.md
+++ b/docs/docs-content/clusters/edge/edge.md
@@ -44,9 +44,9 @@ The following are some highlights of the comprehensive Palette Edge Solution:
 
 - Support for pre-provisioned and on-site device registration
 
-Palette's Edge solution is designed for sites that typically have one or more small devices, such as [Asus NUC](https://www.asus.com/us/displays-desktops/nucs/nuc-mini-pcs). An
-instance of Palette optimized for edge computing is installed in the device along with the operating system and
-Kubernetes.
+Palette's Edge solution is designed for sites that typically have one or more small devices, such as
+[Asus NUC](https://www.asus.com/us/displays-desktops/nucs/nuc-mini-pcs). An instance of Palette optimized for edge
+computing is installed in the device along with the operating system and Kubernetes.
 
 :::info
 


### PR DESCRIPTION
## Describe the Change

This PR addresses feedback. The link is no longer available and instead links to an Intel Portal.

## Review Changes

💻 [Preview URL](https://deploy-preview-2344--docs-spectrocloud.netlify.app/clusters/edge/)

🎫 [DOC-1093](https://spectrocloud.atlassian.net/browse/DOC-1093)


[DOC-1093]: https://spectrocloud.atlassian.net/browse/DOC-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ