### PR TITLE
docs: add the command to bring up TUI before cluster deployment

### DIFF
--- a/docs/docs-content/clusters/edge/site-deployment/initial-setup.md
+++ b/docs/docs-content/clusters/edge/site-deployment/initial-setup.md
@@ -41,9 +41,9 @@ perform the setup, you can issue the command `spectro-edge-console` in the termi
    the first time you've started the Edge host since installation, you will be automatically directed to the TUI.
 
    If you are accessing the Edge host with an SSH connection, you can issue the command `spectro-edge-console` to bring
-   up the TUI. You can do this if you have gone through the initial setup in the TUI and want to change any
-   configuration. However, you can only issue `spectro-edge-console` to bring up the TUI before you have deployed a
-   cluster on the Edge host.
+   up the TUI. You can also use the same command to bring up the TUI if you have gone through the initial setup in the
+   TUI and want to change any configuration. However, you can only do this before you have deployed a cluster on the
+   Edge host.
 
 2. If you have already configured a user in your **user-data** file in the EdgeForge step, this step will be skipped
    automatically.

--- a/docs/docs-content/clusters/edge/site-deployment/initial-setup.md
+++ b/docs/docs-content/clusters/edge/site-deployment/initial-setup.md
@@ -26,8 +26,9 @@ perform the setup, you can issue the command `spectro-edge-console` in the termi
 
 ## Prerequisite
 
-- An Edge host installed with Edge Installer 4.3 or later. The Edge host must be booting up for the first time since
-  installation.
+- An Edge host installed with Edge Installer 4.3 or later.
+
+- The Edge host must not have an active cluster deployed on it.
 
 - The Edge installer ISO used to install Palette on the Edge host must
   [enable initial configuration](../edge-configuration/installer-reference.md#initial-configuration).
@@ -36,7 +37,13 @@ perform the setup, you can issue the command `spectro-edge-console` in the termi
 
 ## Set up Edge Host
 
-1. Power up the Edge host. Do not make any input and allow Palette to choose the boot option automatically.
+1. Power up the Edge host. Do not make any input and allow Palette to choose the boot option automatically. If this is
+   the first time you've started the Edge host since installation, you will be automatically directed to the TUI.
+
+   If you are accessing the Edge host with an SSH connection, you can issue the command `spectro-edge-console` to bring
+   up the TUI. You can do this if you have gone through the initial setup in the TUI and want to change any
+   configuration. However, you can only issue `spectro-edge-console` to bring up the TUI before you have deployed a
+   cluster on the Edge host.
 
 2. If you have already configured a user in your **user-data** file in the EdgeForge step, this step will be skipped
    automatically.

--- a/docs/docs-content/clusters/edge/site-deployment/initial-setup.md
+++ b/docs/docs-content/clusters/edge/site-deployment/initial-setup.md
@@ -24,7 +24,7 @@ perform the setup, you can issue the command `spectro-edge-console` in the termi
 
 :::
 
-## Prerequisite
+## Prerequisites
 
 - An Edge host installed with Edge Installer 4.3 or later.
 


### PR DESCRIPTION
## Describe the Change

This PR adds the command to bring up the initial setup TUI before cluster deployment. 

## Changed Pages

💻 [Preview URL for Page](https://65ea6527f899fb139e2688ed--docs-spectrocloud.netlify.app/clusters/edge/site-deployment/initial-setup)

## Jira Tickets

🎫 [PE-3694](https://spectrocloud.atlassian.net/browse/PE-3694)

## Backports

Can this PR be backported?

- [ ] No. This is a release PR. 


[PE-3694]: https://spectrocloud.atlassian.net/browse/PE-3694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ