### PR TITLE
PAC-1893-integrate custom readme versions with dropdown versions

### DIFF
--- a/docs/docs-content/integrations/prometheus-operator.md
+++ b/docs/docs-content/integrations/prometheus-operator.md
@@ -39,9 +39,7 @@ more about the remote monitoring feature.
 
 ## Versions Supported
 
-<br />
-
-<Tabs queryString="versions">
+<Tabs queryString="parent">
 <TabItem label="51.0.x" value="51.0.x">
 
 ## Prerequisites

--- a/plugins/packs-integrations.js
+++ b/plugins/packs-integrations.js
@@ -246,14 +246,18 @@ function generateRoutes(packsAllData) {
    const parentVersion = pack.versions.find((version) => {
       return version.children.find((child) => child.title === pack.latestVersion);
     });
+    let path = `/integrations/packs?pack=${pack.name}&version=${pack.latestVersion}`;
+    if (parentVersion && parentVersion.title) {
+      path = `${path}&parent=${parentVersion.title}`;
+    }
     return {
-      path: `/integrations/packs?pack=${pack.name}&version=${pack.latestVersion}&parent=${parentVersion?.title || pack.latestVersion}`,
+      path: path,
       exact: false,
       component: "@site/src/components/PacksInformation",
       metadata: {
         sourceFilePath: "../docs/docs-content/integrations/packs.mdx",
       },
-      data: {name: pack.name, version: pack.latestVersion},
+      data: {name: pack.name, version: pack.latestVersion, parent: parentVersion?.title},
     };
   });
 }

--- a/src/components/PacksInformation/PacksInformation.tsx
+++ b/src/components/PacksInformation/PacksInformation.tsx
@@ -7,7 +7,7 @@ export default function Packs(props: any) {
     <>
       {props?.route?.data ?
         (<Switch>
-          <Redirect to={`/integrations/packs?pack=${props.route.data.name}&version=${props.route.data.version}`} />
+          <Redirect to={`/integrations/packs?pack=${props.route.data.name}&version=${props.route.data.version}&parent=${props.route.data.parent}`} />
         </Switch>) : (
           <PacksReadme />
         )

--- a/src/components/PacksInformation/PacksInformation.tsx
+++ b/src/components/PacksInformation/PacksInformation.tsx
@@ -7,7 +7,7 @@ export default function Packs(props: any) {
     <>
       {props?.route?.data ?
         (<Switch>
-          <Redirect to={`/integrations/packs?pack=${props.route.data}`} />
+          <Redirect to={`/integrations/packs?pack=${props.route.data.name}&version=${props.route.data.version}`} />
         </Switch>) : (
           <PacksReadme />
         )

--- a/src/components/PacksReadme/PacksReadme.antd.css
+++ b/src/components/PacksReadme/PacksReadme.antd.css
@@ -6,3 +6,7 @@
 p {
   font-size: 16px;
 }
+[data-theme = "dark"] .ant-select-tree-list-holder-inner {
+  background-color: #1f1f1f;
+  color: whitesmoke;
+}

--- a/src/components/PacksReadme/PacksReadme.module.scss
+++ b/src/components/PacksReadme/PacksReadme.module.scss
@@ -13,16 +13,13 @@
   .customReadme {
     h2[id="versions-supported"] {
       display: none;
-
-      + div {
+      + div > ul {
         display: none;
       }
     }
   }
 
   .infoSection {
-    border: 1px solid #3f74be;
-    background-color: #dbecff;
     border-radius: 6px;
     font-size: 14px;
     font-weight: 400;
@@ -30,40 +27,17 @@
     margin: 15px;
     width: 100%;
 
-    html[data-theme="dark"] & {
-      border: 1px solid #72a8f5;
-      background-color: #192c47;
-    }
-
     .infoHeading {
       display: flex;
       align-items: center;
       font-size: 12px;
       font-weight: 600;
-      color: #000000;
       text-transform: uppercase;
       padding-bottom: 10px;
 
-      html[data-theme="dark"] & {
-        color: #ffffff;
-      }
-
       .infoIcon {
-        color: #3f74be;
         padding-right: 10px;
         font-size: 16px;
-
-        html[data-theme="dark"] & {
-          color: #72a8f5;
-        }
-      }
-    }
-
-    .content {
-      color: #545f7e;
-
-      html[data-theme="dark"] & {
-        color: #b5bdd4;
       }
     }
   }
@@ -78,14 +52,8 @@
     .emptyContentTitle {
       padding-top: 15px;
       font-size: 20px;
-      color: #545f7e;
       font-weight: 500;
       line-height: 24px;
-
-      html[data-theme="dark"] & {
-        color: #b5bdd4;
-        background-color: #111726;
-      }
     }
 
     .emptyContentDescription {
@@ -93,12 +61,6 @@
       color: #545f7e;
       font-weight: 400;
       line-height: 24px;
-
-      html[data-theme="dark"] & {
-        color: #b5bdd4;
-        background-color: #111726;
-      }
-
       margin-top: 10px;
     }
   }
@@ -106,12 +68,6 @@
   .description {
     display: flex;
     width: 100%;
-    background-color: #edeef4;
-
-    html[data-theme="dark"] & {
-      background-color: #1c202b;
-    }
-
     padding: 10px;
 
     .packDescFirstCol {
@@ -149,24 +105,12 @@
       flex-direction: column;
       width: 30%;
       padding: 10px;
-      background-color: white;
-      border: 1px solid #dee1ea;
-
-      html[data-theme="dark"] & {
-        background-color: black;
-        border: 1px solid #1f263c;
-      }
 
       .versionSelect {
         height: max-content;
         display: flex;
         flex-direction: row;
         padding: 10px;
-        border: 1px solid #b6bed4;
-
-        html[data-theme="dark"] & {
-          border: 1px solid #1f263c;
-        }
       }
 
       .versionSelectBox {
@@ -187,4 +131,65 @@
       }
     }
   }
+}
+[data-theme="dark"] .description {
+  background-color: #1c202b;
+}
+[data-theme="light"] .description {
+  background-color: #edeef4;
+}
+[data-theme="dark"] .infoSection {
+  border: 1px solid #72a8f5;
+  background-color: #192c47;
+}
+[data-theme="light"] .infoSection {
+  border: 1px solid #3f74be;
+  background-color: #dbecff;
+}
+[data-theme="dark"] .packDescSecondCol {
+  background-color: black;
+  border: 1px solid #1f263c;
+}
+[data-theme="light"] .packDescSecondCol {
+  background-color: white;
+  border: 1px solid #dee1ea;
+}
+[data-theme="light"] .emptyContentDescription {
+  color: #545f7e;
+}
+[data-theme="dark"] .emptyContentDescription {
+  color: #b5bdd4;
+  background-color: #111726;
+}
+[data-theme="dark"] .emptyContentTitle {
+  color: #b5bdd4;
+  background-color: #111726;
+}
+[data-theme="light"] .emptyContentTitle {
+  color: #545f7e;
+  background-color: black;
+}
+[data-theme="dark"] .infoIcon {
+  color: #72a8f5;
+}
+[data-theme="light"] .infoIcon {
+  color: #3f74be;
+}
+[data-theme="dark"] .infoHeading {
+  color: #ffffff;
+}
+[data-theme="light"] .infoHeading {
+  color: #000000;
+}
+[data-theme="light"] .content {
+  color: #545f7e;
+}
+[data-theme="dark"] .content {
+  color: #b5bdd4;
+}
+[data-theme="dark"] .versionSelect {
+  border: 1px solid #1f263c;
+}
+[data-theme="light"] .versionSelect {
+  border: 1px solid #b6bed4;
 }

--- a/src/components/PacksReadme/PacksReadme.tsx
+++ b/src/components/PacksReadme/PacksReadme.tsx
@@ -95,22 +95,18 @@ export default function PacksReadme() {
     const searchParams = window ? new URLSearchParams(window.location.search) : null;
     const urlParamVersion = searchParams?.get("version");
     const version = urlParamVersion || packData?.latestVersion || packData?.versions[0]?.title || "";
-    let packDataObj;
+    let parentVersionObj: any;
     if (version && !version.endsWith(".x")) {
-      packDataObj = packData?.versions.reduce((acc, tagVersion) => {
-        let childVersion;
-        if (childVersion = tagVersion.children.find((child:any) => child.title === version)) {
-          acc = {
-            childPackUid: childVersion.packUid,
-            parentVersion: tagVersion.title,
-          }
-        }
-        return acc;
-      }, {});
-      setSelectedPackUid(packDataObj.childPackUid || "");
+      parentVersionObj = getParentVersion(version);
+      const packDataObj = parentVersionObj?.children.find((child: any) => child.title === version);
+      setSelectedPackUid(packDataObj?.packUid || "");
     }
     if (!urlParamVersion) {
-      history.replace({ search: `?pack=${packName}&version=${version}&parent=${packDataObj?.parentVersion || ""}` });
+      let path = `?pack=${packName}&version=${version}`;
+      if (parentVersionObj && parentVersionObj.title) {
+        path = `${path}&parent=${parentVersionObj.title}`;
+      }
+      history.replace({ search: path });
     }
     setSelectedVersion(version);
   }, [packData]);
@@ -123,13 +119,14 @@ export default function PacksReadme() {
 
   function versionChange(item: string) {
     const [version, packUid] = item.split("===");
-    history.replace({ search: `?pack=${packName}&version=${version}&parent=${getParentVersion(version)}` });
+    const parentVersion = getParentVersion(version)?.title || "";
+    history.replace({ search: `?pack=${packName}&version=${version}&parent=${parentVersion}` });
     setSelectedVersion(version);
     setSelectedPackUid(packUid);
   }
 
   function getParentVersion(version: string) {
-    return packData.versions.find((tagVersion) => tagVersion.children.find((child: any) => child.title === version))?.title || "";
+    return packData.versions.find((tagVersion) => tagVersion.children.find((child: any) => child.title === version));
   }
 
   function renderVersionOptions() {

--- a/src/components/PacksReadme/PacksReadme.tsx
+++ b/src/components/PacksReadme/PacksReadme.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo, ReactElement } from "react";
 import styles from "./PacksReadme.module.scss";
-import { Select, Tabs, ConfigProvider, theme, TreeSelect } from "antd";
+import { Tabs, ConfigProvider, theme, TreeSelect } from "antd";
 import CustomLabel from "../Technologies/CategorySelector/CustomLabel";
 import PackCardIcon from "../Technologies/PackCardIcon";
 import Markdown from 'markdown-to-jsx';
@@ -110,7 +110,7 @@ export default function PacksReadme() {
       setSelectedPackUid(packDataObj.childPackUid || "");
     }
     if (!urlParamVersion) {
-      history.replace({ search: `?pack=${packName}&version=${version}&parent=${packDataObj?.parentVersio || ""}` });
+      history.replace({ search: `?pack=${packName}&version=${version}&parent=${packDataObj?.parentVersion || ""}` });
     }
     setSelectedVersion(version);
   }, [packData]);

--- a/src/components/PacksReadme/PacksReadme.tsx
+++ b/src/components/PacksReadme/PacksReadme.tsx
@@ -100,15 +100,8 @@ export default function PacksReadme() {
       parentVersionObj = getParentVersion(version);
       const packDataObj = parentVersionObj?.children.find((child: any) => child.title === version);
       setSelectedPackUid(packDataObj?.packUid || "");
+      setSelectedVersion(version);
     }
-    if (!urlParamVersion) {
-      let path = `?pack=${packName}&version=${version}`;
-      if (parentVersionObj && parentVersionObj.title) {
-        path = `${path}&parent=${parentVersionObj.title}`;
-      }
-      history.replace({ search: path });
-    }
-    setSelectedVersion(version);
   }, [packData]);
   let infoContent;
   if (packData.disabled) {

--- a/src/components/Technologies/CategorySelector/CustomLabel.module.scss
+++ b/src/components/Technologies/CategorySelector/CustomLabel.module.scss
@@ -1,13 +1,17 @@
 .customLabel {
   font-size: 14px;
-  background-color: #dee1ea;
-  html[data-theme="dark"] & {
-    color: white;
-    background-color: #1c202b;
-  }
   height: 32px;
   align-self: center;
   padding-top: 5px;
   padding-left: 5px;
   padding-right: 5px;
+}
+[data-theme="dark"] .customLabel {
+  color: white;
+  background-color: #1c202b;
+}
+
+[data-theme="light"] .customLabel {
+  color: black;
+  background-color: #dee1ea;
 }

--- a/src/components/Technologies/CategorySelector/FilterSelect.tsx
+++ b/src/components/Technologies/CategorySelector/FilterSelect.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Select, SelectProps } from "antd";
 import filterStyles from "./CategorySelector.module.scss";
+import "./filterSelect.antd.css";
 
 interface FilterSelectProps {
   selectMode?: SelectProps["mode"];
@@ -22,7 +23,7 @@ export default function FilterSelect({ selectMode, options, onChange, value }: F
       >
         {options.map((item) => {
           return (
-            <Select.Option value={item.value}>
+            <Select.Option value={item.value} key={item.value}>
               {item.label}
             </Select.Option>
           )

--- a/src/components/Technologies/CategorySelector/filterSelect.antd.css
+++ b/src/components/Technologies/CategorySelector/filterSelect.antd.css
@@ -1,0 +1,49 @@
+[data-theme = "dark"] .ant-select-outlined:not(.ant-select-customize-input) .ant-select-selector {
+  border: 1px solid #424242;
+  background: #141414;
+}
+[data-theme = "dark"] .ant-select-selection-placeholder {
+  color: #6a6d76;
+}
+[data-theme = "dark"] .ant-select-arrow {
+  color: #6a6d76;
+}
+[data-theme = "dark"] .ant-select-item-option {
+  color: whitesmoke;
+}
+[data-theme = "dark"] .rc-virtual-list {
+  background-color: #1f1f1f;
+}
+[data-theme = "dark"] .ant-select-dropdown {
+  background-color: #1f1f1f;
+}
+[data-theme = "dark"] .ant-select-dropdown .ant-select-item-option-selected:not(.ant-select-item-option-disabled) {
+  background-color: #111a2c;
+  color: whitesmoke;
+}
+[data-theme = "dark"] .ant-select-dropdown .ant-select-item-option-selected:not(.ant-select-item-option-disabled) .ant-select-item-option-state {
+  color: #1668dc;
+}
+[data-theme = "dark"] .ant-select:not(.ant-select-customize-input) .ant-select-selector {
+  background-color: #1f1f1f;
+}
+[data-theme = "dark"] .ant-select-multiple {
+  .ant-select-selection-item {
+    color: #d6d0d0;
+    background-color: #313131;
+  }
+  .ant-select-selection-overflow .ant-select-selection-item-remove {
+    color: #d6d0d0;
+  }
+}
+[dark-theme = "dark"] .ant-select-multiple .ant-select-selection-overflow .ant-select-selection-item-remove {
+  color: #d6d0d0;
+}
+[data-theme = "dark"] .ant-select-clear {
+  color: #b1adad;
+  background-color: #1f1f1f;
+}
+[data-theme = "dark"] .ant-select-single .ant-select-selector {
+  color: #d6d0d0;
+  background-color: #1f1f1f;
+}

--- a/src/components/Technologies/Technologies.tsx
+++ b/src/components/Technologies/Technologies.tsx
@@ -6,10 +6,9 @@ import { FrontMatterData } from "../Integrations/IntegrationTypes";
 import TechnologyCard from "./TechnologyCard";
 import PacksFilters from "./PacksFilters";
 import { packTypeNames, packTypes } from "../../constants/packs";
-import { Collapse, ConfigProvider, theme } from "antd";
+import { Collapse} from "antd";
 import "./technologies.antd.css";
 import IconMapper from "../IconMapper/IconMapper";
-import { useColorMode } from "@docusaurus/theme-common";
 
 const searchOptions = {
   threshold: 0.5,
@@ -24,8 +23,6 @@ interface TechnologiesProps {
 const PACKLISTFILTERS = "packListFilters";
 
 export default function Technologies({ data, repositories }: TechnologiesProps) {
-  const { colorMode } = useColorMode();
-  const { defaultAlgorithm, darkAlgorithm } = theme;
   const [selectedFilters, setSelectedFilters] = useState<{ category: any[], registries: any[], cloudTypes: any[], source: any[] }>({ category: [], registries: [], cloudTypes: [], source: ["all"] })
   const [searchValue, setSearchValue] = useState<string>("");
   const filteredTechCards = useMemo(() => {
@@ -131,8 +128,8 @@ export default function Technologies({ data, repositories }: TechnologiesProps) 
       if (categoryItems.length) {
         const obj = (<Collapse.Panel header={addPanelHeader(category)} key={category}>{
           categoryItems.map((field) => {
-            const { title, logoUrl, packType, name } = field;
-            return <TechnologyCard name={name} title={title} logoUrl={logoUrl} type={packType}></TechnologyCard>;
+            const { title, logoUrl, packType, name, latestVersion, versions } = field;
+            return <TechnologyCard name={name} title={title} logoUrl={logoUrl} type={packType} version={latestVersion} versions={versions}></TechnologyCard>
           })
         }</Collapse.Panel>)
         return obj;
@@ -175,17 +172,13 @@ export default function Technologies({ data, repositories }: TechnologiesProps) 
 
   return (
     <div className={styles.wrapper}>
-      <ConfigProvider theme={{
-        algorithm: colorMode === "dark" ? darkAlgorithm : defaultAlgorithm,
-      }}>
-        <PacksFilters categories={[...packTypes]} registries={repositories} setSelectedSearchFilters={setSelectedSearchFilters} selectedFilters={selectedFilters} />
-        <Search onSearch={onSearch} placeholder={"Search for integration..."} value={searchValue} />
-        <div className={styles.technologyWrapper}>
-          <Collapse defaultActiveKey={Array.from(filteredTechCards.keys()) as string[]} expandIconPosition="end" >
-            {renderPacksCategories()}
-          </Collapse>
-        </div>
-      </ConfigProvider>
+      <PacksFilters categories={[...packTypes]} registries={repositories} setSelectedSearchFilters={setSelectedSearchFilters} selectedFilters={selectedFilters} />
+      <Search onSearch={onSearch} placeholder={"Search for integration..."} value={searchValue} />
+      <div className={styles.technologyWrapper}>
+        <Collapse defaultActiveKey={Array.from(filteredTechCards.keys()) as string[]} expandIconPosition="end" >
+          {renderPacksCategories()}
+        </Collapse>
+      </div>
     </div>
   );
 }

--- a/src/components/Technologies/TechnologyCard.tsx
+++ b/src/components/Technologies/TechnologyCard.tsx
@@ -9,12 +9,15 @@ interface TechnologyCardProps {
   logoUrl: string;
   type?: string;
   slug?: string;
+  version?: string;
+  versions?: any;
 }
 
-export default function TechnologyCard({ name, title, logoUrl, type, slug }: TechnologyCardProps) {
+export default function TechnologyCard({ name, title, logoUrl, type, slug, version, versions }: TechnologyCardProps) {
+  const parentVersion = versions?.find((tagVersion: any) => tagVersion.children.find((child: any) => child.title === version))?.title || "";
   return (
     <div className={styles.card}>
-      <Link to={slug || `/integrations/packs/${name}`}>
+      <Link to={slug || `/integrations/packs?pack=${name}&version=${version}&parent=${parentVersion}`}>
         <div className={styles.cardContent}>
           <PackCardIcon appType={slug ? "app" : "integration"} logoUrl={logoUrl} type={type} />
           <div className={styles.title}>{title}</div>

--- a/src/components/Technologies/technologies.antd.css
+++ b/src/components/Technologies/technologies.antd.css
@@ -9,3 +9,19 @@
 .ant-menu-horizontal >.ant-menu-submenu:hover::after {
   border-bottom-color: transparent !important
 }
+[data-theme="dark"] .ant-collapse-header-text {
+  color: whitesmoke;
+}
+[data-theme="dark"] .ant-collapse-header {
+  background-color: #161824;
+}
+[data-theme="dark"] .ant-collapse .ant-collapse-content {
+  background-color: #141414;
+  border-top: 1px solid #424242;
+}
+[data-theme="dark"] .ant-collapse-item {
+  border-bottom: 1px solid #424242;
+}
+[data-theme="dark"] .ant-collapse-expand-icon {
+  color: whitesmoke;
+}


### PR DESCRIPTION
## Describe the Change

This integrates the version change in the *.md file with the packs detail information react component version dropdown.
So, had to change the md file with the query string "parent", and changed the router in plugin as well.

The refresh issue which we had with the build serve is fixed, i mean while refreshing in dark mode, the antd components were little bit jumbled and was not properly aligned. This issue was fixed.

This PR ....

Packs List

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket](PAC-1893)

