### PR TITLE
docs: remove spectro-packs project requirement

### DIFF
--- a/docs/docs-content/registries-and-packs/deploy-pack.md
+++ b/docs/docs-content/registries-and-packs/deploy-pack.md
@@ -406,8 +406,8 @@ In the **Projects** section, click on **New Project**. A project in Harbor conta
 This tutorial uses **spectro-oci-registry** as the project name. Keep the default settings for the remaining
 configuration options and proceed by clicking **OK**.
 
-Next, create another project called **spectro-packs**. This specific project is required to complete the validation of
-your registry in Palette.
+<!-- Next, create another project called **spectro-packs**. This specific project is required to complete the validation of
+your registry in Palette. -->
 
 ![Screenshot of Harbor project](/tutorials/deploy-pack/registries-and-packs_deploy-pack_harbor-project.webp)
 

--- a/docs/docs-content/registries-and-packs/deploy-pack.md
+++ b/docs/docs-content/registries-and-packs/deploy-pack.md
@@ -406,9 +406,6 @@ In the **Projects** section, click on **New Project**. A project in Harbor conta
 This tutorial uses **spectro-oci-registry** as the project name. Keep the default settings for the remaining
 configuration options and proceed by clicking **OK**.
 
-<!-- Next, create another project called **spectro-packs**. This specific project is required to complete the validation of
-your registry in Palette. -->
-
 ![Screenshot of Harbor project](/tutorials/deploy-pack/registries-and-packs_deploy-pack_harbor-project.webp)
 
 </TabItem>


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the requirement for an empty 'spectro-packs' project in Harbor registries (Deploy a Custom Pack tutorial), which was fixed in 4.3.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Deploy a Custom Pack](https://deploy-preview-2657--docs-spectrocloud.netlify.app/registries-and-packs/deploy-pack)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
