### PR TITLE
Clarity on which system administrator role can register Nutanix cloud

### DIFF
--- a/docs/docs-content/clusters/data-center/nutanix/register-nutanix-cloud.md
+++ b/docs/docs-content/clusters/data-center/nutanix/register-nutanix-cloud.md
@@ -318,14 +318,14 @@ Nutanix cloud to Palette. Alternatively, you can use an API platform such as [Po
 
 9. Register the worker pool template.
 
-```bash
-curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/templates/workerPoolTemplate" \
-     --header "Content-Type: multipart/form-data" \
-     --header "Authorization: ${TOKEN}" \
-     --form "fileName=@${workerPoolTemplate}"
-```
+   ```bash
+   curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/templates/workerPoolTemplate" \
+       --header "Content-Type: multipart/form-data" \
+       --header "Authorization: ${TOKEN}" \
+       --form "fileName=@${workerPoolTemplate}"
+   ```
 
-11. Register the cloud account keys.
+10. Register the cloud account keys.
 
     ```bash
     curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/cloudAccountKeys" \

--- a/docs/docs-content/clusters/data-center/nutanix/register-nutanix-cloud.md
+++ b/docs/docs-content/clusters/data-center/nutanix/register-nutanix-cloud.md
@@ -198,12 +198,18 @@ Use the steps below to confirm you have the required files and verify the requir
 Follow the steps below from your terminal to set the environment variables and invoke the APIs required to register a
 Nutanix cloud to Palette. Alternatively, you can use an API platform such as [Postman](https://www.postman.com/).
 
-:::warning
+## Prerequisites
 
-The logo file must not exceed 100KB in size. To ensure image quality ensure at least one dimension in either width or
-height is 40 pixels. It is preferable that the image be transparent.
+- You have completed the steps in [Customize YAML Configuration Files](#customize-yaml-configuration-files).
 
-:::
+- Only an
+  [Operations Administrator](../../../enterprise-version/system-management/account-management/account-management.md#operations-administrator)
+  is allowed to register a Nutanix cloud.
+
+- The logo file must not exceed 100KB in size. To ensure image quality ensure at least one dimension in either width or
+  height is 40 pixels. It is preferable that the image be transparent.
+
+## Enablement
 
 1. Export the URL of your self-hosted Palette or VerteX instance and the cloud type as environment variables.
    Additionally, export the path to the YAML templates and logo file.
@@ -231,12 +237,6 @@ height is 40 pixels. It is preferable that the image be transparent.
 2. To acquire system administrator credentials, use the `/v1/auth/syslogin` endpoint. Issue the `curl` command below and
    ensure you replace the credentials with your system console credentials.
 
-   :::warning
-
-   Only an Operations Administrator is allowed to register a Nutanix cloud.
-
-   :::
-
    ```bash
    curl --location "${ENDPOINT}/v1/auth/syslogin" \
    --header 'Content-Type: application/json' \
@@ -255,14 +255,14 @@ height is 40 pixels. It is preferable that the image be transparent.
    }
    ```
 
-4. Copy the authorization token, assign it to a `TOKEN` shell variable, and export it. Replace the authorization value
+3. Copy the authorization token, assign it to a `TOKEN` shell variable, and export it. Replace the authorization value
    below with the value from the output.
 
    ```bash
    export TOKEN="**********"
    ```
 
-5. Register the Nutanix cloud type in Palette using the `/v1/clouds/cloudTypes/register` endpoint.
+4. Register the Nutanix cloud type in Palette using the `/v1/clouds/cloudTypes/register` endpoint.
 
    ```bash
    curl --location --request POST "${ENDPOINT}/v1/clouds/cloudTypes/register" \
@@ -281,7 +281,7 @@ height is 40 pixels. It is preferable that the image be transparent.
         }'
    ```
 
-6. Upload the Nutanix cloud logo.
+5. Upload the Nutanix cloud logo.
 
    ```bash
    curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/logo" \
@@ -289,7 +289,7 @@ height is 40 pixels. It is preferable that the image be transparent.
         --form "fileName=@${cloudLogo}"
    ```
 
-7. Register the cloud provider.
+6. Register the cloud provider.
 
    ```bash
    curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/cloudProvider" \
@@ -298,7 +298,7 @@ height is 40 pixels. It is preferable that the image be transparent.
         --form "fileName=@${infraComponents}"
    ```
 
-8. Register the cluster template.
+7. Register the cluster template.
 
    ```bash
    curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/templates/clusterTemplate" \
@@ -307,7 +307,7 @@ height is 40 pixels. It is preferable that the image be transparent.
         --form "fileName=@${cloudClusterTemplate}"
    ```
 
-9. Register the control plane pool template.
+8. Register the control plane pool template.
 
    ```bash
    curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/templates/controlPlanePoolTemplate" \
@@ -316,14 +316,14 @@ height is 40 pixels. It is preferable that the image be transparent.
          --form "fileName=@${controlPlanePoolTemplate}"
    ```
 
-10. Register the worker pool template.
+9. Register the worker pool template.
 
-   ```bash
-   curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/templates/workerPoolTemplate" \
-        --header "Content-Type: multipart/form-data" \
-        --header "Authorization: ${TOKEN}" \
-        --form "fileName=@${workerPoolTemplate}"
-   ```
+```bash
+curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/templates/workerPoolTemplate" \
+     --header "Content-Type: multipart/form-data" \
+     --header "Authorization: ${TOKEN}" \
+     --form "fileName=@${workerPoolTemplate}"
+```
 
 11. Register the cloud account keys.
 

--- a/docs/docs-content/clusters/data-center/nutanix/register-nutanix-cloud.md
+++ b/docs/docs-content/clusters/data-center/nutanix/register-nutanix-cloud.md
@@ -231,6 +231,12 @@ height is 40 pixels. It is preferable that the image be transparent.
 2. To acquire system administrator credentials, use the `/v1/auth/syslogin` endpoint. Issue the `curl` command below and
    ensure you replace the credentials with your system console credentials.
 
+   :::warning
+
+   Only an Operations Administrator is allowed to register a Nutanix cloud.
+
+   :::
+
    ```bash
    curl --location "${ENDPOINT}/v1/auth/syslogin" \
    --header 'Content-Type: application/json' \
@@ -249,14 +255,14 @@ height is 40 pixels. It is preferable that the image be transparent.
    }
    ```
 
-3. Copy the authorization token, assign it to a `TOKEN` shell variable, and export it. Replace the authorization value
+4. Copy the authorization token, assign it to a `TOKEN` shell variable, and export it. Replace the authorization value
    below with the value from the output.
 
    ```bash
    export TOKEN="**********"
    ```
 
-4. Register the Nutanix cloud type in Palette using the `/v1/clouds/cloudTypes/register` endpoint.
+5. Register the Nutanix cloud type in Palette using the `/v1/clouds/cloudTypes/register` endpoint.
 
    ```bash
    curl --location --request POST "${ENDPOINT}/v1/clouds/cloudTypes/register" \
@@ -275,7 +281,7 @@ height is 40 pixels. It is preferable that the image be transparent.
         }'
    ```
 
-5. Upload the Nutanix cloud logo.
+6. Upload the Nutanix cloud logo.
 
    ```bash
    curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/logo" \
@@ -283,7 +289,7 @@ height is 40 pixels. It is preferable that the image be transparent.
         --form "fileName=@${cloudLogo}"
    ```
 
-6. Register the cloud provider.
+7. Register the cloud provider.
 
    ```bash
    curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/cloudProvider" \
@@ -292,7 +298,7 @@ height is 40 pixels. It is preferable that the image be transparent.
         --form "fileName=@${infraComponents}"
    ```
 
-7. Register the cluster template.
+8. Register the cluster template.
 
    ```bash
    curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/templates/clusterTemplate" \
@@ -301,7 +307,7 @@ height is 40 pixels. It is preferable that the image be transparent.
         --form "fileName=@${cloudClusterTemplate}"
    ```
 
-8. Register the control plane pool template.
+9. Register the control plane pool template.
 
    ```bash
    curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/templates/controlPlanePoolTemplate" \
@@ -310,7 +316,7 @@ height is 40 pixels. It is preferable that the image be transparent.
          --form "fileName=@${controlPlanePoolTemplate}"
    ```
 
-9. Register the worker pool template.
+10. Register the worker pool template.
 
    ```bash
    curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/content/templates/workerPoolTemplate" \
@@ -319,7 +325,7 @@ height is 40 pixels. It is preferable that the image be transparent.
         --form "fileName=@${workerPoolTemplate}"
    ```
 
-10. Register the cloud account keys.
+11. Register the cloud account keys.
 
     ```bash
     curl --location --request PUT "${ENDPOINT}/v1/clouds/cloudTypes/${CLOUD_TYPE}/cloudAccountKeys" \

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/fips.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/fips.md
@@ -15,6 +15,13 @@ Both the Edge Installer ISO and the provider images must be FIPS-compliant.
 
 This page guides you through the process of building FIPS-compliant Edge Installer ISO and provider images.
 
+## Limitations
+
+- FIPS-compliant Edge installer does not work with secure boot. You need to disable secure boot first before installing
+  Palette on your device. The process to disable secure boot varies by device, but generally, you can press F2 upon
+  powering up the Edge host, and find the option to disable secure boot in the Basic Input/Output System (BIOS)
+  interface.
+
 ## Prerequisites
 
 - A physical or virtual Linux machine with _AMD64_ (also known as _x86_64_) processor architecture to build the Edge
@@ -44,13 +51,20 @@ This page guides you through the process of building FIPS-compliant Edge Install
   command to check the existing Docker version. You should have root-level or `sudo` privileges on your Linux machine to
   create privileged containers.
 
-- A [VerteX](/docs/docs-content/vertex/vertex.md) account. Refer to
+- A [VerteX](/docs/docs-content/vertex/vertex.md) or Palette account. Refer to
   [Palette VerteX](/docs/docs-content/vertex/vertex.md#access-palette-vertex) for information on how to set up a VerteX
   account.
 
-- VerteX registration token for pairing Edge hosts with VerteX. You will need tenant admin access to VerteX to generate
-  a new registration token. For detailed instructions, refer to the
+- VerteX registration token for pairing Edge hosts with VerteX or a Palette registration token. You will need tenant
+  admin access to VerteX to generate a new registration token. For detailed instructions, refer to the
   [Create Registration Token](/clusters/edge/site-deployment/site-installation/create-registration-token) guide.
+
+:::warning
+
+You can deploy a FIPS-compliant Edge host to Palette, but this solution will not be FIPS-compliant end-to-end because
+Palette is not FIPS compliant. If you need a FIPS-compliant solution, you need to use VerteX.
+
+:::
 
 ## Build FIPS-Enabled Edge Artifacts
 
@@ -193,20 +207,36 @@ image with.
     | BASE_IMAGE       | The base image used by EdgeForge to build the Edge Installer and provider images. This must be the same image that you build in the previous step.                |
     | ISO_NAME         | The file name of the ISO file that will be generated.                                                                                                             |
 
-14. Create a file named **user-data**. Add the following blocks to the root level of the **user-data** file. Replace the
-    value for `edgeHostToken` with your VerteX registration token, and replace the value `paletteEndPoint` with the URL
-    of your VerteX instance.
+14. Create a file named **user-data**. It must have the `#cloud-init` header at the top of the file. Ensure you have the
+    following blocks at the root level of the **user-data** file. Replace the value for `edgeHostToken` with your VerteX
+    registration token, and replace the value `paletteEndPoint` with the URL of your Palette instance. Replace the user
+    `kairos` and its password with your desired username and password.
 
     ```yaml
+    #cloud-init
     install:
-      grub_options:
-        extra_cmdline: "fips=1"
+       grub_options:
+         extra_cmdline: "fips=1 selinux=0"
 
     stylus:
-      site:
-        edgeHostToken: ********
-        paletteEndpoint: https://vertex.palette-devx.spectrocloud.com
+       site:
+         edgeHostToken: ********
+         paletteEndpoint: https://vertex.palette-devx.spectrocloud.com
+         projectName: Default
+
+    stages:
+       initramfs:
+          - name: "Core system setup"
+            users:
+               kairos:
+                  groups:
+                  - admin
+                  passwd: kairos
     ```
+
+    The command in the `install` block is required for FIPS installations. Configurations in the `stylus` block provide
+    the Edge Host with the registration token and the Palette endpoint. And the configurations in the `stage` block
+    create a system user that you can use to log in to the Operating System (OS).
 
 15. Add further customization to the **user-data** file as needed. This file configures the Edge Installer. Refer to
     [Installer Reference](../../edge-configuration/installer-reference.md) for more information.
@@ -247,7 +277,10 @@ FIPS-complaint provider images are built on top of the base OS image you have bu
 
 1. Follow the [Site Installation](../../site-deployment/stage.md) guide to install the Palette Edge on your Edge host.
 
-2. Issue the following command and ensure that the output is `1`. This means the OS is FIPS enabled.
+2. Press Fn + Ctrl + Cmd + F1 or Ctrl + Cmd + F1 keys on a mac keyboard and provide user credentials to log in to the
+   OS.
+
+3. Issue the following command and ensure that the output is `1`. This means the OS is FIPS enabled.
 
    ```shell
    cat /proc/sys/crypto/fips_enabled


### PR DESCRIPTION
## Describe the Change

Add details that only an Operations Admin is allowed to register a Nutanix cloud. We should link to a page that explains the difference between the different tenant admin roles: I only found [this one](https://docs.spectrocloud.com/vertex/system-management/account-management/#system-administrators), but it's relevant to VerteX only. Do we have a similar page for Palette?

## Changed Pages

[Register Nutanix Cloud](https://docs.spectrocloud.com/clusters/data-center/nutanix/register-nutanix-cloud/#register-the-cloud)