### PR TITLE
Update Palette CLI Binaries URLs

### DIFF
--- a/docs/docs-content/automation/palette-cli/install-palette-cli.md
+++ b/docs/docs-content/automation/palette-cli/install-palette-cli.md
@@ -62,7 +62,7 @@ palette version
 ```
 
 ```shell hideClipboard
-Palette CLI version: 4.3.4
+Palette CLI version: 4.4.5
 ```
 
 ## Next Steps

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -32,6 +32,8 @@ Before upgrading Palette to a new major version, you must first update it to the
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.4.6        |       4.4.11       | :white_check_mark: |
+|       4.3.6        |       4.4.11       | :white_check_mark: |
 |       4.3.6        |       4.4.4        | :white_check_mark: |
 |       4.2.13       |       4.3.6        | :white_check_mark: |
 |       4.2.7        |       4.2.13       | :white_check_mark: |

--- a/docs/docs-content/registries-and-packs/advanced-configuration.md
+++ b/docs/docs-content/registries-and-packs/advanced-configuration.md
@@ -73,7 +73,7 @@ docker run -d \
     -e REGISTRY_LOG_LEVEL=debug \
     -e REGISTRY_AUTH=htpasswd \
     -e REGISTRY_AUTH_HTPASSWD_REALM="My Enterprise Realm" \
-    gcr.io/spectro-images-public/release/spectro-registry:4.0.2
+    gcr.io/spectro-images-public/release/spectro-registry:4.4.0
 ```
 
 Alternatively, you can start the container by mounting a directory with a new configuration file and pointing the server
@@ -85,7 +85,7 @@ docker run -d \
     -p 443:5000 \
     --name spectro-registry \
     --volume $(pwd)/myconfig.yml:/etc/myconfig.yml \
-    gcr.io/spectro-images-public/release/spectro-registry:4.0.2 \
+    gcr.io/spectro-images-public/release/spectro-registry:4.4.0 \
     serve /etc/spectropaxconfig/myconfig.yml
 ```
 

--- a/docs/docs-content/registries-and-packs/spectro-cli-reference.md
+++ b/docs/docs-content/registries-and-packs/spectro-cli-reference.md
@@ -33,7 +33,7 @@ The Spectro CLI tool is currently available for OSX and Linux.
    <TabItem label="OSX" value="osx_cli">
 
    ```bash
-   wget https://spectro-cli.s3.amazonaws.com/v4.3.0/osx/spectro
+   wget https://spectro-cli.s3.amazonaws.com/v4.4.0/osx/spectro
    ```
 
    </TabItem>
@@ -41,7 +41,7 @@ The Spectro CLI tool is currently available for OSX and Linux.
    <TabItem label="Linux" value="linux_cli">
 
    ```bash
-   wget https://spectro-cli.s3.amazonaws.com/v4.3.0/linux/spectro
+   wget https://spectro-cli.s3.amazonaws.com/v4.4.0/linux/spectro
    ```
 
    </TabItem>
@@ -307,5 +307,5 @@ spectro version
 ```
 
 ```bash hideClipboard
-Spectro CLI Version 4.3.4 linux/amd64
+Spectro CLI Version 4.4.0 linux/amd64
 ```

--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -23,12 +23,14 @@ on how to install Palette. Palette VerteX installation guide can be found in the
 The Palette Command Line Interface (CLI) is a tool that you can use to interact with Palette programmatically. Check out
 the [Palette CLI](./automation/palette-cli/palette-cli.md) document for installation guidance.
 
-| Version | Operating System                                                                      | Checksum (SHA256) |
-| ------- | ------------------------------------------------------------------------------------- | ----------------- |
-| 4.4.8   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.4.0/linux/cli/palette) | ``                |
+| Version | Operating System                                                                      | Checksum (SHA256)                                                  |
+| ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 4.4.0   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.4.0/linux/cli/palette) | `9e515f4f78b235a0022d1f10099f0e819fa28ceb356d4a97a34bb4e251a81ea1` |
+| 4.4.5   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.4.5/linux/cli/palette) | `d177e996844f72305d2d952e0ecf5893eb5b1a32442543454cb9720e9fa9b935` |
 
 ## Palette Edge CLI
 
-| Version | Operating System                                                                      | Checksum (SHA256) |
-| ------- | ------------------------------------------------------------------------------------- | ----------------- |
-| 4.4.8   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.2/cli/linux/palette-edge) | ``                |
+| Version | Operating System                                                                      | Checksum (SHA256)                                                  |
+| ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 4.4.2   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.2/cli/linux/palette-edge) | `86d2f9239d2b8517dc6d750631a3a328136a5d49a8ec042899879e9bd25a396e` |
+| 4.4.4   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.4/cli/linux/palette-edge) | `3dae63e503251ff0d8a85c596cddf9c45ac29ca341d0f4d47756c865121fcdb9` |

--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -25,12 +25,12 @@ the [Palette CLI](./automation/palette-cli/palette-cli.md) document for installa
 
 | Version | Operating System                                                                      | Checksum (SHA256)                                                  |
 | ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 4.4.0   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.4.0/linux/cli/palette) | `9e515f4f78b235a0022d1f10099f0e819fa28ceb356d4a97a34bb4e251a81ea1` |
 | 4.4.5   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.4.5/linux/cli/palette) | `d177e996844f72305d2d952e0ecf5893eb5b1a32442543454cb9720e9fa9b935` |
+| 4.4.0   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.4.0/linux/cli/palette) | `9e515f4f78b235a0022d1f10099f0e819fa28ceb356d4a97a34bb4e251a81ea1` |
 
 ## Palette Edge CLI
 
 | Version | Operating System                                                                      | Checksum (SHA256)                                                  |
 | ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 4.4.2   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.2/cli/linux/palette-edge) | `86d2f9239d2b8517dc6d750631a3a328136a5d49a8ec042899879e9bd25a396e` |
 | 4.4.4   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.4/cli/linux/palette-edge) | `3dae63e503251ff0d8a85c596cddf9c45ac29ca341d0f4d47756c865121fcdb9` |
+| 4.4.2   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.2/cli/linux/palette-edge) | `86d2f9239d2b8517dc6d750631a3a328136a5d49a8ec042899879e9bd25a396e` |

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -32,6 +32,8 @@ Before upgrading Palette VerteX to a new major version, you must first update it
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.4.6        |       4.4.11       | :white_check_mark: |
+|       4.3.6        |       4.4.11       | :white_check_mark: |
 |       4.3.6        |       4.4.x        | :white_check_mark: |
 |       4.2.13       |       4.3.6        | :white_check_mark: |
 |       4.2.7        |       4.2.13       | :white_check_mark: |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates download URLs and references to Palette CLI and Palette Edge CLI.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Downloads](https://deploy-preview-3437--docs-spectrocloud.netlify.app/spectro-downloads/)
💻 [Advanced CLI Configuration](https://deploy-preview-3437--docs-spectrocloud.netlify.app/registries-and-packs/advanced-configuration/)
💻 [Palette CLI: Installation](https://deploy-preview-3437--docs-spectrocloud.netlify.app/automation/palette-cli/install-palette-cli/)
💻 [Spectro Cloud CLI Tool](https://deploy-preview-3437--docs-spectrocloud.netlify.app/registries-and-packs/spectro-cli-reference/)
💻 [Self-hosted Upgrade](https://deploy-preview-3437--docs-spectrocloud.netlify.app/enterprise-version/upgrade/)
💻 [VerteX Upgrade](https://deploy-preview-3437--docs-spectrocloud.netlify.app/vertex/upgrade/)


## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1311](https://spectrocloud.atlassian.net/browse/DOC-1311)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._This is a 4.4.a PR.


[DOC-1311]: https://spectrocloud.atlassian.net/browse/DOC-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ