### PR TITLE
[version-4-1] chore: Fix broken links (#2778)

### DIFF
--- a/docs/docs-content/integrations/portworx_operator.md
+++ b/docs/docs-content/integrations/portworx_operator.md
@@ -533,7 +533,7 @@ vsphereSecret:
 
 To activate the Pure Flash Array integration, you will need to create a Kubernetes secret named `px-pure-secret` on your
 cluster containing your
-[Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/install-portworx/kubernetes/install-flasharray.html#create-a-json-configuration-file).
+[Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/install-portworx/kubernetes/flasharray/install-flasharray-on-cloud#create-a-json-configuration-file).
 The secret must be created in the namespace that contains the `StorageCluster` resource. The namespace is `portworx` by
 default.
 
@@ -1142,7 +1142,7 @@ vsphereSecret:
 
 To activate the Pure Flash Array integration, you will need to create a Kubernetes secret named `px-pure-secret` on your
 cluster containing your
-[Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/install-portworx/kubernetes/install-flasharray.html#create-a-json-configuration-file).
+[Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/install-portworx/kubernetes/flasharray/install-flasharray-on-cloud#create-a-json-configuration-file).
 The secret must be created in the namespace that contains the `StorageCluster` resource. The namespace is `kube-system`
 by default.
 
@@ -1733,7 +1733,7 @@ vsphereSecret:
 
 To activate the Pure Flash Array integration, you will need to create a Kubernetes secret named `px-pure-secret` on your
 cluster containing your
-[Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/install-portworx/kubernetes/install-flasharray.html#create-a-json-configuration-file).
+[Flash Array license JSON](https://docs.portworx.com/portworx-enterprise/install-portworx/kubernetes/flasharray/install-flasharray-on-cloud#create-a-json-configuration-file).
 The secret must be created in the namespace that contains the `StorageCluster` resource. The namespace is `kube-system`
 by default.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-1`:
 - [chore: Fix broken links (#2778)](https://github.com/spectrocloud/librarium/pull/2778)