### PR TITLE
[version-3-4] Clean up markup and alignment in the Troubleshooting section (#3255)

### DIFF
--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -17,9 +17,7 @@ The following steps will help you troubleshoot errors in the event issues arise 
 An instance is launched and terminated every 30 minutes prior to completion of its deployment, and the **Events Tab**
 lists errors with the following message:
 
-<br />
-
-```bash hideClipboard
+```hideClipboard bash
 Failed to update kubeadmControlPlane Connection timeout connecting to Kubernetes Endpoint
 ```
 
@@ -35,74 +33,79 @@ why a service may fail are:
     user `spectro`. If you are initiating an SSH session into an installer instance, log in as user `ubuntu`.
 
     ```shell
-        ssh --identity_file <_pathToYourSSHkey_> spectro@X.X.X.X
+    ssh --identity_file <_pathToYourSSHkey_> spectro@X.X.X.X
     ```
 
 2.  Elevate the user access.
 
     ```shell
-        sudo -i
+    sudo -i
     ```
 
 3.  Verify the Kubelet service is operational.
 
     ```shell
-        systemctl status kubelet.service
+    systemctl status kubelet.service
     ```
 
 4.  If the Kubelet service does not work as expected, do the following. If the service operates correctly, you can skip
     this step.
 
-    1. Navigate to the **/var/log/** folder.
-       ```shell
-       cd /var/log/
-       ```
-    2. Scan the **cloud-init-output** file for any errors. Take note of any errors and address them.
-       ```
-       cat cloud-init-output.log
-       ```
+5.  Navigate to the **/var/log/** folder.
 
-5.  If the kubelet service works as expected, do the following.
+    ```shell
+    cd /var/log/
+    ```
+
+6.  Scan the **cloud-init-output** file for any errors. Take note of any errors and address them.
+
+    ```
+    cat cloud-init-output.log
+    ```
+
+7.  If the kubelet service works as expected, do the following.
 
     - Export the kubeconfig file.
 
-    ```shell
-        export KUBECONFIG=/etc/kubernetes/admin.conf
-    ```
+      ```shell
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      ```
 
     - Connect with the cluster's Kubernetes API.
 
-    ```shell
-        kubectl get pods --all-namespaces
-    ```
+      ```shell
+      kubectl get pods --all-namespaces
+      ```
 
     - When the connection is established, verify the pods are in a _Running_ state. Take note of any pods that are not
       in _Running_ state.
 
-    ```shell
-        kubectl get pods -o wide
-    ```
+      ```shell
+      kubectl get pods -o wide
+      ```
 
     - If all the pods are operating correctly, verify their connection with the Palette API.
 
-          - For clusters using Gateway, verify the connection between the Installer and Gateway instance:
-            ```shell
-               curl -k https://<KUBE_API_SERVER_IP>:6443
-            ```
-          - For Public Clouds that do not use Gateway, verify the connection between the public Internet and the Kube
-            endpoint:
+      - For clusters using Gateway, verify the connection between the Installer and Gateway instance:
 
-            ```shell
-                curl -k https://<KUBE_API_SERVER_IP>:6443
-            ```
+        ```shell
+        curl -k https://<KUBE_API_SERVER_IP>:6443
+        ```
 
-            :::info
+      - For Public Clouds that do not use Gateway, verify the connection between the public Internet and the Kube
+        endpoint:
 
-            You can obtain the URL for the Kubernetes API using this command: kubectl cluster-info
+        ```shell
+        curl -k https://<KUBE_API_SERVER_IP>:6443
+        ```
 
-            :::
+        :::info
 
-6.  Check stdout for errors. You can also open a support ticket. Visit our
+        You can obtain the URL for the Kubernetes API using this command: kubectl cluster-info
+
+        :::
+
+8.  Check stdout for errors. You can also open a support ticket. Visit our
     [support page](http://support.spectrocloud.io/).
 
 ## Deployment Violates Pod Security

--- a/docs/docs-content/troubleshooting/cluster-deployment.md
+++ b/docs/docs-content/troubleshooting/cluster-deployment.md
@@ -51,19 +51,19 @@ why a service may fail are:
 4.  If the Kubelet service does not work as expected, do the following. If the service operates correctly, you can skip
     this step.
 
-5.  Navigate to the **/var/log/** folder.
+    1.  Navigate to the **/var/log/** folder.
 
-    ```shell
-    cd /var/log/
-    ```
+        ```shell
+        cd /var/log/
+        ```
 
-6.  Scan the **cloud-init-output** file for any errors. Take note of any errors and address them.
+    2.  Scan the **cloud-init-output** file for any errors. Take note of any errors and address them.
 
-    ```
-    cat cloud-init-output.log
-    ```
+        ```
+        cat cloud-init-output.log
+        ```
 
-7.  If the kubelet service works as expected, do the following.
+5.  If the kubelet service works as expected, do the following.
 
     - Export the kubeconfig file.
 
@@ -105,7 +105,7 @@ why a service may fail are:
 
         :::
 
-8.  Check stdout for errors. You can also open a support ticket. Visit our
+6.  Check stdout for errors. You can also open a support ticket. Visit our
     [support page](http://support.spectrocloud.io/).
 
 ## Deployment Violates Pod Security

--- a/docs/docs-content/troubleshooting/nodes.md
+++ b/docs/docs-content/troubleshooting/nodes.md
@@ -49,8 +49,6 @@ resulted in a node repave. The API payload is incomplete for brevity.
 
 For detailed information, review the cluster upgrades [page](../clusters/clusters.md).
 
-<br />
-
 ## Clusters
 
 ## Scenario - vSphere Cluster and Stale ARP Table
@@ -65,8 +63,6 @@ This is done automatically without any user action.
 You can verify the cleaning process by issuing the following command on non-VIP nodes and observing that the ARP cache
 is never older than 300 seconds.
 
-<br />
-
 ```shell
 watch ip -statistics neighbour
 ```
@@ -78,8 +74,6 @@ Amazon EKS
 [Runbook](https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-awssupport-troubleshooteksworkernode.html)
 for troubleshooting guidance.
 
-<br />
-
 ## Palette Agents Workload Payload Size Issue
 
 A cluster comprised of many nodes can create a situation where the workload report data the agent sends to Palette
@@ -90,8 +84,6 @@ If you encounter this scenario, you can configure the cluster to stop sending wo
 the workload report feature, create a _configMap_ with the following configuration. Use a cluster profile manifest layer
 to create the configMap.
 
-<br />
-
 ```shell
 apiVersion: v1
 kind: ConfigMap
@@ -101,5 +93,3 @@ metadata:
 data:
   feature.workloads: disable
 ```
-
-<br />

--- a/docs/docs-content/troubleshooting/palette-dev-engine.md
+++ b/docs/docs-content/troubleshooting/palette-dev-engine.md
@@ -12,8 +12,6 @@ tags: ["troubleshooting", "pde", "app mode"]
 
 Use the following content to help you troubleshoot issues you may encounter when using Palette Dev Engine (PDE).
 
-<br />
-
 ## Resource Requests
 
 All [Cluster Groups](../clusters/cluster-groups/cluster-groups.md) are configured with a default
@@ -25,14 +23,8 @@ to let the system manage the resources.
 If you specify `requests` but not `limits`, the default limits imposed by the LimitRange will likely be lower than the
 requests, causing the following error.
 
-<br />
-
 ```shell hideClipboard
 Invalid value: "300m": must be less than or equal to CPU limit spec.containers[0].resources.requests: Invalid value: "512Mi": must be less than or equal to memory limit
 ```
 
-<br />
-
 The workaround is to define both the `requests` and `limits`.
-
-<br />

--- a/docs/docs-content/troubleshooting/palette-upgrade.md
+++ b/docs/docs-content/troubleshooting/palette-upgrade.md
@@ -19,8 +19,6 @@ common issues that may occur during an upgrade.
 If you receive the following error message when attempting to upgrade to Palette versions greater than Palette 3.4.X in
 a Kubernetes environment, use the debugging steps to address the issue.
 
-<br />
-
 ```hideClipboard text
 Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "_" and path "/v1/oidc" is already defined in ingress default/hubble-auth-oidc-ingress-resource
 ```
@@ -32,21 +30,15 @@ Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.ng
 
 2. Identify all Ingress resources that belong to _Hubble_ - an internal Palette component.
 
-<br />
-
-```shell
-kubectl get ingress --namespace default
-```
+   ```shell
+   kubectl get ingress --namespace default
+   ```
 
 3. Remove each Ingress resource listed in the output that starts with the name Hubble. Use the following command to
    delete an Ingress resource. Replace `REPLACE_ME` with the name of the Ingress resource you are removing.
 
-<br />
-
-```shell
-kubectl delete ingress --namespace default <REPLACE_ME>
-```
+   ```shell
+   kubectl delete ingress --namespace default <REPLACE_ME>
+   ```
 
 4. Restart the upgrade process.
-
-<br />

--- a/docs/docs-content/troubleshooting/pcg.md
+++ b/docs/docs-content/troubleshooting/pcg.md
@@ -286,7 +286,7 @@ unavailable IP addresses for the worker nodes, or the inability to perform a Net
 9. If the problem persists, download the cluster logs from Palette. The screenshot below will help you locate the button
    to download logs from the cluster details page.
 
-![A screenshot highlighting how to download the cluster logs from Palette.](/troubleshooting-pcg-download_logs.webp)
+   ![A screenshot highlighting how to download the cluster logs from Palette.](/troubleshooting-pcg-download_logs.webp)
 
 10. Share the logs with our support team at [support@spectrocloud.com](mailto:support@spectrocloud.com).
     <br />

--- a/docs/docs-content/troubleshooting/pcg.md
+++ b/docs/docs-content/troubleshooting/pcg.md
@@ -16,8 +16,6 @@ private data center environment.
 
 The following are the high-level steps of deploying a PCG in a private data center environment:
 
-<br />
-
 1. Initiate the installation in Palette. In this step, you get a pairing code and an installer image.
 2. Deploy the PCG installer in the data center environment.
 3. Configure the cloud gateway in Palette, and launch the PCG cluster.
@@ -25,8 +23,6 @@ The following are the high-level steps of deploying a PCG in a private data cent
 While deploying a PCG, you may encounter one of the following scenarios during the above-mentioned steps. Some scenarios
 below apply to all data center environments, whereas others apply to a specific data center environment, such as VMware.
 Each scenario covers a specific problem, including an overview, possible causes, and debugging steps.
-
-<br />
 
 ## Scenario - Jet CrashLoopBackOff
 
@@ -36,15 +32,11 @@ one of the internal Palette components may undergo a _CrashLoopBackOff_ state.
 The internal component, _Jet_, will transition to a healthy state once the PCG cluster is successfully registered with
 Palette.
 
-<br />
-
 ## Debug Steps
 
 Wait 10-15 minutes for the PCG installation to finish so that the internal component receives the required authorization
 token from Palette. Once the internal component is authorized, the PCG cluster will complete the initialization
 successfully.
-
-<br />
 
 ## Scenario - PCG Installer VM Unable to Register With Palette
 
@@ -56,30 +48,24 @@ If the installer fails to register with Palette within the expected timeframe, i
 The error can occur due to network connectivity issues, incorrect pairing code, or an incorrect endpoint configuration
 for Palette in the PCG installer template settings.
 
-<br />
-
 ## Debug Steps
-
-<br />
 
 1. SSH into the PCG installer VM using the username `ubuntu` and the SSH key you provided during the OVA import.
 
 2. Inspect the log file located at **/var/log/cloud-init-output.log**.
 
-<br />
+   ```bash
+   cat /var/log/cloud-init-output.log
+   ```
 
-```bash
-cat /var/log/cloud-init-output.log
-```
+   The **cloud-init-output.log** file will contain error messages if there are failures with connecting to Palette,
+   authenticating, or downloading installation artifacts. A common cause for these errors is incorrect values provided
+   to the OVF template deployment wizard, such as the Palette endpoint or a mistyped pairing code.
 
-The **cloud-init-output.log** file will contain error messages if there are failures with connecting to Palette,
-authenticating, or downloading installation artifacts. A common cause for these errors is incorrect values provided to
-the OVF template deployment wizard, such as the Palette endpoint or a mistyped pairing code.
+   The screenshot below highlights the OVF template properties you must carefully configure and verify before deploying
+   a PCG installer VM.
 
-The screenshot below highlights the OVF template properties you must carefully configure and verify before deploying a
-PCG installer VM.
-
-![A screenshot displaying the OVF template properties you  configure while deploying the PCG installer VM](/troubleshooting-pcg-template_properties.webp)
+   ![A screenshot displaying the OVF template properties you  configure while deploying the PCG installer VM](/troubleshooting-pcg-template_properties.webp)
 
 3. Double-check the accuracy of the pairing code used for the PCG installer VM. A pairing code is a unique
    authentication code Palette generates for each PCG installer instance. Confirm that it matches the value you copied
@@ -98,42 +84,38 @@ PCG installer VM.
 
 6. If the problem persists, issue the following command in the PCG installer VM to create a script to generate a log
    bundle.
-   <br />
 
-```bash
-cat > pcg-debug.sh << 'EOF'
-#!/bin/bash
-DESTDIR="/tmp/"
-CONTAINER_LOGS_DIR="/var/log/containers/"
-CLOUD_INIT_OUTPUT_LOG="/var/log/cloud-init-output.log"
-CLOUD_INIT_LOG="/var/log/cloud-init.log"
-KERN_LOG="/var/log/kern.log"
-KUBELET_LOG="/tmp/kubelet.log"
-SYSLOGS="/var/log/syslog*"
-FILENAME=spectro-logs-$(date +%-Y%-m%-d)-$(date +%-HH%-MM%-SS).tgz
-journalctl -u kubelet > $KUBELET_LOG
-tar --create --gzip -h --file=$DESTDIR$FILENAME $CONTAINER_LOGS_DIR $CLOUD_INIT_LOG $CLOUD_INIT_OUTPUT_LOG $KERN_LOG $KUBELET_LOG $SYSLOGS
-retVal=$?
-if [ $retVal -eq 1 ]; then
-    echo "Error creating spectro logs package"
-else
-    echo "Successfully extracted spectro cloud logs: $DESTDIR$FILENAME"
-fi
-EOF
-```
+   ```bash
+   cat > pcg-debug.sh << 'EOF'
+   #!/bin/bash
+   DESTDIR="/tmp/"
+   CONTAINER_LOGS_DIR="/var/log/containers/"
+   CLOUD_INIT_OUTPUT_LOG="/var/log/cloud-init-output.log"
+   CLOUD_INIT_LOG="/var/log/cloud-init.log"
+   KERN_LOG="/var/log/kern.log"
+   KUBELET_LOG="/tmp/kubelet.log"
+   SYSLOGS="/var/log/syslog*"
+   FILENAME=spectro-logs-$(date +%-Y%-m%-d)-$(date +%-HH%-MM%-SS).tgz
+   journalctl -u kubelet > $KUBELET_LOG
+   tar --create --gzip -h --file=$DESTDIR$FILENAME $CONTAINER_LOGS_DIR $CLOUD_INIT_LOG $CLOUD_INIT_OUTPUT_LOG $KERN_LOG $KUBELET_LOG $SYSLOGS
+   retVal=$?
+   if [ $retVal -eq 1 ]; then
+       echo "Error creating spectro logs package"
+   else
+       echo "Successfully extracted spectro cloud logs: $DESTDIR$FILENAME"
+   fi
+   EOF
+   ```
 
 7. Start the script to generate a log archive. By default, the script places the log archive in the **/tmp/** folder.
    The log archive file name starts with the prefix **spectro-logs-** followed by a timestamp value.
-   <br />
 
-```shell
-chmod +x pcg-debug.sh && ./pcg-debug.sh
-```
+   ```shell
+   chmod +x pcg-debug.sh && ./pcg-debug.sh
+   ```
 
 8. Contact our support team by emailing [support@spectrocloud.com](mailto:support@spectrocloud.com) and attach the logs
    archive to the ticket so the support team can troubleshoot the issue and provide you with further guidance.
-
-<br />
 
 ## Scenario - PCG Installer VM IP Address Assignment Error
 
@@ -145,11 +127,7 @@ The selected IP allocation scheme specified in the network settings of the PCG i
 address to the PCG installer VM. The IP allocation scheme offers two options - static IP or DHCP. You must check the
 selected IP allocation scheme for troubleshooting.
 
-<br />
-
 ## Debug Steps
-
-<br />
 
 1. If you chose the static IP allocation scheme, ensure you have correctly provided the values for the gateway IP
    address, DNS addresses, and static IP subnet prefix. Check that the subnet prefix you provided allows the creation of
@@ -175,8 +153,6 @@ selected IP allocation scheme for troubleshooting.
 8. If the problem persists, email the log files to our support team at
    [support@spectrocloud.com](mailto:support@spectrocloud.com).
 
-<br />
-
 ## Scenario - PCG Installer Deployment Failed
 
 When deploying the PCG installer in VMware, you deploy the OVF template and power on the PCG installer VM. If the VM
@@ -186,14 +162,10 @@ Palette.
 The PCG installer deployment can fail due to internet connectivity or internal misconfigurations, such as an incorrect
 pairing code.
 
-<br />
-
 ## Debug Steps
 
 If the PCG installer VM has a public IP address assigned, you can access the PCG installer's deployment status and
 system logs from the monitoring console. Follow the steps below to review the deployment status and logs.
-
-<br />
 
 1. Open a web browser on your local machine and visit the `https://[IP-ADDRESS]:5080` URL. Replace the `[IP-ADDRESS]`
    placeholder with your PCG installer VM's public IP address.
@@ -207,12 +179,12 @@ system logs from the monitoring console. Follow the steps below to review the de
    highlighted in the screenshot below. The monitoring console allows you to check the high-level status and download
    the individual log files.
 
-![A screenshot of the monitoring console of the PCG installer.](/troubleshooting-pcg-monitoring_console.webp)
+   ![A screenshot of the monitoring console of the PCG installer.](/troubleshooting-pcg-monitoring_console.webp)
 
 4. If any of the statuses is not **Done** after waiting for a while, download the concerned logs. The screenshot below
    displays the **Logs** tab in the monitoring console.
 
-![A screenshot of the logs in the monitoring console of the PCG installer.](/troubleshooting-pcg-monitoring_logs.webp)
+   ![A screenshot of the logs in the monitoring console of the PCG installer.](/troubleshooting-pcg-monitoring_logs.webp)
 
 5. Examine the log files for potential errors and root causes.
 
@@ -223,8 +195,6 @@ system logs from the monitoring console. Follow the steps below to review the de
      import.
    - Use the ping command to check if the VM can reach a public IP address. For example, ping well-known public IPs like
      Google's public DNS server (8.8.8.8) or any other public IP address.
-
-     <br />
 
      ```bash
      ping 8.8.8.8
@@ -240,7 +210,6 @@ system logs from the monitoring console. Follow the steps below to review the de
 
 8. If the problem persists, email the log files to our support team at
    [support@spectrocloud.com](mailto:support@spectrocloud.com).
-   <br />
 
 ## Scenario - PCG Cluster Provisioning Stalled or Failed
 
@@ -250,11 +219,7 @@ minutes to finish the PCG cluster deployment.
 However, if the PCG cluster provisioning gets stuck, it could hint at incorrect cloud gateway configurations,
 unavailable IP addresses for the worker nodes, or the inability to perform a Network Time Protocol (NTP) sync.
 
-<br />
-
 ## Debug Steps
-
-<br />
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
@@ -289,7 +254,6 @@ unavailable IP addresses for the worker nodes, or the inability to perform a Net
    ![A screenshot highlighting how to download the cluster logs from Palette.](/troubleshooting-pcg-download_logs.webp)
 
 10. Share the logs with our support team at [support@spectrocloud.com](mailto:support@spectrocloud.com).
-    <br />
 
 ## Scenario - No Progress After Creating the Container Manager
 
@@ -303,11 +267,7 @@ installation artifacts. Another potential reason is that the PCG installer may n
 store the installation artifacts in the **spectro-templates** folder. The installer downloads the images for the worker
 nodes and stores them in the **spectro-templates** folder during the cluster provisioning.
 
-<br />
-
 ## Debug Steps
-
-<br />
 
 1. Check the outbound internet connectivity from the PCG installer VM. Internet connectivity is needed to communicate
    with the Palette API endpoint, `https://api.spectrocloud.com`, or your self-hosted Palette's API endpoint. Use the
@@ -317,8 +277,6 @@ nodes and stores them in the **spectro-templates** folder during the cluster pro
      import.
    - Use the ping command to check if the VM can reach a public IP address. For example, ping well-known public IPs like
      Google's public DNS server (8.8.8.8) or any other public IP address.
-
-     <br />
 
      ```bash
      ping 8.8.8.8
@@ -333,7 +291,6 @@ nodes and stores them in the **spectro-templates** folder during the cluster pro
    and delete the PCG installer VM and relaunch a new one in a network that supports outbound internet connections.
 
 3. Ensure you have the necessary write permissions for the **spectro-templates** folder in the data center environment.
-   <br />
 
 ## Scenario - Failed to Deploy Image
 
@@ -345,11 +302,7 @@ the events displays the `Failed to deploy image: Failed to create govomiClient` 
 The error can occur if there is a preceding "https://" or "http://" string in the vCenter server URL or if the PCG
 installer VM lacks outbound internet connectivity.
 
-<br />
-
 ## Debug Steps
-
-<br />
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
@@ -389,8 +342,6 @@ installer VM lacks outbound internet connectivity.
    - Use the ping command to check if the VM can reach a public IP address. For example, ping well-known public IPs like
      Google's public DNS server (8.8.8.8) or any other public IP address.
 
-     <br />
-
      ```bash
      ping 8.8.8.8
      ```
@@ -402,7 +353,6 @@ installer VM lacks outbound internet connectivity.
 8. Check for any network restrictions or firewall rules in the data center's network settings that may block
    communication. Adjust the proxy settings, if applicable, to fix the connectivity. Alternatively, you can power down
    and delete the PCG installer VM and relaunch a new one in a network that supports outbound internet connections.
-   <br />
 
 ## Scenario - No Route to the Kubernetes API Server
 
@@ -414,11 +364,7 @@ the events displays the `No route to host.` error.
 The error indicates an issue with the PCG cluster nodes attempting to connect to the cluster's Kubernetes API server.
 This issue can occur due to improper networking configuration or an error in the cloud-init process.
 
-<br />
-
 ## Debug Steps
-
-<br />
 
 1. Check the data center network settings. Ensure no network restrictions, firewalls, or security groups block
    communication between the nodes and the API server.
@@ -449,8 +395,6 @@ This issue can occur due to improper networking configuration or an error in the
      `/readyz` or `'/livez'`. Replace `[path_to_kubeconfig]` placeholder with the path to the kubeconfig file you
      downloaded in the previous step. A status code `ok` or `200` indicates the Kubernetes API server is healthy.
 
-     <br />
-
      ```bash
      kubectl --kubeconfig [path_to_kubeconfig] get --raw='/readyz'
      ```
@@ -459,13 +403,9 @@ This issue can occur due to improper networking configuration or an error in the
      the `verbose` parameter. The output will display the individual health checks so you can decide on further
      debugging steps based on the failed checks.
 
-     <br />
-
      ```bash
      kubectl --kubeconfig [path_to_kubeconfig] get --raw='/readyz?verbose'
      ```
-
-     <br />
 
 5. If the PCG installer VM has a public IP address assigned, SSH into the VM using the username `ubuntu` and the public
    SSH key you provided during the OVA import.
@@ -473,7 +413,6 @@ This issue can occur due to improper networking configuration or an error in the
 6. Navigate to the **/var/log** directory containing the log files.
 
 7. Examine the cloud-init and system logs for potential errors or warnings.
-   <br />
 
 ## Scenario - Permission Denied to Provision
 
@@ -486,11 +425,7 @@ You must have the necessary permissions to provision a PCG cluster in the VMware
 adequate permissions, the PCG cluster provisioning will fail, and you will get the above-mentioned error in the events
 log.
 
-<br />
-
 ## Debug Steps
-
-<br />
 
 1. Ensure you have all the permissions listed in the
    [VMware Privileges](../clusters/data-center/vmware.md#vmware-privileges) section before proceeding to provision a PCG
@@ -499,5 +434,3 @@ log.
 2. Contact your VMware administrator if you are missing any of the required permissions.
 
 3. Delete the existing PCG cluster and redeploy a new one so that the new permissions take effect.
-
-<br />

--- a/docs/docs-content/troubleshooting/troubleshooting.md
+++ b/docs/docs-content/troubleshooting/troubleshooting.md
@@ -11,8 +11,6 @@ tags: ["troubleshooting"]
 Use the following troubleshooting resources to help you address issues that may arise. You can also reach out to our
 support team by opening up a ticket through our [support page](http://support.spectrocloud.io/).
 
-<br />
-
 - [Kubernetes Debugging](kubernetes-tips.md)
 
 - [Cluster Deployment](cluster-deployment.md)
@@ -53,8 +51,6 @@ Follow the link for more details: [Download Cluster Logs](../clusters/clusters.m
 Spectro Cloud maintains an event stream with low-level details of the various orchestration tasks being performed. This
 event stream is a good source for identifying issues in the event an operation does not complete for a long time.
 
-<br />
-
 :::warning
 
 Due to Spectro Cloud’s reconciliation logic, intermittent errors show up in the event stream. As an example, after
@@ -83,5 +79,3 @@ made to perform the task. Failed conditions are a great source of troubleshootin
 For example, failure to create a virtual machine in AWS due to the vCPU limit being exceeded would cause this error is
 shown to the end-users. They could choose to bring down some workloads in the AWS cloud to free up space. The next time
 a VM creation task is attempted, it would succeed and the condition would be marked as a success.
-
-<br />


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-3-4`:
 - [Clean up markup and alignment in the Troubleshooting section (#3255)](https://github.com/spectrocloud/librarium/pull/3255)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)