### PR TITLE
docs: add note that edge management apis are not available 4.3

### DIFF
--- a/docs/api-content/api-docs/1-introduction.md
+++ b/docs/api-content/api-docs/1-introduction.md
@@ -311,7 +311,7 @@ host name.
 
 ```shell
 curl --location 'https://10.10.135.182:5080/v1/edge-mgmt/edgehosts/current' \
---header 'Cookie: Authorization=*******'
+--header 'Authorization=*******'
 ```
 
 ```hideClipboard

--- a/docs/api-content/api-docs/1-introduction.md
+++ b/docs/api-content/api-docs/1-introduction.md
@@ -267,7 +267,11 @@ Palette instance. You can use Edge Management API endpoints to programmatically 
 information about Edge clusters, retrieve the list of available images on your Edge host, and create local clusters
 using embedded cluster definitions.
 
-These APIs are only available to airgapped Edge hosts without a connection to Palette.
+:::warning
+
+The Edge Management API endpoints are only available to airgapped Edge hosts without a connection to Palette.
+
+:::
 
 You can find the Open API Swagger specification for the Edge Management API at the following location:
 https://raw.githubusercontent.com/spectrocloud/librarium/version-4-3/docs/api-content/api-docs/edge-v1/emc-api.json

--- a/docs/api-content/api-docs/1-introduction.md
+++ b/docs/api-content/api-docs/1-introduction.md
@@ -8,7 +8,7 @@ sidebar_custom_props:
   icon: "graph"
 ---
 
-The API documentation section includes documentation for Palette API and Local Management API.
+The API documentation section includes documentation for Palette API and Edge Management API.
 
 ## Palette API
 
@@ -260,14 +260,16 @@ The API rate limits are as follows:
 | /v1/clusterprofiles/:uid/validate/packs                                                 | 50                     | 5              | 250                |
 | /v1/spectroclusters/:uid/profiles                                                       | 50                     | 5              | 250                |
 
-## Local Management API
+## Edge Management API
 
 An Edge host has its own set of API endpoints. These API endpoints are available on each Edge host instead of on a
-Palette instance. You can use Local Management API endpoints to programmatically perform tasks such as retrieve
+Palette instance. You can use Edge Management API endpoints to programmatically perform tasks such as retrieve
 information about Edge clusters, retrieve the list of available images on your Edge host, and create local clusters
 using embedded cluster definitions.
 
-You can find the Open API Swagger specification for the Local Management API at the following location:
+These APIs are only available to airgapped Edge hosts without a connection to Palette.
+
+You can find the Open API Swagger specification for the Edge Management API at the following location:
 https://raw.githubusercontent.com/spectrocloud/librarium/version-4-3/docs/api-content/api-docs/edge-v1/emc-api.json
 
 :::preview
@@ -297,10 +299,9 @@ If your credentials are valid, you will receive a authorization token.
         "Authorization": "******"
     }
 }
-
 ```
 
-Include this token in the header of your subsequent requests to the Local Management API to authenticate your requests.
+Include this token in the header of your subsequent requests to the Edge Management API to authenticate your requests.
 For example, the following request retrieves information about the Edge host such as the processor architecture and the
 host name.
 

--- a/src/components/IconMapper/dynamicFontAwesomeImports.js
+++ b/src/components/IconMapper/dynamicFontAwesomeImports.js
@@ -10,7 +10,6 @@ import { faNetworkWired } from '@fortawesome/free-solid-svg-icons';
 import { faServer } from '@fortawesome/free-solid-svg-icons';
 import { faUsers } from '@fortawesome/free-solid-svg-icons';
 import { faWarehouse } from '@fortawesome/free-solid-svg-icons';
-import { faFlagCheckered } from '@fortawesome/free-solid-svg-icons';
 import { faPalette } from '@fortawesome/free-solid-svg-icons';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
 import { faBookmark } from '@fortawesome/free-solid-svg-icons';
@@ -35,7 +34,6 @@ export const fontAwesomeIcons = {
   "server": faServer,
   "users": faUsers,
   "warehouse": faWarehouse,
-  "flag-checkered": faFlagCheckered,
   "palette": faPalette,
   "book": faBook,
   "bookmark": faBookmark,

--- a/src/components/IconMapper/dynamicFontAwesomeImports.js
+++ b/src/components/IconMapper/dynamicFontAwesomeImports.js
@@ -21,7 +21,6 @@ import { faGears } from '@fortawesome/free-solid-svg-icons';
 import { faScrewdriverWrench } from '@fortawesome/free-solid-svg-icons';
 import { faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import { faShield } from '@fortawesome/free-solid-svg-icons';
-import { faMicrochip } from '@fortawesome/free-solid-svg-icons';
 
 export const fontAwesomeIcons = {
   "cubes": faCubes,
@@ -46,6 +45,5 @@ export const fontAwesomeIcons = {
   "gears": faGears,
   "screwdriver-wrench": faScrewdriverWrench,
   "eye-slash": faEyeSlash,
-  "shield": faShield,
-  "microchip": faMicrochip
+  "shield": faShield
 };


### PR DESCRIPTION
## Describe the Change

This PR adds a clarification that Edge management APIs are only available to airgapped Edge hosts. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
