### PR TITLE
docs: fix broken link and slow down linkinator job DOC-1329

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ pdf-local: ## Generate PDF from local docs
 verify-url-links:
 	@echo "Checking for broken external URLs in markdown files..."
 	rm link_report.csv || echo "No report exists. Proceeding to scan step"
-	@npx linkinator "docs/**/*.md" --markdown --recurse --timeout 60000 --retry --retry-errors-jitter --retry-errors-count 3 \
+	@npx linkinator "docs/**/*.md" --concurrency 50 --markdown --recurse --timeout 100000 --retry --retry-errors-jitter --retry-errors-count 5 \
 		--skip "^https:\/\/docs\.spectrocloud\.com.*$$" \
 		--skip "^https:\/\/docs\.spectrocloud\.com\/.*\/supplemental\-packs$$" \
 		--skip "^http:\/\/docs\.spectrocloud\.com.*$$" \
@@ -190,7 +190,7 @@ verify-url-links:
 verify-url-links-ci: ## Check for broken URLs in production in a GitHub Actions CI environment
 	@echo "Checking for broken external URLs in CI environment..."
 	rm link_report.json || echo "No report exists. Proceeding to scan step"
-	@npx linkinator "docs/**/*.md" --markdown --recurse --timeout 60000 --retry-errors-jitter --retry --retry-errors-count 5 \
+	@npx linkinator "docs/**/*.md" --concurrency 50 --markdown --recurse --timeout 100000 --retry-errors-jitter --retry --retry-errors-count 5 \
 		--skip "^https:\/\/docs\.spectrocloud\.com.*$$" \
 		--skip "^https:\/\/docs\.spectrocloud\.com\/.*\/supplemental\-packs$$" \
 		--skip "^http:\/\/docs\.spectrocloud\.com.*$$" \

--- a/docs/deprecated/integrations/prometheus-operator.md
+++ b/docs/deprecated/integrations/prometheus-operator.md
@@ -1233,7 +1233,7 @@ data "spectrocloud_pack_simple" "pack-info" {
 
 - [Prometheus Remote Write Tuning](https://prometheus.io/docs/practices/remote_write)
 
-- [Thanos & Prometheus](https://prometheus-operator.dev/docs/operator/thanos)
+- [Thanos & Prometheus](https://prometheus-operator.dev/docs/platform/thanos/)
 
 - [Prometheus FAQ](https://prometheus.io/docs/introduction/faq)
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes one broken link. It also drops the concurrency from 100 to 50 connections on the linkinator job and increases its timeout. This should help with throttling and allow the nist links to stop failing. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1329](https://spectrocloud.atlassian.net/browse/DOC-1329)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1329]: https://spectrocloud.atlassian.net/browse/DOC-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ