### PR TITLE
docs: add introduction to govcloud terraform support

### DIFF
--- a/docs/docs-content/automation/terraform/terraform.md
+++ b/docs/docs-content/automation/terraform/terraform.md
@@ -17,18 +17,27 @@ expectations before deployment, and applies the changes to managed resources acc
 ## Spectro Cloud Provider
 
 Palette and Palette VerteX API can be used with the Spectro Cloud Terraform provider. The provider is available in the
-HashiCorp Terraform registry as the
-[Spectro Cloud Provider](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs).
+HashiCorp Terraform registry and offers detailed
+[documentation](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs) on supported data sources
+and resources.
 
 ### Release Notes
 
 Information about the latest changes in the Spectro Cloud provider can be found in the
 [release notes](https://github.com/spectrocloud/terraform-provider-spectrocloud/releases).
 
-### Provider Documentation
+### Government Cloud Support
 
-Detailed documentation on supported data sources and resources are available in the Terraform Spectro Cloud Provider
-[documentation](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs) page.
+The Spectro Cloud Terraform provider supports deploying resources to government clouds that meet strict security and
+compliance requirements:
+
+- [AWS GovCloud](https://aws.amazon.com/govcloud-us/) - To leverage the government partition, set `partition` as
+  `aws-us-gov` when creating an
+  [AWS cloud account](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cloudaccount_aws).
+
+- [Azure Government](https://learn.microsoft.com/en-us/azure/azure-government/documentation-government-welcome) - To
+  leverage the government partition, set `cloud` as `AzureUSGovernmentCloud` when creating an
+  [Azure cloud account](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/resources/cloudaccount_azure).
 
 ### Modules
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a Gov Cloud support introduction section to the Terraform index page.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Terraform](https://deploy-preview-2927--docs-spectrocloud.netlify.app/automation/terraform/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PLT-235](https://spectrocloud.atlassian.net/browse/PLT-235)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[PLT-235]: https://spectrocloud.atlassian.net/browse/PLT-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ