### PR TITLE
docs: address PE-4011 and PE-3874

### DIFF
--- a/docs/docs-content/clusters/edge/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/upgrade-behavior.md
@@ -12,6 +12,14 @@ profile. Depending on the nature of the change, implementing an upgrade might in
 cluster, restarting services, or doing nothing. For more information about cluster repaves, refer to
 [Repave Behavior and Configurations](../cluster-management/node-pool.md#repave-behavior-and-configuration).
 
+:::warning
+
+- If a cluster's Kubernetes service is down, updates to the cluster's profile will not get applied. You must fix the
+  issue impacting the Kubernetes service first and ensure that the Kubernetes service of the cluster is operational
+  before applying updates to the cluster.
+
+:::
+
 ## Known Issues
 
 - For RKE2 clusters, updates to the `stages.*` section in the Operating System (OS) and the Kubernetes pack of the

--- a/docs/docs-content/clusters/edge/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/upgrade-behavior.md
@@ -10,13 +10,15 @@ tags: ["edge", "architecture"]
 When you update an active Edge cluster's profile, Palette will upgrade the active cluster to the latest version of the
 profile. Depending on the nature of the change, implementing an upgrade might involve repaving a cluster, rebooting a
 cluster, restarting services, or doing nothing. For more information about cluster repaves, refer to
-[Repave Behavior and Configurations](../cluster-management/node-pool.md#repave-behavior-and-configuration).
+[Repave Behavior and Configurations](../cluster-management/node-pool.md#repave-behavior-and-configuration). For more
+information about how to update a cluster profile, refer to
+[Update a Cluster](../cluster-management/cluster-updates.md).
 
 :::warning
 
-- If a cluster's Kubernetes service is down, updates to the cluster's profile will not get applied. You must fix the
-  issue impacting the Kubernetes service first and ensure that the Kubernetes service of the cluster is operational
-  before applying updates to the cluster.
+- If a cluster's Kubernetes service is down, updates to the cluster's profile will not get applied to the cluster. You
+  must fix the issue impacting the Kubernetes service first. Once the Kubernetes service is back to being operational,
+  the Palette agent will apply the updates from the cluster profile to the cluster.
 
 :::
 

--- a/docs/docs-content/clusters/edge/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/upgrade-behavior.md
@@ -12,6 +12,12 @@ profile. Depending on the nature of the change, implementing an upgrade might in
 cluster, restarting services, or doing nothing. For more information about cluster repaves, refer to
 [Repave Behavior and Configurations](../cluster-management/node-pool.md#repave-behavior-and-configuration).
 
+## Known Issues
+
+- For RKE2 clusters, updates to the `stages.*` section in the Operating System (OS) and the Kubernetes pack of the
+  cluster profile will trigger a repave instead of a reboot. The only exception is changes to the `stages.reconcile.*`
+  section, which will behave as expected and trigger a configuration reload.
+
 ## Upgrade Behaviors
 
 A cluster could respond to an upgrade in several ways. The table below lists the potential upgrade behaviors you could


### PR DESCRIPTION
## Describe the Change

This PR documents a known issue for PE-4011. Updates to the OS pack and K8s pack in the stages section trigger a repave instead of a reboot. 

## Changed Pages

💻 [Add Preview URL for Page]()

## Jira Tickets

🎫 [PE-4011](https://spectrocloud.atlassian.net/browse/PE-4011)
🎫 [PE-3874](https://spectrocloud.atlassian.net/browse/PE-3874)

## Backports

Can this PR be backported?

- [ ] No. This only applies to 4.3. 


[PE-4011]: https://spectrocloud.atlassian.net/browse/PE-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PE-3874]: https://spectrocloud.atlassian.net/browse/PE-3874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ