### PR TITLE
[version-4-2] Fix markup and alignment in User Management (SSO) and add HTTPS and TLS requirements (#3345)

### DIFF
--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-adfs.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-adfs.md
@@ -9,8 +9,6 @@ hiddenFromNav: false
 tags: ["user-management", "saml-sso"]
 ---
 
-## Enable SSO with Microsoft Active Directory Federation Service (AD FS)
-
 Single sign-on (SSO) is an authentication method that enables users to log in to multiple applications and websites with
 one set of credentials. SSO works upon a trust relationship established and maintained between the service provider (SP)
 and an identity provider (IdP) using certificates. Palette supports SSO based on either SAML or OIDC.
@@ -18,8 +16,6 @@ and an identity provider (IdP) using certificates. Palette supports SSO based on
 The following steps will guide you to enable Palette SSO with
 [Microsoft AD FS](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/development/ad-fs-openid-connect-oauth-concepts)
 based on OIDC.
-
-<br />
 
 :::warning
 
@@ -30,44 +26,36 @@ standard that Palette employs. You can only use the OIDC-based approach for Micr
 
 ## Prerequisites
 
-In order to setup OIDC-based SSO with Microsoft AD FS, you need to use one of the following versions:
+- For Microsoft AD FS to work correctly with Palette, you must enable HTTPS and configure TLS.
 
-- Microsoft AD FS 2022 (comes with Windows Server 2022)
-- Microsoft AD FS 2019 (comes with Windows Server 2019)
-- Microsoft AD FS 2016 (comes with Windows Server 2016)
+- In order to setup OIDC-based SSO with Microsoft AD FS, you need to use one of the following versions:
 
-If you need to be able to your AD FS service from outside your corporate network, you will also need an AD FS Reverse
-Proxy. An official Microsoft tutorial for setting up an AD FS Reverse Proxy is not available, but you can use this blog
-post from
-[Matrixpost](https://blog.matrixpost.net/set-up-active-directory-federation-services-ad-fs-5-0-adfs-reverse-proxy-part-2/)
-for additional guidance.
+  - Microsoft AD FS 2022 (comes with Windows Server 2022)
+  - Microsoft AD FS 2019 (comes with Windows Server 2019)
+  - Microsoft AD FS 2016 (comes with Windows Server 2016)
+
+- If you need to be able to your AD FS service from outside your corporate network, you will also need an AD FS Reverse
+  Proxy. An official Microsoft tutorial for setting up an AD FS Reverse Proxy is not available, but you can use this
+  blog post from
+  [Matrixpost](https://blog.matrixpost.net/set-up-active-directory-federation-services-ad-fs-5-0-adfs-reverse-proxy-part-2/)
+  for additional guidance.
 
 ## Enablement
 
-## Create the AD FS Application Group for Palette
+### Create the AD FS Application Group for Palette
 
 1. Open the AD FS Management console on your Windows Server and add a new Application Group for Palette:
 
-<br />
-
-![Add AD FS Application Group](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-application-group.webp)
-
-<br />
+   ![Add AD FS Application Group](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-application-group.webp)
 
 2. Provide a suitable name for the application group and select **Server Application** from the list of templates. Then
    click **Next**:
 
-<br />
-
-![Name Application Group](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_name-application-group.webp)
-
-<br />
+   ![Name Application Group](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_name-application-group.webp)
 
 3. The next screen displays the **Client Identifier** for this Application Group:
 
-![Get Client Identifier](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_get-client-identifier.webp)
-
-<br />
+   ![Get Client Identifier](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_get-client-identifier.webp)
 
 4. Copy the client identifier value and save it somewhere. You will need to enter this value into the Palette SSO
    configuration later.
@@ -75,61 +63,47 @@ for additional guidance.
 5. Open a web browser and navigate to your Palette subscription. Navigate to **Tenant Settings** --> **SSO** and click
    **OIDC**. Click the button next to **Callback URL** to copy this value to the clipboard:
 
-![Copy Callback URL](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_copy-callback-url.webp)
-
-<br />
+   ![Copy Callback URL](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_copy-callback-url.webp)
 
 6. Switch back to your AD FS Management console and paste the copied value into the **Redirect URI** field, then click
    **Add** to add it to the list:
 
-![Paste Redirect URI](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_paste-redirect-uri.webp)
-
-<br />
+   ![Paste Redirect URI](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_paste-redirect-uri.webp)
 
 7. Switch back to Palette in the web browser and click the button next to **Logout URL** to copy this value to the
    clipboard:
 
-![Copy Logout URL](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_copy-logout-url.webp)
-
-<br />
+   ![Copy Logout URL](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_copy-logout-url.webp)
 
 8. Switch back to your AD FS Management console and paste the copied value into the **Redirect URI** field, then click
    **Add** to add it to the list:
 
-![Paste Logout URI](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_paste-logout-uri.webp)
-
-<br />
+   ![Paste Logout URI](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_paste-logout-uri.webp)
 
 9. These two redirect URIs are required for SSO to work with Palette. You can also add additional redirect URIs. The
    URIs in the table below are useful when you want to use AD FS for OIDC authentication into your Kubernetes clusters.
 
-| URL                                                        | Type of Access                                              |
-| ---------------------------------------------------------- | ----------------------------------------------------------- |
-| `http://localhost:8000`                                    | Using kubectl with the kube-login plugin from a workstation |
-| `https://console.spectrocloud.com/v1/shelly/oidc/callback` | Using the web-based kubectl console                         |
-| `https://<fqdn_of_k8s_dashboard>/oauth/callback`           | Using OIDC authentication into Kubernetes Dashboard         |
+   | URL                                                        | Type of Access                                              |
+   | ---------------------------------------------------------- | ----------------------------------------------------------- |
+   | `http://localhost:8000`                                    | Using kubectl with the kube-login plugin from a workstation |
+   | `https://console.spectrocloud.com/v1/shelly/oidc/callback` | Using the web-based kubectl console                         |
+   | `https://<fqdn_of_k8s_dashboard>/oauth/callback`           | Using OIDC authentication into Kubernetes Dashboard         |
 
 10. When you have completed entering redirect URIs, click **Next**. On the next page of the wizard, select **Generate a
     shared secret** and click **Copy to clipboard** to copy the secret value and save it somewhere. You will need to
     enter this value into the Palette SSO configuration later:
 
-![Copy Shared Secret](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_copy-shared-secret.webp)
-
-<br />
+    ![Copy Shared Secret](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_copy-shared-secret.webp)
 
 11. Click **Next** and on the Summary screen, click **Next** again to complete the wizard. You need to add another
     application to the application group. Select the newly created application group and click **Properties**:
 
-![Open Application Group](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_open-oidc-app.webp)
-
-<br />
+    ![Open Application Group](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_open-oidc-app.webp)
 
 12. In the Properties screen, click **Add application...**. In the wizard that opens, select **Web API** and click
     **Next**:
 
-![Add Web API application](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-web-api.webp)
-
-<br />
+    ![Add Web API application](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-web-api.webp)
 
 13. In the **Identifier** field, add the following entries:
 
@@ -137,85 +111,61 @@ for additional guidance.
 - The base URL of your Palette tenant. This is equal to the URL shown by your browser when logged into Palette minus the
   path. Example `https://johndoe-spectrocloud.console.spectrocloud.com`.
 
-<br />
+  ![Find Base URL](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_base-url.webp)
 
-![Find Base URL](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_base-url.webp)
-
-<br />
-
-![Add Web API Identifiers](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-identifiers.webp)
-
-<br />
+  ![Add Web API Identifiers](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-identifiers.webp)
 
 14. Click **Next** when done. On the next screen, select a suitable policy for who can use this SSO and under what
     circumstances. If you're not sure which policy to choose, select **Permit everyone**, then click **Next**:
 
-<br />
-
-![Select Access Control Policy](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_select-policy.webp)
-
-<br />
+    ![Select Access Control Policy](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_select-policy.webp)
 
 15. On the next screen, by default only the **openid** scope is ticked. However, to include the user's groups in the
     OIDC claim, you need to also enable the **allatclaims** scope. If your AD FS server does not yet have an
     **allatclaims** scope in the list, click **New scope...** and type `allatclaims` in the Name field, then click
     **OK** to add it. Ensure both scopes are enabled and then click **Next**:
 
-![Enable Permitted Scopes](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_enable-scopes.webp)
+    ![Enable Permitted Scopes](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_enable-scopes.webp)
 
 16. On the Summary screen, click **Next** to finish the wizard. You need to set the **Issuance Transform Rules** for the
     Web API application. Open the application again by double-clicking on the Web API entry or clicking **Edit**.
 
-![Re-open Web API Application](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_reopen-webapi-app.webp)
-
-<br />
+    ![Re-open Web API Application](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_reopen-webapi-app.webp)
 
 17. Navigate to the **Issuance Transform Rules** tab and click **Add Rule**.
 
-![Add Issuance Transform Rule 1](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-transform-rule-1.webp)
-
-<br />
+    ![Add Issuance Transform Rule 1](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-transform-rule-1.webp)
 
 18. Select the **Send LDAP Attributes as Claims** template and click **Next**:
 
-![Send LDAP As Claims Rule](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_ldap-as-claims.webp)
-
-<br />
+    ![Send LDAP As Claims Rule](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_ldap-as-claims.webp)
 
 19. Name the rule `OpenID - LDAP Attribute Claims`. Select **Active Directory** as the Attribute store and add the
     following LDAP mappings:
 
-- **E-Mail-Addresses** --> `email`
-- **Given Name** --> `given_name`
-- **Surname** --> `family_name`
+    - **E-Mail-Addresses** --> `email`
+    - **Given Name** --> `given_name`
+    - **Surname** --> `family_name`
 
-You can select the items on the left from the list. You will need to type the items on the right manually. Ensure you
-use all lowercase characters for the values on the right:
+    You can select the items on the left from the list. You will need to type the items on the right manually. Ensure
+    you use all lowercase characters for the values on the right:
 
-![Set LDAP Claims](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_set-ldap-claims.webp)
-
-<br />
+    ![Set LDAP Claims](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_set-ldap-claims.webp)
 
 20. Click **Finish** to add the rule. Now click on **Add Rule...** again to add the second rule:
 
-![Add Issuance Transform Rule 2](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-transform-rule-2.webp)
-
-<br />
+    ![Add Issuance Transform Rule 2](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-transform-rule-2.webp)
 
 21. Select the **Send Group Membership as Claims** template and click **Next**:
 
-![Send Groups As Claims Rule](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_groups-as-claims.webp)
-
-<br />
+    ![Send Groups As Claims Rule](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_groups-as-claims.webp)
 
 22. In the next screen, define the group claim as desired. In the following example, a group in Active Directory is
     called `SpectroTeam - Admins`. The desired behavior is for anyone that is a member of that group, to be issued a
     `groups` claim with the value `Admins`. In Palette this user will automatically be mapped to a group with the same
     name, `Admins`. You can assign RBAC permissions to that group in Palette to give it the desired access.
 
-![Set Group Claim](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_set-group-claim.webp)
-
-<br />
+    ![Set Group Claim](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_set-group-claim.webp)
 
 23. Click **Finish** to add the rule. Click **OK** to save the changes to the Web API rule and click **OK** again to
     save the changes to the application group.
@@ -223,34 +173,32 @@ use all lowercase characters for the values on the right:
 24. Take note of your AD FS identifier, you will need this for Palette in the next step. Typically this is your AD FS
     name plus `/adfs`. You can also take the Federation Service identifier and remove `/services/trust` from that URL:
 
-![Note AD FS Name](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_note-adfs-name.webp)
+    ![Note AD FS Name](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_note-adfs-name.webp)
 
-<br />
-
-## Enable OIDC SSO in Palette
+### Enable OIDC SSO in Palette
 
 25. Open a web browser and navigate to your [Palette](https://console.spectrocloud.com) subscription.
 
-Navigate to **Tenant Settings** --> **SSO** and click on **OIDC**. Enter the following information.
+    Navigate to **Tenant Settings** --> **SSO** and click on **OIDC**. Enter the following information.
 
-| Parameter     | Value                                                                                                                                                                                                                       |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Issuer URL    | Your AD FS issuer URL. Typically this is your AD FS name plus /adfs.                                                                                                                                                        |
-| Client ID     | The client identifier that you saved in step **4**.                                                                                                                                                                         |
-| Client Secret | The shared secret that you generated in step **8**.                                                                                                                                                                         |
-| Default Teams | Leave blank if you don't want users without group claims to be assigned to a default group. If you do, enter the desired default group name. If you use this option, be careful with how much access you give to the group. |
-| Scopes        | Set this to `openid` and `allatclaims`.                                                                                                                                                                                     |
-| Email         | Keep `email` as the default.                                                                                                                                                                                                |
-| First Name    | Keep `given_name` as the default.                                                                                                                                                                                           |
-| Last Name     | Keep `family_name` as the default.                                                                                                                                                                                          |
-| Spectro Team  | Keep `groups` as the default.                                                                                                                                                                                               |
+    | Parameter     | Value                                                                                                                                                                                                                       |
+    | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | Issuer URL    | Your AD FS issuer URL. Typically this is your AD FS name plus /adfs.                                                                                                                                                        |
+    | Client ID     | The client identifier that you saved in step **4**.                                                                                                                                                                         |
+    | Client Secret | The shared secret that you generated in step **8**.                                                                                                                                                                         |
+    | Default Teams | Leave blank if you don't want users without group claims to be assigned to a default group. If you do, enter the desired default group name. If you use this option, be careful with how much access you give to the group. |
+    | Scopes        | Set this to `openid` and `allatclaims`.                                                                                                                                                                                     |
+    | Email         | Keep `email` as the default.                                                                                                                                                                                                |
+    | First Name    | Keep `given_name` as the default.                                                                                                                                                                                           |
+    | Last Name     | Keep `family_name` as the default.                                                                                                                                                                                          |
+    | Spectro Team  | Keep `groups` as the default.                                                                                                                                                                                               |
 
-![Enable Palette OIDC SSO](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_configure-palette-oidc.webp)
+    ![Enable Palette OIDC SSO](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_configure-palette-oidc.webp)
 
 26. When all the information has been entered, click **Enable** to enable SSO. You will receive a message stating **OIDC
     configured successfully**.
 
-## Create Teams in Palette
+### Create Teams in Palette
 
 The remaining step is to create teams in Palette for the group claims that you configured in AD FS, and give them the
 appropriate permissions. For this example, you will create the `Admins` team and give it **Tenant Admin** permissions.
@@ -259,33 +207,25 @@ You can repeat this for any other team that you configured with group claims.
 27. Open a web browser and navigate to your Palette subscription. Navigate to **Tenant Settings** --> **Users & Teams**
     --> **Teams** tab, and click **+ Create Team**.
 
-![Create Palette Team](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_create-team.webp)
-
-<br />
+    ![Create Palette Team](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_create-team.webp)
 
 28. Specify `Admins` in the **Team name** field. You don't need to set any members now, as this will happen
     automatically from the SSO. Click **Confirm** to create the team.
 
-![Name Palette Team](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_name-team.webp)
-
-<br />
+    ![Name Palette Team](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_name-team.webp)
 
 29. The list of teams displays again. Select the newly created **Admins** team to review its details. To give this team
     administrative access to the entire tenant and all the projects in it, assign the **Tenant Admin** role. Select
     **Tenant Roles** and click **+ Add Tenant Role**:
 
-![Palette Tenant Roles](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_tenant-roles.webp)
-
-<br />
+    ![Palette Tenant Roles](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_tenant-roles.webp)
 
 30. Click on **Tenant Admin** to enable the role. Click **Confirm** to add the role.
 
-![Add Tenant Role](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-tenant-role.webp)
+    ![Add Tenant Role](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-tenant-role.webp)
 
-<br />
-
-You will receive a message stating **Roles have been updated**. Repeat this procedure for any other teams, taking care
-to ensure they are given the appropriate permissions.
+    You will receive a message stating **Roles have been updated**. Repeat this procedure for any other teams, taking
+    care to ensure they are given the appropriate permissions.
 
 31. Click the **X** next to **Team Details** in the top left corner to exit this screen.
 
@@ -296,38 +236,34 @@ You have now successfully configured Palette SSO based on OIDC with Microsoft AD
 1. Log in to Palette through SSO as a user that is a member of the `SpectroTeam - Admins` group in Active Directory to
    verify that users are automatically added to the `Admins` group in Palette.
 
-If you're still logged into Palette with a non-SSO user, log out by selecting **Logout** in the **User Menu** at top
-right.
+   If you're still logged into Palette with a non-SSO user, log out by selecting **Logout** in the **User Menu** at top
+   right.
 
-![User Logout](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_user-logout.webp)
-
-<br />
+   ![User Logout](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_user-logout.webp)
 
 2. The Palette login screen now displays a **Sign in** button and no longer presents a username and password field.
    Below the **Sign In** button, there is an **SSO issues? --> Use your password** link. This link can be used to bypass
    SSO and log in with a local Palette account in case there is an issue with SSO and you need to access Palette without
    SSO.
 
-Click on the **Sign in** button to log in via SSO.
+   Click on the **Sign in** button to log in via SSO.
 
-![User SSO Login](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_palette-login.webp)
-
-<br />
+   ![User SSO Login](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_palette-login.webp)
 
 3. If this is the first time you are logging in with SSO, you will be redirected to the Microsoft AD FS login page.
    Depending on your organization's SSO settings, this could be a simple login form or require MFA (Multi-Factor
    Authentication).
 
-Make sure you log in as a user that is a member of the `SpectroTeam - Admins` group in Active Directory. Once
-authenticated, you will automatically be redirected back to Palette and logged into Palette as that user.
+   Make sure you log in as a user that is a member of the `SpectroTeam - Admins` group in Active Directory. Once
+   authenticated, you will automatically be redirected back to Palette and logged into Palette as that user.
 
 4. You are now automatically added to the `Admins` team in Palette. To verify, navigate to the left **Main Menu**,
    select **Tenant Settings** --> **Users & Teams** --> **Teams** tab. Click the **Admins** team and view the team
    members section.
 
-![Palette Team Members](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_team-members.webp)
+   ![Palette Team Members](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_team-members.webp)
 
-The user you logged in as has automatically been added to this team.
+   The user you logged in as has automatically been added to this team.
 
 ## Resources
 

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-entra-id.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-entra-id.md
@@ -39,6 +39,8 @@ Use the following steps to enable OIDC SSO in Palette with Microsoft Entra ID.
 
 - Palette or Palette VerteX version 4.0.X or greater.
 
+- For Microsoft Entra ID to work correctly with Palette, you must enable HTTPS and configure TLS.
+
 - A [Microsoft Entra ID](https://entra.microsoft.com/#home) subscription. You will need an account with one of the
   following roles: Global Administrator, Cloud Application Administrator, or Application Administrator. Alternatively,
   you may be the owner of the service principal.
@@ -118,7 +120,7 @@ Use the following steps to enable OIDC SSO in Palette with Microsoft Entra ID.
     | **Directory (tenant) ID**   | The Directory ID is the unique identifier for your Azure AD tenant.                                        |
     | **Secret Value**            | The Secret Value is the value of the client secret you created in the previous steps.                      |
 
-      <details>
+    <details>
 
     <summary>Additional Redirect URLs</summary>
 
@@ -130,7 +132,7 @@ Use the following steps to enable OIDC SSO in Palette with Microsoft Entra ID.
           | `http://localhost:8000` | UsUseing kubectl with the kube-login plugin from a workstation |
           | `https://<fqdn_of_k8s_dashboard>/oauth/callback` | Use OIDC to authenticate and log in to the Kubernetes Dashboard |
 
-      </details>
+    </details>
 
 #### Configure Microsoft Entra ID with Users and Groups
 
@@ -275,6 +277,8 @@ Use the following steps to enable OIDC in Kubernetes clusters with Microsoft Ent
 ### Prerequisites
 
 - Palette or Palette VerteX version 4.0.X or greater.
+
+- For Microsoft Entra ID to work correctly with Palette, you must enable HTTPS and configure TLS.
 
 - OIDC configured in Palette with Microsoft Entra ID. Refer to the
   [Enable OIDC SSO in Palette](#enable-oidc-sso-in-palette) section for detailed guidance on how to configure OIDC in

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
@@ -55,12 +55,12 @@ up Keycloak as an OIDC provider for Palette.
    kubectl create --filename https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/latest/kubernetes/keycloak.yaml
    ```
 
-:::info
+   :::info
 
-You can also download the YAML file and edit it to suit your requirements before deploying it to your cluster. If you
-choose to do so, replace the GitHub file link in the original command with a file path to your YAML file.
+   You can also download the YAML file and edit it to suit your requirements before deploying it to your cluster. If you
+   choose to do so, replace the GitHub file link in the original command with a file path to your YAML file.
 
-:::
+   :::
 
 3. The installation process takes a couple of minutes. After installation completes, use the following command to
    retrieve the external IP address of the Keycloak service.

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
@@ -21,26 +21,28 @@ up Keycloak as an OIDC provider for Palette.
 
 ## Prerequisites
 
-1. Access to Palette as a Tenant Admin.
+- Access to Palette as a Tenant Admin.
 
-2. The Keycloak service must be exposed on an external IP address, preferably with a domain name. Refer to the
-   [Configuring Keycloak for production](https://www.keycloak.org/server/configuration-production) guide for more
-   information.
+- For Keycloak to work correctly with Palette, you must enable HTTPS and configure TLS.
 
-3. Deploy a Kubernetes cluster with load balancer resources available. You will also need a set of open IP addresses for
-   the Keycloak service.
+- The Keycloak service must be exposed on an external IP address, preferably with a domain name. Refer to the
+  [Configuring Keycloak for production](https://www.keycloak.org/server/configuration-production) guide for more
+  information.
 
-:::tip
+- Deploy a Kubernetes cluster with load balancer resources available. You will also need a set of open IP addresses for
+  the Keycloak service.
 
-You can deploy a Kubernetes cluster in a public cloud with load balancer resources using Palette. You can also deploy to
-an on-prem or edge environment and use the MetalLB pack to expose a load balancer service. Check out the
-[Deploy a Cluster](../../clusters/public-cloud/deploy-k8s-cluster.md) guide for more information.
+  :::tip
 
-:::
+  You can deploy a Kubernetes cluster in a public cloud with load balancer resources using Palette. You can also deploy
+  to an on-prem or edge environment and use the MetalLB pack to expose a load balancer service. Check out the
+  [Deploy a Cluster](../../clusters/public-cloud/deploy-k8s-cluster.md) guide for more information.
 
-4. Kubectl installed and configured to access your Kubernetes cluster.
+  :::
 
-## Setup
+- Kubectl installed and configured to access your Kubernetes cluster.
+
+## Enable SSO with Keycloak
 
 1. Ensure you can access your Kubernetes cluster using the kubectl CLI. Refer to the
    [Access Cluster with CLI](../../clusters/cluster-management/palette-webctl.md) for guidance on how to access your
@@ -63,38 +65,38 @@ choose to do so, replace the GitHub file link in the original command with a fil
 3. The installation process takes a couple of minutes. After installation completes, use the following command to
    retrieve the external IP address of the Keycloak service.
 
-```bash
-kubectl describe service keycloak  | grep "LoadBalancer Ingress" | awk '{print $3}' && \
-IP=$(kubectl describe service keycloak | grep "LoadBalancer Ingress" | awk '{print $3}')
-```
+   ```bash
+   kubectl describe service keycloak  | grep "LoadBalancer Ingress" | awk '{print $3}' && \
+   IP=$(kubectl describe service keycloak | grep "LoadBalancer Ingress" | awk '{print $3}')
+   ```
 
-```shell hideClipboard
-aacf4014d5cd34825803567201217410-1398304919.us-east-1.elb.amazonaws.com
-```
+   ```shell hideClipboard
+   aacf4014d5cd34825803567201217410-1398304919.us-east-1.elb.amazonaws.com
+   ```
 
 4. Next, download the Ingress YAML definition provided by Keycloak to create an Ingress resource in your cluster. The
    command below also automatically replaces the `KEYCLOAK_HOST` placeholder with the external IP address of the
    Keycloak service.
 
-```bash
-wget --quiet --output-document - https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/latest/kubernetes/keycloak-ingress.yaml | sed "s/KEYCLOAK_HOST/$IP/" | kubectl create -f -
-```
+   ```bash
+   wget --quiet --output-document - https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/latest/kubernetes/keycloak-ingress.yaml | sed "s/KEYCLOAK_HOST/$IP/" | kubectl create -f -
+   ```
 
-```shell hideClipboard
-ingress.networking.k8s.io/keycloak created
-```
+   ```shell hideClipboard
+   ingress.networking.k8s.io/keycloak created
+   ```
 
-:::info
+   :::info
 
-If `wget` and `sed` are not available, download the file and manually edit the file to replace `KEYCLOAK_HOST` with the
-external IP address of the Keycloak service.
+   If `wget` and `sed` are not available, download the file and manually edit the file to replace `KEYCLOAK_HOST` with
+   the external IP address of the Keycloak service.
 
-:::
+   :::
 
-After the ingress resource is created, the following services will be available in your cluster. You can review the
-exposed services in the cluster details page.
+   After the ingress resource is created, the following services will be available in your cluster. You can review the
+   exposed services in the cluster details page.
 
-![View of the cluster details page](/keycloak/user-management_saml-sso_keycloak-01-keycloak-service.webp "Keycloak Service")
+   ![View of the cluster details page](/keycloak/user-management_saml-sso_keycloak-01-keycloak-service.webp "Keycloak Service")
 
 5. Create a DNS CNAME record for the URL exposed by load balancer. For example, the CNAME
    `keycloak.dmitry.sa.spectrodemos.com` points to the following URL exposed by the load balancer
@@ -105,72 +107,72 @@ exposed services in the cluster details page.
    `http://keycloak.dmitry.sa.spectrodemos.com:8080/admin`. Use the default credentials `admin:admin` to log into the
    admin console.
 
-:::warning
+   :::warning
 
-We recommend that you change the default credentials after logging in to the admin console.
+   We recommend that you change the default credentials after logging in to the admin console.
 
-:::
+   :::
 
-![Keycloak Admin console](/keycloak//user-management_palette-rback_keycloak_login.webp)
+   ![Keycloak Admin console](/keycloak//user-management_palette-rback_keycloak_login.webp)
 
-7.  Next, log in to [Palette](https://console.spectrocloud.com), and navigate to the left **Main Menu** and select
-    **Tenant Settings**. Next, select **SSO** from the **Tenant Menu** to access the SSO configuration page. Click on
-    the **OIDC** tab to configure OIDC for Palette. Copy the values in the **Callback URL** and **Logout URL** fields.
-    You will need these values to configure Keycloak.
+7. Next, log in to [Palette](https://console.spectrocloud.com), and navigate to the left **Main Menu** and select
+   **Tenant Settings**. Next, select **SSO** from the **Tenant Menu** to access the SSO configuration page. Click on the
+   **OIDC** tab to configure OIDC for Palette. Copy the values in the **Callback URL** and **Logout URL** fields. You
+   will need these values to configure Keycloak.
 
-![The callback URL](/keycloak/user-management_saml-sso_keycloak-02-callback-url.webp "Callback URL")
+   ![The callback URL](/keycloak/user-management_saml-sso_keycloak-02-callback-url.webp "Callback URL")
 
 8. Switch back to the Keycloak admin console and create a client for Palette. Navigate to the left **Main Menu** and
    select **Clients**. Click on the **Create** button to create a new client.
 
-![The Client create screen](/keycloak/user-management_saml-sso_keycloak-03-create-client.webp "Create Client")
+   ![The Client create screen](/keycloak/user-management_saml-sso_keycloak-03-create-client.webp "Create Client")
 
 9. Select **Client Type** value "OpenID Connect" and fill in the fields **Client ID** and **Name** with the value
    `palette`. Click on **Next**.
 
-![Fill out the user name](/keycloak/user-management_saml-sso_keycloak-04-palette-username.webp "Palette username")
+   ![Fill out the user name](/keycloak/user-management_saml-sso_keycloak-04-palette-username.webp "Palette username")
 
 10. Select **Client authentication** for increased security and check the **Standard Flow** box and the **Direct Access
     Grants** box. Click on **Next**.
 
-![Client Authentication creation screen number two](/keycloak/user-management_saml-sso_keycloak-05-client-authentication.webp "Client Authentication")
+    ![Client Authentication creation screen number two](/keycloak/user-management_saml-sso_keycloak-05-client-authentication.webp "Client Authentication")
 
 11. Fill out the following fields with the instructions provided in the table.
 
-| **Field**                           | **Description**                                                                                                                                                                                                                    |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Root URL**                        | Your Palette URL. For Palette SaaS, this value is prefixed with your tenant name. For example, `https://docs-test.console.spectrocloud.com`. For self-hosted Palette, or VerteX, this value is the URL of your Palette deployment. |
-| **Valid Redirect URIs**             | The callback URL you copied from the Palette SSO configuration page.                                                                                                                                                               |
-| **Valid post logout redirect URIs** | The logout URL you copied from the Palette SSO configuration page.                                                                                                                                                                 |
+    | **Field**                           | **Description**                                                                                                                                                                                                                    |
+    | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | **Root URL**                        | Your Palette URL. For Palette SaaS, this value is prefixed with your tenant name. For example, `https://docs-test.console.spectrocloud.com`. For self-hosted Palette, or VerteX, this value is the URL of your Palette deployment. |
+    | **Valid Redirect URIs**             | The callback URL you copied from the Palette SSO configuration page.                                                                                                                                                               |
+    | **Valid post logout redirect URIs** | The logout URL you copied from the Palette SSO configuration page.                                                                                                                                                                 |
 
 12. Click on **Save** to save the client configuration.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-06-keycloak-callback.webp "Keycloak callback")
+    ![alt_text](/keycloak/user-management_saml-sso_keycloak-06-keycloak-callback.webp "Keycloak callback")
 
 13. In the following screen, select the **Credentials** tab to retrieve client secret.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-07-keycloak-credentials.webp "Keycloak Credentials")
+    ![alt_text](/keycloak/user-management_saml-sso_keycloak-07-keycloak-credentials.webp "Keycloak Credentials")
 
 14. Switch back to Palette and paste client secret in the **Client Secret** field. Fill out the following fields with
     the instructions provided in the table below.
 
-| **Field**         | **Description**                                                                                                                            |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Issuer URL**    | Your Keycloak URL with `/realms/master` appended to the end. For example, `http://keycloak.dmitry.sa.spectrodemos.com:8080/realms/master`. |
-| **Client ID**     | The client ID you created in the previous steps. In this guide, the name `palette` was used.                                               |
-| **Client Secret** | The client secret you retrieved in the previous step.                                                                                      |
+    | **Field**         | **Description**                                                                                                                            |
+    | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+    | **Issuer URL**    | Your Keycloak URL with `/realms/master` appended to the end. For example, `http://keycloak.dmitry.sa.spectrodemos.com:8080/realms/master`. |
+    | **Client ID**     | The client ID you created in the previous steps. In this guide, the name `palette` was used.                                               |
+    | **Client Secret** | The client secret you retrieved in the previous step.                                                                                      |
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-08-palette-callback.webp "Palette Callback")
+    ![alt_text](/keycloak/user-management_saml-sso_keycloak-08-palette-callback.webp "Palette Callback")
 
-16. Scroll down to the bottom of the page, and click on **Enable**. If all values are correct, you will receive green
+15. Scroll down to the bottom of the page, and click on **Enable**. If all values are correct, you will receive green
     message stating "OIDC configured successfully" at the top right corner.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-09-palette-oidc-enabled.webp "Palette OIDC Enabled")
+    ![alt_text](/keycloak/user-management_saml-sso_keycloak-09-palette-oidc-enabled.webp "Palette OIDC Enabled")
 
-17. Navigate back to the Keycloak admin console. In the left **Main Menu**, select **Users**. Fill in first name, second
+16. Navigate back to the Keycloak admin console. In the left **Main Menu**, select **Users**. Fill in first name, second
     name, and the email address of the admin user.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-10-keycloak-admin.webp "Keycloak Admin")
+    ![alt_text](/keycloak/user-management_saml-sso_keycloak-10-keycloak-admin.webp "Keycloak Admin")
 
 You have now configured SSO for Palette with Keycloak. You can now log in to Palette using the admin user you created in
 Keycloak. Use the validation steps below to validate the SSO configuration. Check out the
@@ -185,9 +187,9 @@ Use the following steps to validate the SSO configuration.
 2. Sign in to Palette using the admin user you created in Keycloak. You will be redirected to the Keycloak login page.
    Enter the credentials for the admin user you created in Keycloak.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-11-palette-sso.webp "Palette SSO")
+   ![alt_text](/keycloak/user-management_saml-sso_keycloak-11-palette-sso.webp "Palette SSO")
 
-![Keycloak Admin console](/keycloak//user-management_palette-rback_keycloak_login.webp)
+   ![Keycloak Admin console](/keycloak//user-management_palette-rback_keycloak_login.webp)
 
 3. Upon successful authentication, you will be redirected to Palette. You will be logged in to Palette as the admin user
    you created in Keycloak.
@@ -197,29 +199,29 @@ Use the following steps to validate the SSO configuration.
 1. Log in to Palette as a Tenant Admin. Navigate to the left **Main Menu** and select **Users & Teams**. Click on the
    **Teams** tab to access the Teams page. Click on the **Create Team** button to create a new team.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-14-palette-groups.webp "Palette groups")
+   ![alt_text](/keycloak/user-management_saml-sso_keycloak-14-palette-groups.webp "Palette groups")
 
 2. Provide a team name, such as `admins` but leave the **Members** field empty. Click on **Confirm** to create the team.
 
 3. Next, select the **admins** row to access the team settings page. Click on **New Project Role** and add the **Project
    Admin** role to the **Default** project. Click on **Confirm** to save the changes.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-15-palette-project.webp "Palette Project")
+   ![alt_text](/keycloak/user-management_saml-sso_keycloak-15-palette-project.webp "Palette Project")
 
 4. From the left **Main Menu**, select **Tenant Settings**. Next, click on **SSO** to access the SSO configuration page.
    Click on the **OIDC** tab to access the OIDC configuration page. Scroll down to the **SSO Admins** section and select
    the **admins** team from the **Default Team** drop-down Menu. Click on **Save**.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-16-palette-sso-admins.webp "Palette SSO Admins")
+   ![alt_text](/keycloak/user-management_saml-sso_keycloak-16-palette-sso-admins.webp "Palette SSO Admins")
 
 5. Navigate back to the Keycloak admin console. From the left **Main Menu** click on **Users**. Create a user and ensure
    the field **Username**, **Email**, and **First Name** are filled out. Click on **Save** to save the user.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-17-keycloak-user.webp "Keycloak user")
+   ![alt_text](/keycloak/user-management_saml-sso_keycloak-17-keycloak-user.webp "Keycloak user")
 
 6. Next, click on the **Credentials** tab and assign the user password.
 
-![alt_text](/keycloak/user-management_saml-sso_keycloak-18-keycloak-password.webp "Keycloak password")
+   ![alt_text](/keycloak/user-management_saml-sso_keycloak-18-keycloak-password.webp "Keycloak password")
 
 Repeat the steps above for all users you want to add to the **admins** team. You can now log in to Palette with the
 users you created in Keycloak. The users will be assigned the **Project Admin** role for the **Default** project. Check

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-okta-saml.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-okta-saml.md
@@ -19,6 +19,8 @@ The following steps will guide you on how to enable Palette SSO with
 
 ## Prerequisites
 
+- For Okta SAML to work correctly with Palette, you must enable HTTPS and configure TLS.
+
 - You need to have either a free or paid subscription with Okta. Okta provides free
   [developer subscriptions](https://developer.okta.com/signup/) for testing purposes.
 
@@ -33,158 +35,112 @@ repeat this for any other team that you configured with group claims.
 1.  Open a web browser and navigate to your Palette subscription. Navigate to **Tenant Settings** --> **Users & Teams**
     --> **Teams** tab, and click **+ Create Team**.
 
-![Create Palette Team](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_create-team.webp)
+    ![Create Palette Team](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_create-team.webp)
 
-<br />
+2.  Specify `Okta Team` in the **Team name** field. You don't need to set any members now, as this will happen
+    automatically from the SSO. Click **Confirm** to create the team.
 
-2. Specify `Okta Team` in the **Team name** field. You don't need to set any members now, as this will happen
-   automatically from the SSO. Click **Confirm** to create the team.
+    ![Name Palette Team](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_name-team.webp)
 
-![Name Palette Team](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_name-team.webp)
+3.  The list of teams displays again. Select the newly created **Okta Team** team to review its details. To give this
+    team administrative access to the entire tenant and all the projects in it, assign the **Tenant Admin** role. Select
+    **Tenant Roles** and click **+ Add Tenant Role**:
 
-<br />
+    ![Palette Tenant Roles](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_tenant-roles.webp)
 
-3. The list of teams displays again. Select the newly created **Okta Team** team to review its details. To give this
-   team administrative access to the entire tenant and all the projects in it, assign the **Tenant Admin** role. Select
-   **Tenant Roles** and click **+ Add Tenant Role**:
+4.  Click on **Tenant Admin** to enable the role. Click **Confirm** to add the role.
 
-![Palette Tenant Roles](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_tenant-roles.webp)
+    ![Add Tenant Role](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-tenant-role.webp)
 
-<br />
+    You will receive a message stating **Roles have been updated**. Repeat this procedure for any other teams, taking
+    care to ensure they are given the appropriate permissions.
 
-4. Click on **Tenant Admin** to enable the role. Click **Confirm** to add the role.
-
-![Add Tenant Role](/palette-sso-with-adfs-images/how-to_palette-sso-with-adfs_add-tenant-role.webp)
-
-<br />
-
-You will receive a message stating **Roles have been updated**. Repeat this procedure for any other teams, taking care
-to ensure they are given the appropriate permissions.
-
-5. Click the **X** next to **Team Details** in the top left corner to exit this screen.
+5.  Click the **X** next to **Team Details** in the top left corner to exit this screen.
 
 ### Create the Okta Application
 
-1. Log in to your Okta Admin console and navigate to **Applications** --> **Applications**. Click the **Create App
+6. Log in to your Okta Admin console and navigate to **Applications** --> **Applications**. Click the **Create App
    Integration** button.
 
-<br />
+   :::info
 
-:::info
+   Your Okta login URL has the following format, `https://{your-okta-account-id}-admin.okta.com/admin/getting-started`.
+   Replace `{your-okta-account-id}` with your Okta account ID.
 
-Your Okta login URL has the following format, `https://{your-okta-account-id}-admin.okta.com/admin/getting-started`.
-Replace `{your-okta-account-id}` with your Okta account ID.
+   :::
 
-:::
+7. In the screen that opens, select **SAML 2.0** for the sign-in method. Then click **Next**.
 
-<br />
+   ![Create Okta Application](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_create-application.webp)
 
-2. In the screen that opens, select **SAML 2.0** for the sign-in method. Then click **Next**.
-
-<br />
-
-![Create Okta Application](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_create-application.webp)
-
-<br />
-
-1. The following screen allows you to configure the new App Integration. On the **App name** field, change the name from
+8. The following screen allows you to configure the new App Integration. On the **App name** field, change the name from
    `My Web App` to `Spectro Cloud Palette SAML`. If desired, you can also upload a logo for the application.
 
-<br />
+   ![Configure Okta General Settings](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_general-settings.webp)
 
-![Configure Okta General Settings](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_general-settings.webp)
-
-<br />
-
-4. Open a web browser and navigate to your Palette subscription. Navigate to **Tenant Settings** --> **SSO** and click
+9. Open a web browser and navigate to your Palette subscription. Navigate to **Tenant Settings** --> **SSO** and click
    **SAML**. Click the button next to **Login URL** to copy the value to the clipboard.
 
-5. Set the value of **Service** to **Okta**.
+10. Set the value of **Service** to **Okta**.
 
-<br />
+    ![Configure General SSO Settings](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_palette-manage-sso-okta-saml.webp)
 
-![Configure General SSO Settings](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_palette-manage-sso-okta-saml.webp)
+11. Switch back to your Okta Admin console and paste the copied value to the **Single sign-on URL** and **Audience URI
+    (SP Entity ID)**.
 
-<br />
+12. Specify values within **Attribute Statements** and **Group Attribute Statements** to link user values from Okta to
+    SpectroCloud.
 
-6. Switch back to your Okta Admin console and paste the copied value to the **Single sign-on URL** and **Audience URI
-   (SP Entity ID)**.
+    Under **Attribute Statements (Optional)** specify the below values.
 
-7. Specify values within **Attribute Statements** and **Group Attribute Statements** to link user values from Okta to
-   SpectroCloud.
+    | Name        | Name Format   | Value            |
+    | ----------- | ------------- | ---------------- |
+    | `FirstName` | `Unspecified` | `user.firstName` |
+    | `LastName`  | `Unspecified` | `user.lastName`  |
+    | `Email`     | `Unspecified` | `user.email`     |
 
-Under **Attribute Statements (Optional)** specify the below values.
+    Under **Group Attribute Statements (Optional)** specify the below values.
 
-| Name        | Name Format   | Value            |
-| ----------- | ------------- | ---------------- |
-| `FirstName` | `Unspecified` | `user.firstName` |
-| `LastName`  | `Unspecified` | `user.lastName`  |
-| `Email`     | `Unspecified` | `user.email`     |
+    | Name          | Name Format   | Filter          | Value |
+    | ------------- | ------------- | --------------- | ----- |
+    | `SpectroTeam` | `Unspecified` | `Matches Regex` | Blank |
 
-Under **Group Attribute Statements (Optional)** specify the below values.
+    ![Configure Attribute Statements](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_attribute-statements.webp)
 
-| Name          | Name Format   | Filter          | Value |
-| ------------- | ------------- | --------------- | ----- |
-| `SpectroTeam` | `Unspecified` | `Matches Regex` | Blank |
+13. Finish the creation of the application with default values.
 
-<br />
+14. Once brought to main application page, copy the **Metadata URL**, open it up in a separate page, then copy of the
+    contents of the XML.
 
-![Configure Attribute Statements](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_attribute-statements.webp)
+    ![Copy Okta SAML Metadata](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_metadata-url.webp)
 
-<br />
-
-8. Finish the creation of the application with default values.
-
-9. Once brought to main application page, copy the **Metadata URL**, open it up in a separate page, then copy of the
-   contents of the XML.
-
-<br />
-
-![Copy Okta SAML Metadata](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_metadata-url.webp)
-
-<br />
-
-10. Go back to Palette SSO settings then paste the contents of the Okta SAML Metadata into **Identity Provider
+15. Go back to Palette SSO settings then paste the contents of the Okta SAML Metadata into **Identity Provider
     Metadata**.
 
-<br />
+    ![Paste Metadata in Palette SSO Manager](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_palette-manage-sso-okta-saml.webp)
 
-![Paste Metadata in Palette SSO Manager](/saml-okta-images/user-management_saml-sso_palette-sso-with-okta-saml_palette-manage-sso-okta-saml.webp)
-
-<br />
-
-11. Under **Default Teams**, search for then click the Palette team we created called **Okta Team**. This connects all
+16. Under **Default Teams**, search for then click the Palette team we created called **Okta Team**. This connects all
     Okta users with the team and the team permissions we set earlier.
 
-12. When all the information has been entered, click Enable to activate SSO. You will receive a message stating SAML
+17. When all the information has been entered, click Enable to activate SSO. You will receive a message stating SAML
     configured successfully.
 
-### Validate
+## Validate
 
 1. Log in to Palette through SSO as an Okta user who is a member of the Okta application to verify SSO. If you are still
    logged into Palette with a non-SSO user, log out by selecting **Logout** in the **User Menu** at the top right.
 
-<br />
-
-![User Logout](/oidc-okta-images/oidc-okta_user-logout.webp)
-
-<br />
+   ![User Logout](/oidc-okta-images/oidc-okta_user-logout.webp)
 
 2. The Palette login screen now displays a **Sign in** button and no longer presents a username and password field.
    Below the **Sign In** button, there is an **SSO issues? --> Use your password** link. This link can be used to bypass
    SSO and log in with a local Palette account in case there is an issue with SSO and you need to access Palette without
    SSO. Click on the **Sign in** button to log in via SSO.
 
-<br />
-
-![User SSO Login](/oidc-okta-images/oidc-okta_palette-login.webp)
-
-<br />
+   ![User SSO Login](/oidc-okta-images/oidc-okta_palette-login.webp)
 
 3. If this is the first time you are logging in with SSO, you will be redirected to the Okta login page. Depending on
    your organization's SSO settings, this could be a simple login form or require MFA (Multi-Factor Authentication).
-
-<br />
 
 4. You are now automatically added to the `Okta Team` team in Palette. To verify, navigate to the left **Main Menu**,
    select **Tenant Settings** --> **Users & Teams** --> **Teams** tab. Click on the **Okta Team** team and view the team

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-okta.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-okta.md
@@ -19,6 +19,8 @@ The following steps will guide you on how to enable Palette SSO with
 
 ## Prerequisites
 
+- For Okta OIDC to work correctly with Palette, you must enable HTTPS and configure TLS.
+
 - You need to have either a free or paid subscription with Okta. Okta provides free
   [developer subscriptions](https://developer.okta.com/signup/) for testing purposes.
 
@@ -33,14 +35,12 @@ The following steps will guide you on how to enable Palette SSO with
 1. Log in to your Okta Admin console and navigate to **Applications** --> **Applications**. Click the **Create App
    Integration** button.
 
-<br />
+   :::info
 
-:::info
+   Your Okta login URL has the following format, `https://{your-okta-account-id}-admin.okta.com/admin/getting-started`.
+   Replace `{your-okta-account-id}` with your Okta account ID.
 
-Your Okta login URL has the following format, `https://{your-okta-account-id}-admin.okta.com/admin/getting-started`.
-Replace `{your-okta-account-id}` with your Okta account ID.
-
-:::
+   :::
 
 2. In the screen that opens, select **OIDC - OpenID Connect**` for the sign-in method, then select **Web Application**
    for the application type. Then click **Next**.
@@ -49,90 +49,54 @@ Replace `{your-okta-account-id}` with your Okta account ID.
    change the name from `My Web App` to `Spectro Cloud Palette OIDC`. If desired, you can also upload a logo for the
    application. Leave the **Grant type** to its default value - **Authorization Code**.
 
-<br />
-
-![Configure General Settings](/oidc-okta-images/oidc-okta_okta-general-settings.webp)
-
-<br />
+   ![Configure General Settings](/oidc-okta-images/oidc-okta_okta-general-settings.webp)
 
 4. Open a web browser and navigate to your Palette subscription. Navigate to **Tenant Settings** --> **SSO** and click
    **OIDC**. Click the button next to **Callback URL** to copy the value to the clipboard.
 
-<br />
-
-![Copy Callback URL](/oidc-okta-images/oidc-okta_copy-callback-url.webp)
-
-<br />
+   ![Copy Callback URL](/oidc-okta-images/oidc-okta_copy-callback-url.webp)
 
 5. Switch back to your Okta Admin console and paste the copied value into the **Sign-in redirect URIs** field, replacing
    the existing value:
 
-<br />
-
-![Paste Redirect URI](/oidc-okta-images/oidc-okta_paste-redirect-uri.webp)
-
-<br />
+   ![Paste Redirect URI](/oidc-okta-images/oidc-okta_paste-redirect-uri.webp)
 
 6. Switch back to Palette in the web browser and click the button next to **Logout URL** to copy the value to the
    clipboard.
 
-<br />
-
-![Copy Logout URL](/oidc-okta-images/oidc-okta_copy-logout-url.webp)
-
-<br />
+   ![Copy Logout URL](/oidc-okta-images/oidc-okta_copy-logout-url.webp)
 
 7. Switch back to your Okta Admin console and paste the copied value into the **Redirect URI** field, then click **Add**
    to add it to the list:
 
-<br />
-
-![Paste Logout URI](/oidc-okta-images/oidc-okta_paste-logout-uri.webp)
-
-<br />
+   ![Paste Logout URI](/oidc-okta-images/oidc-okta_paste-logout-uri.webp)
 
 8. These two redirect URIs are required for SSO to work with Palette. You can also add additional redirect URIs. The
    URIs in the table below are useful when you want to use Okta for OIDC authentication into your Kubernetes clusters.
 
-<br />
-
-| URL                                                        | Type of Access                                               |
-| ---------------------------------------------------------- | ------------------------------------------------------------ |
-| `http://localhost:8000`                                    | Using kubectl with the kube-login plugin from a workstation. |
-| `https://console.spectrocloud.com/v1/shelly/oidc/callback` | Using the web-based kubectl console.                         |
-| `https://<fqdn_of_k8s_dashboard>/oauth/callback`           | Using OIDC authentication into Kubernetes Dashboard.         |
-
-<br />
+   | URL                                                        | Type of Access                                               |
+   | ---------------------------------------------------------- | ------------------------------------------------------------ |
+   | `http://localhost:8000`                                    | Using kubectl with the kube-login plugin from a workstation. |
+   | `https://console.spectrocloud.com/v1/shelly/oidc/callback` | Using the web-based kubectl console.                         |
+   | `https://<fqdn_of_k8s_dashboard>/oauth/callback`           | Using OIDC authentication into Kubernetes Dashboard.         |
 
 9. When you have completed entering redirect URIs, scroll down to the **Assignments** section and section and select
    **Allow everyone in your organization to access**. Leave the **Enable immediate access with Federation Broker Mode**
    option enabled and click **Save**.
 
-<br />
-
-![Configure Assignments](/oidc-okta-images/oidc-okta_assignments.webp)
-
-<br />
+   ![Configure Assignments](/oidc-okta-images/oidc-okta_assignments.webp)
 
 10. You have now created the Okta Application! Next, you need to retrieve the Client ID and Client Secret information,
     which you will use in the following steps. You should have landed on the **General** tab of your Okta Application.
     Click the **Copy to clipboard** button next to the **Client ID** to copy the secret value and save it somewhere. You
     will need this value for later.
 
-<br />
-
-![Copy Client ID](/oidc-okta-images/oidc-okta_copy-client-id.webp)
-
-<br />
+    ![Copy Client ID](/oidc-okta-images/oidc-okta_copy-client-id.webp)
 
 11. Click the **Copy to clipboard** button next to the **Client Secret** to copy the secret value and save it. You will
     need this value for a later step.
 
-<br />
-
-![Copy Shared Secret](/oidc-okta-images/oidc-okta_copy-shared-secret.webp)
-
-<br />
+    ![Copy Shared Secret](/oidc-okta-images/oidc-okta_copy-shared-secret.webp)
 
 ### Create an Okta Authorization Server
 
@@ -140,137 +104,89 @@ To ensure Okta issues OIDC tokens with the correct claims, you must create a cus
 Authorization Server is required to customize the authorization tokens issued by Okta so that they contain the necessary
 OIDC claims required by Palette and Kubernetes.
 
-<br />
-
 12. Navigate to **Security** --> **API** and on the **Authorization Servers** tab and click **Add Authorization
     Server**.
 
-<br />
-
-![Add Authorization Server](/oidc-okta-images/oidc-okta_add-authz-server.webp)
-
-<br />
+    ![Add Authorization Server](/oidc-okta-images/oidc-okta_add-authz-server.webp)
 
 13. Enter a name for the server, for example `Palette OIDC`. For the **Audience** field, enter the client identifier
     that you saved in step **10**. Optionally provide a description. Then click **Save**.
 
-<br />
-
-![Name Authorization Server](/oidc-okta-images/oidc-okta_name-authz-server.webp)
-
-<br />
+    ![Name Authorization Server](/oidc-okta-images/oidc-okta_name-authz-server.webp)
 
 14. Navigate to the **Claims** tab and click **Add Claim**.
 
-<br />
-
-![Add Claims](/oidc-okta-images/oidc-okta_add-claims.webp)
+    ![Add Claims](/oidc-okta-images/oidc-okta_add-claims.webp)
 
 15. Enter the required information from the following tables below and click **Create**. Use this flow to create three
     claims in total. First, create two claims for the user information.
 
-<br />
-
-| Claim Name   | Include in token type | Value Type | Value            | Disable claim | Include In |
-| ------------ | --------------------- | ---------- | ---------------- | ------------- | ---------- |
-| u_first_name | ID Token (Always)     | Expression | `user.firstName` | Unchecked     | Any scope  |
-| u_last_name  | ID Token (Always)     | Expression | `user.lastName`  | Unchecked     | Any scope  |
+    | Claim Name   | Include in token type | Value Type | Value            | Disable claim | Include In |
+    | ------------ | --------------------- | ---------- | ---------------- | ------------- | ---------- |
+    | u_first_name | ID Token (Always)     | Expression | `user.firstName` | Unchecked     | Any scope  |
+    | u_last_name  | ID Token (Always)     | Expression | `user.lastName`  | Unchecked     | Any scope  |
 
 16. Next, create a claim for group membership. The example below will include the names of any groups that the Okta user
     is a member of, that start with `palette-`, in the `groups` claim of the ticket. For Palette SSO, Palette will make
     the user a member of Teams in Palette that have the identical name.
 
-<br />
+    | Claim Name | Include in token type | Value Type | Filter                  | Disable claim | Include In |
+    | ---------- | --------------------- | ---------- | ----------------------- | ------------- | ---------- |
+    | groups     | ID Token (Always)     | Groups     | Starts with: `palette-` | Unchecked     | Any scope  |
 
-| Claim Name | Include in token type | Value Type | Filter                  | Disable claim | Include In |
-| ---------- | --------------------- | ---------- | ----------------------- | ------------- | ---------- |
-| groups     | ID Token (Always)     | Groups     | Starts with: `palette-` | Unchecked     | Any scope  |
-
-<br />
-
-![Claims Result](/oidc-okta-images/oidc-okta_claims-result.webp)
-
-<br />
+    ![Claims Result](/oidc-okta-images/oidc-okta_claims-result.webp)
 
 17. Click **\<-- Back to Authorization Servers** at the top of the page to navigate back to the list of all servers. The
     authorization server you created is displayed in the list. Select the **Issuer URI** shown and copy it to the
     clipboard. Save this value as you will use it in a later step.
 
-<br />
-
-![Get Issuer URI](/oidc-okta-images/oidc-okta_get-issuer-uri.webp)
-
-<br />
+    ![Get Issuer URI](/oidc-okta-images/oidc-okta_get-issuer-uri.webp)
 
 18. Navigate to the **Access Policies** tab and click **Add Policy**.
 
-<br />
-
-![Add Access Policy](/oidc-okta-images/oidc-okta_add-access-policy.webp)
-
-<br />
+    ![Add Access Policy](/oidc-okta-images/oidc-okta_add-access-policy.webp)
 
 19. Set the **Name** and **Description** fields to `Palette`, then change the **Assign to** option to the Okta
     Application you created in step three -`Spectro Cloud Palette OIDC`. Type in the first few characters of the
     application name and wait for a search result to come up that you can click on.
 
-<br />
-
-![Name Access Policy](/oidc-okta-images/oidc-okta_name-access-policy.webp)
-
-<br />
+    ![Name Access Policy](/oidc-okta-images/oidc-okta_name-access-policy.webp)
 
 20. Click the **Add rule** button to add a rule to this Access Policy:
 
-<br />
-
-![Add Policy Rule](/oidc-okta-images/oidc-okta_add-policy-rule.webp)
-
-<br />
+    ![Add Policy Rule](/oidc-okta-images/oidc-okta_add-policy-rule.webp)
 
 21. Set the **Rule Name** to `AuthCode`. Then deselect all Grant types but one, only leaving **Authorization Code**
     selected. Then click **Create Rule**.
 
-<br />
-
-![Configure Policy Rule](/oidc-okta-images/oidc-okta_configure-policy-rule.webp)
-
-<br />
+    ![Configure Policy Rule](/oidc-okta-images/oidc-okta_configure-policy-rule.webp)
 
 You have now completed all configuration steps in Okta.
-
-<br />
 
 ### Enable OIDC SSO in Palette
 
 22. Open a web browser and navigate to your [Palette](https://console.spectrocloud.com) subscription.
 
-Navigate to **Tenant Settings** --> **SSO** and click on **OIDC**. Enter the following information.
+    Navigate to **Tenant Settings** --> **SSO** and click on **OIDC**. Enter the following information.
 
-| Parameter     | Value                                                                                                                                                                                                                         |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Issuer URL    | The Issuer URI that you saved in step **15**.                                                                                                                                                                                 |
-| Client ID     | The client identifier that you saved in step **10**.                                                                                                                                                                          |
-| Client Secret | The shared secret that you generated in step **11**.                                                                                                                                                                          |
-| Default Teams | Leave blank if you don't want users without group claims to be assigned to a default group. If you do, enter the desired default group name. If you use this option, be careful with how much access you assign to the group. |
-| Scopes        | Keep `openid`, `profile` and `email` as the default.                                                                                                                                                                          |
-| Email         | Keep `email` as the default.                                                                                                                                                                                                  |
-| First Name    | Set this to `u_first_name`.                                                                                                                                                                                                   |
-| Last Name     | Set this to `u_last_name`.                                                                                                                                                                                                    |
-| Spectro Team  | Keep `groups` as the default.                                                                                                                                                                                                 |
+    | Parameter     | Value                                                                                                                                                                                                                         |
+    | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | Issuer URL    | The Issuer URI that you saved in step **15**.                                                                                                                                                                                 |
+    | Client ID     | The client identifier that you saved in step **10**.                                                                                                                                                                          |
+    | Client Secret | The shared secret that you generated in step **11**.                                                                                                                                                                          |
+    | Default Teams | Leave blank if you don't want users without group claims to be assigned to a default group. If you do, enter the desired default group name. If you use this option, be careful with how much access you assign to the group. |
+    | Scopes        | Keep `openid`, `profile` and `email` as the default.                                                                                                                                                                          |
+    | Email         | Keep `email` as the default.                                                                                                                                                                                                  |
+    | First Name    | Set this to `u_first_name`.                                                                                                                                                                                                   |
+    | Last Name     | Set this to `u_last_name`.                                                                                                                                                                                                    |
+    | Spectro Team  | Keep `groups` as the default.                                                                                                                                                                                                 |
 
-<br />
-
-![Enable Palette OIDC SSO](/oidc-okta-images/oidc-okta_configure-palette-oidc.webp)
-
-<br />
+    ![Enable Palette OIDC SSO](/oidc-okta-images/oidc-okta_configure-palette-oidc.webp)
 
 23. When all the information has been entered, click **Enable** to activate SSO. You will receive a message stating
     **OIDC configured successfully**.
 
-###
-
-Create Teams in Palette
+### Create Teams in Palette
 
 The remaining step is to create teams in Palette for the group that you allowed to be passed in the OIDC ticket in Okta,
 and give them the appropriate permissions. For this example, you will create the `palette-tenant-admins` team and give
@@ -279,82 +195,54 @@ it **Tenant Admin** permissions. You can repeat this for any other team that you
 24. Open a web browser and navigate to your Palette subscription. Navigate to **Tenant Settings** --> **Users & Teams**
     --> **Teams** tab, and click **+ Create Team**.
 
-<br />
-
-![Create Palette Team](/oidc-okta-images/oidc-okta_create-team.webp)
-
-<br />
+    ![Create Palette Team](/oidc-okta-images/oidc-okta_create-team.webp)
 
 25. Specify `palette-tenant-admins` in the **Team name** field. You don't need to set any members now, as this will
     happen automatically from the SSO. Click **Confirm** to create the team.
 
-<br />
-
-![Name Palette Team](/oidc-okta-images/oidc-okta_name-team.webp)
-
-<br />
+    ![Name Palette Team](/oidc-okta-images/oidc-okta_name-team.webp)
 
 26. The list of teams displays again. Select the newly created **palette-tenant-admins** team to review its details. To
     give this team administrative access to the entire tenant and all the projects in it, assign the **Tenant Admin**
     role. Select **Tenant Roles** and click **+ Add Tenant Role**:
 
-<br />
-
-![Palette Tenant Roles](/oidc-okta-images/oidc-okta_tenant-roles.webp)
-
-<br />
+    ![Palette Tenant Roles](/oidc-okta-images/oidc-okta_tenant-roles.webp)
 
 27. Click on **Tenant Admin** to enable the role. Click **Confirm** to add the role.
 
-<br />
+    ![Add Tenant Role](/oidc-okta-images/oidc-okta_add-tenant-role.webp)
 
-![Add Tenant Role](/oidc-okta-images/oidc-okta_add-tenant-role.webp)
-
-<br />
-
-You will receive a message stating **Roles have been updated**. Repeat this procedure for any other teams while ensuring
-they are given the appropriate access permissions.
+    You will receive a message stating **Roles have been updated**. Repeat this procedure for any other teams while
+    ensuring they are given the appropriate access permissions.
 
 28. Click the **X** next to **Team Details** in the top left corner to exit this screen.
 
 You have now successfully configured Palette SSO based on OIDC with Okta.
 
-### Validate
+## Validate
 
 1. Log in to Palette through SSO as a user that is a member of the `palette-tenant-admins` group in Okta to verify that
    users are automatically added to the `palette-tenant-admins` group in Palette. If you're still logged into Palette
    with a non-SSO user, log out by selecting **Logout** in the **User Drop-down Menu** at the top right.
 
-<br />
-
-![User Logout](/oidc-okta-images/oidc-okta_user-logout.webp)
-
-<br />
+   ![User Logout](/oidc-okta-images/oidc-okta_user-logout.webp)
 
 2. The Palette login screen now displays a **Sign in** button and no longer presents a username and password field.
    Below the **Sign In** button, there is an **SSO issues? --> Use your password** link. This link can be used to bypass
    SSO and log in with a local Palette account in case there is an issue with SSO and you need to access Palette without
    SSO. Click on the **Sign in** button to log in via SSO.
 
-<br />
-
-![User SSO Login](/oidc-okta-images/oidc-okta_palette-login.webp)
-
-<br />
+   ![User SSO Login](/oidc-okta-images/oidc-okta_palette-login.webp)
 
 3. If this is the first time you are logging in with SSO, you will be redirected to the Okta login page. Depending on
    your organization's SSO settings, this could be a simple login form or require MFA (Multi-Factor Authentication).
 
-<br />
+   :::info
 
-:::info
+   Make sure you log in as a user that is a member of the `palette-tenant-admins` group in Okta. Once authenticated, you
+   will automatically be redirected back to Palette and logged into Palette as that user.
 
-Make sure you log in as a user that is a member of the `palette-tenant-admins` group in Okta. Once authenticated, you
-will automatically be redirected back to Palette and logged into Palette as that user.
-
-:::
-
-<br />
+   :::
 
 4. You are now automatically added to the `palette-tenant-admins` team in Palette. To verify, navigate to the left
    **Main Menu**, select **Tenant Settings** --> **Users & Teams** --> **Teams** tab. Click the

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-onelogin.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-onelogin.md
@@ -21,13 +21,15 @@ for OIDC-based SSO in your Kubernetes cluster.
 
 ## Prerequisites
 
+- For OneLogin to work correctly with Palette, you must enable HTTPS and configure TLS.
+
 - An active OneLogin subscription and administrator-level permissions. If you are using this for testing purposes,
   OneLogin provides a [developer subscription](https://developers.onelogin.com/).
 
 - For OIDC-based SSO in your Kubernetes cluster, you will need to install
   [kubelogin](https://github.com/int128/kubelogin) on your local workstation to retrieve access tokens for your cluster.
 
-## Setup
+## Enable SSO with OneLogin
 
 Use the following steps to configure OneLogin as a third-party IdP in Palette.
 
@@ -40,7 +42,7 @@ Use the following steps to configure OneLogin as a third-party IdP in Palette.
 
 3. In the search bar, type "OpenID Connect" to find the generic OIDC app connector.
 
-![Search for OpenID Connect](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_search-oidc.webp)
+   ![Search for OpenID Connect](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_search-oidc.webp)
 
 4. Select the **OpenID Connect** app connector to add it to your account.
 
@@ -48,45 +50,45 @@ Use the following steps to configure OneLogin as a third-party IdP in Palette.
    display name **Spectro Cloud Palette OIDC** and click **Save**. OpenLog displays the configuration screen for your
    new application.
 
-![Enter Display Name](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_oidc-app-name.webp)
+   ![Enter Display Name](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_oidc-app-name.webp)
 
 6. Select the **Configuration** tab and fill out the following input values.
 
-| **Field**                 | **Description**                                                                                                   |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| Login URL                 | The URL where users are sent to log in.                                                                           |
-| Redirect URIs             | The Uniform Resource Identifiers (URIs) to which OneLogin will redirect the user after successful authentication. |
-| Post Logout Redirect URIs | The URIs where you will be redirected after successfully logging out of the current session.                      |
+   | **Field**                 | **Description**                                                                                                   |
+   | ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+   | Login URL                 | The URL where users are sent to log in.                                                                           |
+   | Redirect URIs             | The Uniform Resource Identifiers (URIs) to which OneLogin will redirect the user after successful authentication. |
+   | Post Logout Redirect URIs | The URIs where you will be redirected after successfully logging out of the current session.                      |
 
 7. The URLs needed to configure OneLogin can be found in your Palette account. From the left **Main Menu** click on
    **Tenant Admin**. Next, select **Tenant Settings** to access the settings page. From the settings page, select
    **SSO** and click on the **OIDC** tab. Copy the **Callback URL** value to your clipboard.
 
-![Copy Callback URL](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_callbackurl.webp)
+   ![Copy Callback URL](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_callbackurl.webp)
 
 8. Paste the Palette **Callback URL** value in the **Login Url** and **Redirect URI's** sections.
 
-![Add Login URL and Redirect URL](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_login-redirect-uris.webp)
+   ![Add Login URL and Redirect URL](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_login-redirect-uris.webp)
 
 9. Next, do the same for the **Logout Redirect URIs** and copy the **Logout URL** value located below the **Callback
    URL** from Palette.
 
-![Add Logout URL](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_logout-uri.webp)
+   ![Add Logout URL](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_logout-uri.webp)
 
 10. Your configuration should look similar to the following screenshot.
 
-![URI config](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_uri-config.webp)
+    ![URI config](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_uri-config.webp)
 
 11. Select the **Parameters** tab and click on the **Groups** field. Ensure the bottom configuration contains the
     **MemberOf** value so that the correct group value is passed.
 
-![Check MemberOf field](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_group-field.webp)
+    ![Check MemberOf field](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_group-field.webp)
 
 12. Navigate to the left **Main Menu** and select **SSO**. From the SSO settings page, copy the **Client ID**, **Client
     Secret**, and **Issuer URL** values. These values are important credentials that Palette will use to authenticate
     with OneLogin. Make sure to save them securely. Click **Save** to save all changes.
 
-![ClientID & Client Secret](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_clientid-clientsecret.webp)
+    ![ClientID & Client Secret](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_clientid-clientsecret.webp)
 
 ### Create Role, Security Policy, and Group
 
@@ -94,7 +96,7 @@ Use the following steps to configure OneLogin as a third-party IdP in Palette.
     **New Role**. Create an **Admin** role and select your **Role App**. The **Spectro Cloud Palette OIDC** app is used
     in this example. When selecting the app, a green check will appear next to the name. Click **Save**.
 
-![Add Role](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_app-role.webp)
+    ![Add Role](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_app-role.webp)
 
 14. You can create an optional security policy. To create a security policy, navigate to **Security** and select
     **Policies**.
@@ -109,7 +111,7 @@ Use the following steps to configure OneLogin as a third-party IdP in Palette.
 
 18. Select your security policy and click **Save**.
 
-![Add Security Policy](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_group-sec-policy.webp)
+    ![Add Security Policy](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_group-sec-policy.webp)
 
 19. Automate the mapping of a user to a role and group by creating a _Mapping_. Navigate to **Users**, followed by
     **Mappings** and select **New Mapping**.
@@ -125,13 +127,13 @@ receive the group name. As a result, Palette will not be able to set the correct
 
 :::
 
-![Add Mapping](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_mapping-role-group.webp)
+    ![Add Mapping](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_mapping-role-group.webp)
 
 21. Navigate to the **Users** screen and select your user.
 
 22. Select the **Authentication** tab and select the group and security policy you created earlier. Click on **Save**.
 
-![Add User to Group](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_user-auth-group.webp)
+    ![Add User to Group](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_user-auth-group.webp)
 
 ### Enable OIDC in Palette
 
@@ -148,41 +150,41 @@ Ensure the expected scopes are added. Otherwise, Palette may be unable to retrie
 
 :::
 
-![Full OIDC config](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_oidc-full-palette.webp)
+    ![Full OIDC config](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_oidc-full-palette.webp)
 
 You now have a working configuration for OneLogin as a third-party IdP in Palette. Check out the
 [Create Teams in Palette](#create-teams-in-palette) section to learn how to create teams in Palette and map them to
 groups in OneLogin.
 
-## Validate
+### Validate
 
 Use the following steps to validate the configuration.
 
 1. Log out of Palette by navigating to the top right **User Menu** and selecting **Log Out**. You will be redirected to
    a new login screen.
 
-![Logout](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_logout.webp)
+   ![Logout](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_logout.webp)
 
 2. In the login screen that displays, click the **Sign In** button. You will be required to authenticate with OneLogin.
    If you are already authenticated with OneLogin, you will be signed in automatically to Palette with the proper
    permissions inherited from the Palette team you are a member of. If you cannot sign in, you can use the username and
    password method.
 
-![SSO Login Screen](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_login-screen.webp)
+   ![SSO Login Screen](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_login-screen.webp)
 
 3. To check which teams you are mapped to, navigate to the left **Main Menu** and select **Users & Teams**. In the
    **Users** tab, find your user name to review the teams you are a member of.
 
-![Check Team Member](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_team-member.webp)
+   ![Check Team Member](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_team-member.webp)
 
-:::tip
+   :::tip
 
-With the [OpenID Connect Inspector](https://developers.onelogin.com/openid-connect/inspector), you can send requests to
-OneLogin and check what is sent in the payload. This way, you can ensure you are using the correct claims and scopes.
-Add the Inspector's callback URL to your application's Redirect URIs list when using the Inspector. Check out the -
-[OpenID Connect Inspector Tutorial](https://youtu.be/do0agd71hE8) to learn more.
+   With the [OpenID Connect Inspector](https://developers.onelogin.com/openid-connect/inspector), you can send requests
+   to OneLogin and check what is sent in the payload. This way, you can ensure you are using the correct claims and
+   scopes. Add the Inspector's callback URL to your application's Redirect URIs list when using the Inspector. Check out
+   the - [OpenID Connect Inspector Tutorial](https://youtu.be/do0agd71hE8) to learn more.
 
-:::
+   :::
 
 ## Create Teams in Palette
 
@@ -209,7 +211,7 @@ OneLogin.
    users who are part of the mapped administrators group will be automatically added to the team. Click **Confirm** to
    continue.
 
-![Create New Team](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_new-team.webp)
+   ![Create New Team](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_new-team.webp)
 
 5. Next, you need to assign the members of this team a set of permissions. Assign all members the **Tenant Admin**
    permissions. You can customize the assigned permissions as needed. For this example admin access is granted.
@@ -221,7 +223,7 @@ OneLogin.
 
 8. You should have a configuration similar to the following image.
 
-![Permissions](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_roles-full.webp)
+   ![Permissions](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_roles-full.webp)
 
 You have now configured Palette to use OneLogin as a third-party IDP. Use the above steps to create additional groups in
 OneLogin and Palette.

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-onelogin.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-onelogin.md
@@ -119,13 +119,13 @@ Use the following steps to configure OneLogin as a third-party IdP in Palette.
 20. Assign the mapping a name and set it to map every member of the Administrators group. Set the **MemberOf** value to
     **Administrators**.
 
-:::warning
+    :::warning
 
-Setting the **MemberOf** value to **Administrators** is essential so the response from OneLogin contains the group name,
-which you will match with a Team in Palette. If you do not explicitly set the **MemberOf** value, Palette will not
-receive the group name. As a result, Palette will not be able to set the correct RBAC settings for your user.
+    Setting the **MemberOf** value to **Administrators** is essential so the response from OneLogin contains the group
+    name, which you will match with a Team in Palette. If you do not explicitly set the **MemberOf** value, Palette will
+    not receive the group name. As a result, Palette will not be able to set the correct RBAC settings for your user.
 
-:::
+    :::
 
     ![Add Mapping](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_mapping-role-group.webp)
 
@@ -144,11 +144,11 @@ receive the group name. As a result, Palette will not be able to set the correct
 
 25. Next, add the **groups** scope in the **Scopes** field, and click **Enable** to continue.
 
-:::warning
+    :::warning
 
-Ensure the expected scopes are added. Otherwise, Palette may be unable to retrieve the group name.
+    Ensure the expected scopes are added. Otherwise, Palette may be unable to retrieve the group name.
 
-:::
+    :::
 
     ![Full OIDC config](/oidc-onelogin-images/user-management_saml-sso_palette_sso_with_onelogin_oidc-full-palette.webp)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-2`:
 - [Fix markup and alignment in User Management (SSO) and add HTTPS and TLS requirements (#3345)](https://github.com/spectrocloud/librarium/pull/3345)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)