### PR TITLE
chore: add vale rule to enforce colon usage

### DIFF
--- a/docs/docs-content/clusters/edge/edge-configuration/cloud-init.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/cloud-init.md
@@ -337,7 +337,7 @@ stages:
 
 #### Invoke Custom Script
 
-An example of applying logic after the device has booted by using the `boot.after` stage. <br />
+An example of applying logic after the device has booted by using the `boot.after` stage:
 
 ```yaml
 boot.after:

--- a/docs/docs-content/clusters/edge/edge-configuration/cloud-init.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/cloud-init.md
@@ -337,7 +337,7 @@ stages:
 
 #### Invoke Custom Script
 
-An example of applying logic after the device has booted by using the `boot.after` stage:
+An example of applying logic after the device has booted by using the `boot.after` stage.
 
 ```yaml
 boot.after:

--- a/vale/styles/spectrocloud/colon.yml
+++ b/vale/styles/spectrocloud/colon.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: "Use colons only to introduce lists, unless in code blocks or inline code."
+link: https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro+Cloud+Internal+Style+Guide#Colon-Usage
+nonword: true
+level: error
+scope: raw
+tokens:
+  - ([:][\n]{2,}[^-\n])
+exceptions:
+  - '`[^`]*:[^`]*`'
+

--- a/vale/styles/spectrocloud/colon.yml
+++ b/vale/styles/spectrocloud/colon.yml
@@ -5,7 +5,7 @@ nonword: true
 level: error
 scope: raw
 tokens:
-  - ([:][\n]{2,}[^-\n])
+  - '(?<!:)[:][\n]{2,}[^-\n]'
 exceptions:
   - '`[^`]*:[^`]*`'
 


### PR DESCRIPTION
## Describe the Change

This PR ensures that colons are only used to introduce a list. It specifically looks for a colon, followed by two new line characters, and then any character that is not a dash or a new line. I think this is also the most frequent mistake for us which is to introduce a command with a colon. 

It does not try to catch instances of inline colon usage such as `There are three kinds of apples: fuji, honey crisp, and cosmic crisp`, which I think is permissible and avoids flagging all the false positives in code blocks. 

It is possible that this rule could lead to some false positives in code snippets, but there should be only very few of these, and i think we can usually remove the extra new line character if they occur. 

## Changed Pages

N/A

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1114](https://spectrocloud.atlassian.net/browse/DOC-1114)

## Backports

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._


[DOC-1114]: https://spectrocloud.atlassian.net/browse/DOC-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ