### PR TITLE
docs: add vsphere supported versions table

### DIFF
--- a/docs/docs-content/clusters/data-center/vmware/vmware.md
+++ b/docs/docs-content/clusters/data-center/vmware/vmware.md
@@ -40,6 +40,16 @@ of the PCG architecture page for more information.
 After you have deployed the PCG, you can proceed to create and manage VMware clusters in Palette. Refer to the
 [Create and Manage VMware Clusters](create-manage-vmware-clusters.md) guide for detailed instructions.
 
+## Supported Versions
+
+The following versions of VMware vSphere are supported in Palette.
+
+| **Version**       | **Supported** |
+| ----------------- | ------------- |
+| **vSphere 6.7U3** | ✅            |
+| **vSphere 7.0**   | ✅            |
+| **vSphere 8.0**   | ✅            |
+
 ## Resources
 
 - [Architecture](architecture.md)

--- a/docs/docs-content/vertex/supported-platforms.md
+++ b/docs/docs-content/vertex/supported-platforms.md
@@ -58,8 +58,8 @@ to learn more about the available regions.
 
 The following versions of VMware vSphere are supported in VerteX.
 
-| **Version**     | **Supported?** |
-| --------------- | -------------- |
-| **vSphere 6.7** | ✅             |
-| **vSphere 7.0** | ✅             |
-| **vSphere 8.0** | ✅             |
+| **Version**       | **Supported?** |
+| ----------------- | -------------- |
+| **vSphere 6.7U3** | ✅             |
+| **vSphere 7.0**   | ✅             |
+| **vSphere 8.0**   | ✅             |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a VMware vSphere supported versions table to the VMware index page and fixes the vSphere 6.7U3 version in the Vertex Supported Platforms page.

Note: disregard the name of the branch.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [VMware](https://deploy-preview-3101--docs-spectrocloud.netlify.app/clusters/data-center/vmware/)
💻 [VerteX Supported Platforms](https://deploy-preview-3101--docs-spectrocloud.netlify.app/vertex/supported-platforms/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
