### PR TITLE
Remove unnecessary prerequisite from VMware airgap guide

### DIFF
--- a/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/airgap.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/airgap.md
@@ -27,10 +27,8 @@ Palette upgrade.
 
 - Access to the Palette airgap support Virtual Machine (VM) that you used for the initial Palette installation.
 
-- Refer to [Access Palette](/enterprise-version/#access-palette) to download the following from our support:
-  - The new airgap Palette installation bin.
-  - The OVA with the Operating System (OS) and Kubernetes distribution required for the Palette nodes (if the new
-    version of Palette requires a new version of the OS and Kubernetes).
+- Refer to [Access Palette](/enterprise-version/#access-palette) to download the new airgap Palette installation bin.
+
 - A diff or text comparison tool of your choice.
 
 ## Upgrade

--- a/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/airgap.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/airgap.md
@@ -27,7 +27,8 @@ Palette upgrade.
 
 - Access to the Palette airgap support Virtual Machine (VM) that you used for the initial Palette installation.
 
-- Refer to [Access Palette](/enterprise-version/#access-palette) to download the new airgap Palette installation bin.
+- Refer to [Access Palette](../../enterprise-version.md#access-palette) to download the new airgap Palette installation
+  bin.
 
 - A diff or text comparison tool of your choice.
 

--- a/docs/docs-content/vertex/upgrade/upgrade-vmware/airgap.md
+++ b/docs/docs-content/vertex/upgrade/upgrade-vmware/airgap.md
@@ -29,11 +29,8 @@ Palette VerteX upgrade.
 - Access to the Palette VerteX airgap support Virtual Machine (VM) that you used for the initial Palette VerteX
   installation.
 
-- Refer to [Access Palette VerteX](../../vertex.md#access-palette-vertex) to download the following from our support:
-
-  - The new airgap Palette VerteX installation bin.
-  - The OVA with the Operating System (OS) and Kubernetes distribution required for the Palette VerteX nodes (if the new
-    version of Palette VerteX requires a new version of the OS and Kubernetes).
+- Refer to [Access Palette VerteX](../../vertex.md#access-palette-vertex) to download the new airgap Palette VerteX
+  installation bin.
 
 - A diff or text comparison tool of your choice.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes an unnecessary prerequisite from the Enterprise and VerteX guides on upgrading self-hosted Palette.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
