### PR TITLE
Fix broken links to Prometheus Operator Thanos and Thanos Ruler

### DIFF
--- a/docs/docs-content/integrations/prometheus-operator.md
+++ b/docs/docs-content/integrations/prometheus-operator.md
@@ -163,7 +163,7 @@ Toggle the **Enable** button to enable the use of Ingress.
 
 #### Thanos SideCar
 
-[Thanos](https://prometheus-operator.dev/docs/operator/thanos/) is an open-source system for running large-scale,
+[Thanos](https://prometheus-operator.dev/docs/platform/thanos/) is an open-source system for running large-scale,
 distributed, and highly available Prometheus setups. Thanos allows Prometheus to store data for extended periods in
 object storage, such as Amazon S3 or Google Cloud Storage, instead of a local disk. This enables Prometheus to scale
 horizontally without the risk of using up local storage space.
@@ -194,7 +194,7 @@ charts:
 
 By default, Thanos Ruler event data is saved in object storage specified for Thanos, but you can specify a different
 object storage for event data. Refer to the
-[Thanos Ruler](https://prometheus-operator.dev/docs/operator/thanos/?#thanos-ruler) resource to learn more.
+[Thanos Ruler](https://prometheus-operator.dev/docs/platform/thanos/#thanos-ruler) resource to learn more.
 
 <br />
 
@@ -384,7 +384,7 @@ Toggle the **Enable** button to enable the use of Ingress.
 
 #### Thanos SideCar
 
-[Thanos](https://prometheus-operator.dev/docs/operator/thanos/) is an open-source system for running large-scale,
+[Thanos](https://prometheus-operator.dev/docs/platform/thanos/) is an open-source system for running large-scale,
 distributed, and highly available Prometheus setups. Thanos allows Prometheus to store data for extended periods in
 object storage, such as Amazon S3 or Google Cloud Storage, instead of a local disk. This enables Prometheus to scale
 horizontally without the risk of using up local storage space.
@@ -415,7 +415,7 @@ charts:
 
 By default, Thanos Ruler event data is saved in object storage specified for Thanos, but you can specify a different
 object storage for event data. Refer to the
-[Thanos Ruler](https://prometheus-operator.dev/docs/operator/thanos/?#thanos-ruler) resource to learn more.
+[Thanos Ruler](https://prometheus-operator.dev/docs/platform/thanos/#thanos-ruler) resource to learn more.
 
 <br />
 
@@ -605,7 +605,7 @@ Toggle the **Enable** button to enable the use of Ingress.
 
 #### Thanos SideCar
 
-[Thanos](https://prometheus-operator.dev/docs/operator/thanos/) is an open-source system for running large-scale,
+[Thanos](https://prometheus-operator.dev/docs/platform/thanos/) is an open-source system for running large-scale,
 distributed, and highly available Prometheus setups. Thanos allows Prometheus to store data for extended periods in
 object storage, such as Amazon S3 or Google Cloud Storage, instead of a local disk. This enables Prometheus to scale
 horizontally without the risk of using up local storage space.
@@ -636,7 +636,7 @@ charts:
 
 By default, Thanos Ruler event data is saved in object storage specified for Thanos, but you can specify a different
 object storage for event data. Refer to the
-[Thanos Ruler](https://prometheus-operator.dev/docs/operator/thanos/?#thanos-ruler) resource to learn more.
+[Thanos Ruler](https://prometheus-operator.dev/docs/platform/thanos/#thanos-ruler) resource to learn more.
 
 <br />
 
@@ -826,7 +826,7 @@ Toggle the **Enable** button to enable the use of Ingress.
 
 #### Thanos SideCar
 
-[Thanos](https://prometheus-operator.dev/docs/operator/thanos/) is an open-source system for running large-scale,
+[Thanos](https://prometheus-operator.dev/docs/platform/thanos/) is an open-source system for running large-scale,
 distributed, and highly available Prometheus setups. Thanos allows Prometheus to store data for extended periods in
 object storage, such as Amazon S3 or Google Cloud Storage, instead of a local disk. This enables Prometheus to scale
 horizontally without the risk of using up local storage space.
@@ -857,7 +857,7 @@ charts:
 
 By default, Thanos Ruler event data is saved in object storage specified for Thanos, but you can specify a different
 object storage for event data. Refer to the
-[Thanos Ruler](https://prometheus-operator.dev/docs/operator/thanos/?#thanos-ruler) resource to learn more.
+[Thanos Ruler](https://prometheus-operator.dev/docs/platform/thanos/#thanos-ruler) resource to learn more.
 
 <br />
 
@@ -1009,7 +1009,7 @@ Toggle the **Enable** button to enable the use of Ingress.
 
 #### Thanos SideCar
 
-[Thanos](https://prometheus-operator.dev/docs/operator/thanos/) is an open-source system for running large-scale,
+[Thanos](https://prometheus-operator.dev/docs/platform/thanos/) is an open-source system for running large-scale,
 distributed, and highly available Prometheus setups. Thanos allows Prometheus to store data for extended periods in
 object storage, such as Amazon S3 or Google Cloud Storage, instead of a local disk. This enables Prometheus to scale
 horizontally without the risk of using up local storage space.
@@ -1040,7 +1040,7 @@ charts:
 
 By default, Thanos Ruler event data is saved in object storage specified for Thanos, but you can specify a different
 object storage for event data. Refer to the
-[Thanos Ruler](https://prometheus-operator.dev/docs/operator/thanos/?#thanos-ruler) resource to learn more.
+[Thanos Ruler](https://prometheus-operator.dev/docs/platform/thanos/#thanos-ruler) resource to learn more.
 
 <br />
 
@@ -1150,7 +1150,7 @@ Toggle the **Enable** button to enable the use of Ingress.
 
 #### Thanos SideCar
 
-[Thanos](https://prometheus-operator.dev/docs/operator/thanos/) is an open-source system for running large-scale,
+[Thanos](https://prometheus-operator.dev/docs/platform/thanos/) is an open-source system for running large-scale,
 distributed, and highly available Prometheus setups. Thanos allows Prometheus to store data for extended periods in
 object storage, such as Amazon S3 or Google Cloud Storage, instead of a local disk. This enables Prometheus to scale
 horizontally without the risk of using up local storage space.
@@ -1180,7 +1180,7 @@ charts:
 #### Thanos Ruler Object Store
 
 You can specify a different object storage to store the Thanos Ruler event data. Defaults to the object storage
-specified for Thanos. Refer to the [Thanos Ruler](https://prometheus-operator.dev/docs/operator/thanos/?#thanos-ruler)
+specified for Thanos. Refer to the [Thanos Ruler](https://prometheus-operator.dev/docs/platform/thanos/#thanos-ruler)
 resource to learn more.
 
 <br />


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes broken links that refer to Thanos and Thanos Rules from the Prometheus Operator docs.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Prometheus Operator](integrations/prometheus-operator/)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
