### PR TITLE
Update signed-content.md

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/signed-content.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/signed-content.md
@@ -75,8 +75,8 @@ your Edge hosts come from a trusted source. For more information about content b
 5. In **CanvOS**, create a file named **.edge_custom_config.yaml**.
 
 6. Populate the YAML file with the following content. Replace the value for `base64EncodedValue` with the base64 encoded
-   value of your public key. 
-   You can convert your PEM file to base64 using this command replacing `sample.pem` with your filename.
+   value of your public key. You can convert your PEM file to base64 using this command replacing `sample.pem` with your
+   filename.
 
    ```bash
    base64 -w 0 sample-key.pem
@@ -90,7 +90,7 @@ your Edge hosts come from a trusted source. For more information about content b
              description: "This is a public key used for verifying content bundles and cluster definitions." 
    ```
 
-8. In your **.arg** file, add the following parameter `EDGE_CUSTOM_CONFIG` and provide the path to your
+7. In your **.arg** file, add the following parameter `EDGE_CUSTOM_CONFIG` and provide the path to your
    **.edge_custom_config.yaml** file.
 
    ```text {12}
@@ -108,7 +108,7 @@ your Edge hosts come from a trusted source. For more information about content b
     EDGE_CUSTOM_CONFIG=.edge-custom-config.yaml
    ```
 
-9. Finish the rest of the EdgeForge process to build either the installer ISO or provider images. For more information,
+8. Finish the rest of the EdgeForge process to build either the installer ISO or provider images. For more information,
    refer to [Build Installer ISO](./build-installer-iso.md) and [Build Provider Images](./build-provider-images.md).
 
    :::info

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/signed-content.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/signed-content.md
@@ -75,8 +75,12 @@ your Edge hosts come from a trusted source. For more information about content b
 5. In **CanvOS**, create a file named **.edge_custom_config.yaml**.
 
 6. Populate the YAML file with the following content. Replace the value for `base64EncodedValue` with the base64 encoded
-   value of your public key. The PEM format is base64 encoded. If you have your public key in the PEM format, you only
-   need to copy the base64 portion of the key, without the header nor footer.
+   value of your public key. 
+   You can convert your PEM file to base64 using this command replacing `sample.pem` with your filename.
+
+   ```bash
+   base64 -w 0 sample-key.pem
+   ```
 
    ```yaml
    content:
@@ -86,7 +90,7 @@ your Edge hosts come from a trusted source. For more information about content b
              description: "This is a public key used for verifying content bundles and cluster definitions." 
    ```
 
-7. In your **.arg** file, add the following parameter `EDGE_CUSTOM_CONFIG` and provide the path to your
+8. In your **.arg** file, add the following parameter `EDGE_CUSTOM_CONFIG` and provide the path to your
    **.edge_custom_config.yaml** file.
 
    ```text {12}
@@ -104,7 +108,7 @@ your Edge hosts come from a trusted source. For more information about content b
     EDGE_CUSTOM_CONFIG=.edge-custom-config.yaml
    ```
 
-8. Finish the rest of the EdgeForge process to build either the installer ISO or provider images. For more information,
+9. Finish the rest of the EdgeForge process to build either the installer ISO or provider images. For more information,
    refer to [Build Installer ISO](./build-installer-iso.md) and [Build Provider Images](./build-provider-images.md).
 
    :::info


### PR DESCRIPTION
Changed step 6 in the signed content workflow to reflect converting the PEM file to base64.

Updated the steps for signed content to reflect converting the PEM file to base64 encoding rather than just copying the section without the headers and footers.

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR addresses a bug in the flow of how to create signed content by providing the steps to convert the PEM file to base64 encoded.

## Changed Pages

[<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->](https://docs.spectrocloud.com/clusters/edge/edgeforge-workflow/palette-canvos/signed-content/#embed-a-public-key-in-edge-artifacts)

💻 [Add Preview URL for Page]()

## Jira Tickets

None

🎫 [Jira Ticket]()

## Backports

None

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [X] No. _Does not impact previous versions as this feature is 4.4.X specific
