### PR TITLE
Palette CLI Airgap auto detect

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -108,3 +108,4 @@ fd60bdc4fdfe8b66925db07865cb530eab4978df:docs/docs-content/integrations/kubernet
 9e62b4b635976b0ab93d4dddcf29d33365664091:docs/docs-content/integrations/kubernetes.md:generic-api-key:1125
 e4040084011d4d7935a589959b96ebc5cfba7a94:docs/docs-content/integrations/kubernetes.md:generic-api-key:759
 e4040084011d4d7935a589959b96ebc5cfba7a94:docs/docs-content/integrations/kubernetes.md:generic-api-key:1125
+e4040084011d4d7935a589959b96ebc5cfba7a94:docs/docs-content/integrations/kubernetes.md:generic-api-key:391

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -106,3 +106,5 @@ fd60bdc4fdfe8b66925db07865cb530eab4978df:docs/docs-content/integrations/kubernet
 9e62b4b635976b0ab93d4dddcf29d33365664091:docs/docs-content/integrations/kubernetes.md:generic-api-key:391
 9e62b4b635976b0ab93d4dddcf29d33365664091:docs/docs-content/integrations/kubernetes.md:generic-api-key:759
 9e62b4b635976b0ab93d4dddcf29d33365664091:docs/docs-content/integrations/kubernetes.md:generic-api-key:1125
+e4040084011d4d7935a589959b96ebc5cfba7a94:docs/docs-content/integrations/kubernetes.md:generic-api-key:759
+e4040084011d4d7935a589959b96ebc5cfba7a94:docs/docs-content/integrations/kubernetes.md:generic-api-key:1125

--- a/docs/docs-content/enterprise-version/enterprise-version.md
+++ b/docs/docs-content/enterprise-version/enterprise-version.md
@@ -12,7 +12,7 @@ keywords: ["self-hosted", "enterprise"]
 Palette is available as a self-hosted platform offering. You can install the self-hosted version of Palette in your data
 centers or public cloud providers to manage Kubernetes clusters.
 
-![A diagram of Palette deployment models eager-load](/architecture_architecture-overview-deployment-models-on-prem-focus.png)
+![A diagram of Palette deployment models](/architecture_architecture-overview-deployment-models-on-prem-focus.png)
 
 :::info
 

--- a/docs/docs-content/enterprise-version/enterprise-version.md
+++ b/docs/docs-content/enterprise-version/enterprise-version.md
@@ -12,7 +12,7 @@ keywords: ["self-hosted", "enterprise"]
 Palette is available as a self-hosted platform offering. You can install the self-hosted version of Palette in your data
 centers or public cloud providers to manage Kubernetes clusters.
 
-![A diagram of Palette deployment models](/architecture_architecture-overview-deployment-models-on-prem-focus.png)
+![A diagram of Palette deployment models eager-load](/architecture_architecture-overview-deployment-models-on-prem-focus.png)
 
 :::info
 

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -152,7 +152,7 @@ Use the following steps to install Palette.
 
     If you are using the Palette CLI from inside an
     [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap
-    environment and prompt you if you want to use the **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR)
+    environment and prompt you to **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR)
     configuration**. Type `y` to use the local resources and skip filling in the repository URL and credentials.
 
     :::
@@ -192,7 +192,7 @@ Use the following steps to install Palette.
 :::info
 
 If you are using the Palette CLI from inside an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md),
-the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped
+the CLI will automatically detect the airgap environment and prompt you to **Use local, air-gapped
 Pack Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
 
 :::
@@ -226,7 +226,7 @@ for more information.
     		| **Use Public Registry for Images**               | Type `y` to use a public registry for images. Type `n` to a different registry for images. If you are using another registry for images, you will be prompted to enter the registry URL, base path, username, and password. Airgap users, select `n` so that you can specify the values for the OCI registry that contains all the required images. |
 
     		When prompted to **Pull images from public registry**, type `n` and specify the OCI registry configuration values for
-    		your image registry. If you are an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped Image Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
+    		your image registry. If you are an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap environment and prompt you to **Use local, air-gapped Image Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
         Refer to the table above for more information.
 
 :::info

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -150,7 +150,8 @@ Use the following steps to install Palette.
 
     :::info
 
-    If you are using the Palette CLI from inside an airgap support VM, the CLI will automatically detect the airgap
+    If you are using the Palette CLI from inside an
+    [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap
     environment and prompt you if you want to use the **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR)
     configuration**. Type `y` to use the local resources and skip filling in the repository URL and credentials.
 
@@ -190,9 +191,9 @@ Use the following steps to install Palette.
 
 :::info
 
-If you are using the Palette CLI from inside an airgap support VM, the CLI will automatically detect the airgap
-environment and prompt you if you want to use the **Use local, air-gapped Pack Registry?** Type `y` to use the local
-resources and skip filling in the OCI registry URL and credentials.
+If you are using the Palette CLI from inside an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md),
+the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped
+Pack Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
 
 :::
 
@@ -225,7 +226,7 @@ for more information.
     		| **Use Public Registry for Images**               | Type `y` to use a public registry for images. Type `n` to a different registry for images. If you are using another registry for images, you will be prompted to enter the registry URL, base path, username, and password. Airgap users, select `n` so that you can specify the values for the OCI registry that contains all the required images. |
 
     		When prompted to **Pull images from public registry**, type `n` and specify the OCI registry configuration values for
-    		your image registry. If you are an airgap support VM, the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped Image Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
+    		your image registry. If you are an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped Image Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
         Refer to the table above for more information.
 
 :::info

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -148,6 +148,14 @@ Use the following steps to install Palette.
     - Non-Airgap: `https://saas-repo.console.spectrocloud.com`
     - Airgap: The URL or IP address of the Spectro Cloud Repository that is provided to you by the airgap setup script
 
+    :::info
+
+    If you are using the Palette CLI from inside an airgap support VM, the CLI will automatically detect the airgap
+    environment and prompt you if you want to use the **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR)
+    configuration**. Type `y` to use the local resources and skip filling in the repository URL and credentials.
+
+    :::
+
 9.  Enter the repository credentials. Our support team provides the credentials you need to access the public Spectro
     Cloud repository. Airgap installations, provide the credentials to your private repository provided to you by the
     airgap setup script .
@@ -174,11 +182,19 @@ Use the following steps to install Palette.
 <Tabs groupId="mode">
 	<TabItem label="Non-Airgap" value="non-airgap">
 
-    Select `y` to use the Spectro Cloud FIPS repository and proceed to the next step.
+    Select `y` to use the Spectro Cloud repository and proceed to the next step.
 
     </TabItem>
 
     <TabItem label="Airgap" value="airgap">
+
+:::info
+
+If you are using the Palette CLI from inside an airgap support VM, the CLI will automatically detect the airgap
+environment and prompt you if you want to use the **Use local, air-gapped Pack Registry?** Type `y` to use the local
+resources and skip filling in the OCI registry URL and credentials.
+
+:::
 
     Select the OCI registry type and provide the configuration values. Review the following table for more information.
 
@@ -209,7 +225,8 @@ for more information.
     		| **Use Public Registry for Images**               | Type `y` to use a public registry for images. Type `n` to a different registry for images. If you are using another registry for images, you will be prompted to enter the registry URL, base path, username, and password. Airgap users, select `n` so that you can specify the values for the OCI registry that contains all the required images. |
 
     		When prompted to **Pull images from public registry**, type `n` and specify the OCI registry configuration values for
-    		your image registry. Refer to the table above for more information.
+    		your image registry. If you are an airgap support VM, the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped Image Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
+        Refer to the table above for more information.
 
 :::info
 

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -152,8 +152,8 @@ Use the following steps to install Palette.
 
     If you are using the Palette CLI from inside an
     [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap
-    environment and prompt you to **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR)
-    configuration**. Type `y` to use the local resources and skip filling in the repository URL and credentials.
+    environment and prompt you to **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR) configuration**. Type
+    `y` to use the local resources and skip filling in the repository URL and credentials.
 
     :::
 
@@ -192,8 +192,8 @@ Use the following steps to install Palette.
 :::info
 
 If you are using the Palette CLI from inside an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md),
-the CLI will automatically detect the airgap environment and prompt you to **Use local, air-gapped
-Pack Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
+the CLI will automatically detect the airgap environment and prompt you to **Use local, air-gapped Pack Registry?** Type
+`y` to use the local resources and skip filling in the OCI registry URL and credentials.
 
 :::
 

--- a/docs/docs-content/integrations/kubernetes.md
+++ b/docs/docs-content/integrations/kubernetes.md
@@ -388,7 +388,7 @@ Follow these steps to configure OIDC for managed EKS clusters.
    clientConfig:
      oidc-issuer-url: "{{ .spectro.pack.kubernetes-eks.managedControlPlane.oidcIdentityProvider.issuerUrl }}"
      oidc-client-id: "{{ .spectro.pack.kubernetes-eks.managedControlPlane.oidcIdentityProvider.clientId }}"
-     oidc-client-secret: 1gsranjjmdgahm10j8r6m47ejokm9kafvcbhi3d48jlc3rfpprhv
+     oidc-client-secret: **************************************************
      oidc-extra-scope: profile,email
    ```
 
@@ -756,7 +756,7 @@ Follow these steps to configure OIDC for managed EKS clusters.
    clientConfig:
      oidc-issuer-url: "{{ .spectro.pack.kubernetes-eks.managedControlPlane.oidcIdentityProvider.issuerUrl }}"
      oidc-client-id: "{{ .spectro.pack.kubernetes-eks.managedControlPlane.oidcIdentityProvider.clientId }}"
-     oidc-client-secret: 1gsranjjmdgahm10j8r6m47ejokm9kafvcbhi3d48jlc3rfpprhv
+     oidc-client-secret: **************************************************
      oidc-extra-scope: profile,email
    ```
 
@@ -1122,7 +1122,7 @@ Follow these steps to configure OIDC for managed EKS clusters.
    clientConfig:
      oidc-issuer-url: "{{ .spectro.pack.kubernetes-eks.managedControlPlane.oidcIdentityProvider.issuerUrl }}"
      oidc-client-id: "{{ .spectro.pack.kubernetes-eks.managedControlPlane.oidcIdentityProvider.clientId }}"
-     oidc-client-secret: 1gsranjjmdgahm10j8r6m47ejokm9kafvcbhi3d48jlc3rfpprhv
+     oidc-client-secret: **************************************************
      oidc-extra-scope: profile,email
    ```
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -159,8 +159,8 @@ Use the following steps to install Palette VerteX.
 
     If you are using the Palette CLI from inside an
     [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap
-    environment and prompt you to **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR)
-    configuration**. Type `y` to use the local resources and skip filling in the repository URL and credentials.
+    environment and prompt you to **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR) configuration**. Type
+    `y` to use the local resources and skip filling in the repository URL and credentials.
 
     :::
 
@@ -199,8 +199,8 @@ Use the following steps to install Palette VerteX.
 :::info
 
 If you are using the Palette CLI from inside an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md),
-the CLI will automatically detect the airgap environment and prompt you to **Use local, air-gapped
-Pack Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
+the CLI will automatically detect the airgap environment and prompt you to **Use local, air-gapped Pack Registry?** Type
+`y` to use the local resources and skip filling in the OCI registry URL and credentials.
 
 :::
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -155,6 +155,15 @@ Use the following steps to install Palette VerteX.
     - Non-Airgap: `https://saas-repo-fips.console.spectrocloud.com`
     - Airgap: The URL or IP address of the Spectro Cloud Repository that is provided to you by the airgap setup script.
 
+    :::info
+
+    If you are using the Palette CLI from inside an
+    [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap
+    environment and prompt you if you want to use the **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR)
+    configuration**. Type `y` to use the local resources and skip filling in the repository URL and credentials.
+
+    :::
+
 9.  Enter the repository credentials. Our support team provides the credentials you need to access the public Spectro
     Cloud repository. Airgap installations, provide the credentials to your private repository provided to you by the
     airgap setup script .
@@ -187,6 +196,14 @@ Use the following steps to install Palette VerteX.
 
     <TabItem label="Airgap" value="airgap">
 
+:::info
+
+If you are using the Palette CLI from inside an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md),
+the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped
+Pack Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
+
+:::
+
     Select the OCI registry type and provide the configuration values. Review the following table for more information.
 
 :::warning
@@ -216,7 +233,8 @@ for more information.
     		| **Use Public Registry for Images**               | Type `y` to use a public registry for images. Type `n` to a different registry for images. If you are using another registry for images, you will be prompted to enter the registry URL, base path, username, and password. Airgap users, select `n` so that you can specify the values for the OCI registry that contains all the required images. |
 
     		When prompted to **Pull images from public registry**, type `n` and specify the OCI registry configuration values for
-    		your image registry. Refer to the table above for more information.
+    		your image registry. If you are an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped Image Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
+        Refer to the table above for more information.
 
 :::info
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -159,7 +159,7 @@ Use the following steps to install Palette VerteX.
 
     If you are using the Palette CLI from inside an
     [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap
-    environment and prompt you if you want to use the **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR)
+    environment and prompt you to **Use local, air-gapped Spectro Cloud Artifact Repository (SCAR)
     configuration**. Type `y` to use the local resources and skip filling in the repository URL and credentials.
 
     :::
@@ -199,7 +199,7 @@ Use the following steps to install Palette VerteX.
 :::info
 
 If you are using the Palette CLI from inside an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md),
-the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped
+the CLI will automatically detect the airgap environment and prompt you to **Use local, air-gapped
 Pack Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
 
 :::
@@ -233,7 +233,7 @@ for more information.
     		| **Use Public Registry for Images**               | Type `y` to use a public registry for images. Type `n` to a different registry for images. If you are using another registry for images, you will be prompted to enter the registry URL, base path, username, and password. Airgap users, select `n` so that you can specify the values for the OCI registry that contains all the required images. |
 
     		When prompted to **Pull images from public registry**, type `n` and specify the OCI registry configuration values for
-    		your image registry. If you are an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap environment and prompt you if you want to use the **Use local, air-gapped Image Registry?** Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
+    		your image registry. If you are an [airgap support VM](../airgap/vmware-vsphere-airgap-instructions.md), the CLI will automatically detect the airgap environment and prompt you to **Use local, air-gapped Image Registry?**. Type `y` to use the local resources and skip filling in the OCI registry URL and credentials.
         Refer to the table above for more information.
 
 :::info


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR documents a new feature that was added to the Palette CLI. When used inside an airgap support VM. The CLI will automatically detect Harbor and OCI registry values hosted locally. Users can now skip filling out these values. 

One additional change is the removal of a value that triggered get leaks in `/integrations/Kubernetes.md`. The value was replaced with `*******`.

- [VMware Install Instructions](https://65f9f927568faa17801ba93f--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/install)
- [Vertex VMware Install Instructions](https://65f9f927568faa17801ba93f--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/install)

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page](https://65f9f927568faa17801ba93f--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/install)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PLT-1100](https://spectrocloud.atlassian.net/browse/PLT-1100)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release branch PR.


[PLT-1100]: https://spectrocloud.atlassian.net/browse/PLT-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ