### PR TITLE
chore: add vale rule - commands longform DOC-941

### DIFF
--- a/vale/styles/spectrocloud/longform.yml
+++ b/vale/styles/spectrocloud/longform.yml
@@ -1,0 +1,25 @@
+---
+extends: existence
+message: "Avoid using the short form of commands. Replace the short form flag in '%s' with the corresponding long form flag."
+link: https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro+Cloud+Internal+Style+Guide#Commands-%26-Parameters
+level: error
+ignorecase: false
+scope: raw
+tokens:
+# Match a word followed by one or more spaces, followed by the short form of a flag (one to three letters). The short flag can appear one or more times consecutively. For example: palette -h.
+    - (\b([\w]+))([\s ]{1,}[-][a-zA-Z]{1,3})+
+exceptions:
+    - ls([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - cd([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - cp([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - mv([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - rm([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - mkdir([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - rmdir([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - cat([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - pwd([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - echo([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - chmod([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - chown([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - sed([\s ]{1,}[-][a-zA-Z]{1,3})+
+    - wc([\s ]{1,}[-][a-zA-Z]{1,3})+


### PR DESCRIPTION
## Describe the Change

This PR adds a Vale rule to avoid the utilization of short-form commands, as described in our [internal style guide](https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro+Cloud+Internal+Style+Guide#Commands-%26-Parameters).

The rule applies to short-form flags (1-3 characters length) that are preceded by a word. The flag can appear multiple times. Below are presented a few illustrative examples that would trigger the rule.
- palette -d
- palette -ALL
- palette -d -f
- palette -lls -d -ALL

When the short-form flag is not preceded by a word, as for example in the [Palette CLI PCG commands](https://docs.spectrocloud.com/palette-cli/commands/pcg) page, the rule is not triggered. There are also commands that don't have long-form flags (e.g.,`ls` command), which were included as exceptions.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

🎫 [DOC-941](https://spectrocloud.atlassian.net/browse/DOC-941)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-941]: https://spectrocloud.atlassian.net/browse/DOC-941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ