### PR TITLE
docs: highlight CIS hardening

### DIFF
--- a/docs/docs-content/clusters/edge/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture.md
@@ -17,6 +17,9 @@ The following are architectural highlights of Palette-provisioned Edge native cl
 
 - Configurable Kubernetes API servers to work with virtual IP address (VIP) or Dynamic DNS.
 
+- Edge artifacts hardened by default according to
+  [Center for Internet Security (CIS) standards](https://www.cisecurity.org/cis-benchmarks).
+
 - Edge supports adding multiple devices to the site to form a multi-node Kubernetes cluster.
 
 - Operating system (OS) images are derived from immutable container-based OS images provided by the

--- a/docs/docs-content/clusters/edge/edge.md
+++ b/docs/docs-content/clusters/edge/edge.md
@@ -28,9 +28,12 @@ The following are some highlights of the comprehensive Palette Edge Solution:
 
 - Low touch, plug-and-play setup
 
-- Immutable update for Kubernetes and operating system (OS) with zero downtime
+- Immutable update for Kubernetes and Operating System (OS) with zero downtime
 
 - Distro-agnostic Kubernetes and OS
+
+- Edge artifacts hardened by default according to
+  [Center for Internet Security (CIS) standards](https://www.cisecurity.org/cis-benchmarks).
 
 - Secured remote troubleshooting
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
@@ -53,6 +53,11 @@ EdgeForge contains the following critical components:
 
 - Edge Provider Container Images.
 
+The EdgeForge process applies Center for Information System (CIS) hardening to the Edge artifacts by default. This means
+we implement the guidelines and solutions provided by CIS to secure your systems automatically. The code for how we
+achieve CIS hardening is open-source, available in the
+[CanvOS repository](https://github.com/spectrocloud/CanvOS/tree/main/cis-harden).
+
 ### Edge Installer ISO
 
 An ISO file that bootstraps the installation is created in the EdgeForge process. The ISO image contains the Edge


### PR DESCRIPTION
## Describe the Change

This PR highlights CIS hardening that we apply to Edge artifacts by default. 

## Changed Pages

💻 [Edge Overview](https://deploy-preview-3034--docs-spectrocloud.netlify.app/clusters/edge/)

- [EdgeForge](https://deploy-preview-3034--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow)

## Jira Tickets

🎫 [PE-4303](https://spectrocloud.atlassian.net/browse/PE-4303)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. 


[PE-4303]: https://spectrocloud.atlassian.net/browse/PE-4303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ