### PR TITLE
docs: update pack version in the terraform snippet

### DIFF
--- a/docs/docs-content/integrations/metallb.md
+++ b/docs/docs-content/integrations/metallb.md
@@ -52,8 +52,6 @@ one is needed.
 The _lb-metallb_ manifest-based pack supports direct configuration of an L2 IP address set. The _lb-metallb-helm_
 Helm-based pack provides an L2 address pool.
 
-<br />
-
 ### Manifest
 
 Manifest-based MetalLB supports direct configuration of an L2 IP address set. You can set either a range of addresses or
@@ -61,8 +59,6 @@ use CIDR format, such as `192.168.250.48/29`. A more advanced MetalLB configurat
 (BGP) routing requires you to write your own manifests and add them to the Palette cluster profile.
 
 The example shows the syntax used to set an address range.
-
-<br />
 
 ```yaml
 manifests:
@@ -76,8 +72,6 @@ manifests:
       - 192.168.250.48-192.168.250.55
 ```
 
-<br />
-
 ### Helm Chart
 
 Helm-based MetalLB default gives you an L2 address pool by default. It has two sections,
@@ -86,8 +80,6 @@ Helm-based MetalLB default gives you an L2 address pool by default. It has two s
 Use the `charts:metallb-full:configuration` parameter section to set resource types that MetalLB supports. The pack
 default gives you an L2 address pool. To set up a more advanced scenario, you can use the other resource types provided
 in the pack. The pack includes a commented-out example for each resource.
-
-<br />
 
 ```yaml
 charts:
@@ -113,13 +105,9 @@ charts:
       bfdprofiles: {}
 ```
 
-<br />
-
 The `charts:metallb-full:metallb` parameter section provides access to all the options of the base chart that installs
 MetalLB. You don’t need to change anything unless you want to install MetalLB in Free Range Routing (FRR) mode. To use
 FRR mode, set the option to `true`, as the example shows.
-
-<br />
 
 ```yaml
 charts:
@@ -200,8 +188,6 @@ Gateway Protocol (BGP) routing requires you to write your own manifests and add 
 
 The example shows the syntax used to set an address range.
 
-<br />
-
 ```yaml
 manifests:
   metallb:
@@ -228,8 +214,6 @@ advantage of new features.
 </TabItem>
 </Tabs>
 
-<br />
-
 ## Troubleshooting
 
 If controller and speaker pods are not assigning new IP addresses that you provided in the MetalLB pack, it is likely
@@ -240,31 +224,21 @@ The MetalLB controller and speakers use the configMap as a volume mount.
 
 Any changed IP addresses will get updated in the configMap. You can confirm this by issuing the following command.
 
-<br />
-
 ```bash
 kubectl describe cm config --namespace metallb-system
 ```
 
-<br />
-Since the controller and speaker pods are using a previous copy of the configMap, existing deployments are unaware of the
-changes made to configMap.
-
-<br />
-<br />
+Since the controller and speaker pods are using a previous copy of the configMap, existing deployments are unaware of
+the changes made to configMap.
 
 To ensure updated addresses are reflected in the configMap, you need to restart the controller and speaker pods so they
 fetch the new configMap and start assigning new addresses correctly. Issue the commands below to restart the controller
 and speaker.
 
-<br />
-
 ```bash
 kubectl rollout restart deploy controller --namespace metallb-system
 kubectl rollout restart ds speaker --namespace metallb-system
 ```
-
-<br />
 
 ## Terraform
 
@@ -278,8 +252,6 @@ data "spectrocloud_pack" "MetalLB-Helm" {
      version = "0.13.7"
 }
 ```
-
-<br />
 
 ## References
 

--- a/docs/docs-content/integrations/microk8s.md
+++ b/docs/docs-content/integrations/microk8s.md
@@ -289,7 +289,7 @@ data "spectrocloud_registry" "public_registry" {
 
 data "spectrocloud_pack" "k8s" {
   name    = "kubernetes-microk8s"
-  version = "1.28"
+  version = "1.27"
   registry_uid = data.spectrocloud_registry.public_registry.id
 }
 ```


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the version of the Microk8s pack in the Terraform snippet as version 1.28 will no longer be included in 4.4.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Microk8s](https://deploy-preview-3003--docs-spectrocloud.netlify.app/integrations/microk8s/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._ This is a 4.4 PR.
