### PR TITLE
docs: add Getting Started callout to landing page DOC-1124

### DIFF
--- a/docs/docs-content/introduction/introduction.md
+++ b/docs/docs-content/introduction/introduction.md
@@ -19,6 +19,14 @@ With a unique approach to managing multiple clusters, Palette gives IT teams com
 production-scale efficiencies to provide developers with highly curated Kubernetes stacks and tools based on their
 specific needs, with granular governance and enterprise-grade security.
 
+:::tip 
+
+Make sure to check out the [Getting Started](../getting-started/getting-started.md) section to learn how you can
+use Palette to deploy and update your Kubernetes clusters. This section contains hands-on tutorials for Amazon Web
+Services (AWS), Microsoft Azure and Google Cloud Platform (GCP). 
+
+:::
+
 Palette VerteX edition is also available to meet the stringent requirements of regulated industries such as government
 and public sector organizations. Palette VerteX integrates Spectro Cloud’s Federal Information Processing Standards
 (FIPS) 140-2 cryptographic modules. To learn more about FIPS-enabled Palette, check out
@@ -28,7 +36,7 @@ and public sector organizations. Palette VerteX integrates Spectro Cloud’s Fed
 
 ## What Makes Palette Different?
 
-<br />
+Palette helps our customers accelerate and grow through Kubernetes management at scale.
 
 ### Full-Stack Management
 
@@ -68,7 +76,7 @@ Profiles.
 
 ## Who Can Benefit From Palette?
 
-<br />
+Palette provides benefits to developers and platform engineers who maintain Kubernetes environments.
 
 ### Developers
 

--- a/docs/docs-content/introduction/introduction.md
+++ b/docs/docs-content/introduction/introduction.md
@@ -19,11 +19,11 @@ With a unique approach to managing multiple clusters, Palette gives IT teams com
 production-scale efficiencies to provide developers with highly curated Kubernetes stacks and tools based on their
 specific needs, with granular governance and enterprise-grade security.
 
-:::tip 
+:::tip
 
-Make sure to check out the [Getting Started](../getting-started/getting-started.md) section to learn how you can
-use Palette to deploy and update your Kubernetes clusters. This section contains hands-on tutorials for Amazon Web
-Services (AWS), Microsoft Azure and Google Cloud Platform (GCP). 
+Make sure to check out the [Getting Started](../getting-started/getting-started.md) section to learn how you can use
+Palette to deploy and update your Kubernetes clusters. This section contains hands-on tutorials for Amazon Web Services
+(AWS), Microsoft Azure and Google Cloud Platform (GCP).
 
 :::
 


### PR DESCRIPTION
This patch adds a call out box to the Docs landing page. It also adds 2 sentences to break up the sequential headers.

## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This patch adds a call out box to the Docs landing page.
It also adds 2 sentences to break up the sequential headers.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Landing Page](https://deploy-preview-2487--docs-spectrocloud.netlify.app/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1124](https://spectrocloud.atlassian.net/browse/DOC-1124)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1124]: https://spectrocloud.atlassian.net/browse/DOC-1124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ