### PR TITLE
RKE2 Overlay Network Support

### DIFF
--- a/docs/docs-content/clusters/edge/networking/vxlan-overlay.md
+++ b/docs/docs-content/clusters/edge/networking/vxlan-overlay.md
@@ -62,7 +62,7 @@ server. The region experiences a bad weather event that causes a sustained outag
 ## Prerequisites
 
 - At least one Edge host registered with your Palette account.
-- Your cluster profile must have K3s as its Kubernetes distribution.
+- Your cluster profile must have K3s or RKE2 as its Kubernetes distribution.
 - All Edge hosts must be on the same Layer-2 network.
 - If you are launching your Edge hosts in virtual machine environments and you are using either Cilium or Flannel as
   your container network interface (CNI), ensure that you add the following commands in the **user-data** file at the


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds RKE2 as a supported K8s distro to enable the Overlay Network on Edge clusters.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1229](https://spectrocloud.atlassian.net/browse/DOC-1229)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1229]: https://spectrocloud.atlassian.net/browse/DOC-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ