### PR TITLE
ci: fix branch determination logic

### DIFF
--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -5,10 +5,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
     branches-ignore: ["version-*", "release-*"]
-    paths:
-      - 'src/**'
-      - 'package.json'
-      - 'package-lock.json'
 
 
 env:
@@ -33,7 +29,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' || contains(github.event.pull_request.labels.*.name, 'visual-tests') }}
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' && contains(github.event.pull_request.labels.*.name, 'visual-tests') }}
     steps:
       # If the condition above is not met, aka, the PR is not in draft status, then this step is skipped.
       # Because this step is part of the critical path, omission of this step will result in remaining CI steps not gettinge executed.

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -37,7 +37,7 @@ jobs:
           echo "GITHUB_BASE_REF: ${{ github.base_ref }}"
           echo "GITHUB_HEAD_REF: ${{ github.head_ref }}"
           echo "GITHUB_REF_NAME: ${{ github.ref_name }}"
-          echo "HTML_REPORT_URL_PATH ${{ env.HTML_REPORT_URL_PATH }}""
+          echo "HTML_REPORT_URL_PATH ${{ env.HTML_REPORT_URL_PATH }}"
           exit 0
 
 

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -236,7 +236,7 @@ jobs:
       uses: mshick/add-pr-comment@v2
       with:
         message: |
-            📋 Visual Report for branch ${{ github.GITHUB_HEAD_REF }} with CI run ${{ github.run_id }} and attempt ${{ github.run_attempt }} is ready at
+            📋 Visual Report for branch ${{ github.head_ref }} with CI run ${{ github.run_id }} and attempt ${{ github.run_attempt }} is ready at
               https://spectrocloud.github.io/librarium/${{env.HTML_REPORT_URL_PATH}}
 
               💡 You may have to wait for DNS to resolve or the GitHub Pages job to complete. You can view the progress of the GitHub Pages job [here](https://github.com/spectrocloud/librarium/actions/workflows/pages/pages-build-deployment).

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -14,8 +14,7 @@ env:
   ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
   ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
   ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
-  HTML_REPORT_URL_PATH: reports/${{ github.GITHUB_HEAD_REF }}/${{ github.run_id }}/${{ github.run_attempt }}
-
+  HTML_REPORT_URL_PATH: reports/${{ github.github_head_ref }}/${{ github.run_id }}/${{ github.run_attempt }}
 
 
 concurrency:
@@ -34,7 +33,12 @@ jobs:
       # If the condition above is not met, aka, the PR is not in draft status, then this step is skipped.
       # Because this step is part of the critical path, omission of this step will result in remaining CI steps not gettinge executed.
       # As of 8/8/2022 there is now way to enforce this beahvior in GitHub Actions CI.
-      - run: exit 0
+      - run: |
+          echo "GITHUB_BASE_REF: ${{ github.base_ref }}"
+          echo "GITHUB_HEAD_REF: ${{ github.head_ref }}"
+          echo "GITHUB_REF_NAME: ${{ github.ref_name }}"
+          exit 0
+
 
 
   create-assets:

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -5,10 +5,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
     branches-ignore: ["version-*", "release-*"]
-    paths:
-      - 'src/**'
-      - 'package.json'
-      - 'package-lock.json'
 
 
 env:
@@ -33,7 +29,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' ||  contains(github.event.pull_request.labels.*.name, 'visual-tests') }}
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' && contains(github.event.pull_request.labels.*.name, 'visual-tests') }}
     steps:
       # If the condition above is not met, aka, the PR is not in draft status, then this step is skipped.
       # Because this step is part of the critical path, omission of this step will result in remaining CI steps not gettinge executed.

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -18,7 +18,7 @@ env:
   ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
   ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
   ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
-  HTML_REPORT_URL_PATH: reports/${{ github.ref_name }}/${{ github.run_id }}/${{ github.run_attempt }}
+  HTML_REPORT_URL_PATH: reports/${{ github.GITHUB_HEAD_REF }}/${{ github.run_id }}/${{ github.run_attempt }}
 
 
 
@@ -235,7 +235,7 @@ jobs:
       uses: mshick/add-pr-comment@v2
       with:
         message: |
-            📋 Visual Report for PR ${{ github.ref_name }} with CI run ${{ github.run_id }} and attempt ${{ github.run_attempt }} is ready at
+            📋 Visual Report for branch ${{ github.GITHUB_HEAD_REF }} with CI run ${{ github.run_id }} and attempt ${{ github.run_attempt }} is ready at
               https://spectrocloud.github.io/librarium/${{env.HTML_REPORT_URL_PATH}}
 
               💡 You may have to wait for DNS to resolve or the GitHub Pages job to complete. You can view the progress of the GitHub Pages job [here](https://github.com/spectrocloud/librarium/actions/workflows/pages/pages-build-deployment).

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
     branches-ignore: ["version-*", "release-*"]
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
 
 
 env:
@@ -29,7 +33,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' && contains(github.event.pull_request.labels.*.name, 'visual-tests') }}
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' || contains(github.event.pull_request.labels.*.name, 'visual-tests') }}
     steps:
       # If the condition above is not met, aka, the PR is not in draft status, then this step is skipped.
       # Because this step is part of the critical path, omission of this step will result in remaining CI steps not gettinge executed.

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -37,6 +37,7 @@ jobs:
           echo "GITHUB_BASE_REF: ${{ github.base_ref }}"
           echo "GITHUB_HEAD_REF: ${{ github.head_ref }}"
           echo "GITHUB_REF_NAME: ${{ github.ref_name }}"
+          echo "HTML_REPORT_URL_PATH ${{ env.HTML_REPORT_URL_PATH }}""
           exit 0
 
 

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -14,7 +14,7 @@ env:
   ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
   ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
   ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
-  HTML_REPORT_URL_PATH: reports/${{ github.github_head_ref }}/${{ github.run_id }}/${{ github.run_attempt }}
+  HTML_REPORT_URL_PATH: reports/${{ github.head_ref }}/${{ github.run_id }}/${{ github.run_attempt }}
 
 
 concurrency:

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,6 +4,6 @@
     "allowJs": true
   },
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", "./.eslintrc.js", "*.d.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "./.eslintrc.js", "*.d.ts", "visuals/**/*.ts", "playwright.config.ts"],
   "exclude": ["**/node_modules", "deprecated"]
 }

--- a/visuals/screenshot.api.spec.ts
+++ b/visuals/screenshot.api.spec.ts
@@ -1,12 +1,12 @@
 import * as fs from "fs";
 import { test, expect } from "@playwright/test";
 import { extractSitemapPathnames, WaitForDocusaurusHydration } from "./utils";
+import excludeList from "./exclude.json";
 
 const siteUrl = "http://localhost:3000";
 const sitemapPath = "build/sitemap.xml";
 const stylesheetPath = "visuals/screenshot.css";
 const stylesheet = fs.readFileSync(stylesheetPath).toString();
-const excludeList = require("./exclude.json");
 
 test.describe.configure({ mode: "parallel" });
 
@@ -21,7 +21,7 @@ function isApiDocsPathname(pathname: string, excludeList: string[]): boolean {
   return false;
 }
 
-test.beforeAll(async () => {
+test.beforeAll(() => {
   console.log("Excluded pages: ", excludeList);
   console.log("Total pages: ", extractSitemapPathnames(sitemapPath).length);
 });

--- a/visuals/screenshot.docs.spec.ts
+++ b/visuals/screenshot.docs.spec.ts
@@ -1,12 +1,12 @@
 import * as fs from "fs";
 import { test, expect } from "@playwright/test";
 import { extractSitemapPathnames, WaitForDocusaurusHydration } from "./utils";
-// Constants:
+import excludeList from "./exclude.json";
+
 const siteUrl = "http://localhost:3000";
 const sitemapPath = "build/sitemap.xml";
 const stylesheetPath = "visuals/screenshot.css";
 const stylesheet = fs.readFileSync(stylesheetPath).toString();
-const excludeList = require("./exclude.json");
 
 test.describe.configure({ mode: "parallel" });
 
@@ -23,7 +23,7 @@ function isVersionedDocsPathname(pathname: string, excludeList: string[]): boole
   return true;
 }
 
-test.beforeAll(async () => {
+test.beforeAll(() => {
   console.log("Excluded pages: ", excludeList);
   console.log("Total pages: ", extractSitemapPathnames(sitemapPath).length);
 });


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes a couple of things that surfaced during the backport.

- Eslint was not capturing playwright config and test files.
- Fixed minor eslint errors, such as import vs require and removing async from functions not using await in the test run.
- The CI trigger logic was not working correctly. The final logic is to only trigger when label is added.
- The branch delete logic was not cleaning up because the report was stored using `github.ref_name`. This variable changes context depending on a PR or not. What we need is `github. GITHUB_HEAD_REF` as this will always pull down the branch name.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page]()


## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
