### PR TITLE
vSphere Version 6 series support

### DIFF
--- a/docs/docs-content/clusters/pcg/deploy-pcg/vmware.md
+++ b/docs/docs-content/clusters/pcg/deploy-pcg/vmware.md
@@ -144,7 +144,7 @@ vSphere version you are using to view the required privileges for the Spectro ro
 
 </TabItem>
 
-<TabItem label="6.0.x" value="6.0.x">
+<TabItem label="6.7U3" value="6.7U3">
 
 | **vSphere Object**         | **Privileges**                                     |
 | -------------------------- | -------------------------------------------------- |
@@ -250,7 +250,7 @@ Virtual Machines.
 
 </TabItem>
 
-<TabItem label="6.0.x" value="6.0.x">
+<TabItem label="6.7U3" value="6.7U3">
 
 | **vSphere Object**         | **Privileges**                                                                                                                    |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/vmware-system-requirements.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/vmware-system-requirements.md
@@ -99,7 +99,7 @@ vSphere version you are using to view the required privileges for the spectro ro
 
 </TabItem>
 
-<TabItem label="6.0.x" value="6.0.x">
+<TabItem label="6.7U3" value="6.7U3">
 
 | **vSphere Object**         | **Privileges**                                     |
 | -------------------------- | -------------------------------------------------- |
@@ -205,7 +205,7 @@ Virtual Machines.
 
 </TabItem>
 
-<TabItem label="6.0.x" value="6.0.x">
+<TabItem label="6.7U3" value="6.7U3">
 
 | **vSphere Object**         | **Privileges**                                                                                                                    |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/vmware-system-requirements.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/vmware-system-requirements.md
@@ -99,7 +99,7 @@ vSphere version you are using to view the required privileges for the spectro ro
 
 </TabItem>
 
-<TabItem label="6.0.x" value="6.0.x">
+<TabItem label="6.7U3" value="6.7U3">
 
 | **vSphere Object**         | **Privileges**                                     |
 | -------------------------- | -------------------------------------------------- |
@@ -205,7 +205,7 @@ Virtual Machines.
 
 </TabItem>
 
-<TabItem label="6.0.x" value="6.0.x">
+<TabItem label="6.7U3" value="6.7U3">
 
 | **vSphere Object**         | **Privileges**                                                                                                                    |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR explicitly states that vSphere 6.7U3 is supported.

## Changed Pages

- [VerteX vSphere Permissions](https://deploy-preview-3053--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/vmware-system-requirements/)
- [Palette vSphere Permissions](https://deploy-preview-3053--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/vmware-system-requirements/)
- [PCG vSphere Requirement](https://deploy-preview-3053--docs-spectrocloud.netlify.app/clusters/pcg/deploy-pcg/vmware/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1216](https://spectrocloud.atlassian.net/browse/DOC-1216)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1216]: https://spectrocloud.atlassian.net/browse/DOC-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ