### PR TITLE
docs: DOC-1127

### DIFF
--- a/docs/docs-content/release-notes.md
+++ b/docs/docs-content/release-notes.md
@@ -103,6 +103,12 @@ the following sections for a complete list of features, improvements, and known 
   [Calico](https://docs.spectrocloud.com/integrations/calico), the cluster deployments fail. A workaround is to use the
   AWS VPC CNI in the interim while the issue is resolved.
 
+- If a Kubernetes cluster deployed onto VMware is deleted, and later re-created with the same name, the cluster creation
+  process fails. The issue is caused by existing resources remaining inside PCG, or System PCG, that are not cleaned up
+  during the cluster deletion process. Refer to
+  [VMware Resources Remain After Cluster Deletion](./troubleshooting/pcg.md#scenario---vmware-resources-remain-after-cluster-deletion)
+  troubleshooting guide for resolution steps.
+
 ### Edge
 
 #### Breaking Changes

--- a/docs/docs-content/release-notes.md
+++ b/docs/docs-content/release-notes.md
@@ -105,7 +105,7 @@ the following sections for a complete list of features, improvements, and known 
 
 - If a Kubernetes cluster deployed onto VMware is deleted, and later re-created with the same name, the cluster creation
   process fails. The issue is caused by existing resources remaining inside PCG, or System PCG, that are not cleaned up
-  during the cluster deletion process. Refer to
+  during the cluster deletion process. Refer to the
   [VMware Resources Remain After Cluster Deletion](./troubleshooting/pcg.md#scenario---vmware-resources-remain-after-cluster-deletion)
   troubleshooting guide for resolution steps.
 

--- a/docs/docs-content/troubleshooting/pcg.md
+++ b/docs/docs-content/troubleshooting/pcg.md
@@ -174,9 +174,9 @@ log.
 
 ## Scenario - VMware Resources Remain After Cluster Deletion
 
-In the scenario where a VMWare workload cluster is deleted and later re-created with the same name, the resources from the
-previous cluster may not be fully cleaned up. This can cause the new cluster to fail to provision. To address
-this issue, you must manually clean up the resources from the previous cluster. Use the following steps for guidance.
+In the scenario where a VMWare workload cluster is deleted and later re-created with the same name, the resources from
+the previous cluster may not be fully cleaned up. This can cause the new cluster to fail to provision. To address this
+issue, you must manually clean up the resources from the previous cluster. Use the following steps for guidance.
 
 :::info
 

--- a/docs/docs-content/troubleshooting/pcg.md
+++ b/docs/docs-content/troubleshooting/pcg.md
@@ -175,7 +175,7 @@ log.
 ## Scenario - VMware Resources Remain After Cluster Deletion
 
 In the scenario where a VMWare workload cluster is deleted and later re-created with the same name, the resources from the
-previous cluster may need to be cleaned up properly. This can cause the new cluster to fail to provision. To address
+previous cluster may not be fully cleaned up. This can cause the new cluster to fail to provision. To address
 this issue, you must manually clean up the resources from the previous cluster. Use the following steps for guidance.
 
 :::info

--- a/docs/docs-content/troubleshooting/pcg.md
+++ b/docs/docs-content/troubleshooting/pcg.md
@@ -171,3 +171,48 @@ log.
 2. Contact your VMware administrator if you are missing any of the required permissions.
 
 3. Delete the existing PCG cluster and redeploy a new one so that the new permissions take effect.
+
+## Scenario - VMware Resources Remain After Cluster Deletion
+
+In the scenario, a VMWare workload cluster is deleted, and later re-created with the same name, the resources from the
+previous cluster may need to be cleaned up properly. This can cause the new cluster to fail to provision. To address
+this issue, you must manually clean up the resources from the previous cluster. Use the following steps to clean up the
+resources.
+
+:::info
+
+If you are using the System PCG for VMware cluster deployments, follow the same steps below but target the self-hosted
+Palette or VerteX cluster instead when issuing the kubectl command. You will need access to the kubeconfig file for the
+self-hosted Palette or VerteX cluster. Reach out to your Palette system administrator for the kubeconfig file.
+
+:::
+
+### Debug Steps
+
+1. Open a terminal session and ensure you have the [kubectl command-line tool](https://kubernetes.io/docs/tasks/tools/)
+   installed.
+
+2. Download the kubeconfig file for the PCG cluster from Palette. The kubeconfig file contains the necessary
+   configuration details to access the Kubernetes cluster.
+
+   :::tip
+
+   You can find the kubeconfig file in the PCG cluster's details page in Palette. Navigate to the left **Main Menu** and
+   select **Tenant Settings**. From the **Tenant settings Menu**, select **Private Cloud Gateways**. Select the PCG
+   cluster that is deployed in the VMware environment to access the details page.
+
+   :::
+
+3. Setup kubectl to use the kubeconfig file you downloaded in the previous step. Check out the
+   [Access Cluster with CLI](../clusters/cluster-management/palette-webctl.md) page to learn how to set up kubectl.
+
+   ```bash
+   export KUBECONFIG=[path_to_kubeconfig]
+   ```
+
+4. Issue the following command to remove the remaining cluster resources. Replace `<cluster-name>` with the name of the
+   cluster you removed.
+
+   ```bash
+   kubectl delete VSphereFailureDomain  <cluster-name>
+   ```

--- a/docs/docs-content/troubleshooting/pcg.md
+++ b/docs/docs-content/troubleshooting/pcg.md
@@ -174,10 +174,9 @@ log.
 
 ## Scenario - VMware Resources Remain After Cluster Deletion
 
-In the scenario, a VMWare workload cluster is deleted, and later re-created with the same name, the resources from the
+In the scenario where a VMWare workload cluster is deleted and later re-created with the same name, the resources from the
 previous cluster may need to be cleaned up properly. This can cause the new cluster to fail to provision. To address
-this issue, you must manually clean up the resources from the previous cluster. Use the following steps to clean up the
-resources.
+this issue, you must manually clean up the resources from the previous cluster. Use the following steps for guidance.
 
 :::info
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a known issue to the release notes. Additionally, a new troubleshooting section explaining how to address the issue has been added.

- [Release Notes](https://660440a31c095c134cbb38ec--docs-spectrocloud.netlify.app/release-notes)
- [Troubleshooting](https://660440a31c095c134cbb38ec--docs-spectrocloud.netlify.app/troubleshooting/pcg#scenario---vmware-resources-remain-after-cluster-deletion)

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page](https://660440a31c095c134cbb38ec--docs-spectrocloud.netlify.app/release-notes)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1127](https://spectrocloud.atlassian.net/browse/DOC-1127)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._
 This is release PR.


[DOC-1127]: https://spectrocloud.atlassian.net/browse/DOC-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ