### PR TITLE
docs: Storylane Demo Spike DOC-1209

### DIFF
--- a/docs/docs-content/getting-started/storylane-demo.md
+++ b/docs/docs-content/getting-started/storylane-demo.md
@@ -1,0 +1,11 @@
+---
+sidebar_label: "Storylane Demo Spike"
+title: "Storylane Demo Spike"
+description: "Temp file for Storylane demo."
+icon: ""
+hide_table_of_contents: false
+sidebar_position: 90
+tags: ["getting-started"]
+---
+
+<DemoComponent url="https://app.storylane.io/demo/s7y07xzhfvzc" title="Create an Add-on Profile" />

--- a/src/components/StorylaneDemo/DemoComponent.tsx
+++ b/src/components/StorylaneDemo/DemoComponent.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+interface DemoProps {
+    url: string;
+    title: string;
+  }
+
+export default function DemoComponent({ url, title }: DemoProps) {
+  return (
+    <div>
+      <script src="https://js.storylane.io/js/v1/storylane.js"></script>
+      <div
+        className="sl-embed"
+        style={{
+            textAlign: "center",
+            padding: "1em",
+            position: "relative",
+            width: "100%",
+            height: 0,
+            paddingBottom: "56.25%",
+        }}
+      >
+        <iframe
+          className="sl-demo"
+          src={url}
+          name="sl-embed"
+          allow="fullscreen"
+          width="1280"
+          height="800"
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+          }}
+          title={title || "Storylane Demo"}
+        ></iframe>
+      </div>
+    </div>
+  );
+}

--- a/src/components/StorylaneDemo/index.ts
+++ b/src/components/StorylaneDemo/index.ts
@@ -1,0 +1,3 @@
+import DemoComponent from "./DemoComponent";
+
+export default DemoComponent;

--- a/src/theme/MDXComponents/MDXComponents.ts
+++ b/src/theme/MDXComponents/MDXComponents.ts
@@ -14,6 +14,7 @@ import SimpleCardGrid from "@site/src/components/SimpleCardGrid/index";
 import ReleaseNotesVersions from "@site/src/components/ReleaseNotesVersions/index";
 import PartialsComponent from "@site/src/components/PartialsComponent";
 import VersionedLink from "@site/src/components/VersionedLink";
+import DemoComponent from "@site/src/components/StorylaneDemo";
 
 export default {
   ...MDXComponents,
@@ -32,4 +33,5 @@ export default {
   ReleaseNotesVersions,
   PartialsComponent,
   VersionedLink,
+  DemoComponent
 };


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR creates a new Storylane component for embedding demos in librarium. The component is similar to the YouTube video embed, but uses the Storylane JS scripts. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Storylane Demo Page](https://deploy-preview-3046--docs-spectrocloud.netlify.app/getting-started/storylane-demo/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1209](https://spectrocloud.atlassian.net/browse/DOC-1209)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1209]: https://spectrocloud.atlassian.net/browse/DOC-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ