### PR TITLE
Implement a Vale rule for the Oxford comma

### DIFF
--- a/vale/styles/spectrocloud/oxford-comma.yml
+++ b/vale/styles/spectrocloud/oxford-comma.yml
@@ -5,4 +5,4 @@ link: https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro
 scope: sentence
 nonword: true
 tokens:
-  - '(?i)\b(?:\w+\b(?:, \w+)* (?:and|or) [a-z]+(?: [a-z]+)*[.?!])'
+  - '(\b(?:\w+(?: \w+)?, )+\b(?:\w+(?: \w+)?) (?:and|or) \w+(?: \w+)?[.?!])'

--- a/vale/styles/spectrocloud/oxford-comma.yml
+++ b/vale/styles/spectrocloud/oxford-comma.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: "You need to use the Oxford comma in '%s'."
+level: suggestion
+link: https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro+Cloud+Internal+Style+Guide#Commas
+scope: sentence
+nonword: true
+tokens:
+  - '(?i)\b(?:\w+\b(?:, \w+)* (?:and|or) [a-z]+(?: [a-z]+)*[.?!])'


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a Vale rule to check usage of the Oxford commas.

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1115](https://spectrocloud.atlassian.net/browse/DOC-1115)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1115]: https://spectrocloud.atlassian.net/browse/DOC-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ