### PR TITLE
Airgap Support VM custom SSL Certs

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/checklist.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/checklist.md
@@ -25,3 +25,8 @@ installation.
 
 - [ ] Review the list of [pack binaries](../../airgap/supplemental-packs.md) to download and upload to your OCI
       registry.
+- [ ] If you have custom SSL certificates you want to include, copy the custom SSL certificates, in base64 PEM format,
+      to the support VM. The custom certificates must be placed in the **/opt/spectro/ssl** folder. Include the
+      following files:
+  - **server.crt**
+  - **server.key**

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -243,7 +243,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
     - **server.crt**
     - **server.key**
 
-    If you don't provide custom certificate then the airgap setup process will generate a self-signed certificate for
+    If you do not provide a custom SSL certificate, the airgap setup process will generate a self-signed certificate for
     you.
 
     :::warning

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -236,7 +236,25 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
     sudo --login
     ```
 
-19. Start the airgap initialization process by issuing the following command. The script requires the hostname or IP
+19. If you have custom SSL certificates you want to apply to the image and pack registry, and the Spectro Cloud
+    Repository, copy the custom SSL certificates, in base64 PEM format, to the airgap support VM. The custom
+    certificates must be placed in the **/opt/spectro/ssl** folder. Include the following files:
+
+    - **server.crt**
+    - **server.key**
+
+    If you don't provide custom certificate then the airgap setup process will generate a self-signed certificate for
+    you.
+
+    :::warning
+
+    The custom SSL certificates must be in base64 PEM format. If you have custom SSL certificates in a different format,
+    convert them to base64 PEM format before copying them to the support VM. The airgap setup process also expects the
+    files to be named **server.crt** and **server.key**.
+
+    :::
+
+20. Start the airgap initialization process by issuing the following command. The script requires the hostname or IP
     address of the airgap support VM. Choose the preferred method for your environment. Be aware that the script will
     generate a self-signed certificate for the value you provide.
 
@@ -317,10 +335,10 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
         </TabItem>
         </Tabs>
 
-20. The output of the script contains credentials and values you will need when completing the installation with the
+21. The output of the script contains credentials and values you will need when completing the installation with the
     Palette CLI. If you need to review this information in the future, invoke the script again.
 
-21. Review the [Additional Packs](../../airgap/supplemental-packs.md) page and identify any additional packs you want to
+22. Review the [Additional Packs](../../airgap/supplemental-packs.md) page and identify any additional packs you want to
     add to your OCI registry. By default, the installation includes only the minimum required packs. You can also add
     additional packs after the installation is complete.
 

--- a/docs/docs-content/enterprise-version/system-management/ssl-certificate-management.md
+++ b/docs/docs-content/enterprise-version/system-management/ssl-certificate-management.md
@@ -12,8 +12,8 @@ keywords: ["self-hosted", "enterprise"]
 Palette uses Secure Sockets Layer (SSL) certificates to secure internal and external communication with Hypertext
 Transfer Protocol Secure (HTTPS). External Palette endpoints, such as the
 [system console](../system-management/system-management.md#system-console),
-[Palette dashboard](../../getting-started/dashboard.md), Palette API, and gRPC endpoints, are enabled by default
-with HTTPS using an auto-generated self-signed certificate. You can replace the self-signed certificate with a custom SSL
+[Palette dashboard](../../getting-started/dashboard.md), Palette API, and gRPC endpoints, are enabled by default with
+HTTPS using an auto-generated self-signed certificate. You can replace the self-signed certificate with a custom SSL
 certificate to secure these endpoints.
 
 :::info

--- a/docs/docs-content/enterprise-version/system-management/ssl-certificate-management.md
+++ b/docs/docs-content/enterprise-version/system-management/ssl-certificate-management.md
@@ -9,17 +9,16 @@ tags: ["palette", "management"]
 keywords: ["self-hosted", "enterprise"]
 ---
 
-When you install Palette, a self-signed certificate is generated and used by default. You can upload your own SSL
-certificate to replace the default certificate.
-
-Palette uses SSL certificates to secure external communication. Internal components communication is by default secured
-and use HTTPS. External communication with Palette, such as the system console, gRPC endpoint, and API endpoint,
-requires you to upload an SSL certificate to enable HTTPS.
+Palette uses Secure Sockets Layer (SSL) certificates to secure internal and external communication with Hypertext
+Transfer Protocol Secure (HTTPS). External Palette endpoints, such as the
+[system console](../system-management/system-management.md#system-console),
+[Palette dashboard](../../getting-started/dashboard.md), the Palette API, and the gRPC endpoint, are enabled by default
+with HTTPS using an auto-generated self-signed certificate. You can replace the self-signed certificate with your SSL
+certificate to secure these endpoints.
 
 :::info
 
-Enabling HTTPS is a non-disruptive operation. You can enable HTTPS at any time without affecting the system's
-functionality.
+You can swap out the external endpoint certificate at any time without affecting the system's functionality.
 
 :::
 
@@ -69,4 +68,4 @@ You can validate that your certificate is uploaded correctly by using the follow
    with `https://`.
 
 Palette is now using your uploaded certificate to create a secure HTTPS connection with external clients. Users can now
-securely access the system console, gRPC endpoint, and API endpoint.
+securely access the system console, Palette dashboard, the gRPC endpoint, and the Palette API endpoint.

--- a/docs/docs-content/enterprise-version/system-management/ssl-certificate-management.md
+++ b/docs/docs-content/enterprise-version/system-management/ssl-certificate-management.md
@@ -12,13 +12,13 @@ keywords: ["self-hosted", "enterprise"]
 Palette uses Secure Sockets Layer (SSL) certificates to secure internal and external communication with Hypertext
 Transfer Protocol Secure (HTTPS). External Palette endpoints, such as the
 [system console](../system-management/system-management.md#system-console),
-[Palette dashboard](../../getting-started/dashboard.md), the Palette API, and the gRPC endpoint, are enabled by default
-with HTTPS using an auto-generated self-signed certificate. You can replace the self-signed certificate with your SSL
+[Palette dashboard](../../getting-started/dashboard.md), Palette API, and gRPC endpoints, are enabled by default
+with HTTPS using an auto-generated self-signed certificate. You can replace the self-signed certificate with a custom SSL
 certificate to secure these endpoints.
 
 :::info
 
-You can swap out the external endpoint certificate at any time without affecting the system's functionality.
+You can swap out the external endpoint certificate at any time without affecting the system functionality.
 
 :::
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/checklist.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/checklist.md
@@ -25,3 +25,9 @@ installation.
 
 - [ ] Review the list of [pack binaries](../../airgap/supplemental-packs.md) to download and upload to your OCI
       registry.
+
+- [ ] If you have custom SSL certificates you want to include, copy the custom SSL certificates, in base64 PEM format,
+      to the support VM. The custom certificates must be placed in the **/opt/spectro/ssl** folder. Include the
+      following files:
+  - **server.crt**
+  - **server.key**

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -237,7 +237,25 @@ If you are working in Vim, press `i` to enter insert mode in the text editor. Pr
     sudo --login
     ```
 
-19. Start the airgap initialization process by issuing the following command. The script requires the hostname or IP
+19. If you have custom SSL certificates you want to apply to the image and pack registry, and the Spectro Cloud
+    Repository, copy the custom SSL certificates, in base64 PEM format, to the airgap support VM. The custom
+    certificates must be placed in the **/opt/spectro/ssl** folder. Include the following files:
+
+    - **server.crt**
+    - **server.key**
+
+    If you don't provide custom certificate then the airgap setup process will generate a self-signed certificate for
+    you.
+
+    :::warning
+
+    The custom SSL certificates must be in base64 PEM format. If you have custom SSL certificates in a different format,
+    convert them to base64 PEM format before copying them to the support VM. The airgap setup process also expects the
+    files to be named **server.crt** and **server.key**.
+
+    :::
+
+20. Start the airgap initialization process by issuing the following command. The script requires the hostname or IP
     address of the airgap support VM. Choose the preferred method for your environment. Be aware that the script will
     generate a self-signed certificate for the value you provide.
 
@@ -318,10 +336,10 @@ If you are working in Vim, press `i` to enter insert mode in the text editor. Pr
         </TabItem>
         </Tabs>
 
-20. The output of the script contains credentials and values you will need when completing the installation with the
+21. The output of the script contains credentials and values you will need when completing the installation with the
     Palette CLI. If you need to review this information in the future, invoke the script again.
 
-21. Review the [Additional Packs](../../airgap/supplemental-packs.md) page and identify any additional packs you want to
+22. Review the [Additional Packs](../../airgap/supplemental-packs.md) page and identify any additional packs you want to
     add to your OCI registry. By default, the installation includes only the minimum required packs. You can also add
     additional packs after the installation is complete.
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -244,7 +244,7 @@ If you are working in Vim, press `i` to enter insert mode in the text editor. Pr
     - **server.crt**
     - **server.key**
 
-    If you don't provide custom certificate then the airgap setup process will generate a self-signed certificate for
+    If you do not provide a custom SSL certificat, the airgap setup process will generate a self-signed certificate for
     you.
 
     :::warning

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -244,7 +244,7 @@ If you are working in Vim, press `i` to enter insert mode in the text editor. Pr
     - **server.crt**
     - **server.key**
 
-    If you do not provide a custom SSL certificat, the airgap setup process will generate a self-signed certificate for
+    If you do not provide a custom SSL certificate, the airgap setup process will generate a self-signed certificate for
     you.
 
     :::warning

--- a/docs/docs-content/vertex/system-management/ssl-certificate-management.md
+++ b/docs/docs-content/vertex/system-management/ssl-certificate-management.md
@@ -18,7 +18,7 @@ certificate to secure these endpoints.
 
 :::info
 
-You can swap out the external endpoint certificate at any time without affecting the system's functionality.
+You can swap out the external endpoint certificate at any time without affecting the system functionality.
 
 :::
 

--- a/docs/docs-content/vertex/system-management/ssl-certificate-management.md
+++ b/docs/docs-content/vertex/system-management/ssl-certificate-management.md
@@ -9,17 +9,16 @@ tags: ["vertex", "management"]
 keywords: ["self-hosted", "vertex"]
 ---
 
-When you install Palette VerteX, a self-signed certificate is generated and used by default. You can upload your own SSL
-certificate to replace the default certificate.
-
-Palette VerteX uses SSL certificates to secure external communication. The internal components communication is by
-default secured and use HTTPS. External communication with Palette VerteX, such as the system console, gRPC endpoint,
-and API endpoint, requires you to upload an SSL certificate to enable HTTPS.
+Palette VerteX uses Secure Sockets Layer (SSL) certificates to secure internal and external communication with Hypertext
+Transfer Protocol Secure (HTTPS). External VerteX endpoints, such as the
+[system console](../system-management/system-management.md#system-console),
+[VerteX dashboard](../../getting-started/dashboard.md), the VerteX API, and the gRPC endpoint, are enabled by default
+with HTTPS using an auto-generated self-signed certificate. You can replace the self-signed certificate with your SSL
+certificate to secure these endpoints.
 
 :::info
 
-Enabling HTTPS is a non-disruptive operation. You can enable HTTPS at any time without affecting the system's
-functionality.
+You can swap out the external endpoint certificate at any time without affecting the system's functionality.
 
 :::
 
@@ -68,5 +67,5 @@ You can validate that your certificate is uploaded correctly by using the follow
 2. Log back into the Palette VerteX system console. Ensure the connection is secure by checking the URL. The URL should
    start with `https://`.
 
-Palette VerteX is now using your uploaded certificate to create a secure HTTPS connection with external clients. Users
-can now securely access the system console, gRPC endpoint, and API endpoint.
+VerteX is now using your uploaded certificate to create a secure HTTPS connection with external clients. Users can now
+securely access the system console, VerteX dashboard, the gRPC endpoint, and the VerteX API endpoint.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds instructions on providing a custom SSL certificate to the airgap support VM.

## Changed Pages

- [VerteX Airgap Checklist](https://deploy-preview-2846--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/airgap-install/checklist/)
- [Palette Airgap Checklist](https://deploy-preview-2846--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/airgap-install/checklist/)
- [VerteX Airgap Setup Guide](https://deploy-preview-2846--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions/)
- [Palette Airgap Setup Guide](https://deploy-preview-2846--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions/)


Two other pages that have minor clarification are the System Console Certificate Management page. The current wording made it seem like you have to upload a custom cert to enable HTTPS. However, Palette by default now comes with a self-signed cert so HTTPS is provided out-of-the-box.

- [VerteX Certificate Management](https://deploy-preview-2846--docs-spectrocloud.netlify.app/vertex/system-management/ssl-certificate-management/)
- [Palette Certificate Management](https://deploy-preview-2846--docs-spectrocloud.netlify.app/enterprise-version/system-management/ssl-certificate-management/)

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1149](https://spectrocloud.atlassian.net/browse/DOC-1149)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1149]: https://spectrocloud.atlassian.net/browse/DOC-1149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ