### PR TITLE
[version-4-0] chore: bump docker/build-push-action from 5 to 6 (#3204)

### DIFF
--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -55,7 +55,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         id: build-and-push
         with:
           context: .


### PR DESCRIPTION

This PR fixes the backport issue from PR #3204 