### PR TITLE
PLT-1117: Add Palette CLI Import docs

### DIFF
--- a/docs/docs-content/palette-cli/commands/import.md
+++ b/docs/docs-content/palette-cli/commands/import.md
@@ -1,0 +1,72 @@
+---
+sidebar_label: "Import"
+title: "Import"
+description: "Learn how to import pre-existing clusters using a Palette CLI command."
+hide_table_of_contents: false
+sidebar_position: 10
+tags: ["palette-cli"]
+---
+
+The `import` command imports a cluster into Palette in full permission mode based on local KUBECONFIG files. Refer to the [Imported Clusters](../../clusters/imported-clusters/cluster-import.md) reference page to learn more about imported clusters.
+
+## Prerequisites
+ * Kubernetes version >= 1.19.X
+
+ * Ensure your environment has network access to Palette SaaS or your self-hosted Palette instance.
+
+ * Access to your cluster environment through kubectl.
+
+
+<br />
+
+| **Long Flag**      | **Description**                                                                  | **Type** |
+| ------------------ | -------------------------------------------------------------------------------- | -------- |
+| `--kubeconfig`     | Path to the kubeconfig for the cluster you'd like to import (optional)           | string   |
+| `--kubeconfig-dir` | Path to directory containing kubeconfigs for one or more clusters (optional)     | string   |
+| `--uuid`           | If true, a partial UUID is appended to each cluster name (optional)              | boolean  |
+
+:::tip 
+
+If neither flag is provided, the `KUBECONFIG` environment variable and `~/.kube/config` will be checked and used respectively.
+
+:::
+
+## Examples
+
+### One Cluster with UUID
+
+Import a cluster based on current `KUBECONFIG` found within `~/.kube/config` and append a partial UUID.
+
+```shell
+palette import --uuid
+```
+
+### One Cluster with Specified Kubeconfig
+
+Import cluster with specified `KUBECONFIG`.
+
+```shell
+palette import --kubeconfig my-cluster.kubeconfig
+```
+```shell hideClipboard
+Imported cluster my-cluster-b4430654
+```
+
+### Many Clusters within Directory
+
+Import clusters from directory with multiple `KUBECONFIG` files
+
+```shell hideClipboard
+configs
+├── my-cluster-1.kubeconfig
+├── my-cluster-2.kubeconfig
+└── my-cluster-3.kubeconfig
+```
+```shell
+palette import --kubeconfig-dir configs --uuid
+```
+```shell hideClipboard
+Imported cluster my-cluster-1-e7c1ea5e
+Imported cluster my-cluster-2-98669d7c
+Imported cluster my-cluster-3d7cc792f
+```


### PR DESCRIPTION
## Describe the Change

This PR adds documentation around recent changes within Palette CLI, specifically documenting the `palette import` command added within PLT-1117.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/PLT-1117)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

This feature will not exist prior to 4.3.
