### PR TITLE
Update the TechPreview component to also accept custom text

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -209,7 +209,7 @@ p img.markdown-image {
   border-radius: 1vw;
 }
 
-.custom-admonition {
-  border: 1px solid var(--custom-important-color);
-  background-color: var(--custom-alert-bg-color);
+.admonition-tech-preview {
+  border: 1px solid var(--custom-purple-important-color);
+  background-color: var(--custom-purple-alert-bg-color);
 }

--- a/src/css/dark-mode.scss
+++ b/src/css/dark-mode.scss
@@ -29,8 +29,8 @@ html[data-theme="dark"] {
   --ifm-color-warning-dark: #ffc832;
   --ifm-alert-padding-horizontal: 1.5rem;
   --custom-table-header-color: #1c202b;
-  --custom-important-color: #7d77ca;
-  --custom-alert-bg-color: #1a173b;
+  --custom-purple-important-color: #7d77ca;
+  --custom-purple-alert-bg-color: #1a173b;
 
   .theme-last-updated {
     color: var(--ifm-font-color-base);

--- a/src/css/light-mode.scss
+++ b/src/css/light-mode.scss
@@ -26,8 +26,8 @@ html[data-theme="light"] {
   --ifm-color-warning-dark: #a8882f;
   --ifm-alert-padding-horizontal: 1.5rem;
   --custom-table-header-color: #f7f7f7;
-  --custom-important-color: #7d77ca;
-  --custom-alert-bg-color: #dcdaf9;
+  --custom-purple-important-color: #7d77ca;
+  --custom-purple-alert-bg-color: #dcdaf9;
 
   .theme-doc-sidebar-item-category-level-1 .menu__list-item {
     .menu__link:hover {

--- a/src/theme/Admonition/Icon/TechPreview.js
+++ b/src/theme/Admonition/Icon/TechPreview.js
@@ -2,6 +2,6 @@ import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFlag } from "@fortawesome/free-solid-svg-icons";
 
-export default function IconTechPreview(props) {
+export default function IconTechPreview() {
   return <FontAwesomeIcon icon={faFlag} />;
 }

--- a/src/theme/Admonition/Type/TechPreview.js
+++ b/src/theme/Admonition/Type/TechPreview.js
@@ -16,12 +16,15 @@ const defaultProps = {
       tech preview
     </Translate>
   ),
+  defaultText:
+    "This is a Tech Preview feature and is subject to change. Do not use this feature in production workloads.",
 };
 
 export default function AdmonitionTypeTechPreview(props) {
+  const text = props.children || defaultProps.defaultText;
   return (
     <AdmonitionLayout {...defaultProps} {...props} className={clsx(infimaClassName, props.className)}>
-      {"This is a Tech Preview feature and is subject to change. Do not use this feature in production workloads."}
+      {text}
     </AdmonitionLayout>
   );
 }

--- a/src/theme/Admonition/Type/TechPreview.js
+++ b/src/theme/Admonition/Type/TechPreview.js
@@ -4,7 +4,7 @@ import Translate from "@docusaurus/Translate";
 import AdmonitionLayout from "@theme/Admonition/Layout";
 import IconTechPreview from "../Icon/TechPreview";
 
-const infimaClassName = "alert custom-admonition";
+const infimaClassName = "alert admonition-tech-preview";
 
 const defaultProps = {
   icon: <IconTechPreview />,
@@ -23,7 +23,7 @@ const defaultProps = {
 export default function AdmonitionTypeTechPreview(props) {
   const text = props.children || defaultProps.defaultText;
   return (
-    <AdmonitionLayout {...defaultProps} {...props} className={clsx(infimaClassName, props.className)}>
+    <AdmonitionLayout {...defaultProps} className={clsx(infimaClassName, props.className)}>
       {text}
     </AdmonitionLayout>
   );


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the TechPreview component to accept custom text if necessary. If no custom text is provided, the admonition displays our standard message: *This is a Tech Preview feature and is subject to change. Do not use this feature in production workloads.*

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1099](https://spectrocloud.atlassian.net/browse/DOC-1099)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1099]: https://spectrocloud.atlassian.net/browse/DOC-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ