### PR TITLE
[version-4-1] docs: fix broken link and slow down linkinator job (#3549)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ pdf-local: ## Generate PDF from local docs
 verify-url-links:
 	@echo "Checking for broken external URLs in markdown files..."
 	rm link_report.csv || echo "No report exists. Proceeding to scan step"
-	@npx linkinator "docs/**/*.md" --markdown --recurse --timeout 60000 --retry --retry-errors-jitter --retry-errors-count 3 \
+	@npx linkinator "docs/**/*.md" --concurrency 50 --markdown --recurse --timeout 100000 --retry --retry-errors-jitter --retry-errors-count 5 \
 		--skip "^https:\/\/docs\.spectrocloud\.com.*$$" \
 		--skip "^https:\/\/docs\.spectrocloud\.com\/.*\/supplemental\-packs$$" \
 		--skip "^http:\/\/docs\.spectrocloud\.com.*$$" \
@@ -181,7 +181,7 @@ verify-url-links:
 verify-url-links-ci: ## Check for broken URLs in production in a GitHub Actions CI environment
 	@echo "Checking for broken external URLs in CI environment..."
 	rm link_report.json || echo "No report exists. Proceeding to scan step"
-	@npx linkinator "docs/**/*.md" --markdown --recurse --timeout 60000 --retry-errors-jitter --retry --retry-errors-count 5 \
+	@npx linkinator "docs/**/*.md" --concurrency 50 --markdown --recurse --timeout 100000 --retry-errors-jitter --retry --retry-errors-count 5 \
 		--skip "^https:\/\/docs\.spectrocloud\.com.*$$" \
 		--skip "^https:\/\/docs\.spectrocloud\.com\/.*\/supplemental\-packs$$" \
 		--skip "^http:\/\/docs\.spectrocloud\.com.*$$" \


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-1`:
 - [docs: fix broken link and slow down linkinator job (#3549)](https://github.com/spectrocloud/librarium/pull/3549)