### PR TITLE
xz-utils security advisory

### DIFF
--- a/docs/docs-content/security-bulletins/cve-reports.md
+++ b/docs/docs-content/security-bulletins/cve-reports.md
@@ -32,7 +32,7 @@ _Are there any links users can visit to find out more?_
 
 -->
 
-## April 2, 2024 - CVE-2024-3094 Malicious Code in XZ Library - 10 CVSS
+## April 2, 2024 - CVE-2024-3094 Malicious Code in XZ Utility - 10 CVSS
 
 Malicious code was discovered in the upstream tarballs of the XZ utility, starting with version 5.6.0, contain malicious
 code. This code is hidden within a test file in the source code and is extracted by the liblzma build process. The code

--- a/docs/docs-content/security-bulletins/cve-reports.md
+++ b/docs/docs-content/security-bulletins/cve-reports.md
@@ -42,7 +42,7 @@ and modifying the data interaction with this library.
 
 #### Impact
 
-No impact. Palette supports below OS images and none of them uses the impacted versions of xz-utils package.
+No impact. Palette supports below OS distributions and none of them uses the impacted versions of xz-utils package.
 - [Ubuntu 20.04/22.04/23.04](https://ubuntu.com/security/CVE-2024-3094)
 - [RHEL 8](https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users)
 - [OpenSUSE Leap](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)

--- a/docs/docs-content/security-bulletins/cve-reports.md
+++ b/docs/docs-content/security-bulletins/cve-reports.md
@@ -32,18 +32,20 @@ _Are there any links users can visit to find out more?_
 
 -->
 
-## April 2, 2024 - CVE-2024-3094 Malicious code was discovered in the upstream tarballs of xz - 10 CVSS
+## April 2, 2024 - CVE-2024-3094 Malicious Code in XZ Library - 10 CVSS
 
-Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. Through a series of complex 
-obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the 
-source code, which is then used to modify specific functions in the liblzma code. 
-This results in a modified liblzma library that can be used by any software linked against this library, intercepting 
-and modifying the data interaction with this library.
+Malicious code was discovered in the upstream tarballs of the XZ utility, starting with version 5.6.0, contain malicious
+code. This code is hidden within a test file in the source code and is extracted by the liblzma build process. The code
+then modifies specific functions in the liblzma library, resulting in a modified version of the library. Any software
+that links against this modified library may have its data interaction intercepted and modified. You can learn more
+about the vulnerability in the [CVE-2024-3094](https://nvd.nist.gov/vuln/detail/CVE-2024-3094) reference page.
 
 #### Impact
 
-No impact. Palette supports below OS distributions and none of them uses the impacted versions of xz-utils package.
-- [Ubuntu 20.04/22.04/23.10](https://ubuntu.com/security/CVE-2024-3094)
+No impact. None of the OS distributions supported by Palette use the impacted versions of the XZ utils package. Below
+are the links to the security advisories for all the Palette supported OS distributions:
+
+- [Ubuntu 20.04, 22.04, 23.10](https://ubuntu.com/security/CVE-2024-3094)
 - [RHEL 8](https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users)
 - [OpenSUSE Leap](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
 - [SLE Micro](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
@@ -59,9 +61,9 @@ Not Applicable
 #### References
 
 - [CVE-2024-3094](https://nvd.nist.gov/vuln/detail/CVE-2024-3094)
-- [Ubuntu](https://ubuntu.com/security/CVE-2024-3094)
-- [RedHat](https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users)
-- [SUSE](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
+- [Ubuntu CVE Disclosure](https://ubuntu.com/security/CVE-2024-3094)
+- [RedHat CVE Disclosure](https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users)
+- [SUSE CVE Disclosure](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
 
 <br />
 

--- a/docs/docs-content/security-bulletins/cve-reports.md
+++ b/docs/docs-content/security-bulletins/cve-reports.md
@@ -32,6 +32,28 @@ _Are there any links users can visit to find out more?_
 
 -->
 
+## April 2, 2024 - CVE-2024-3094 Malicious code was discovered in the upstream tarballs of xz - 10 CVSS
+
+Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. Through a series of complex obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the source code, which is then used to modify specific functions in the liblzma code. This results in a modified liblzma library that can be used by any software linked against this library, intercepting and modifying the data interaction with this library.
+
+#### Impact
+
+No impact for Palette and VerteX. Ubuntu 20.04 and Ubuntu 22.04 (used in Palette and VerteX PXK OS Images) uses non-impacted version of xz-utils package. 
+
+#### Patches
+
+Not Applicable
+
+### Workarounds
+
+Not Applicable
+
+#### References
+
+- [CVE-2024-3094](https://nvd.nist.gov/vuln/detail/CVE-2024-3094)
+
+<br />
+
 ## January 10, 2024 - CVE-2023-39323 Bypass CGO Restrictions - 8.1 CVSS
 
 Line directives `//line` can be used to bypass the restrictions on `//go:cgo_` directives, allowing blocked linker and

--- a/docs/docs-content/security-bulletins/cve-reports.md
+++ b/docs/docs-content/security-bulletins/cve-reports.md
@@ -34,11 +34,17 @@ _Are there any links users can visit to find out more?_
 
 ## April 2, 2024 - CVE-2024-3094 Malicious code was discovered in the upstream tarballs of xz - 10 CVSS
 
-Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. Through a series of complex obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the source code, which is then used to modify specific functions in the liblzma code. This results in a modified liblzma library that can be used by any software linked against this library, intercepting and modifying the data interaction with this library.
+Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. Through a series of complex 
+obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the 
+source code, which is then used to modify specific functions in the liblzma code. 
+This results in a modified liblzma library that can be used by any software linked against this library, intercepting 
+and modifying the data interaction with this library.
 
 #### Impact
 
-No impact for Palette and VerteX. Ubuntu 20.04 and Ubuntu 22.04 (used in Palette and VerteX PXK OS Images) uses non-impacted version of xz-utils package. 
+No impact. Palette uses Ubuntu 22.04 OS images while VerteX uses Ubuntu 20.04 OS images for Enterprise, 
+Private Cloud Gateway and Tenant clusters. Both Ubuntu 22.04 and Ubuntu 20.04 images uses an older non-impacted 
+version of xz-utils package. 
 
 #### Patches
 
@@ -51,6 +57,7 @@ Not Applicable
 #### References
 
 - [CVE-2024-3094](https://nvd.nist.gov/vuln/detail/CVE-2024-3094)
+- [Ubuntu Security Advisory](https://ubuntu.com/security/CVE-2024-3094)
 
 <br />
 

--- a/docs/docs-content/security-bulletins/cve-reports.md
+++ b/docs/docs-content/security-bulletins/cve-reports.md
@@ -42,9 +42,11 @@ and modifying the data interaction with this library.
 
 #### Impact
 
-No impact. Palette uses Ubuntu 22.04 OS images while VerteX uses Ubuntu 20.04 OS images for Enterprise, 
-Private Cloud Gateway and Tenant clusters. Both Ubuntu 22.04 and Ubuntu 20.04 images uses an older non-impacted 
-version of xz-utils package. 
+No impact. Palette uses below OS images and none of them uses the impacted versions of xz-utils package.
+- [Ubuntu 20.04/22.04/23.04](https://ubuntu.com/security/CVE-2024-3094)
+- [RHEL 8](https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users)
+- [OpenSUSE Leap](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
+- [SLES Micro](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
 
 #### Patches
 
@@ -57,7 +59,9 @@ Not Applicable
 #### References
 
 - [CVE-2024-3094](https://nvd.nist.gov/vuln/detail/CVE-2024-3094)
-- [Ubuntu Security Advisory](https://ubuntu.com/security/CVE-2024-3094)
+- [Ubuntu](https://ubuntu.com/security/CVE-2024-3094)
+- [RedHat](https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users)
+- [SUSE](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
 
 <br />
 

--- a/docs/docs-content/security-bulletins/cve-reports.md
+++ b/docs/docs-content/security-bulletins/cve-reports.md
@@ -42,7 +42,7 @@ and modifying the data interaction with this library.
 
 #### Impact
 
-No impact. Palette uses below OS images and none of them uses the impacted versions of xz-utils package.
+No impact. Palette supports below OS images and none of them uses the impacted versions of xz-utils package.
 - [Ubuntu 20.04/22.04/23.04](https://ubuntu.com/security/CVE-2024-3094)
 - [RHEL 8](https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users)
 - [OpenSUSE Leap](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)

--- a/docs/docs-content/security-bulletins/cve-reports.md
+++ b/docs/docs-content/security-bulletins/cve-reports.md
@@ -43,10 +43,10 @@ and modifying the data interaction with this library.
 #### Impact
 
 No impact. Palette supports below OS distributions and none of them uses the impacted versions of xz-utils package.
-- [Ubuntu 20.04/22.04/23.04](https://ubuntu.com/security/CVE-2024-3094)
+- [Ubuntu 20.04/22.04/23.10](https://ubuntu.com/security/CVE-2024-3094)
 - [RHEL 8](https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users)
 - [OpenSUSE Leap](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
-- [SLES Micro](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
+- [SLE Micro](https://www.suse.com/c/suse-addresses-supply-chain-attack-against-xz-compression-library/)
 
 #### Patches
 


### PR DESCRIPTION
## Describe the Change

This PR adds the security advisory for recent critical CVE on x-utils package used in our OS images.

## Changed Pages

💻 [Preview URL](https://deploy-preview-2557--docs-spectrocloud.netlify.app/security-bulletins/cve-reports#april-2-2024---cve-2024-3094-malicious-code-was-discovered-in-the-upstream-tarballs-of-xz---10-cvss)

## Jira Tickets

No JIRA ticket.

## Backports

Not required
