### PR TITLE
Update the self-hosted and VerteX upgrade matrices

### DIFF
--- a/_partials/index.ts
+++ b/_partials/index.ts
@@ -1,2 +1,0 @@
-// This file is generated. DO NOT EDIT!
-export * as partialexample22696 from '@site/_partials/_partial_example.mdx';

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -32,6 +32,7 @@ Before upgrading Palette to a new major version, you must first update it to the
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.3.6        |       4.4.x        | :white_check_mark: |
 |       4.2.13       |       4.3.6        | :white_check_mark: |
 |       4.2.7        |       4.2.13       | :white_check_mark: |
 |       4.1.x        |       4.3.6        |        :x:         |

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -32,6 +32,7 @@ Before upgrading Palette VerteX to a new major version, you must first update it
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.3.6        |       4.4.x        | :white_check_mark: |
 |       4.2.13       |       4.3.6        | :white_check_mark: |
 |       4.2.7        |       4.2.13       | :white_check_mark: |
 |       4.1.x        |       4.3.6        |        :x:         |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the upgrade matrices for self-hosted and VerteX.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Self-Hosted Palette > Upgrade](https://deploy-preview-2923--docs-spectrocloud.netlify.app/enterprise-version/upgrade/)
💻 [Palette VerteX > Upgrade](https://deploy-preview-2923--docs-spectrocloud.netlify.app/vertex/upgrade/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1195](https://spectrocloud.atlassian.net/browse/DOC-1195)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. — Belongs to 4.4.


[DOC-1195]: https://spectrocloud.atlassian.net/browse/DOC-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ