### PR TITLE
[version-4-1] Document the step for removing kind images after EC and PCG installation (#3337)

### DIFF
--- a/docs/docs-content/clusters/pcg/deploy-pcg/maas.md
+++ b/docs/docs-content/clusters/pcg/deploy-pcg/maas.md
@@ -221,6 +221,39 @@ is not required for the DNS records to be accessible from the internet.
 
     :::
 
+9.  To avoid potential vulnerabilities, once the installation is complete, remove the `kind` images that were installed
+    in the environment where you initiated the installation.
+
+    Issue the following command to list all instances of `kind` that exist in the environment.
+
+    ```shell
+    docker images
+    ```
+
+    ```shell
+    REPOSITORY     TAG        IMAGE ID       CREATED        SIZE
+    kindest/node   v1.26.13   131ad18222cc   5 months ago   910MB
+    ```
+
+    Then, use the following command template to remove all instances of `kind`.
+
+    ```shell
+    docker image rm kindest/node:<version>
+    ```
+
+    Consider the following example for reference.
+
+    ```shell
+    docker image rm kindest/node:v1.26.13
+    ```
+
+    ```shell
+    Untagged: kindest/node:v1.26.13
+    Untagged: kindest/node@sha256:15ae92d507b7d4aec6e8920d358fc63d3b980493db191d7327541fbaaed1f789
+    Deleted: sha256:131ad18222ccb05561b73e86bb09ac3cd6475bb6c36a7f14501067cba2eec785
+    Deleted: sha256:85a1a4dfc468cfeca99e359b74231e47aedb007a206d0e2cae2f8290e7290cfd
+    ```
+
 ## Validate
 
 Once installed, the PCG registers itself with Palette. To verify the PCG is registered, use the following steps.

--- a/docs/docs-content/clusters/pcg/deploy-pcg/openstack.md
+++ b/docs/docs-content/clusters/pcg/deploy-pcg/openstack.md
@@ -454,6 +454,39 @@ The following permissions are required to deploy a PCG to OpenStack and for Pale
 
     :::
 
+9.  To avoid potential vulnerabilities, once the installation is complete, remove the `kind` images that were installed
+    in the environment where you initiated the installation.
+
+    Issue the following command to list all instances of `kind` that exist in the environment.
+
+    ```shell
+    docker images
+    ```
+
+    ```shell
+    REPOSITORY     TAG        IMAGE ID       CREATED        SIZE
+    kindest/node   v1.26.13   131ad18222cc   5 months ago   910MB
+    ```
+
+    Then, use the following command template to remove all instances of `kind`.
+
+    ```shell
+    docker image rm kindest/node:<version>
+    ```
+
+    Consider the following example for reference.
+
+    ```shell
+    docker image rm kindest/node:v1.26.13
+    ```
+
+    ```shell
+    Untagged: kindest/node:v1.26.13
+    Untagged: kindest/node@sha256:15ae92d507b7d4aec6e8920d358fc63d3b980493db191d7327541fbaaed1f789
+    Deleted: sha256:131ad18222ccb05561b73e86bb09ac3cd6475bb6c36a7f14501067cba2eec785
+    Deleted: sha256:85a1a4dfc468cfeca99e359b74231e47aedb007a206d0e2cae2f8290e7290cfd
+    ```
+
 ## Validate
 
 Once installed, the PCG registers itself with Palette. To verify the PCG is registered, use the following steps.

--- a/docs/docs-content/clusters/pcg/deploy-pcg/vmware.md
+++ b/docs/docs-content/clusters/pcg/deploy-pcg/vmware.md
@@ -536,6 +536,39 @@ The following requirements apply to tags:
 
     :::
 
+13. To avoid potential vulnerabilities, once the installation is complete, remove the `kind` images that were installed
+    in the environment where you initiated the installation.
+
+    Issue the following command to list all instances of `kind` that exist in the environment.
+
+    ```shell
+    docker images
+    ```
+
+    ```shell
+    REPOSITORY     TAG        IMAGE ID       CREATED        SIZE
+    kindest/node   v1.26.13   131ad18222cc   5 months ago   910MB
+    ```
+
+    Then, use the following command template to remove all instances of `kind`.
+
+    ```shell
+    docker image rm kindest/node:<version>
+    ```
+
+    Consider the following example for reference.
+
+    ```shell
+    docker image rm kindest/node:v1.26.13
+    ```
+
+    ```shell
+    Untagged: kindest/node:v1.26.13
+    Untagged: kindest/node@sha256:15ae92d507b7d4aec6e8920d358fc63d3b980493db191d7327541fbaaed1f789
+    Deleted: sha256:131ad18222ccb05561b73e86bb09ac3cd6475bb6c36a7f14501067cba2eec785
+    Deleted: sha256:85a1a4dfc468cfeca99e359b74231e47aedb007a206d0e2cae2f8290e7290cfd
+    ```
+
 ## Validate
 
 Once installed, the PCG registers itself with Palette. To verify the PCG is registered, use the following steps.

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
@@ -350,9 +350,7 @@ Use the following steps to install Palette.
     ```
 
 18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
-    you will be prompted to create a new password. Enter a new password and save your changes. Refer to the
-    [password requirements](../../../system-management/account-management/credentials.md#password-requirements-and-security)
-    documentation page to learn more about the password requirements.
+    you will be prompted to create a new password. Enter a new password and save your changes.
 
     Use the username `admin` and your new password to log in to the system console. You can create additional system
     administrator accounts and assign roles to users in the system console. Refer to the

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
@@ -316,7 +316,48 @@ Use the following steps to install Palette.
     export KUBECONFIG=/ubuntu/.palette/ec/ec-20231012215923/spectro_mgmt.conf
     ```
 
-17. Copy the URL to the browser to access the system console. You will be prompted to reset the password.
+17. To avoid potential vulnerabilities, once the installation is complete, remove the `kind` images that were installed
+    in the environment where you initiated the installation.
+
+    Issue the following command to list all instances of `kind` that exist in the environment.
+
+    ```shell
+    docker images
+    ```
+
+    ```shell
+    REPOSITORY     TAG        IMAGE ID       CREATED        SIZE
+    kindest/node   v1.26.13   131ad18222cc   5 months ago   910MB
+    ```
+
+    Then, use the following command template to remove all instances of `kind`.
+
+    ```shell
+    docker image rm kindest/node:<version>
+    ```
+
+    Consider the following example for reference.
+
+    ```shell
+    docker image rm kindest/node:v1.26.13
+    ```
+
+    ```shell
+    Untagged: kindest/node:v1.26.13
+    Untagged: kindest/node@sha256:15ae92d507b7d4aec6e8920d358fc63d3b980493db191d7327541fbaaed1f789
+    Deleted: sha256:131ad18222ccb05561b73e86bb09ac3cd6475bb6c36a7f14501067cba2eec785
+    Deleted: sha256:85a1a4dfc468cfeca99e359b74231e47aedb007a206d0e2cae2f8290e7290cfd
+    ```
+
+18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
+    you will be prompted to create a new password. Enter a new password and save your changes. Refer to the
+    [password requirements](../../../system-management/account-management/credentials.md#password-requirements-and-security)
+    documentation page to learn more about the password requirements.
+
+    Use the username `admin` and your new password to log in to the system console. You can create additional system
+    administrator accounts and assign roles to users in the system console. Refer to the
+    [Account Management](../../../system-management/account-management/account-management.md) documentation page for
+    more information.
 
     :::info
 
@@ -328,7 +369,7 @@ Use the following steps to install Palette.
 
     ![Screenshot of the Palette system console showing Username and Password fields.](/palette_installation_install-on-vmware_palette-system-console.webp)
 
-18. Copy the URL and paste it in your browser's URL field to access the system console. You will be prompted to reset
+19. Copy the URL and paste it in your browser's URL field to access the system console. You will be prompted to reset
     the password.
 
     :::info
@@ -339,17 +380,17 @@ Use the following steps to install Palette.
 
     :::
 
-19. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
+20. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
     you will be prompted to create a new password. Enter a new password and save your changes. You will be redirected to
     the Palette system console.
 
-20. After login, a Summary page is displayed. Palette is installed with a self-signed SSL certificate. To assign a
+21. After login, a Summary page is displayed. Palette is installed with a self-signed SSL certificate. To assign a
     different SSL certificate you must upload the SSL certificate, SSL certificate key, and SSL certificate authority
     files to Palette. You can upload the files using the Palette system console. Refer to the
     [Configure HTTPS Encryption](../../../system-management/ssl-certificate-management.md) page for instructions on how
     to upload the SSL certificate files to Palette.
 
-21. The last step is to start setting up a tenant. To learn how to create a tenant, check out the
+22. The last step is to start setting up a tenant. To learn how to create a tenant, check out the
     [Tenant Management](../../../system-management/tenant-management.md) guide.
 
     ![Screenshot of the Summary page showing where to click Go to Tenant Management button.](/palette_installation_install-on-vmware_goto-tenant-management.webp)

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
@@ -352,10 +352,7 @@ Use the following steps to install Palette.
 18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
     you will be prompted to create a new password. Enter a new password and save your changes.
 
-    Use the username `admin` and your new password to log in to the system console. You can create additional system
-    administrator accounts and assign roles to users in the system console. Refer to the
-    [Account Management](../../../system-management/account-management/account-management.md) documentation page for
-    more information.
+    Use the username `admin` and your new password to log in to the system console.
 
     :::info
 

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -345,7 +345,48 @@ Use the following steps to install Palette.
     export KUBECONFIG=/ubuntu/.palette/ec/ec-20231012215923/spectro_mgmt.conf
     ```
 
-17. Copy the URL to the browser to access the system console. You will be prompted to reset the password.
+17. To avoid potential vulnerabilities, once the installation is complete, remove the `kind` images that were installed
+    in the environment where you initiated the installation.
+
+    Issue the following command to list all instances of `kind` that exist in the environment.
+
+    ```shell
+    docker images
+    ```
+
+    ```shell
+    REPOSITORY     TAG        IMAGE ID       CREATED        SIZE
+    kindest/node   v1.26.13   131ad18222cc   5 months ago   910MB
+    ```
+
+    Then, use the following command template to remove all instances of `kind`.
+
+    ```shell
+    docker image rm kindest/node:<version>
+    ```
+
+    Consider the following example for reference.
+
+    ```shell
+    docker image rm kindest/node:v1.26.13
+    ```
+
+    ```shell
+    Untagged: kindest/node:v1.26.13
+    Untagged: kindest/node@sha256:15ae92d507b7d4aec6e8920d358fc63d3b980493db191d7327541fbaaed1f789
+    Deleted: sha256:131ad18222ccb05561b73e86bb09ac3cd6475bb6c36a7f14501067cba2eec785
+    Deleted: sha256:85a1a4dfc468cfeca99e359b74231e47aedb007a206d0e2cae2f8290e7290cfd
+    ```
+
+18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
+    you will be prompted to create a new password. Enter a new password and save your changes. Refer to the
+    [password requirements](../../system-management/account-management/credentials.md#password-requirements-and-security)
+    documentation page to learn more about the password requirements.
+
+    Use the username `admin` and your new password to log in to the system console. You can create additional system
+    administrator accounts and assign roles to users in the system console. Refer to the
+    [Account Management](../../system-management/account-management/account-management.md) documentation page for more
+    information.
 
     :::info
 
@@ -357,7 +398,7 @@ Use the following steps to install Palette.
 
     ![Screenshot of the Palette system console showing Username and Password fields.](/palette_installation_install-on-vmware_palette-system-console.webp)
 
-18. Copy the URL and paste it in your browser's URL field to access the system console. You will be prompted to reset
+19. Copy the URL and paste it in your browser's URL field to access the system console. You will be prompted to reset
     the password.
 
     :::info
@@ -368,17 +409,17 @@ Use the following steps to install Palette.
 
     :::
 
-19. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
+20. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
     you will be prompted to create a new password. Enter a new password and save your changes. You will be redirected to
     the Palette system console.
 
-20. After login, a Summary page is displayed. Palette is installed with a self-signed SSL certificate. To assign a
+21. After login, a Summary page is displayed. Palette is installed with a self-signed SSL certificate. To assign a
     different SSL certificate you must upload the SSL certificate, SSL certificate key, and SSL certificate authority
     files to Palette. You can upload the files using the Palette system console. Refer to the
     [Configure HTTPS Encryption](../../system-management/ssl-certificate-management.md) page for instructions on how to
     upload the SSL certificate files to Palette.
 
-21. The last step is to start setting up a tenant. To learn how to create a tenant, check out the
+22. The last step is to start setting up a tenant. To learn how to create a tenant, check out the
     [Tenant Management](../../system-management/tenant-management.md) guide.
 
     ![Screenshot of the Summary page showing where to click Go to Tenant Management button.](/palette_installation_install-on-vmware_goto-tenant-management.webp)

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -379,9 +379,7 @@ Use the following steps to install Palette.
     ```
 
 18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
-    you will be prompted to create a new password. Enter a new password and save your changes. Refer to the
-    [password requirements](../../system-management/account-management/credentials.md#password-requirements-and-security)
-    documentation page to learn more about the password requirements.
+    you will be prompted to create a new password. Enter a new password and save your changes.
 
     Use the username `admin` and your new password to log in to the system console. You can create additional system
     administrator accounts and assign roles to users in the system console. Refer to the

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -381,10 +381,7 @@ Use the following steps to install Palette.
 18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
     you will be prompted to create a new password. Enter a new password and save your changes.
 
-    Use the username `admin` and your new password to log in to the system console. You can create additional system
-    administrator accounts and assign roles to users in the system console. Refer to the
-    [Account Management](../../system-management/account-management/account-management.md) documentation page for more
-    information.
+    Use the username `admin` and your new password to log in to the system console.
 
     :::info
 

--- a/docs/docs-content/tutorials/cluster-deployment/pcg/deploy-app-pcg.md
+++ b/docs/docs-content/tutorials/cluster-deployment/pcg/deploy-app-pcg.md
@@ -257,6 +257,49 @@ You can also track the PCG deployment progress from your terminal. Depending on 
 environment, the deployment might take up to 30 minutes. Upon completion, the local kind cluster is automatically
 deleted from your machine.
 
+:::tip
+
+To avoid potential vulnerabilities, once the installation is complete, remove the `kind` images that were installed in
+the environment where you initiated the installation.
+
+<details>
+
+<summary>Remove `kind` Images</summary>
+
+Issue the following command to list all instances of `kind` that exist in the environment.
+
+```shell
+docker images
+```
+
+```shell
+REPOSITORY     TAG        IMAGE ID       CREATED        SIZE
+kindest/node   v1.26.13   131ad18222cc   5 months ago   910MB
+```
+
+Then, use the following command template to remove all instances of `kind`.
+
+```shell
+docker image rm kindest/node:<version>
+```
+
+Consider the following example for reference.
+
+```shell
+docker image rm kindest/node:v1.26.13
+```
+
+```shell
+Untagged: kindest/node:v1.26.13
+Untagged: kindest/node@sha256:15ae92d507b7d4aec6e8920d358fc63d3b980493db191d7327541fbaaed1f789
+Deleted: sha256:131ad18222ccb05561b73e86bb09ac3cd6475bb6c36a7f14501067cba2eec785
+Deleted: sha256:85a1a4dfc468cfeca99e359b74231e47aedb007a206d0e2cae2f8290e7290cfd
+```
+
+</details>
+
+:::
+
 ![Palette CLI PCG deployment](/clusters_pcg_deploy-app-pcg_pcg-cli.webp)
 
 Next, log in to Palette as a tenant admin. Navigate to the left **Main Menu** and select **Tenant Settings**. Click on

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
@@ -340,7 +340,48 @@ Use the following steps to install Palette VerteX.
     export KUBECONFIG=/ubuntu/.palette/ec/ec-20231012215923/spectro_mgmt.conf
     ```
 
-17. Copy the URL and paste it in your browser's URL field to access the system console. You will be prompted to reset.
+17. To avoid potential vulnerabilities, once the installation is complete, remove the `kind` images that were installed
+    in the environment where you initiated the installation.
+
+    Issue the following command to list all instances of `kind` that exist in the environment.
+
+    ```shell
+    docker images
+    ```
+
+    ```shell
+    REPOSITORY     TAG        IMAGE ID       CREATED        SIZE
+    kindest/node   v1.26.13   131ad18222cc   5 months ago   910MB
+    ```
+
+    Then, use the following command template to remove all instances of `kind`.
+
+    ```shell
+    docker image rm kindest/node:<version>
+    ```
+
+    Consider the following example for reference.
+
+    ```shell
+    docker image rm kindest/node:v1.26.13
+    ```
+
+    ```shell
+    Untagged: kindest/node:v1.26.13
+    Untagged: kindest/node@sha256:15ae92d507b7d4aec6e8920d358fc63d3b980493db191d7327541fbaaed1f789
+    Deleted: sha256:131ad18222ccb05561b73e86bb09ac3cd6475bb6c36a7f14501067cba2eec785
+    Deleted: sha256:85a1a4dfc468cfeca99e359b74231e47aedb007a206d0e2cae2f8290e7290cfd
+    ```
+
+18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
+    you will be prompted to create a new password. Enter a new password and save your changes. Refer to the
+    [password requirements](../../../system-management/account-management/credentials.md#password-requirements-and-security)
+    documentation page to learn more about the password requirements.
+
+    Use the username `admin` and your new password to log in to the system console. You can create additional system
+    administrator accounts and assign roles to users in the system console. Refer to the
+    [Account Management](../../../system-management/account-management/account-management.md) documentation page for
+    more information.
 
     :::info
 
@@ -352,17 +393,17 @@ Use the following steps to install Palette VerteX.
 
     ![Screenshot of the Palette VerteX system console showing Username and Password fields.](/vertex_installation_install-on-vmware_vertex-system-console.webp)
 
-18. Log in to the System Console using the credentials provided in the Enterprise Cluster Details output. After login,
+19. Log in to the System Console using the credentials provided in the Enterprise Cluster Details output. After login,
     you will be prompted to create a new password. Enter a new password and save your changes. You will be redirected to
     the Palette VerteX system console.
 
-19. After login, a Summary page is displayed. Palette VerteX is installed with a self-signed SSL certificate. To assign
+20. After login, a Summary page is displayed. Palette VerteX is installed with a self-signed SSL certificate. To assign
     a different SSL certificate you must upload the SSL certificate, SSL certificate key, and SSL certificate authority
     files to Palette VerteX. You can upload the files using the Palette VerteX system console. Refer to the
     [Configure HTTPS Encryption](/vertex/system-management/ssl-certificate-management) page for instructions on how to
     upload the SSL certificate files to Palette VerteX.
 
-20. The last step is to start setting up a tenant. To learn how to create a tenant, check out the
+21. The last step is to start setting up a tenant. To learn how to create a tenant, check out the
     [Tenant Management](../../../system-management/tenant-management.md) guide.
 
     ![Screenshot of the Summary page showing where to click Go to Tenant Management button.](/vertex_installation_install-on-vmware_goto-tenant-management.webp)

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
@@ -376,10 +376,7 @@ Use the following steps to install Palette VerteX.
 18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
     you will be prompted to create a new password. Enter a new password and save your changes.
 
-    Use the username `admin` and your new password to log in to the system console. You can create additional system
-    administrator accounts and assign roles to users in the system console. Refer to the
-    [Account Management](../../../system-management/account-management/account-management.md) documentation page for
-    more information.
+    Use the username `admin` and your new password to log in to the system console.
 
     :::info
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
@@ -374,9 +374,7 @@ Use the following steps to install Palette VerteX.
     ```
 
 18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
-    you will be prompted to create a new password. Enter a new password and save your changes. Refer to the
-    [password requirements](../../../system-management/account-management/credentials.md#password-requirements-and-security)
-    documentation page to learn more about the password requirements.
+    you will be prompted to create a new password. Enter a new password and save your changes.
 
     Use the username `admin` and your new password to log in to the system console. You can create additional system
     administrator accounts and assign roles to users in the system console. Refer to the

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -316,10 +316,7 @@ Use the following steps to install Palette VerteX.
 18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
     you will be prompted to create a new password. Enter a new password and save your changes.
 
-    Use the username `admin` and your new password to log in to the system console. You can create additional system
-    administrator accounts and assign roles to users in the system console. Refer to the
-    [Account Management](../../system-management/account-management/account-management.md) documentation page for more
-    information.
+    Use the username `admin` and your new password to log in to the system console.
 
     :::info
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -280,7 +280,48 @@ Use the following steps to install Palette VerteX.
     export KUBECONFIG=/ubuntu/.palette/ec/ec-20231012215923/spectro_mgmt.conf
     ```
 
-17. Copy the URL and paste it in your browser's URL field to access the system console. You will be prompted to reset.
+17. To avoid potential vulnerabilities, once the installation is complete, remove the `kind` images that were installed
+    in the environment where you initiated the installation.
+
+    Issue the following command to list all instances of `kind` that exist in the environment.
+
+    ```shell
+    docker images
+    ```
+
+    ```shell
+    REPOSITORY     TAG        IMAGE ID       CREATED        SIZE
+    kindest/node   v1.26.13   131ad18222cc   5 months ago   910MB
+    ```
+
+    Then, use the following command template to remove all instances of `kind`.
+
+    ```shell
+    docker image rm kindest/node:<version>
+    ```
+
+    Consider the following example for reference.
+
+    ```shell
+    docker image rm kindest/node:v1.26.13
+    ```
+
+    ```shell
+    Untagged: kindest/node:v1.26.13
+    Untagged: kindest/node@sha256:15ae92d507b7d4aec6e8920d358fc63d3b980493db191d7327541fbaaed1f789
+    Deleted: sha256:131ad18222ccb05561b73e86bb09ac3cd6475bb6c36a7f14501067cba2eec785
+    Deleted: sha256:85a1a4dfc468cfeca99e359b74231e47aedb007a206d0e2cae2f8290e7290cfd
+    ```
+
+18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
+    you will be prompted to create a new password. Enter a new password and save your changes. Refer to the
+    [password requirements](../../system-management/account-management/credentials.md#password-requirements-and-security)
+    documentation page to learn more about the password requirements.
+
+    Use the username `admin` and your new password to log in to the system console. You can create additional system
+    administrator accounts and assign roles to users in the system console. Refer to the
+    [Account Management](../../system-management/account-management/account-management.md) documentation page for more
+    information.
 
     :::info
 
@@ -292,17 +333,17 @@ Use the following steps to install Palette VerteX.
 
     ![Screenshot of the Palette VerteX system console showing Username and Password fields.](/vertex_installation_install-on-vmware_vertex-system-console.webp)
 
-18. Log in to the System Console using the credentials provided in the Enterprise Cluster Details output. After login,
+19. Log in to the System Console using the credentials provided in the Enterprise Cluster Details output. After login,
     you will be prompted to create a new password. Enter a new password and save your changes. You will be redirected to
     the Palette VerteX system console.
 
-19. After login, a Summary page is displayed. Palette VerteX is installed with a self-signed SSL certificate. To assign
+20. After login, a Summary page is displayed. Palette VerteX is installed with a self-signed SSL certificate. To assign
     a different SSL certificate you must upload the SSL certificate, SSL certificate key, and SSL certificate authority
     files to Palette VerteX. You can upload the files using the Palette VerteX system console. Refer to the
     [Configure HTTPS Encryption](/vertex/system-management/ssl-certificate-management) page for instructions on how to
     upload the SSL certificate files to Palette VerteX.
 
-20. The last step is to start setting up a tenant. To learn how to create a tenant, check out the
+21. The last step is to start setting up a tenant. To learn how to create a tenant, check out the
     [Tenant Management](../../system-management/tenant-management.md) guide.
 
     ![Screenshot of the Summary page showing where to click Go to Tenant Management button.](/vertex_installation_install-on-vmware_goto-tenant-management.webp)

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -314,9 +314,7 @@ Use the following steps to install Palette VerteX.
     ```
 
 18. Log in to the system console using the credentials provided in the Enterprise Cluster Details output. After login,
-    you will be prompted to create a new password. Enter a new password and save your changes. Refer to the
-    [password requirements](../../system-management/account-management/credentials.md#password-requirements-and-security)
-    documentation page to learn more about the password requirements.
+    you will be prompted to create a new password. Enter a new password and save your changes.
 
     Use the username `admin` and your new password to log in to the system console. You can create additional system
     administrator accounts and assign roles to users in the system console. Refer to the


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-1`:
 - [Document the step for removing kind images after EC and PCG installation (#3337) (#3362)](https://github.com/spectrocloud/librarium/pull/3362)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)