### PR TITLE
docs: add hello universe pack page, fix ngrok pack title

### DIFF
--- a/docs/docs-content/integrations/hello-universe.md
+++ b/docs/docs-content/integrations/hello-universe.md
@@ -1,0 +1,83 @@
+---
+sidebar_label: "Hello Universe"
+title: "Hello Universe"
+description: "Learn about the Hello Universe pack and how you can use it within your Kubernetes clusters."
+hide_table_of_contents: true
+type: "integration"
+category: ["app services", "amd64"]
+sidebar_class_name: "hide-from-sidebar"
+logoUrl: "https://raw.githubusercontent.com/spectrocloud/pack-central/main/packs/hello-universe-1.1.1/logo.png"
+tags: ["packs", "hello-universe", "app-services"]
+---
+
+[Hello Universe](https://github.com/spectrocloud/hello-universe) is a demo web application utilized to help users learn
+more about [Palette](../introduction/introduction.md) and its features. It functions as a standalone front-end
+application and provides users with a local click counter and funny Spectro Cloud-themed images.
+
+## Versions Supported
+
+- 1.1.1
+
+## Prerequisites
+
+- A Palette account.
+
+- A cluster profile where the Hello Universe pack can be integrated.
+
+- A Palette cluster with port `:8080` available. If port 8080 is not available, you can set a different port in the
+  **values.yaml** file.
+
+- Ensure sufficient CPU resources within the cluster to allocate a minimum of 100 milliCPU and a maximum of 200 milliCPU
+  per replica.
+
+## Parameters
+
+The following parameters are applied to the **hello-universe.yaml** manifest through the **values.yaml** file. Users do
+not need to take any additional actions regarding these parameters.
+
+| **Parameter**                     | **Description**                                                                | **Default Value**                           | **Required** |
+| --------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------- | ------------ |
+| `manifests.namespace`             | The namespace in which the application will be deployed.                       | `hello-universe`                            | No           |
+| `manifests.images.hello-universe` | The application image that will be utilized to create the containers.          | `ghcr.io/spectrocloud/hello-universe:1.1.1` | No           |
+| `manifests.port`                  | The cluster port number on which the service will listen for incoming traffic. | `8080`                                      | No           |
+| `manifests.replicas`              | The number of Pods to be created.                                              | `1`                                         | No           |
+
+## Usage
+
+To utilize the Hello Universe pack, create either a
+[full Palette cluster profile](../profiles/cluster-profiles/create-cluster-profiles/create-full-profile.md) or an
+[add-on Palette cluster profile](../profiles/cluster-profiles/create-cluster-profiles/create-addon-profile/) and add the
+pack to your profile.
+
+If your infrastructure provider does not offer a native load balancer solution, such as VMware and MAAS, the
+[MetalLB](./metallb.md) pack must be included to the cluster profile to help the LoadBalancer service specified in the
+manifest obtain an IP address.
+
+After defining the cluster profile, use it to deploy a new cluster or attach it as an add-on profile to an existing
+cluster.
+
+Once the cluster status displays **Running** and **Healthy**, access the Hello Universe application through the exposed
+service URL along with the displayed port number.
+
+## Terraform
+
+You can reference the Hello Universe pack in Terraform with the following data resource.
+
+```hcl
+data "spectrocloud_registry" "community_registry" {
+  name = "Palette Registry"
+}
+data "spectrocloud_pack" "hellouniverse" {
+  name         = "hello-universe"
+  version      = "1.1.1"
+  registry_uid = data.spectrocloud_registry.community_registry.id
+}
+```
+
+## References
+
+- [Hello Universe GitHub Repository](https://github.com/spectrocloud/hello-universe)
+
+- [Deploy a Custom Pack Tutorial](../registries-and-packs/deploy-pack.md)
+
+- [Registries and Packs](../registries-and-packs/registries-and-packs.md)

--- a/docs/docs-content/integrations/ngrok.md
+++ b/docs/docs-content/integrations/ngrok.md
@@ -22,7 +22,7 @@ lowest latency. The ngrok Ingress Controller for Kubernetes equips you to serve 
 configure networking details such as ELBs, IPs, network interfaces, or VPC routing, radically simplifying ingress into
 Kubernetes.
 
-# Versions Supported
+## Versions Supported
 
 - 0.9.0
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR introduces a new custom content page for the **Hello Universe** pack and addresses an issue with the title of the custom content page of the **ngrok** pack.



## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Hello Universe](https://deploy-preview-2433--docs-spectrocloud.netlify.app/integrations/hello-universe)
💻 [ngrok](https://deploy-preview-2433--docs-spectrocloud.netlify.app/integrations/ngrok)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1111](https://spectrocloud.atlassian.net/browse/DOC-1111)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1111]: https://spectrocloud.atlassian.net/browse/DOC-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ