### PR TITLE
[version-4-2] docs: bump tutorials tag DOC-1303 (#3396)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,6 @@ vale/
 tsconfig.json
 src/components/IconMapper/dynamicFontAwesomeImports.js
 docs/docs-content/security-bulletins/cve-reports.md
+
+# Ignore partials
+_partials/

--- a/_partials/tutorials/_checkout_tutorial_tag.mdx
+++ b/_partials/tutorials/_checkout_tutorial_tag.mdx
@@ -1,0 +1,10 @@
+---
+partial_category: tutorials
+partial_name: checkout-tutorials-tag
+---
+
+Check out the following git tag.
+
+```shell
+git checkout v1.1.7
+```

--- a/_partials/tutorials/_download_tutorial_image_docker.mdx
+++ b/_partials/tutorials/_download_tutorial_image_docker.mdx
@@ -1,0 +1,10 @@
+---
+partial_category: tutorials
+partial_name: download-tutorials-image-docker
+---
+
+Download the tutorial image to your local machine.
+
+```bash
+docker pull ghcr.io/spectrocloud/tutorials:1.1.7
+```

--- a/_partials/tutorials/_download_tutorial_image_podman.mdx
+++ b/_partials/tutorials/_download_tutorial_image_podman.mdx
@@ -1,0 +1,10 @@
+---
+partial_category: tutorials
+partial_name: download-tutorials-image-podman
+---
+
+Download the tutorial image to your local machine.
+
+```bash
+podman pull ghcr.io/spectrocloud/tutorials:1.1.7
+```

--- a/_partials/tutorials/_run_tutorial_container_docker.mdx
+++ b/_partials/tutorials/_run_tutorial_container_docker.mdx
@@ -1,0 +1,10 @@
+---
+partial_category: tutorials
+partial_name: run-tutorials-container-docker
+---
+
+Next, start the container, and open a bash session into it.
+
+```shell
+docker run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.7 bash
+```

--- a/_partials/tutorials/_run_tutorial_container_podman.mdx
+++ b/_partials/tutorials/_run_tutorial_container_podman.mdx
@@ -1,0 +1,10 @@
+---
+partial_category: tutorials
+partial_name: run-tutorials-container-podman
+---
+
+Next, start the container, and open a bash session into it.
+
+```shell
+podman run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.7 bash
+```

--- a/_partials/tutorials/_stop_tutorial_container_docker.mdx
+++ b/_partials/tutorials/_stop_tutorial_container_docker.mdx
@@ -1,0 +1,9 @@
+---
+partial_category: tutorials
+partial_name: stop-tutorials-container-docker
+---
+
+```shell
+docker stop tutorialContainer && \
+docker rmi --force ghcr.io/spectrocloud/tutorials:1.1.7
+```

--- a/_partials/tutorials/_stop_tutorial_container_podman.mdx
+++ b/_partials/tutorials/_stop_tutorial_container_podman.mdx
@@ -1,0 +1,9 @@
+---
+partial_category: tutorials
+partial_name: stop-tutorials-container-podman
+---
+
+```shell
+podman stop tutorialContainer && \
+podman rmi --force ghcr.io/spectrocloud/tutorials:1.1.7
+```

--- a/docs/docs-content/clusters/public-cloud/deploy-k8s-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/deploy-k8s-cluster.md
@@ -830,17 +830,9 @@ displaying the version number.
 docker version
 ```
 
-Download the tutorial image to your local machine.
+<PartialsComponent category="tutorials" name="download-tutorials-image-docker" />
 
-```bash
-docker pull ghcr.io/spectrocloud/tutorials:1.1.3
-```
-
-Next, start the container, and open a bash session into it.
-
-```shell
-docker run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.3 bash
-```
+<PartialsComponent category="tutorials" name="run-tutorials-container-docker" />
 
 Navigate to the tutorial code.
 
@@ -866,17 +858,9 @@ Use the following command and ensure you receive an output displaying the instal
 podman info
 ```
 
-Download the tutorial image to your local machine.
+<PartialsComponent category="tutorials" name="download-tutorials-image-podman" />
 
-```bash
-podman pull ghcr.io/spectrocloud/tutorials:1.1.3
-```
-
-Next, start the container, and open a bash session into it.
-
-```shell
-podman run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.3 bash
-```
+<PartialsComponent category="tutorials" name="run-tutorials-container-podman" />
 
 Navigate to the tutorial code.
 
@@ -900,11 +884,7 @@ Change the directory to the tutorial folder.
 cd tutorials/
 ```
 
-Check out the following git tag.
-
-```shell
-git checkout v1.1.3
-```
+<PartialsComponent category="tutorials" name="checkout-tutorials-tag" />
 
 Change the directory to the tutorial code.
 
@@ -1354,19 +1334,13 @@ the **Enter** key. Next, issue the following command to stop the container.
 
 <TabItem label="Docker" value="docker">
 
-```shell
-docker stop tutorialContainer && \
-docker rmi --force ghcr.io/spectrocloud/tutorials:1.1.3
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-docker" />
 
 </TabItem>
 
 <TabItem label="Podman" value="podman">
 
-```shell
-podman stop tutorialContainer && \
-podman rmi --force ghcr.io/spectrocloud/tutorials:1.1.3
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-podman" />
 
 </TabItem>
 

--- a/docs/docs-content/getting-started/terraform.md
+++ b/docs/docs-content/getting-started/terraform.md
@@ -75,17 +75,9 @@ displaying the version number.
 docker version
 ```
 
-Download the tutorial image to your local machine.
+<PartialsComponent category="tutorials" name="download-tutorials-image-docker" />
 
-```bash
-docker pull ghcr.io/spectrocloud/tutorials:1.1.3
-```
-
-Next, start the container, and open a bash session into it.
-
-```shell
-docker run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.3 bash
-```
+<PartialsComponent category="tutorials" name="run-tutorials-container-docker" />
 
 Navigate to the tutorial code.
 
@@ -111,17 +103,9 @@ Use the following command and ensure you receive an output displaying the instal
 podman info
 ```
 
-Download the tutorial image to your local machine.
+<PartialsComponent category="tutorials" name="download-tutorials-image-podman" />
 
-```bash
-podman pull ghcr.io/spectrocloud/tutorials:1.1.3
-```
-
-Next, start the container, and open a bash session into it.
-
-```shell
-podman run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.3 bash
-```
+<PartialsComponent category="tutorials" name="run-tutorials-container-podman" />
 
 Navigate to the tutorial code.
 
@@ -145,11 +129,7 @@ Change the directory to the tutorial folder.
 cd tutorials/
 ```
 
-Check out the following git tag.
-
-```shell
-git checkout v1.1.3
-```
+<PartialsComponent category="tutorials" name="checkout-tutorials-tag" />
 
 Change the directory to the tutorial code.
 
@@ -531,19 +511,13 @@ the **Enter** key. Next, issue the following command to stop the container.
 
 <TabItem label="Docker" value="docker">
 
-```shell
-docker stop tutorialContainer && \
-docker rmi --force ghcr.io/spectrocloud/tutorials:1.1.3
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-docker" />
 
 </TabItem>
 
 <TabItem label="Podman" value="podman">
 
-```shell
-podman stop tutorialContainer && \
-podman rmi --force ghcr.io/spectrocloud/tutorials:1.1.3
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-podman" />
 
 </TabItem>
 

--- a/docs/docs-content/tutorials/cluster-deployment/pde/deploy-app.md
+++ b/docs/docs-content/tutorials/cluster-deployment/pde/deploy-app.md
@@ -389,21 +389,9 @@ displaying the version number.
 docker version
 ```
 
-Download the tutorial image to your local machine.
+<PartialsComponent category="tutorials" name="download-tutorials-image-docker" />
 
-<br />
-
-```bash
-docker pull ghcr.io/spectrocloud/tutorials:1.1.3
-```
-
-Next, start the container, and open a bash session into it.
-
-<br />
-
-```shell
-docker run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.3 bash
-```
+<PartialsComponent category="tutorials" name="run-tutorials-container-docker" />
 
 Navigate to the tutorial code.
 
@@ -431,19 +419,9 @@ Use the following command and ensure you receive an output displaying the instal
 podman info
 ```
 
-Download the tutorial image to your local machine. <br />
+<PartialsComponent category="tutorials" name="download-tutorials-image-podman" />
 
-```bash
-podman pull ghcr.io/spectrocloud/tutorials:1.1.3
-```
-
-Next, start the container, and open a bash session into it.
-
-<br />
-
-```shell
-podman run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.3 bash
-```
+<PartialsComponent category="tutorials" name="run-tutorials-container-podman" />
 
 Navigate to the tutorial code.
 
@@ -473,13 +451,7 @@ Change directory to the tutorial folder.
 cd tutorials/
 ```
 
-Check out the following git tag.
-
-<br />
-
-```shell
-git checkout v1.0.4
-```
+<PartialsComponent category="tutorials" name="checkout-tutorials-tag" />
 
 Change directory to the tutorial code.
 
@@ -1294,19 +1266,13 @@ the **Enter** key. Next, issue the following command to stop the container.
 
 <TabItem label="Docker" value="Docker">
 
-```shell
-docker stop tutorialContainer && \
-docker rmi --force ghcr.io/spectrocloud/tutorials:1.1.3
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-docker" />
 
 </TabItem>
 
 <TabItem label="Podman" value="Podman">
 
-```shell
-podman stop tutorialContainer && \
-podman rmi --force ghcr.io/spectrocloud/tutorials:1.1.3
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-podman" />
 
 </TabItem>
 

--- a/docs/docs-content/tutorials/cluster-deployment/public-cloud/deploy-k8s-cluster.md
+++ b/docs/docs-content/tutorials/cluster-deployment/public-cloud/deploy-k8s-cluster.md
@@ -828,17 +828,9 @@ displaying the version number.
 docker version
 ```
 
-Download the tutorial image to your local machine.
+<PartialsComponent category="tutorials" name="download-tutorials-image-docker" />
 
-```bash
-docker pull ghcr.io/spectrocloud/tutorials:1.1.3
-```
-
-Next, start the container, and open a bash session into it.
-
-```shell
-docker run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.3 bash
-```
+<PartialsComponent category="tutorials" name="run-tutorials-container-docker" />
 
 Navigate to the tutorial code.
 
@@ -864,17 +856,9 @@ Use the following command and ensure you receive an output displaying the instal
 podman info
 ```
 
-Download the tutorial image to your local machine.
+<PartialsComponent category="tutorials" name="download-tutorials-image-podman" />
 
-```bash
-podman pull ghcr.io/spectrocloud/tutorials:1.1.3
-```
-
-Next, start the container, and open a bash session into it.
-
-```shell
-podman run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.3 bash
-```
+<PartialsComponent category="tutorials" name="run-tutorials-container-podman" />
 
 Navigate to the tutorial code.
 
@@ -898,11 +882,7 @@ Change the directory to the tutorial folder.
 cd tutorials/
 ```
 
-Check out the following git tag.
-
-```shell
-git checkout v1.1.3
-```
+<PartialsComponent category="tutorials" name="checkout-tutorials-tag" />
 
 Change the directory to the tutorial code.
 
@@ -1352,19 +1332,13 @@ the **Enter** key. Next, issue the following command to stop the container.
 
 <TabItem label="Docker" value="docker">
 
-```shell
-docker stop tutorialContainer && \
-docker rmi --force ghcr.io/spectrocloud/tutorials:1.1.3
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-docker" />
 
 </TabItem>
 
 <TabItem label="Podman" value="podman">
 
-```shell
-podman stop tutorialContainer && \
-podman rmi --force ghcr.io/spectrocloud/tutorials:1.1.3
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-podman" />
 
 </TabItem>
 

--- a/docs/docs-content/tutorials/cluster-management/update-maintain/update-k8s-cluster.md
+++ b/docs/docs-content/tutorials/cluster-management/update-maintain/update-k8s-cluster.md
@@ -96,11 +96,7 @@ Change the directory to the tutorial folder.
 cd tutorials/
 ```
 
-Check out the following git tag.
-
-```shell
-git checkout v1.1.3
-```
+<PartialsComponent category="tutorials" name="checkout-tutorials-tag" />
 
 Change the directory to the tutorial code.
 

--- a/docs/docs-content/tutorials/profiles/deploy-pack.md
+++ b/docs/docs-content/tutorials/profiles/deploy-pack.md
@@ -94,17 +94,17 @@ the currently active containers.
 docker ps
 ```
 
-Use the following command to download the `ghcr.io/spectrocloud/tutorials:1.1.2` image to your local machine. This
+Use the following command to download the `ghcr.io/spectrocloud/tutorials:1.1.7` image to your local machine. This
 Docker image includes the necessary tools.
 
 ```bash
-docker pull ghcr.io/spectrocloud/tutorials:1.1.2
+docker pull ghcr.io/spectrocloud/tutorials:1.1.7
 ```
 
 Next, start the container and open a bash session into it.
 
 ```bash
-docker run --name tutorialContainer --publish 7000:5000 --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.2 bash
+docker run --name tutorialContainer --publish 7000:5000 --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.7 bash
 ```
 
 </TabItem>
@@ -117,17 +117,17 @@ Ensure that Podman is available by issuing a command to list the currently activ
 podman ps
 ```
 
-Use the following command to download the `ghcr.io/spectrocloud/tutorials:1.1.2` image to your local machine. This image
+Use the following command to download the `ghcr.io/spectrocloud/tutorials:1.1.7` image to your local machine. This image
 includes the necessary tools.
 
 ```bash
-podman pull ghcr.io/spectrocloud/tutorials:1.1.2
+podman pull ghcr.io/spectrocloud/tutorials:1.1.7
 ```
 
 Next, start the container and open a bash session into it.
 
 ```bash
-podman run --name tutorialContainer --publish 7000:5000 --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.2 bash
+podman run --name tutorialContainer --publish 7000:5000 --interactive --tty ghcr.io/spectrocloud/tutorials:1.1.7 bash
 ```
 
 </TabItem>
@@ -1290,19 +1290,13 @@ the following commands.
 
 <TabItem label="Docker" value="Docker">
 
-```bash
-docker container rm --force tutorialContainer
-docker image rm --force ghcr.io/spectrocloud/tutorials:1.1.2
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-docker" />
 
 </TabItem>
 
 <TabItem label="Podman" value="Podman">
 
-```bash
-podman container rm --force tutorialContainer
-podman image rm --force ghcr.io/spectrocloud/tutorials:1.1.2
-```
+<PartialsComponent category="tutorials" name="stop-tutorials-container-podman" />
 
 </TabItem>
 


### PR DESCRIPTION
This PR is manual cherry-pick. 

# Backport

This will backport the following commits from `master` to `version-4-2`:
 - [docs: bump tutorials tag DOC-1303 (#3396)](https://github.com/spectrocloud/librarium/pull/3396)
