### PR TITLE
chore: fix css spacing issue and correct edge forge indentation

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
@@ -98,27 +98,27 @@ customization.
 
 1. Check out the [CanvOS](https://github.com/spectrocloud/CanvOS) GitHub repository containing the starter code.
 
-```bash
-git clone https://github.com/spectrocloud/CanvOS.git
-```
+   ```bash
+   git clone https://github.com/spectrocloud/CanvOS.git
+   ```
 
 2. Change to the **CanvOS/** directory.
 
-```bash
-cd CanvOS
-```
+   ```bash
+   cd CanvOS
+   ```
 
 3. View the available [git tag](https://github.com/spectrocloud/CanvOS/tags).
 
-```bash
-git tag
-```
+   ```bash
+   git tag
+   ```
 
 4. Check out the newest available tag. This guide uses the tag **v4.0.6** as an example.
 
-```shell
-git checkout v4.0.6
-```
+   ```shell
+   git checkout v4.0.6
+   ```
 
 5. Review the files relevant for this guide.
 
@@ -132,9 +132,9 @@ git checkout v4.0.6
    uses the value `palette-learn` as an example. However, you can assign any lowercase and alphanumeric string to the
    `CUSTOM_TAG` argument.
 
-```bash
-export CUSTOM_TAG=palette-learn
-```
+   ```bash
+   export CUSTOM_TAG=palette-learn
+   ```
 
 7. Issue the command below to create the **.arg** file containing the custom tag. The remaining arguments in the
    **.arg** file will use the default values. For example, `ubuntu` is the default operating system, `demo` is the
@@ -142,178 +142,182 @@ export CUSTOM_TAG=palette-learn
    file in the current directory or the [README](https://github.com/spectrocloud/CanvOS#readme) to learn more about the
    available customizable arguments.
 
-:::info
+   :::info
 
-The default ttl.sh image registry is free and does not require a sign-up. Images pushed to ttl.sh are ephemeral and will
-expire after the 24 hrs time limit. Should you need to use a different image registry, refer to the Advanced workflow on
-this page.
+   The default ttl.sh image registry is free and does not require a sign-up. Images pushed to ttl.sh are ephemeral and
+   will expire after the 24 hrs time limit. Should you need to use a different image registry, refer to the Advanced
+   workflow on this page.
 
-:::
+   :::
 
-Using the arguments defined in the **.arg** file, the final provider images you generate will have the following naming
-convention, `[IMAGE_REGISTRY]/[IMAGE_REPO]:[CUSTOM_TAG]`. For example, one of the provider images will be
-`ttl.sh/ubuntu:k3s-1.27.2-v4.0.6-palette-learn`.
+   Using the arguments defined in the **.arg** file, the final provider images you generate will have the following
+   naming convention, `[IMAGE_REGISTRY]/[IMAGE_REPO]:[CUSTOM_TAG]`. For example, one of the provider images will be
+   `ttl.sh/ubuntu:k3s-1.27.2-v4.0.6-palette-learn`.
 
-```bash
-cat << EOF > .arg
-CUSTOM_TAG=$CUSTOM_TAG
-IMAGE_REGISTRY=ttl.sh
-OS_DISTRIBUTION=ubuntu
-IMAGE_REPO=ubuntu
-OS_VERSION=22.04
-K8S_DISTRIBUTION=k3s
-ISO_NAME=palette-edge-installer
-ARCH=amd64
-HTTPS_PROXY=
-HTTP_PROXY=
-PROXY_CERT_PATH=
-UPDATE_KERNEL=false
-EOF
-```
+   ```bash
+   cat << EOF > .arg
+   CUSTOM_TAG=$CUSTOM_TAG
+   IMAGE_REGISTRY=ttl.sh
+   OS_DISTRIBUTION=ubuntu
+   IMAGE_REPO=ubuntu
+   OS_VERSION=22.04
+   K8S_DISTRIBUTION=k3s
+   ISO_NAME=palette-edge-installer
+   ARCH=amd64
+   HTTPS_PROXY=
+   HTTP_PROXY=
+   PROXY_CERT_PATH=
+   UPDATE_KERNEL=false
+   EOF
+   ```
 
-View the newly created file to ensure the customized arguments are set correctly.
+   View the newly created file to ensure the customized arguments are set correctly.
 
-```bash
-cat .arg
-```
+   ```bash
+   cat .arg
+   ```
 
 8. Issue the command below to save your tenant registration token to an environment variable. Replace
    `[your_token_here]` with your actual registration token.
 
-```bash
-export token=[your_token_here]
-```
+   ```bash
+   export token=[your_token_here]
+   ```
 
 9. Use the following command to create the **user-data** file containing the tenant registration token.
 
-```shell
-cat <<EOF > user-data
-#cloud-config
-stylus:
-site:
-  edgeHostToken: $token
-install:
-poweroff: true
-stages:
-initramfs:
-  - name: "Core system setup"
-    users:
-      kairos:
-        groups:
-          - admin
-        passwd: kairos
-EOF
-```
+   ```shell
+   cat <<EOF > user-data
+   #cloud-config
 
-View the newly created user data file to ensure the token is set correctly.
+   stylus:
+      site:
+        edgeHostToken: $token
 
-```bash
-cat user-data
-```
+   install:
+      poweroff: true
+
+   stages:
+      initramfs:
+      - name: "Core system setup"
+        users:
+          kairos:
+            groups:
+              - admin
+            passwd: kairos
+   EOF
+   ```
+
+   View the newly created user data file to ensure the token is set correctly.
+
+   ```bash
+   cat user-data
+   ```
 
 10. The CanvOS utility uses [Earthly](https://earthly.dev/) to build the target artifacts. By default, images are
     created for all the Palette-supported Kubernetes versions. Comment out the versions you do not need in the file
     **Earthfile** to speed up the build process and save disk space.
 
-```
-build-provider-images:
-#    BUILD  +provider-image --K8S_VERSION=1.24.6
-  BUILD  +provider-image --K8S_VERSION=1.25.2
-  BUILD  +provider-image --K8S_VERSION=1.26.4
-  BUILD  +provider-image --K8S_VERSION=1.27.2
-```
+    ```
+    build-provider-images:
+    #    BUILD  +provider-image --K8S_VERSION=1.24.6
+      BUILD  +provider-image --K8S_VERSION=1.25.2
+      BUILD  +provider-image --K8S_VERSION=1.26.4
+      BUILD  +provider-image --K8S_VERSION=1.27.2
+    ```
 
 11. Issue the following command to start the build process.
 
-```bash
-sudo ./earthly.sh +build-all-images
-```
+    ```bash
+    sudo ./earthly.sh +build-all-images
+    ```
 
-```bash hideClipboard
-===================== Earthly Build SUCCESS =====================
-Share your logs with an Earthly account (experimental)! Register for one at https://ci.earthly.dev.
-```
+    ```bash hideClipboard
+    ===================== Earthly Build SUCCESS =====================
+    Share your logs with an Earthly account (experimental)! Register for one at https://ci.earthly.dev.
+    ```
 
-:::info
+    :::info
 
-If you plan to build Edge artifacts using a content bundle, use the `+build-provider-images` option instead of the
-`+build-all-images` option in the command above. The command, `sudo ./earthly.sh +build-provider-images`, will build the
-provider images but not the Edge installer ISO.
+    If you plan to build Edge artifacts using a content bundle, use the `+build-provider-images` option instead of the
+    `+build-all-images` option in the command above. The command, `sudo ./earthly.sh +build-provider-images`, will build
+    the provider images but not the Edge installer ISO.
 
-:::
+    :::
 
-This command may take up to 15-20 minutes to finish depending on the resources of the host machine. Upon completion, the
-command will display the manifest, as shown in the example below, that you will use in your cluster profile later in
-this tutorial. Note that the `system.xxxxx` attribute values in the manifest example are the same as what you defined
-earlier in the **.arg** file.
+    This command may take up to 15-20 minutes to finish depending on the resources of the host machine. Upon completion,
+    the command will display the manifest, as shown in the example below, that you will use in your cluster profile
+    later in this tutorial. Note that the `system.xxxxx` attribute values in the manifest example are the same as what
+    you defined earlier in the **.arg** file.
 
-Copy and save the output attributes in a notepad or clipboard to use later in your cluster profile.
+    Copy and save the output attributes in a notepad or clipboard to use later in your cluster profile.
 
-```yaml
-pack:
-  content:
-    images:
-      - image: "{{.spectro.pack.edge-native-byoi.options.system.uri}}"
-  # Below config is default value, please uncomment if you want to modify default values
-  # drain:
-  #cordon: true
-  #timeout: 60 # The length of time to wait before giving up, zero means infinite
-  #gracePeriod: 60 # Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used
-  #ignoreDaemonSets: true
-  #deleteLocalData: true # Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained)
-  #force: true # Continue even if there are pods that do not declare a controller
-  #disableEviction: false # Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution
-  #skipWaitForDeleteTimeout: 60 # If pod DeletionTimestamp older than N seconds, skip waiting for the pod. Seconds must be greater than 0 to skip.
-options:
-  system.uri:
-    "{{ .spectro.pack.edge-native-byoi.options.system.registry }}/{{ .spectro.pack.edge-native-byoi.options.system.repo
-    }}:{{ .spectro.pack.edge-native-byoi.options.system.k8sDistribution }}-{{ .spectro.system.kubernetes.version }}-{{
-    .spectro.pack.edge-native-byoi.options.system.peVersion }}-{{
-    .spectro.pack.edge-native-byoi.options.system.customTag }}"
+    ```yaml
+    pack:
+      content:
+        images:
+          - image: "{{.spectro.pack.edge-native-byoi.options.system.uri}}"
+      # Below config is default value, please uncomment if you want to modify default values
+      # drain:
+      #cordon: true
+      #timeout: 60 # The length of time to wait before giving up, zero means infinite
+      #gracePeriod: 60 # Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used
+      #ignoreDaemonSets: true
+      #deleteLocalData: true # Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained)
+      #force: true # Continue even if there are pods that do not declare a controller
+      #disableEviction: false # Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution
+      #skipWaitForDeleteTimeout: 60 # If pod DeletionTimestamp older than N seconds, skip waiting for the pod. Seconds must be greater than 0 to skip.
+    options:
+      system.uri:
+        "{{ .spectro.pack.edge-native-byoi.options.system.registry }}/{{
+        .spectro.pack.edge-native-byoi.options.system.repo }}:{{
+        .spectro.pack.edge-native-byoi.options.system.k8sDistribution }}-{{ .spectro.system.kubernetes.version }}-{{
+        .spectro.pack.edge-native-byoi.options.system.peVersion }}-{{
+        .spectro.pack.edge-native-byoi.options.system.customTag }}"
 
-  system.registry: ttl.sh
-  system.repo: ubuntu
-  system.k8sDistribution: k3s
-  system.osName: ubuntu
-  system.peVersion: v4.0.6
-  system.customTag: palette-learn
-  system.osVersion: 22
-```
+      system.registry: ttl.sh
+      system.repo: ubuntu
+      system.k8sDistribution: k3s
+      system.osName: ubuntu
+      system.peVersion: v4.0.6
+      system.customTag: palette-learn
+      system.osVersion: 22
+    ```
 
 12. List the Docker images to review the provider images created. By default, provider images for all the Palette's
     Edge-supported Kubernetes versions are created. You can identify the provider images by reviewing the image tag
     value you used in the **.arg** file's `CUSTOM_TAG` argument.
 
-```shell
-docker images --filter=reference='*/*:*palette-learn'
-```
+    ```shell
+    docker images --filter=reference='*/*:*palette-learn'
+    ```
 
-```hideClipboard bash
-REPOSITORY             TAG                                   IMAGE ID       CREATED         SIZE
-ttl.sh/ubuntu          k3s-1.27.2-v4.0.6-palette-learn       075134ad5d4b   10 minutes ago   4.11GB
-ttl.sh/ubuntu          k3s-1.25.2-v4.0.6-palette-learn       02424d29fcac   10 minutes ago   4.09GB
-ttl.sh/ubuntu          k3s-1.26.4-v4.0.6-palette-learn       4e373ddfb53f   10 minutes ago   4.11GB
-```
+    ```hideClipboard bash
+    REPOSITORY             TAG                                   IMAGE ID       CREATED         SIZE
+    ttl.sh/ubuntu          k3s-1.27.2-v4.0.6-palette-learn       075134ad5d4b   10 minutes ago   4.11GB
+    ttl.sh/ubuntu          k3s-1.25.2-v4.0.6-palette-learn       02424d29fcac   10 minutes ago   4.09GB
+    ttl.sh/ubuntu          k3s-1.26.4-v4.0.6-palette-learn       4e373ddfb53f   10 minutes ago   4.11GB
+    ```
 
 13. To use the provider images in your cluster profile, push them to the image registry mentioned in the **.arg** file.
     The current example uses the [ttl.sh](https://ttl.sh/) image registry. This image registry is free to use and does
     not require a sign-up. Images pushed to _ttl.sh_ are ephemeral and will expire after the 24 hrs time limit. Use the
     following commands to push the provider images to the _ttl.sh_ image registry.
 
-```bash
-docker push ttl.sh/ubuntu:k3s-1.25.2-v4.0.6-palette-learn
-docker push ttl.sh/ubuntu:k3s-1.26.4-v4.0.6-palette-learn
-docker push ttl.sh/ubuntu:k3s-1.27.2-v4.0.6-palette-learn
-```
+    ```bash
+    docker push ttl.sh/ubuntu:k3s-1.25.2-v4.0.6-palette-learn
+    docker push ttl.sh/ubuntu:k3s-1.26.4-v4.0.6-palette-learn
+    docker push ttl.sh/ubuntu:k3s-1.27.2-v4.0.6-palette-learn
+    ```
 
-:::warning
+    :::warning
 
-As a reminder, [ttl.sh](https://ttl.sh/) is a short-lived image registry. If you do not use these provider images in
-your cluster profile within 24 hours of pushing to _ttl.sh_, they will expire and must be re-pushed. Refer to the
-Advanced workflow in the current guide to learn how to use another registry, such as Docker Hub, and tag the docker
-images accordingly.
+    As a reminder, [ttl.sh](https://ttl.sh/) is a short-lived image registry. If you do not use these provider images in
+    your cluster profile within 24 hours of pushing to _ttl.sh_, they will expire and must be re-pushed. Refer to the
+    Advanced workflow in the current guide to learn how to use another registry, such as Docker Hub, and tag the docker
+    images accordingly.
 
-:::
+    :::
 
 14. After pushing the provider images to the image registry, open a web browser and log in to
     [Palette](https://console.spectrocloud.com). Ensure you are in the **Default** project scope before creating a
@@ -325,74 +329,76 @@ images accordingly.
 16. Add the following [BYOS Edge OS](../../../../integrations/byoos.md) pack to the OS layer in the **Profile Layers**
     section.
 
-| **Pack Type** | **Registry** | **Pack Name** | **Pack Version** |
-| ------------- | ------------ | ------------- | ---------------- |
-| OS            | Public Repo  | BYOS Edge OS  | `1.0.0`          |
+    | **Pack Type** | **Registry** | **Pack Name** | **Pack Version** |
+    | ------------- | ------------ | ------------- | ---------------- |
+    | OS            | Public Repo  | BYOS Edge OS  | `1.0.0`          |
 
 17. Replace the cluster profile's BYOOS pack manifest with the following custom manifest so that the cluster profile can
     pull the provider image from the ttl.sh image registry.
 
-The `system.xxxxx` attribute values below refer to the arguments defined in the **.arg** file. If you modified the
-arguments in the **.arg** file, you must modify the attribute values below accordingly.
+    The `system.xxxxx` attribute values below refer to the arguments defined in the **.arg** file. If you modified the
+    arguments in the **.arg** file, you must modify the attribute values below accordingly.
 
-```yaml
-pack:
-  content:
-    images:
-      - image: "{{.spectro.pack.edge-native-byoi.options.system.uri}}"
-  # Below config is default value, please uncomment if you want to modify default values
-  # drain:
-  #cordon: true
-  #timeout: 60 # The length of time to wait before giving up, zero means infinite
-  #gracePeriod: 60 # Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used
-  #ignoreDaemonSets: true
-  #deleteLocalData: true # Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained)
-  #force: true # Continue even if there are pods that do not declare a controller
-  #disableEviction: false # Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution
-  #skipWaitForDeleteTimeout: 60 # If pod DeletionTimestamp older than N seconds, skip waiting for the pod. Seconds must be greater than 0 to skip.
-options:
-  system.uri:
-    "{{ .spectro.pack.edge-native-byoi.options.system.registry }}/{{ .spectro.pack.edge-native-byoi.options.system.repo
-    }}:{{ .spectro.pack.edge-native-byoi.options.system.k8sDistribution }}-{{ .spectro.system.kubernetes.version }}-{{
-    .spectro.pack.edge-native-byoi.options.system.peVersion }}-{{
-    .spectro.pack.edge-native-byoi.options.system.customTag }}"
+    ```yaml
+    pack:
+      content:
+        images:
+          - image: "{{.spectro.pack.edge-native-byoi.options.system.uri}}"
+      # Below config is default value, please uncomment if you want to modify default values
+      # drain:
+      #cordon: true
+      #timeout: 60 # The length of time to wait before giving up, zero means infinite
+      #gracePeriod: 60 # Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used
+      #ignoreDaemonSets: true
+      #deleteLocalData: true # Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained)
+      #force: true # Continue even if there are pods that do not declare a controller
+      #disableEviction: false # Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution
+      #skipWaitForDeleteTimeout: 60 # If pod DeletionTimestamp older than N seconds, skip waiting for the pod. Seconds must be greater than 0 to skip.
+    options:
+      system.uri:
+        "{{ .spectro.pack.edge-native-byoi.options.system.registry }}/{{
+        .spectro.pack.edge-native-byoi.options.system.repo }}:{{
+        .spectro.pack.edge-native-byoi.options.system.k8sDistribution }}-{{ .spectro.system.kubernetes.version }}-{{
+        .spectro.pack.edge-native-byoi.options.system.peVersion }}-{{
+        .spectro.pack.edge-native-byoi.options.system.customTag }}"
 
-  system.registry: ttl.sh
-  system.repo: ubuntu
-  system.k8sDistribution: k3s
-  system.osName: ubuntu
-  system.peVersion: v4.0.6
-  system.customTag: palette-learn
-  system.osVersion: 22
-```
+      system.registry: ttl.sh
+      system.repo: ubuntu
+      system.k8sDistribution: k3s
+      system.osName: ubuntu
+      system.peVersion: v4.0.6
+      system.customTag: palette-learn
+      system.osVersion: 22
+    ```
 
-The screenshot below displays how to reference a provider image in the BYOOS pack of your cluster profile.
+    The screenshot below displays how to reference a provider image in the BYOOS pack of your cluster profile.
 
-![Screenshot of a sample cluster profile's OS layer ](/tutorials/palette-canvos/clusters_edge_palette-canvos_edit_profile.webp)
+    ![Screenshot of a sample cluster profile's OS layer ](/tutorials/palette-canvos/clusters_edge_palette-canvos_edit_profile.webp)
 
-:::info
+    :::info
 
-The BYOOS pack's `system.uri` attribute references the Kubernetes version selected in the cluster profile by using the
-`{{ .spectro.system.kubernetes.version }}` [macro](../../../cluster-management/macros.md). This is how the provider
-images you created and pushed to a registry are tied to the OS and Kubernetes version you selected in the **.arg** file.
+    The BYOOS pack's `system.uri` attribute references the Kubernetes version selected in the cluster profile by using
+    the `{{ .spectro.system.kubernetes.version }}` [macro](../../../cluster-management/macros.md). This is how the
+    provider images you created and pushed to a registry are tied to the OS and Kubernetes version you selected in the
+    **.arg** file.
 
-:::
+    :::
 
 18. Add the following **Palette Optimized K3s** pack to the Kubernetes layer of your cluster profile. Select the k3s
     version 1.27.x because earlier in this how-to guide, you pushed a provider image compatible with k3s v1.27.2 to the
     ttl.sh image registry.
 
-| **Pack Type** | **Registry** | **Pack Name**         | **Pack Version** |
-| ------------- | ------------ | --------------------- | ---------------- |
-| Kubernetes    | Public Repo  | Palette Optimized k3s | `1.27.x`         |
+    | **Pack Type** | **Registry** | **Pack Name**         | **Pack Version** |
+    | ------------- | ------------ | --------------------- | ---------------- |
+    | Kubernetes    | Public Repo  | Palette Optimized k3s | `1.27.x`         |
 
 19. Add the network layer to your cluster profile, and choose a Container Network Interface (CNI) pack that best fits
     your needs, such as Calico, Flannel, Cilium, or Custom CNI. For example, you can add the following network layer.
     This step completes the core infrastructure layers in the cluster profile.
 
-| **Pack Type** | **Registry** | **Pack Name** | **Pack Version** |
-| ------------- | ------------ | ------------- | ---------------- |
-| Network       | Public Repo  | Calico        | `3.25.x`         |
+    | **Pack Type** | **Registry** | **Pack Name** | **Pack Version** |
+    | ------------- | ------------ | ------------- | ---------------- |
+    | Network       | Public Repo  | Calico        | `3.25.x`         |
 
 20. Add add-on layers and manifests to your cluster profile per your requirements.
 
@@ -503,280 +509,277 @@ git checkout v4.0.6
 6. Review the **.arg** file containing the customizable arguments, such as image tag, image registry, image repository,
    and OS distribution. The table below shows all arguments, their default value, and allowed values.
 
-| **Argument**       | **Description**                                                                              | **Default Value**      | **Allowed Values**                                                                             |
-| ------------------ | -------------------------------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------- |
-| `CUSTOM_TAG`       | Tag for the provider images                                                                  | demo                   | Lowercase alphanumeric string without spaces.                                                  |
-| `IMAGE_REGISTRY`   | Image registry name                                                                          | ttl.sh                 | Your image registry hostname, without `http` or `https` <br /> Example: docker.io/spectrocloud |
-| `OS_DISTRIBUTION`  | OS Distribution                                                                              | ubuntu                 | ubuntu, opensuse-leap                                                                          |
-| `IMAGE_REPO`       | Image repository name.<br /> It is the same as the OS distribution.                          | `$OS_DISTRIBUTION`     | Your image repository name.                                                                    |
-| `OS_VERSION`       | OS version, only applies to Ubuntu                                                           | 22                     | 20, 22                                                                                         |
-| `K8S_DISTRIBUTION` | Kubernetes Distribution                                                                      | k3s                    | k3s, rke2, kubeadm                                                                             |
-| `ISO_NAME`         | Name of the Installer ISO                                                                    | palette-edge-installer | Lowercase alphanumeric string without spaces. The characters `-` and `_` are allowed.          |
-| `ARCH`             | Architecture of the image.                                                                   | `amd64`                | `amd64`, `arm64`                                                                               |
-| `FIPS_ENABLED`     | to generate FIPS compliant binaries `true`or`false`                                          | `false`                | `true`, `false`                                                                                |
-| `HTTP_PROXY`       | URL of the HTTP Proxy server.                                                                | `""`                   | URL string                                                                                     |
-| `HTTPS_PROXY`      | URL of the HTTPS Proxy server.                                                               | `""`                   | URL string                                                                                     |
-| `NO_PROXY`         | URLS that should be excluded from the proxy.                                                 | `""`                   | Comma separated URL string                                                                     |
-| `PROXY_CERT_PATH`  | Absolute path of the SSL Proxy certificate in PEM format.                                    | `""`                   | Absolute path string                                                                           |
-| `UPDATE_KERNEL`    | Determines whether to upgrade the Kernel version to the latest from the upstream OS provider | `false`                | `true`, `false`                                                                                |
+   | **Argument**       | **Description**                                                                              | **Default Value**      | **Allowed Values**                                                                             |
+   | ------------------ | -------------------------------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------- |
+   | `CUSTOM_TAG`       | Tag for the provider images                                                                  | demo                   | Lowercase alphanumeric string without spaces.                                                  |
+   | `IMAGE_REGISTRY`   | Image registry name                                                                          | ttl.sh                 | Your image registry hostname, without `http` or `https` <br /> Example: docker.io/spectrocloud |
+   | `OS_DISTRIBUTION`  | OS Distribution                                                                              | ubuntu                 | ubuntu, opensuse-leap                                                                          |
+   | `IMAGE_REPO`       | Image repository name.<br /> It is the same as the OS distribution.                          | `$OS_DISTRIBUTION`     | Your image repository name.                                                                    |
+   | `OS_VERSION`       | OS version, only applies to Ubuntu                                                           | 22                     | 20, 22                                                                                         |
+   | `K8S_DISTRIBUTION` | Kubernetes Distribution                                                                      | k3s                    | k3s, rke2, kubeadm                                                                             |
+   | `ISO_NAME`         | Name of the Installer ISO                                                                    | palette-edge-installer | Lowercase alphanumeric string without spaces. The characters `-` and `_` are allowed.          |
+   | `ARCH`             | Architecture of the image.                                                                   | `amd64`                | `amd64`, `arm64`                                                                               |
+   | `FIPS_ENABLED`     | to generate FIPS compliant binaries `true`or`false`                                          | `false`                | `true`, `false`                                                                                |
+   | `HTTP_PROXY`       | URL of the HTTP Proxy server.                                                                | `""`                   | URL string                                                                                     |
+   | `HTTPS_PROXY`      | URL of the HTTPS Proxy server.                                                               | `""`                   | URL string                                                                                     |
+   | `NO_PROXY`         | URLS that should be excluded from the proxy.                                                 | `""`                   | Comma separated URL string                                                                     |
+   | `PROXY_CERT_PATH`  | Absolute path of the SSL Proxy certificate in PEM format.                                    | `""`                   | Absolute path string                                                                           |
+   | `UPDATE_KERNEL`    | Determines whether to upgrade the Kernel version to the latest from the upstream OS provider | `false`                | `true`, `false`                                                                                |
 
-Next, you will customize these arguments to use during the build process.
+   Next, you will customize these arguments to use during the build process.
 
 7. Issue the command below to assign an image tag value that will be used when creating the provider images. This guide
    uses the value `palette-learn` as an example. However, you can assign any lowercase and alphanumeric string to the
    `CUSTOM_TAG` argument.
 
-```bash
-export CUSTOM_TAG=palette-learn
-```
+   ```bash
+   export CUSTOM_TAG=palette-learn
+   ```
 
 8. Use the command below to save the Docker Hub image registry hostname in the `IMAGE_REGISTRY` argument. Before you
    execute the command, replace `[DOCKER-ID]` in the declaration below with your Docker ID. Your image registry hostname
    must comply with standard DNS rules and may not contain underscores.
 
-```bash
-export IMAGE_REGISTRY=docker.io/[DOCKER-ID]
-```
+   ```bash
+   export IMAGE_REGISTRY=docker.io/[DOCKER-ID]
+   ```
 
 9. Issue the following command to use the openSUSE Leap OS distribution.
 
-```bash
-export OS_DISTRIBUTION=opensuse-leap
-```
+   ```bash
+   export OS_DISTRIBUTION=opensuse-leap
+   ```
 
 10. Issue the command below to create the **.arg** file containing the custom tag, Docker Hub image registry hostname,
     and openSUSE Leap OS distribution. The **.arg** file uses the default values for the remaining arguments. You can
     refer to the existing **.arg.template** file to learn more about the available customizable arguments.
 
-```bash
-cat << EOF > .arg
-IMAGE_REGISTRY=$IMAGE_REGISTRY
-OS_DISTRIBUTION=$OS_DISTRIBUTION
-IMAGE_REPO=$OS_DISTRIBUTION
-CUSTOM_TAG=$CUSTOM_TAG
-K8S_DISTRIBUTION=k3s
-ISO_NAME=palette-edge-installer
-ARCH=amd64
-HTTPS_PROXY=
-HTTP_PROXY=
-PROXY_CERT_PATH=
-UPDATE_KERNEL=false
-EOF
-```
+    ```bash
+    cat << EOF > .arg
+    IMAGE_REGISTRY=$IMAGE_REGISTRY
+    OS_DISTRIBUTION=$OS_DISTRIBUTION
+    IMAGE_REPO=$OS_DISTRIBUTION
+    CUSTOM_TAG=$CUSTOM_TAG
+    K8S_DISTRIBUTION=k3s
+    ISO_NAME=palette-edge-installer
+    ARCH=amd64
+    HTTPS_PROXY=
+    HTTP_PROXY=
+    PROXY_CERT_PATH=
+    UPDATE_KERNEL=false
+    EOF
+    ```
 
-View the newly created file to ensure the customized arguments are set correctly.
+    View the newly created file to ensure the customized arguments are set correctly.
 
-```bash
-cat .arg
-```
+    ```bash
+    cat .arg
+    ```
 
-:::warning
+    :::warning
 
-Using the arguments defined in the **.arg** file, the final provider image name will have the following naming pattern,
-`[IMAGE_REGISTRY]/[IMAGE_REPO]:[CUSTOM_TAG]`. Ensure the final artifact name conforms to the Docker Hub image name
-syntax - `[HOST]/[DOCKER-ID]/[REPOSITORY]:[TAG]`.
+    Using the arguments defined in the **.arg** file, the final provider image name will have the following naming
+    pattern, `[IMAGE_REGISTRY]/[IMAGE_REPO]:[CUSTOM_TAG]`. Ensure the final artifact name conforms to the Docker Hub
+    image name syntax - `[HOST]/[DOCKER-ID]/[REPOSITORY]:[TAG]`.
 
-:::
+    :::
 
 11. Use the following command to append the [WireGuard](https://www.wireguard.com/install/) installation instructions to
     the Dockerfile. You can install more tools and dependencies and configure the image to meet your needs. Add your
     customizations below the line tagged with the `Add any other image customizations here` comment in the Dockerfile.
     Do not edit or add any lines before this tagged comment.
 
-```bash
-echo 'RUN sudo zypper refresh && sudo zypper install -y wireguard-tools' >> Dockerfile
-```
+    ```bash
+    echo 'RUN sudo zypper refresh && sudo zypper install -y wireguard-tools' >> Dockerfile
+    ```
 
-View the newly created file to ensure the instruction to install WireGuard is appended correctly.
+    View the newly created file to ensure the instruction to install WireGuard is appended correctly.
 
-```bash
-cat Dockerfile
-```
+    ```bash
+    cat Dockerfile
+    ```
 
-:::warning
+    :::warning
 
-Using the `-y` option with the `sudo zypper install` command is critical to successfully build the images. The default
-behavior for package installations is to prompt the user for permission to install the package. A user prompt will cause
-the image creation process to fail. This guidance applies to all dependencies you add through the **Dockerfile**.
+    Using the `-y` option with the `sudo zypper install` command is critical to successfully build the images. The
+    default behavior for package installations is to prompt the user for permission to install the package. A user
+    prompt will cause the image creation process to fail. This guidance applies to all dependencies you add through the
+    **Dockerfile**.
 
-:::
+    :::
 
 12. Issue the command below to save your tenant registration token to a local variable. Replace `[your_token_here]` with
     your actual registration token.
 
-```bash
-export token=[your_token_here]
-```
+    ```bash
+    export token=[your_token_here]
+    ```
 
 13. Use the following command to create the **user-data** file containing the tenant registration token.
 
-```shell
-cat << EOF > user-data
-#cloud-config
-stylus:
-  site:
-    paletteEndpoint: api.spectrocloud.com
-    edgeHostToken: $token
-    projectName: stores
-    tags:
-      key1: value1
-      key2: value2
-      key3: value3
-    name: edge-randomid
-    registrationURL: https://edge-registration-app.vercel.app/
+    ```shell
+    cat << EOF > user-data
+    #cloud-config
+    stylus:
+      site:
+        paletteEndpoint: api.spectrocloud.com
+        edgeHostToken: $token
+        projectName: stores
+        tags:
+          key1: value1
+          key2: value2
+          key3: value3
+        name: edge-randomid
+        registrationURL: https://edge-registration-app.vercel.app/
 
-    network:
-      httpProxy: http://proxy.example.com
-      httpsProxy: https://proxy.example.com
-      noProxy: 10.10.128.10,10.0.0.0/8
+        network:
+          httpProxy: http://proxy.example.com
+          httpsProxy: https://proxy.example.com
+          noProxy: 10.10.128.10,10.0.0.0/8
 
-      nameserver: 1.1.1.1
-      interfaces:
-          enp0s3:
-              type: static
-              ipAddress: 10.0.10.25/24
-              gateway: 10.0.10.1
-              nameserver: 10.10.128.8
-          enp0s4:
-              type: dhcp
-    caCerts:
-      - |
-        ------BEGIN CERTIFICATE------
-        *****************************
-        *****************************
-        ------END CERTIFICATE------
-      - |
-        ------BEGIN CERTIFICATE------
-        *****************************
-        *****************************
-        ------END CERTIFICATE------
-  registryCredentials:
-    domain: registry.example.com
-    username: bob
-    password: ####
-    insecure: false
-install:
-  poweroff: true
-users:
-  - name: kairos
-    passwd: kairos
-EOF
-```
+          nameserver: 1.1.1.1
+          interfaces:
+              enp0s3:
+                  type: static
+                  ipAddress: 10.0.10.25/24
+                  gateway: 10.0.10.1
+                  nameserver: 10.10.128.8
+              enp0s4:
+                  type: dhcp
+        caCerts:
+          - |
+            ------BEGIN CERTIFICATE------
+            *****************************
+            *****************************
+            ------END CERTIFICATE------
+          - |
+            ------BEGIN CERTIFICATE------
+            *****************************
+            *****************************
+            ------END CERTIFICATE------
+      registryCredentials:
+        domain: registry.example.com
+        username: bob
+        password: ####
+        insecure: false
+    install:
+      poweroff: true
+    users:
+      - name: kairos
+        passwd: kairos
+    EOF
+    ```
 
-:::info
+    :::info
 
-If you need to pull images from a private image registry, you can supply the credentials for the registry in the user
-data file in the `registryCredentials` field or in the cluster profile. Credentials specified in **user-data**
-overwrites the credentials provided in the cluster profile. To learn how to provide credentials in cluster profiles,
-refer to
-[Deploy Cluster with a Private Registry](../../site-deployment/deploy-custom-registries/deploy-private-registry.md).
+    If you need to pull images from a private image registry, you can supply the credentials for the registry in the
+    user data file in the `registryCredentials` field or in the cluster profile. Credentials specified in **user-data**
+    overwrites the credentials provided in the cluster profile. To learn how to provide credentials in cluster profiles,
+    refer to
+    [Deploy Cluster with a Private Registry](../../site-deployment/deploy-custom-registries/deploy-private-registry.md).
 
-:::
+    :::
 
-View the newly created user data file to ensure the token is set correctly.
+    View the newly created user data file to ensure the token is set correctly.
 
-```bash
-cat user-data
-```
+    ```bash
+    cat user-data
+    ```
 
-If you want further customization, check the existing **user-data.template** file, and refer to the
-[Edge Configuration Stages](../../edge-configuration/cloud-init.md) and
-[User Data Parameters](../../edge-configuration/installer-reference.md) documents to learn more.
+    If you want further customization, check the existing **user-data.template** file, and refer to the
+    [Edge Configuration Stages](../../edge-configuration/cloud-init.md) and
+    [User Data Parameters](../../edge-configuration/installer-reference.md) documents to learn more.
 
 14. CanvOS utility uses [Earthly](https://earthly.dev/) to build the target artifacts. Issue the following command to
     start the build process.
 
-```bash
-sudo ./earthly.sh +build-all-images
-```
+    ```bash
+    sudo ./earthly.sh +build-all-images
+    ```
 
-```hideClipboard bash {2}
-# Output condensed for readability
-===================== Earthly Build SUCCESS =====================
-Share your logs with an Earthly account (experimental)! Register for one at https://ci.earthly.dev.
-```
+    ```hideClipboard bash {2}
+    # Output condensed for readability
+    ===================== Earthly Build SUCCESS =====================
+    Share your logs with an Earthly account (experimental)! Register for one at https://ci.earthly.dev.
+    ```
 
-<br />
+    :::info
 
-:::info
+    If you plan to build Edge artifacts using a content bundle, use the `+build-provider-images` option instead of the
+    `+build-all-images` option in the command above. The command, `sudo ./earthly.sh +build-provider-images`, will build
+    the provider images but not the Edge installer ISO.
 
-If you plan to build Edge artifacts using a content bundle, use the `+build-provider-images` option instead of the
-`+build-all-images` option in the command above. The command, `sudo ./earthly.sh +build-provider-images`, will build the
-provider images but not the Edge installer ISO.
+    :::
 
-:::
+    This command may take up to 15-20 minutes to finish depending on the resources of the host machine. Upon completion,
+    the command will display the manifest, as shown in the example below, that you will use in your cluster profile
+    later in this tutorial. Note that the `system.xxxxx` attribute values in the manifest example are the same as what
+    you defined earlier in the **.arg** file.
 
-<br />
+    Copy and save the output attributes in a notepad or clipboard to use later in your cluster profile.
 
-This command may take up to 15-20 minutes to finish depending on the resources of the host machine. Upon completion, the
-command will display the manifest, as shown in the example below, that you will use in your cluster profile later in
-this tutorial. Note that the `system.xxxxx` attribute values in the manifest example are the same as what you defined
-earlier in the **.arg** file.
+    ```bash hideClipboard
+    pack:
+      content:
+        images:
+          - image: "{{.spectro.pack.edge-native-byoi.options.system.uri}}"
+      # Below config is default value, please uncomment if you want to modify default values
+      #drain:
+        #cordon: true
+        #timeout: 60 # The length of time to wait before giving up, zero means infinite
+        #gracePeriod: 60 # Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used
+        #ignoreDaemonSets: true
+        #deleteLocalData: true # Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained)
+        #force: true # Continue even if there are pods that do not declare a controller
+        #disableEviction: false # Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution
+        #skipWaitForDeleteTimeout: 60 # If pod DeletionTimestamp older than N seconds, skip waiting for the pod. Seconds must be greater than 0 to skip.
+    options:
+      system.uri: "{{ .spectro.pack.edge-native-byoi.options.system.registry }}/{{ .spectro.pack.edge-native-byoi.options.system.repo }}:{{ .spectro.pack.edge-native-byoi.options.system.k8sDistribution }}-{{ .spectro.system.kubernetes.version }}-{{ .spectro.pack.edge-native-byoi.options.system.peVersion }}-{{ .spectro.pack.edge-native-byoi.options.system.customTag }}"
 
-Copy and save the output attributes in a notepad or clipboard to use later in your cluster profile.
-
-```bash hideClipboard
-pack:
-  content:
-    images:
-      - image: "{{.spectro.pack.edge-native-byoi.options.system.uri}}"
-  # Below config is default value, please uncomment if you want to modify default values
-  #drain:
-    #cordon: true
-    #timeout: 60 # The length of time to wait before giving up, zero means infinite
-    #gracePeriod: 60 # Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used
-    #ignoreDaemonSets: true
-    #deleteLocalData: true # Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained)
-    #force: true # Continue even if there are pods that do not declare a controller
-    #disableEviction: false # Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution
-    #skipWaitForDeleteTimeout: 60 # If pod DeletionTimestamp older than N seconds, skip waiting for the pod. Seconds must be greater than 0 to skip.
-options:
-  system.uri: "{{ .spectro.pack.edge-native-byoi.options.system.registry }}/{{ .spectro.pack.edge-native-byoi.options.system.repo }}:{{ .spectro.pack.edge-native-byoi.options.system.k8sDistribution }}-{{ .spectro.system.kubernetes.version }}-{{ .spectro.pack.edge-native-byoi.options.system.peVersion }}-{{ .spectro.pack.edge-native-byoi.options.system.customTag }}"
-
-  system.registry: docker.io/spectrocloud
-  system.repo: opensuse-leap
-  system.k8sDistribution: k3s
-  system.osName: opensuse-leap
-  system.peVersion: v4.0.6
-  system.customTag: palette-learn
-  system.osVersion:
-```
+      system.registry: docker.io/spectrocloud
+      system.repo: opensuse-leap
+      system.k8sDistribution: k3s
+      system.osName: opensuse-leap
+      system.peVersion: v4.0.6
+      system.customTag: palette-learn
+      system.osVersion:
+    ```
 
 15. List the Docker images to review the provider images created. By default, provider images for all the Palette's
     Edge-supported Kubernetes versions are created. You can identify the provider images by reviewing the image tag
     value you used in the **.arg** file's `CUSTOM_TAG` argument.
 
-```shell
-docker images --filter=reference='*/*:*palette-learn'
-```
+    ```shell
+    docker images --filter=reference='*/*:*palette-learn'
+    ```
 
-```hideClipboard bash
-REPOSITORY                   TAG                               IMAGE ID       CREATED          SIZE
-spectrocloud/opensuse-leap   k3s-1.27.2-v4.0.6-palette-learn   2427e3667b2f   24 minutes ago   2.22GB
-spectrocloud/opensuse-leap   k3s-1.26.6-v4.0.6-palette-learn   0f2efd533a33   24 minutes ago   2.22GB
-spectrocloud/opensuse-leap   k3s-1.25.2-v4.0.6-palette-learn   2427e3667b2f   24 minutes ago   2.22GB
-```
+    ```hideClipboard bash
+    REPOSITORY                   TAG                               IMAGE ID       CREATED          SIZE
+    spectrocloud/opensuse-leap   k3s-1.27.2-v4.0.6-palette-learn   2427e3667b2f   24 minutes ago   2.22GB
+    spectrocloud/opensuse-leap   k3s-1.26.6-v4.0.6-palette-learn   0f2efd533a33   24 minutes ago   2.22GB
+    spectrocloud/opensuse-leap   k3s-1.25.2-v4.0.6-palette-learn   2427e3667b2f   24 minutes ago   2.22GB
+    ```
 
 16. To use the provider images in your cluster profile, push them to your image registry mentioned in the **.arg** file.
     Issue the following command to log in to Docker Hub. Provide your Docker ID and password when prompted.
 
-```bash
-docker login
-```
+    ```bash
+    docker login
+    ```
 
-```hideClipboard bash
-Login Succeeded
-```
+    ```hideClipboard bash
+    Login Succeeded
+    ```
 
 17. Use the following commands to push the provider images to the Docker Hub image registry you specified. Replace the
     `[DOCKER-ID]` and version numbers in the command below with your Docker ID and respective Kubernetes versions that
     the utility created.
 
-```bash
-docker push docker.io/[DOCKER-ID]/opensuse-leap:k3s-1.27.2-v4.0.6-palette-learn
-docker push docker.io/[DOCKER-ID]/opensuse-leap:k3s-1.26.6-v4.0.6-palette-learn
-docker push docker.io/[DOCKER-ID]/opensuse-leap:k3s-1.25.2-v4.0.6-palette-learn
-```
+    ```bash
+    docker push docker.io/[DOCKER-ID]/opensuse-leap:k3s-1.27.2-v4.0.6-palette-learn
+    docker push docker.io/[DOCKER-ID]/opensuse-leap:k3s-1.26.6-v4.0.6-palette-learn
+    docker push docker.io/[DOCKER-ID]/opensuse-leap:k3s-1.25.2-v4.0.6-palette-learn
+    ```
 
 18. After pushing the provider images to the image registry, open a web browser and log in to
     [Palette](https://console.spectrocloud.com). Ensure you are in the **Default** project scope before creating a
@@ -788,83 +791,85 @@ docker push docker.io/[DOCKER-ID]/opensuse-leap:k3s-1.25.2-v4.0.6-palette-learn
 20. Add the following [BYOS Edge OS](../../../../integrations/byoos.md) pack to the OS layer in the **Profile Layers**
     section.
 
-| **Pack Type** | **Registry** | **Pack Name** | **Pack Version** |
-| ------------- | ------------ | ------------- | ---------------- |
-| OS            | Public Repo  | BYOS Edge OS  | `1.0.0`          |
+    | **Pack Type** | **Registry** | **Pack Name** | **Pack Version** |
+    | ------------- | ------------ | ------------- | ---------------- |
+    | OS            | Public Repo  | BYOS Edge OS  | `1.0.0`          |
 
 21. Replace the cluster profile's BYOOS pack manifest with the output that was provided to you earlier and that you
     copied.
 
-The `system.xxxxx` attribute values below refer to the arguments defined in the **.arg** file. If you modified the
-arguments in the **.arg** file, you must modify the attribute values below accordingly.
+    The `system.xxxxx` attribute values below refer to the arguments defined in the **.arg** file. If you modified the
+    arguments in the **.arg** file, you must modify the attribute values below accordingly.
 
-```yaml hideClipboard
-pack:
-  content:
-    images:
-      - image: "{{.spectro.pack.edge-native-byoi.options.system.uri}}"
-  # Below config is default value, please uncomment if you want to modify default values
-  #drain:
-  #cordon: true
-  #timeout: 60 # The length of time to wait before giving up, zero means infinite
-  #gracePeriod: 60 # Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used
-  #ignoreDaemonSets: true
-  #deleteLocalData: true # Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained)
-  #force: true # Continue even if there are pods that do not declare a controller
-  #disableEviction: false # Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution
-  #skipWaitForDeleteTimeout: 60 # If pod DeletionTimestamp older than N seconds, skip waiting for the pod. Seconds must be greater than 0 to skip.
-options:
-  system.uri:
-    "{{ .spectro.pack.edge-native-byoi.options.system.registry }}/{{ .spectro.pack.edge-native-byoi.options.system.repo
-    }}:{{ .spectro.pack.edge-native-byoi.options.system.k8sDistribution }}-{{ .spectro.system.kubernetes.version }}-{{
-    .spectro.pack.edge-native-byoi.options.system.peVersion }}-{{
-    .spectro.pack.edge-native-byoi.options.system.customTag }}"
+    ```yaml hideClipboard
+    pack:
+      content:
+        images:
+          - image: "{{.spectro.pack.edge-native-byoi.options.system.uri}}"
+      # Below config is default value, please uncomment if you want to modify default values
+      #drain:
+      #cordon: true
+      #timeout: 60 # The length of time to wait before giving up, zero means infinite
+      #gracePeriod: 60 # Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used
+      #ignoreDaemonSets: true
+      #deleteLocalData: true # Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained)
+      #force: true # Continue even if there are pods that do not declare a controller
+      #disableEviction: false # Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution
+      #skipWaitForDeleteTimeout: 60 # If pod DeletionTimestamp older than N seconds, skip waiting for the pod. Seconds must be greater than 0 to skip.
+    options:
+      system.uri:
+        "{{ .spectro.pack.edge-native-byoi.options.system.registry }}/{{
+        .spectro.pack.edge-native-byoi.options.system.repo }}:{{
+        .spectro.pack.edge-native-byoi.options.system.k8sDistribution }}-{{ .spectro.system.kubernetes.version }}-{{
+        .spectro.pack.edge-native-byoi.options.system.peVersion }}-{{
+        .spectro.pack.edge-native-byoi.options.system.customTag }}"
 
-  system.registry: docker.io/spectrocloud
-  system.repo: opensuse-leap
-  system.k8sDistribution: k3s
-  system.osName: opensuse-leap
-  system.peVersion: v4.0.6
-  system.customTag: palette-learn
-  system.osVersion:
-```
+      system.registry: docker.io/spectrocloud
+      system.repo: opensuse-leap
+      system.k8sDistribution: k3s
+      system.osName: opensuse-leap
+      system.peVersion: v4.0.6
+      system.customTag: palette-learn
+      system.osVersion:
+    ```
 
-The screenshot below displays how to reference a provider image in the BYOOS pack of your cluster profile.
+    The screenshot below displays how to reference a provider image in the BYOOS pack of your cluster profile.
 
-![Screenshot of a sample cluster profile's OS layer ](/tutorials/palette-canvos/clusters_edge_palette-canvos_edit_profile.webp)
+    ![Screenshot of a sample cluster profile's OS layer ](/tutorials/palette-canvos/clusters_edge_palette-canvos_edit_profile.webp)
 
-:::info
+    :::info
 
-The BYOOS pack's `system.uri` attribute references the Kubernetes version selected in the cluster profile by using the
-`{{ .spectro.system.kubernetes.version }}` [macro](../../../cluster-management/macros.md). This is how the provider
-images you created and pushed to a registry are tied to the OS and Kubernetes version you selected in the **.arg** file.
+    The BYOOS pack's `system.uri` attribute references the Kubernetes version selected in the cluster profile by using
+    the `{{ .spectro.system.kubernetes.version }}` [macro](../../../cluster-management/macros.md). This is how the
+    provider images you created and pushed to a registry are tied to the OS and Kubernetes version you selected in the
+    **.arg** file.
 
-:::
+    :::
 
 22. Add the following **Palette Optimized K3s** pack to the Kubernetes layer of your cluster profile. Select the k3s
     version 1.27.x because earlier in this how-to guide, you pushed a provider image compatible with k3s v1.27.2 to the
     ttl.sh image registry.
 
-| **Pack Type** | **Registry** | **Pack Name**         | **Pack Version** |
-| ------------- | ------------ | --------------------- | ---------------- |
-| Kubernetes    | Public Repo  | Palette Optimized k3s | `1.27.x`         |
+    | **Pack Type** | **Registry** | **Pack Name**         | **Pack Version** |
+    | ------------- | ------------ | --------------------- | ---------------- |
+    | Kubernetes    | Public Repo  | Palette Optimized k3s | `1.27.x`         |
 
 23. Add the network layer to your cluster profile, and choose a Container Network Interface (CNI) pack that best fits
     your needs, such as Calico, Flannel, Cilium, or Custom CNI. For example, you can add the following network layer.
     This step completes the core infrastructure layers in the cluster profile.
 
-| **Pack Type** | **Registry** | **Pack Name** | **Pack Version** |
-| ------------- | ------------ | ------------- | ---------------- |
-| Network       | Public Repo  | Calico        | `3.25.x`         |
+    | **Pack Type** | **Registry** | **Pack Name** | **Pack Version** |
+    | ------------- | ------------ | ------------- | ---------------- |
+    | Network       | Public Repo  | Calico        | `3.25.x`         |
 
 24. Add add-on layers and manifests to your cluster profile per your requirements.
 
 25. If there are no errors or compatibility issues, Palette displays the newly created complete cluster profile for
-    review. Verify the layers you added, and finish creating the cluster profile. <br />
+    review. Verify the layers you added, and finish creating the cluster profile.
 
 ### Validate
 
-List the Edge installer ISO image and checksum by issuing the following command from the **CanvOS/** directory. <br />
+List the Edge installer ISO image and checksum by issuing the following command from the **CanvOS/** directory.
 
 ```shell
 ls build/

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
@@ -590,7 +590,7 @@ git checkout v4.0.6
     Do not edit or add any lines before this tagged comment.
 
     ```bash
-    echo 'RUN sudo zypper refresh && sudo zypper install -y wireguard-tools' >> Dockerfile
+    echo 'RUN sudo zypper refresh && sudo zypper install --non-interactive wireguard-tools' >> Dockerfile
     ```
 
     View the newly created file to ensure the instruction to install WireGuard is appended correctly.
@@ -852,7 +852,7 @@ git checkout v4.0.6
 
     | **Pack Type** | **Registry** | **Pack Name**         | **Pack Version** |
     | ------------- | ------------ | --------------------- | ---------------- |
-    | Kubernetes    | Public Repo  | Palette Optimized k3s | `1.27.x`         |
+    | Kubernetes    | Public Repo  | Palette Optimized K3s | `1.27.x`         |
 
 23. Add the network layer to your cluster profile, and choose a Container Network Interface (CNI) pack that best fits
     your needs, such as Calico, Flannel, Cilium, or Custom CNI. For example, you can add the following network layer.

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -219,3 +219,9 @@ p img.markdown-image {
     display: none;
   }
 }
+
+// Reduce the spacing between lines in code blocks
+
+.theme-code-block code {
+  line-height: 1.6em;
+}


### PR DESCRIPTION
## Describe the Change

This PR reduces the line height for code elements so that our code does not look like it has double space. Also fixes an indentation issue in the EdgeForge documentation. 

## Changed Pages

💻 [Build Edge Artifacts](https://deploy-preview-2737--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/)

## Jira Tickets

🎫 [DOC-1168](https://spectrocloud.atlassian.net/browse/DOC-1168)

## Backports

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._


[DOC-1168]: https://spectrocloud.atlassian.net/browse/DOC-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ