### PR TITLE
docs: updated proxy domain table

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -68,6 +68,8 @@ jobs:
           node-version: "20"
           cache: "npm"
 
+      - run: npm ci
+
       - name: Prettier Check
         run: npx prettier . --check
 

--- a/docs/docs-content/architecture/palette-public-ips.md
+++ b/docs/docs-content/architecture/palette-public-ips.md
@@ -66,34 +66,3 @@ gRPC is used for all communication between the management platform and the workl
 | registry3.spectrocloud.com                    | 443       |
 | 415789037893.dkr.ecr.us-east-1.amazonaws.com  | 443       |
 | 415789037893.dkr.ecr.us-west-2.amazonaws.com  | 443       |
-
-| Domain                                        | Ports     |
-| :-------------------------------------------- | :-------- |
-| api.spectrocloud.com                          | 443       |
-| api1.spectrocloud.com                         | 443       |
-| api2.spectrocloud.com                         | 443       |
-| api3.spectrocloud.com                         | 443       |
-| message.spectrocloud.com                      | 443, 4222 |
-| message1.spectrocloud.com                     | 443, 4222 |
-| message2.spectrocloud.com                     | 443, 4222 |
-| message3.spectrocloud.com                     | 443, 4222 |
-| msg.spectrocloud.com                          | 443       |
-| msg1.spectrocloud.com                         | 443       |
-| msg2.spectrocloud.com                         | 443       |
-| msg3.spectrocloud.com                         | 443       |
-| console.spectrocloud.com                      | 443       |
-| proxy.console.spectrocloud.com                | 443       |
-| registry.spectrocloud.com                     | 443       |
-| saas-repo.console.spectrocloud.com            | 443       |
-| registry.spectrocloud.com                     | 443       |
-| maasgoldenimage-console.s3.amazonaws.com      | 443       |
-| openstackgoldenimage-console.s3.amazonaws.com | 443       |
-| edgegoldenimage-console.s3.amazonaws.com      | 443       |
-| vmwaregoldenimage-console.s3.amazonaws.com    | 443       |
-| registry1.spectrocloud.com                    | 443       |
-| registry2.spectrocloud.com                    | 443       |
-| registry3.spectrocloud.com                    | 443       |
-| 415789037893.dkr.ecr.us-east-1.amazonaws.com  | 443       |
-| 415789037893.dkr.ecr.us-west-2.amazonaws.com  | 443       |
-
-<br />

--- a/docs/docs-content/enterprise-version/install-palette/install-palette.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-palette.md
@@ -85,7 +85,7 @@ following domains and ports are accessible. The proxy server should meet the fol
   | docker.com                | 443      | Common third party container images                   |
   | raw.githubusercontent.com | 443      | Common third party content                            |
   | projectcalico.org         | 443      | Calico container images                               |
-  | quay.io                   | 443      | Common third-party container images                   |
+  | quay.io                   | 443      | Common third party container images                   |
   | grafana.com               | 443      | Grafana container images and manifests                |
   | github.com                | 443      | Common third party content                            |
   | k8s.gcr.io                | 443      | Kubernetes images [deprecated]                        |

--- a/docs/docs-content/enterprise-version/install-palette/install-palette.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-palette.md
@@ -64,11 +64,15 @@ active nodes and pods at any given time.
 
 ## Proxy Requirements
 
+Palette connects to the internet to download images and packages. If your environment uses a proxy server, ensure the
+following domains and ports are accessible. The proxy server should meet the following requirements:
+
 - A proxy used for outgoing connections should support both HTTP and HTTPS traffic.
 
 - Allow connectivity to domains and ports in the table.
 
-  <br />
+- Review the [gRPC and Proxies](../../architecture/grps-proxy.md) page to learn more about Palette's support for gRPC in
+  a proxy environment.
 
   | **Top-Level Domain**      | **Port** | **Description**                                       |
   | ------------------------- | -------- | ----------------------------------------------------- |
@@ -84,6 +88,9 @@ active nodes and pods at any given time.
   | quay.io                   | 443      | Common third-party container images                   |
   | grafana.com               | 443      | Grafana container images and manifests                |
   | github.com                | 443      | Common third party content                            |
+  | k8s.gcr.io                | 443      | Kubernetes images [deprecated]                        |
+  | registry.k8s.io           | 443      | Kubernetes images                                     |
+  | docker.pkg.dev            | 443      | Common third party content                            |
 
 ## Resources
 

--- a/docs/docs-content/integrations/metallb.md
+++ b/docs/docs-content/integrations/metallb.md
@@ -247,8 +247,8 @@ kubectl describe cm config --namespace metallb-system
 ```
 
 <br />
-Since the controller and speaker pods are using a previous copy of the configMap, existing deployments are unaware of the
-changes made to configMap.
+Since the controller and speaker pods are using a previous copy of the configMap, existing deployments are unaware of
+the changes made to configMap.
 
 <br />
 <br />

--- a/docs/docs-content/vertex/install-palette-vertex/install-palette-vertex.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-palette-vertex.md
@@ -66,11 +66,15 @@ number of active nodes and pods at any given time.
 
 ## Proxy Requirements
 
+VerteX connects to the internet to download images and packages. If your environment uses a proxy server, ensure the
+following domains and ports are accessible. The proxy server should meet the following requirements:
+
 - A proxy used for outgoing connections should support both HTTP and HTTPS traffic.
 
 - Allow connectivity to domains and ports in the table.
 
-  <br />
+- Review the [gRPC and Proxies](../../architecture/grps-proxy.md) page to learn more about VerteX's support for gRPC in
+  a proxy environment.
 
   | **Top-Level Domain**      | **Port** | **Description**                                       |
   | ------------------------- | -------- | ----------------------------------------------------- |
@@ -83,9 +87,12 @@ number of active nodes and pods at any given time.
   | docker.com                | 443      | Common third party container images                   |
   | raw.githubusercontent.com | 443      | Common third party content                            |
   | projectcalico.org         | 443      | Calico container images                               |
-  | quay.io                   | 443      | Common 3rd party container images                     |
+  | quay.io                   | 443      | Common third-party container images                   |
   | grafana.com               | 443      | Grafana container images and manifests                |
   | github.com                | 443      | Common third party content                            |
+  | k8s.gcr.io                | 443      | Kubernetes images [deprecated]                        |
+  | registry.k8s.io           | 443      | Kubernetes images                                     |
+  | docker.pkg.dev            | 443      | Common third party content                            |
 
 ## Resources
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-palette-vertex.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-palette-vertex.md
@@ -87,7 +87,7 @@ following domains and ports are accessible. The proxy server should meet the fol
   | docker.com                | 443      | Common third party container images                   |
   | raw.githubusercontent.com | 443      | Common third party content                            |
   | projectcalico.org         | 443      | Calico container images                               |
-  | quay.io                   | 443      | Common third-party container images                   |
+  | quay.io                   | 443      | Common third party container images                   |
   | grafana.com               | 443      | Grafana container images and manifests                |
   | github.com                | 443      | Common third party content                            |
   | k8s.gcr.io                | 443      | Kubernetes images [deprecated]                        |

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "jest-fetch-mock": "^3.0.3",
         "lint-staged": "^13.2.3",
         "netlify-cli": "^17.17.1",
-        "prettier": "3.2.5",
+        "prettier": "3.3.0",
         "semantic-release": "^20.1.0",
         "test-links": "^0.0.1",
         "ts-jest": "^29.1.2",
@@ -52131,7 +52131,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
+      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "jest-fetch-mock": "^3.0.3",
     "lint-staged": "^13.2.3",
     "netlify-cli": "^17.17.1",
-    "prettier": "3.2.5",
+    "prettier": "3.3.0",
     "semantic-release": "^20.1.0",
     "test-links": "^0.0.1",
     "ts-jest": "^29.1.2",


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the domain list table to reflect the [newer official k8s registry](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/)  `registry.k8s.io` .


- [Palette Proxy](https://deploy-preview-2966--docs-spectrocloud.netlify.app/enterprise-version/install-palette/#proxy-requirements)
- [VerteX Proxy](https://deploy-preview-2966--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/#proxy-requirements)

Other changes include:
- [Fixed](https://deploy-preview-2966--docs-spectrocloud.netlify.app/architecture/palette-public-ips/) a bug where the domain table was double rendered. 
- Added a link to the gRPC and Proxy page 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page](https://deploy-preview-2966--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/#proxy-requirements)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
