### PR TITLE
[version-4-0] Clean up markup and alignment in the Troubleshooting section (#3255)

### DIFF
--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -17,8 +17,6 @@ The following steps will help you troubleshoot errors in the event issues arise 
 An instance is launched and terminated every 30 minutes prior to completion of its deployment, and the **Events Tab**
 lists errors with the following message:
 
-<br />
-
 ```hideClipboard bash
 Failed to update kubeadmControlPlane Connection timeout connecting to Kubernetes Endpoint
 ```
@@ -35,66 +33,71 @@ why a service may fail are:
     user `spectro`. If you are initiating an SSH session into an installer instance, log in as user `ubuntu`.
 
     ```shell
-        ssh --identity_file <_pathToYourSSHkey_> spectro@X.X.X.X
+    ssh --identity_file <_pathToYourSSHkey_> spectro@X.X.X.X
     ```
 
 2.  Elevate the user access.
 
     ```shell
-        sudo -i
+    sudo -i
     ```
 
 3.  Verify the Kubelet service is operational.
 
     ```shell
-        systemctl status kubelet.service
+    systemctl status kubelet.service
     ```
 
 4.  If the Kubelet service does not work as expected, do the following. If the service operates correctly, you can skip
     this step.
 
-    1. Navigate to the **/var/log/** folder.
-       ```shell
-       cd /var/log/
-       ```
-    2. Scan the **cloud-init-output** file for any errors. Take note of any errors and address them.
-       ```
-       cat cloud-init-output.log
-       ```
+5.  Navigate to the **/var/log/** folder.
 
-5.  If the kubelet service works as expected, do the following.
+    ```shell
+    cd /var/log/
+    ```
+
+6.  Scan the **cloud-init-output** file for any errors. Take note of any errors and address them.
+
+    ```
+    cat cloud-init-output.log
+    ```
+
+7.  If the kubelet service works as expected, do the following.
 
     - Export the kubeconfig file.
 
-    ```shell
-        export KUBECONFIG=/etc/kubernetes/admin.conf
-    ```
+      ```shell
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      ```
 
     - Connect with the cluster's Kubernetes API.
 
-    ```shell
-        kubectl get pods --all-namespaces
-    ```
+      ```shell
+      kubectl get pods --all-namespaces
+      ```
 
     - When the connection is established, verify the pods are in a _Running_ state. Take note of any pods that are not
       in _Running_ state.
 
-    ```shell
-        kubectl get pods -o wide
-    ```
+      ```shell
+      kubectl get pods -o wide
+      ```
 
     - If all the pods are operating correctly, verify their connection with the Palette API.
 
-          - For clusters using Gateway, verify the connection between the Installer and Gateway instance:
-            ```shell
-               curl -k https://<KUBE_API_SERVER_IP>:6443
-            ```
-          - For Public Clouds that do not use Gateway, verify the connection between the public Internet and the Kube
-            endpoint:
+      - For clusters using Gateway, verify the connection between the Installer and Gateway instance:
 
-            ```shell
-                curl -k https://<KUBE_API_SERVER_IP>:6443
-            ```
+        ```shell
+        curl -k https://<KUBE_API_SERVER_IP>:6443
+        ```
+
+      - For Public Clouds that do not use Gateway, verify the connection between the public Internet and the Kube
+        endpoint:
+
+        ```shell
+        curl -k https://<KUBE_API_SERVER_IP>:6443
+        ```
 
       :::info
 
@@ -102,7 +105,7 @@ why a service may fail are:
 
       :::
 
-6.  Check stdout for errors. You can also open a support ticket. Visit our
+8.  Check stdout for errors. You can also open a support ticket. Visit our
     [support page](http://support.spectrocloud.io/).
 
 ## Deployment Violates Pod Security

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -51,19 +51,19 @@ why a service may fail are:
 4.  If the Kubelet service does not work as expected, do the following. If the service operates correctly, you can skip
     this step.
 
-5.  Navigate to the **/var/log/** folder.
+    1.  Navigate to the **/var/log/** folder.
 
-    ```shell
-    cd /var/log/
-    ```
+        ```shell
+        cd /var/log/
+        ```
 
-6.  Scan the **cloud-init-output** file for any errors. Take note of any errors and address them.
+    2.  Scan the **cloud-init-output** file for any errors. Take note of any errors and address them.
 
-    ```
-    cat cloud-init-output.log
-    ```
+        ```
+        cat cloud-init-output.log
+        ```
 
-7.  If the kubelet service works as expected, do the following.
+5.  If the kubelet service works as expected, do the following.
 
     - Export the kubeconfig file.
 
@@ -105,7 +105,7 @@ why a service may fail are:
 
       :::
 
-8.  Check stdout for errors. You can also open a support ticket. Visit our
+6.  Check stdout for errors. You can also open a support ticket. Visit our
     [support page](http://support.spectrocloud.io/).
 
 ## Deployment Violates Pod Security

--- a/docs/docs-content/troubleshooting/edge.mdx
+++ b/docs/docs-content/troubleshooting/edge.mdx
@@ -18,8 +18,6 @@ If you need to override or reconfigure the read-only file system, you can do so 
 
 ## Debug Steps
 
-<br />
-
 1. Power on the Edge host.
 
 2. Press the keyboard key `E` after highlighting the menu in `grubmenu`.

--- a/docs/docs-content/troubleshooting/enterprise-install.md
+++ b/docs/docs-content/troubleshooting/enterprise-install.md
@@ -40,7 +40,7 @@ This error may occur if the self-hosted pack registry specified in the installat
 
 7. Check the box **Insecure Skip TLS Verify** and click on **Confirm**.
 
-![A pack registry configuration screen.](/troubleshooting_enterprise-install_pack-registry-tls.webp)
+   ![A pack registry configuration screen.](/troubleshooting_enterprise-install_pack-registry-tls.webp)
 
 After a few moments, a system profile will be created and Palette or VerteX will be able to self-link successfully. If
 you continue to encounter issues, contact our support team by emailing

--- a/docs/docs-content/troubleshooting/nodes.md
+++ b/docs/docs-content/troubleshooting/nodes.md
@@ -49,8 +49,6 @@ resulted in a node repave. The API payload is incomplete for brevity.
 
 For detailed information, review the cluster upgrades [page](../clusters/clusters.md).
 
-<br />
-
 ## Clusters
 
 ## Scenario - vSphere Cluster and Stale ARP Table
@@ -65,8 +63,6 @@ This is done automatically without any user action.
 You can verify the cleaning process by issuing the following command on non-VIP nodes and observing that the ARP cache
 is never older than 300 seconds.
 
-<br />
-
 ```shell
 watch ip -statistics neighbour
 ```
@@ -78,8 +74,6 @@ Amazon EKS
 [Runbook](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-awssupport-troubleshooteksworkernode.html)
 for troubleshooting guidance.
 
-<br />
-
 ## Palette Agents Workload Payload Size Issue
 
 A cluster comprised of many nodes can create a situation where the workload report data the agent sends to Palette
@@ -90,8 +84,6 @@ If you encounter this scenario, you can configure the cluster to stop sending wo
 the workload report feature, create a _configMap_ with the following configuration. Use a cluster profile manifest layer
 to create the configMap.
 
-<br />
-
 ```shell
 apiVersion: v1
 kind: ConfigMap
@@ -101,5 +93,3 @@ metadata:
 data:
   feature.workloads: disable
 ```
-
-<br />

--- a/docs/docs-content/troubleshooting/palette-dev-engine.md
+++ b/docs/docs-content/troubleshooting/palette-dev-engine.md
@@ -12,8 +12,6 @@ tags: ["troubleshooting", "pde", "app mode"]
 
 Use the following content to help you troubleshoot issues you may encounter when using Palette Dev Engine (PDE).
 
-<br />
-
 ## Resource Requests
 
 All [Cluster Groups](../clusters/cluster-groups/cluster-groups.md) are configured with a default
@@ -25,14 +23,8 @@ to let the system manage the resources.
 If you specify `requests` but not `limits`, the default limits imposed by the LimitRange will likely be lower than the
 requests, causing the following error.
 
-<br />
-
 ```shell hideClipboard
 Invalid value: "300m": must be less than or equal to CPU limit spec.containers[0].resources.requests: Invalid value: "512Mi": must be less than or equal to memory limit
 ```
 
-<br />
-
 The workaround is to define both the `requests` and `limits`.
-
-<br />

--- a/docs/docs-content/troubleshooting/palette-upgrade.md
+++ b/docs/docs-content/troubleshooting/palette-upgrade.md
@@ -19,8 +19,6 @@ address common issues that may occur during an upgrade.
 If you receive the following error message when attempting to upgrade to Palette versions greater than Palette 3.4.X in
 a Kubernetes environment, use the debugging steps to address the issue.
 
-<br />
-
 ```hideClipboard text
 Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "_" and path "/v1/oidc" is already defined in ingress default/hubble-auth-oidc-ingress-resource
 ```
@@ -32,21 +30,15 @@ Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.ng
 
 2. Identify all Ingress resources that belong to _Hubble_ - an internal Palette component.
 
-<br />
-
-```shell
-kubectl get ingress --namespace default
-```
+   ```shell
+   kubectl get ingress --namespace default
+   ```
 
 3. Remove each Ingress resource listed in the output that starts with the name Hubble. Use the following command to
    delete an Ingress resource. Replace `REPLACE_ME` with the name of the Ingress resource you are removing.
 
-<br />
-
-```shell
-kubectl delete ingress --namespace default <REPLACE_ME>
-```
+   ```shell
+   kubectl delete ingress --namespace default <REPLACE_ME>
+   ```
 
 4. Restart the upgrade process.
-
-<br />

--- a/docs/docs-content/troubleshooting/pcg.md
+++ b/docs/docs-content/troubleshooting/pcg.md
@@ -96,7 +96,7 @@ unavailable IP addresses for the worker nodes, or the inability to perform a Net
 9. If the problem persists, download the cluster logs from Palette. The screenshot below will help you locate the button
    to download logs from the cluster details page.
 
-![A screenshot highlighting how to download the cluster logs from Palette.](/troubleshooting-pcg-download_logs.webp)
+   ![A screenshot highlighting how to download the cluster logs from Palette.](/troubleshooting-pcg-download_logs.webp)
 
 10. Share the logs with our support team at [support@spectrocloud.com](mailto:support@spectrocloud.com).
 

--- a/docs/docs-content/troubleshooting/pcg.md
+++ b/docs/docs-content/troubleshooting/pcg.md
@@ -27,8 +27,6 @@ selected IP allocation scheme specified in the network settings of the PCG insta
 node. The IP allocation scheme offers two options - static IP or DHCP. You must check the selected IP allocation scheme
 for troubleshooting.
 
-<br />
-
 ## Debug Steps
 
 1. If you chose the static IP allocation scheme, ensure you have correctly provided the values for the gateway IP
@@ -62,8 +60,6 @@ minutes to finish the PCG cluster deployment.
 
 However, if the PCG cluster provisioning gets stuck, it could hint at incorrect cloud gateway configurations,
 unavailable IP addresses for the worker nodes, or the inability to perform a Network Time Protocol (NTP) sync.
-
-<br />
 
 ## Debug Steps
 
@@ -106,8 +102,6 @@ If one of the event logs displays the `No route to host.` error. The error indic
 attempting to connect to the cluster's Kubernetes API server. This issue can occur due to improper networking
 configuration or an error in the cloud-init process.
 
-<br />
-
 ## Debug Steps
 
 1. Check the data center network settings. Ensure no network restrictions, firewalls, or security groups block
@@ -139,8 +133,6 @@ configuration or an error in the cloud-init process.
      `/readyz` or `'/livez'`. Replace `[path_to_kubeconfig]` placeholder with the path to the kubeconfig file you
      downloaded in the previous step. A status code `ok` or `200` indicates the Kubernetes API server is healthy.
 
-     <br />
-
      ```bash
      kubectl --kubeconfig [path_to_kubeconfig] get --raw='/readyz'
      ```
@@ -162,20 +154,16 @@ configuration or an error in the cloud-init process.
 
 7. Examine the cloud-init and system logs for potential errors or warnings.
 
-   <br />
-
 8. If the problem persists, reach out to our support team at
    [support@spectrocloud.com](mailto:support@spectrocloud.com).
 
 ## Scenario - Permission Denied to Provision
 
-if you receive the event log message "Permission to perform this operation denied" error.
+If you receive the event log message "Permission to perform this operation denied" error.
 
 You must have the necessary permissions to provision a PCG cluster in the VMware environment. If you do not have
 adequate permissions, the PCG cluster provisioning will fail, and you will get the above-mentioned error in the events
 log.
-
-<br />
 
 1. Ensure you have all the permissions listed in the [VMware Privileges](../clusters/pcg/deploy-pcg/vmware.md) section
    before proceeding to provision a PCG cluster.

--- a/docs/docs-content/troubleshooting/troubleshooting.md
+++ b/docs/docs-content/troubleshooting/troubleshooting.md
@@ -11,8 +11,6 @@ tags: ["troubleshooting"]
 Use the following troubleshooting resources to help you address issues that may arise. You can also reach out to our
 support team by opening up a ticket through our [support page](http://support.spectrocloud.io/).
 
-<br />
-
 - [Cluster Deployment](cluster-deployment.md)
 
 - [Edge](edge.mdx)
@@ -53,8 +51,6 @@ Follow the link for more details: [Download Cluster Logs](../clusters/clusters.m
 Spectro Cloud maintains an event stream with low-level details of the various orchestration tasks being performed. This
 event stream is a good source for identifying issues in the event an operation does not complete for a long time.
 
-<br />
-
 :::warning
 
 Due to Spectro Cloud’s reconciliation logic, intermittent errors show up in the event stream. As an example, after
@@ -83,5 +79,3 @@ made to perform the task. Failed conditions are a great source of troubleshootin
 For example, failure to create a virtual machine in AWS due to the vCPU limit being exceeded would cause this error is
 shown to the end-users. They could choose to bring down some workloads in the AWS cloud to free up space. The next time
 a VM creation task is attempted, it would succeed and the condition would be marked as a success.
-
-<br />


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-0`:
 - [Clean up markup and alignment in the Troubleshooting section (#3255)](https://github.com/spectrocloud/librarium/pull/3255)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)