### PR TITLE
[version-4-2] Add a note about MongoDB replication completion (#3165)

### DIFF
--- a/docs/docs-content/troubleshooting/palette-upgrade.md
+++ b/docs/docs-content/troubleshooting/palette-upgrade.md
@@ -17,9 +17,7 @@ address common issues that may occur during an upgrade.
 If you receive the following error message when attempting to upgrade to Palette versions greater than Palette 3.4.X in
 a Kubernetes environment, use the debugging steps to address the issue.
 
-<br />
-
-```hideClipboard text
+```text hideClipboard
 Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "_" and path "/v1/oidc" is already defined in ingress default/hubble-auth-oidc-ingress-resource
 ```
 
@@ -30,24 +28,18 @@ Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.ng
 
 2. Identify all Ingress resources that belong to _Hubble_ - an internal Palette component.
 
-<br />
-
-```shell
-kubectl get ingress --namespace default
-```
+   ```shell
+   kubectl get ingress --namespace default
+   ```
 
 3. Remove each Ingress resource listed in the output that starts with the name Hubble. Use the following command to
    delete an Ingress resource. Replace `REPLACE_ME` with the name of the Ingress resource you are removing.
 
-<br />
-
-```shell
-kubectl delete ingress --namespace default <REPLACE_ME>
-```
+   ```shell
+   kubectl delete ingress --namespace default <REPLACE_ME>
+   ```
 
 4. Restart the upgrade process.
-
-<br />
 
 ## Volume Attachment Errors Volume in VMware Environment
 
@@ -152,9 +144,16 @@ IDs. Use the following steps to correctly identify the issue and resolve it.
     ```shell {4} hideClipboard
     NAME      READY   STATUS              RESTARTS   AGE
     mongo-0   2/2     Running             0          18h
-    mongo-1   0/2     ContainerCreating   0          4s
+    mongo-1   2/2     Running             0          18h
     mongo-2   2/2     Running             0          68s
     ```
+
+    :::warning
+
+    Once the pod is in the **Running** status, wait for at least five minutes for the replication to complete before
+    proceeding with the other pods.
+
+    :::
 
     Palette will proceed with the upgrade and attempt to upgrade the remaining MongoDB pods. Repeat the steps for each
     of the MongoDB pods that are not starting correctly due to the volume attachment error.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-2`:
 - [docs: Add a note about MongoDB replication completion (#3165)](https://github.com/spectrocloud/librarium/pull/3165)

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)