### PR TITLE
docs: Audit logs

### DIFF
--- a/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
@@ -79,7 +79,7 @@ out and archived. You can still download your log files from any period, but the
    $PrivDropToGroup root
    $Umask 0000
    $template ForwardFormat,"<%pri%>1 %timestamp:::date-rfc3339% %HOSTNAME% %syslogtag% %procid% - - %msg%\n"
-   if ($syslogfacility-text == 'local7' and $syslogseverity-text == 'notice' and $syslogtag contains 'your-tag') then {
+   if ($syslogfacility-text == 'local7' and $syslogseverity-text == 'notice' and $syslogtag contains '<your-tag>') then {
         action(
             type="omfile"
             file="/var/log/stylus-audit.log"

--- a/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
@@ -9,7 +9,7 @@ tags: ["edge"]
 
 On any operational Edge host, many services write events, logs, and any other applicable audit log to the
 `/var/log/stylus-audit.log` file. If you have application workloads on your cluster, you can also configure them to
-write audit logs to the same file. This allows you to keep all audit logs in a single location for easy management
+write audit logs to the same file. This allows you to keep all audit logs in a single location for easy management and
 retrieval. Audit logs written to the `/var/log/stylus-audit.log` file can be downloaded from Local UI.
 
 ## Configure Audit Logs to be Written to File
@@ -17,7 +17,7 @@ retrieval. Audit logs written to the `/var/log/stylus-audit.log` file can be dow
 You can configure your own application to write log entries to the `/var/log/stylus-audit.log` file by setting up the
 applications to write to `syslog` and configure your `syslog` daemon to direct the logs to the file. The exact steps to
 do this vary by application, but the log entries must conform to the expected schema. In addition, you can also direct
-Palette agent's logs to be directed to another file.
+Palette agent's logs to be directed to another file if you want to collect the logs in a different file.
 
 By default, you can view one year's worth of audit logs in Local UI. Log files past the one year mark will be rotated
 out and archived. You can still download your log files from any period, but they will not be viewable in Local UI.
@@ -59,8 +59,8 @@ out and archived. You can still download your log files from any period, but the
 
 1. Clone the CanvOS repository and change into the directory.
 
-2. Create a file at the path `overlay/files/etc/rsyslog.d/48-audit.conf`. You can change the filename, but it must sort
-   alphanumerically before `49-stylus-audit.conf`.
+2. Create a file at the path `overlay/files/etc/rsyslog.d/48-audit.conf`. You can change the filename, but it must be a
+   `conf` file and sort alphanumerically before `49-stylus-audit.conf`. For example, `30-my-log.conf`.
 
 <Tabs>
 
@@ -86,11 +86,16 @@ out and archived. You can still download your log files from any period, but the
     }
    ```
 
+   Ensure your logs follow the RFC 5424 Syslog protocol, with the message in JSON format. The JSON object must contain
+   the following keys: `edgeHostId`, `contentMsg`, `action`, `actor`, `actorType`, `resourceId`, `resourceName`,
+   `resourceKind`. If your log entries do not follow this RFE 5424 Syslog protocol, or do not contain the necessary
+   keys, they will still be logged, but will not show up in Local UI.
+
 </TabItem>
 
 <TabItem label="Send Palette Logs to Another File">
 
-3. Populate the file with the following configuration. Replace `your-file` with the file name of your log file.
+3. Populate the file with the following configuration. Replace `your-file` with the name of your log file.
 
    ```conf
    $PrivDropToUser root
@@ -127,11 +132,11 @@ out and archived. You can still download your log files from any period, but the
 
 ## View and Download Log File from Local UI
 
-Log files are stored in the `/var/log/` folder. By default, the active log file stores up to one year's worth of logs.
-When the one peiord is reached, the log file is rotated out and archived. If the log messages are configured to be
-picked up by Local UI, they will show up in Local UI. You can also download all log files in the `/var/log/` file from
-Local UI, including files that are older than one-year old, as well as files that were not configured to be displayed by
-Local UI.
+Log files are stored in the `/var/log/` folder. By default, the active log file `stylus-audit.log` stores up to one
+year's worth of logs. When the one period is reached, or when the file size reaches 100 MB, the log file is rotated out
+and archived. If the log messages are configured to be picked up by Local UI, they will show up in Local UI. You can
+also download all log files in the `/var/log/` file from Local UI, including files that are older than one-year old, as
+well as files that were not configured to be displayed by Local UI.
 
 ### Prerequisites
 

--- a/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
@@ -59,6 +59,10 @@ out and archived. You can still download your log files from any period, but the
 
 1. Clone the CanvOS repository and change into the directory.
 
+   ```shell
+    git clone https://github.com/spectrocloud/CanvOS.git
+   ```
+
 2. Create a file at the path `overlay/files/etc/rsyslog.d/48-audit.conf`. You can change the filename, but it must be a
    `conf` file and sort alphanumerically before `49-stylus-audit.conf`. For example, `30-my-log.conf`.
 

--- a/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
@@ -64,7 +64,7 @@ out and archived. You can still download your log files from any period, but the
 
 <Tabs>
 
-<TabIem label="Send Application Logs to Palette Log File">
+<TabItem label="Send Application Logs to Palette Log File">
 
 3. Populate the file with the following configuration. Replace `your-tag` with the tag you configured for the logs of
    your own application. If you changed the facility or the severity level from the suggested values, replace them with

--- a/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
@@ -1,0 +1,153 @@
+---
+sidebar_label: "Configure and Access Audit Logs"
+title: "Configure and Access Audit Logs"
+description: "Instructions for configuring applications to write to the audit log file and how to download the files. "
+hide_table_of_contents: false
+sidebar_position: 110
+tags: ["edge"]
+---
+
+On any operational Edge host, many services write events, logs, and any other applicable audit log to the
+`/var/log/stylus-audit.log` file. If you have application workloads on your cluster, you can also configure them to
+write audit logs to the same file. This allows you to keep all audit logs in a single location for easy management
+retrieval. Audit logs written to the `/var/log/stylus-audit.log` file can be downloaded from Local UI.
+
+## Configure Audit Logs to be Written to File
+
+You can configure your own application to write log entries to the `/var/log/stylus-audit.log` file by setting up the
+applications to write to `syslog` and configure your `syslog` daemon to direct the logs to the file. The exact steps to
+do this vary by application, but the log entries must conform to the expected schema. In addition, you can also direct
+Palette agent's logs to be directed to another file.
+
+By default, you can view one year's worth of audit logs in Local UI. Log files past the one year mark will be rotated
+out and archived. You can still download your log files from any period, but they will not be viewable in Local UI.
+
+### Limitations
+
+- This feature is available to airgapped Edge hosts without a connection to Palette only.
+
+### Prerequisites
+
+- You must have configured your application to write logs to `syslog` with a given facility and severity level. We
+  recommend setting the facility as `local7` and severity as `notice`. We also recommend that you add a tag to your
+  application logs to distinguish it from other logs.
+
+- The audit entries logged to `syslog` must be in the RFC 5424 Syslog protocol, with the message in JSON format. The
+  JSON object must contain the following keys: `edgeHostId`, `contentMsg`, `action`, `actor`, `actorType`, `resourceId`,
+  `resourceName`, `resourceKind`. For more information about the Syslog protocol, refer to
+  [RFC 5424 - The Syslog Protocol](https://datatracker.ietf.org/doc/html/rfc5424).
+
+- This how-to is based on the EdgeForge process. We recommend that you familiarize yourself with
+  [EdgeForge](../../edgeforge-workflow/edgeforge-workflow.md) and the process to build Edge artifacts.
+
+- A physical or virtual Linux machine with _AMD64_ (also known as _x86_64_) processor architecture to build the Edge
+  artifacts. You can issue the following command in the terminal to check your processor architecture.
+
+  ```bash
+  uname -m
+  ```
+
+- Minimum hardware configuration of the Linux machine:
+
+  - 4 CPU
+  - 8 GB memory
+  - 150 GB storage
+
+- [Git](https://git-scm.com/downloads). You can ensure git installation by issuing the `git --version` command.
+
+### Procedure
+
+1. Clone the CanvOS repository and change into the directory.
+
+2. Create a file at the path `overlay/files/etc/rsyslog.d/48-audit.conf`. You can change the filename, but it must sort
+   alphanumerically before `49-stylus-audit.conf`.
+
+<Tabs>
+
+<TabIem label="Send Application Logs to Palette Log File">
+
+3. Populate the file with the following configuration. Replace `your-tag` with the tag you configured for the logs of
+   your own application. If you changed the facility or the severity level from the suggested values, replace them with
+   your actual values.
+
+   ```conf
+   $PrivDropToUser root
+   $PrivDropToGroup root
+   $Umask 0000
+   $template ForwardFormat,"<%pri%>1 %timestamp:::date-rfc3339% %HOSTNAME% %syslogtag% %procid% - - %msg%\n"
+   if ($syslogfacility-text == 'local7' and $syslogseverity-text == 'notice' and $syslogtag contains 'your-tag') then {
+        action(
+            type="omfile"
+            file="/var/log/stylus-audit.log"
+            FileCreateMode="0600"
+            fileowner="root"
+            template="ForwardFormat"
+        )
+    }
+   ```
+
+</TabItem>
+
+<TabItem label="Send Palette Logs to Another File">
+
+3. Populate the file with the following configuration. Replace `your-file` with the file name of your log file.
+
+   ```conf
+   $PrivDropToUser root
+   $PrivDropToGroup root
+   $Umask 0000
+   $template ForwardFormat,"<%pri%>1 %timestamp:::date-rfc3339% %HOSTNAME% %syslogtag% %procid% - - %msg%\n"
+   if ($syslogfacility-text == 'local7' and $syslogseverity-text == 'notice' and $syslogtag contains 'stylus-audit') then {
+        action(
+            type="omfile"
+            file="/var/log/your-file"
+            FileCreateMode="0600"
+            fileowner="root"
+            template="ForwardFormat"
+        )
+    }
+   ```
+
+   This makes sure that the Palette agent logs are sent both to the file you configured and to the default
+   `stylus-audit.log` file.
+
+</TabItem>
+
+</Tabs>
+
+4. Follow [Build Edge Installer ISO](../../edgeforge-workflow/palette-canvos/build-installer-iso.md) to build an Edge
+   installer ISO and install an Edge host. Then follow the relevant guides in
+   [Deployment](../../site-deployment/site-deployment.md) to deploy a cluster with your application workloads.
+
+### Validate
+
+1. Log in to Local UI. For more information, refer to [Access Local UI Console](access-console.md).
+
+2. In the left **Main Menu**, click **Audit Log**. Confirm that the logs from your applications are being collected.
+
+## View and Download Log File from Local UI
+
+Log files are stored in the `/var/log/` folder. By default, the active log file stores up to one year's worth of logs.
+When the one peiord is reached, the log file is rotated out and archived. If the log messages are configured to be
+picked up by Local UI, they will show up in Local UI. You can also download all log files in the `/var/log/` file from
+Local UI, including files that are older than one-year old, as well as files that were not configured to be displayed by
+Local UI.
+
+### Prerequisites
+
+- An active Edge host installed in the `airgap` installation mode.
+
+### Procedure
+
+1. Log in to Local UI. For more information, refer to [Access Local UI Console](access-console.md).
+
+2. In the left **Main Menu**, click **Audit Log**. You can view all audit log entries on this page. By default, local UI
+   will display log entries dated up to one year ago.
+
+3. To download the log files, click the **Download Logs** button in the upper-right corner. This will download all files
+   in the `/var/log` folder, including archived old log files as well as any additional log files you configured to be
+   stored in the directory.
+
+### Validate
+
+1. Open the downloaded file. Confirm that the logs are included in the file.

--- a/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
@@ -92,8 +92,8 @@ out and archived. You can still download your log files from any period, but the
 
    Ensure your logs follow the RFC 5424 Syslog protocol, with the message in JSON format. The JSON object must contain
    the following keys: `edgeHostId`, `contentMsg`, `action`, `actor`, `actorType`, `resourceId`, `resourceName`,
-   `resourceKind`. If your log entries do not follow the RFE 5424 Syslog protocol, or do not contain the necessary
-   keys, they will still be logged, but will not show up in Local UI.
+   `resourceKind`. If your log entries do not follow the RFE 5424 Syslog protocol, or do not contain the necessary keys,
+   they will still be logged, but will not show up in Local UI.
 
 </TabItem>
 
@@ -125,8 +125,8 @@ out and archived. You can still download your log files from any period, but the
 
 </Tabs>
 
-4. Follow the [Build Edge Installer ISO](../../edgeforge-workflow/palette-canvos/build-installer-iso.md) guide to build an Edge
-   installer ISO and install an Edge host. Then follow the relevant guides in
+4. Follow the [Build Edge Installer ISO](../../edgeforge-workflow/palette-canvos/build-installer-iso.md) guide to build
+   an Edge installer ISO and install an Edge host. Then follow the relevant guides in
    [Deployment](../../site-deployment/site-deployment.md) to deploy a cluster with your application workloads.
 
 ### Validate
@@ -138,10 +138,11 @@ out and archived. You can still download your log files from any period, but the
 ## View and Download Log File from Local UI
 
 Log files are stored in the `/var/log/` folder. The active log file `stylus-audit.log` stores up to one year's worth of
-logs. After a year, or when the file size reaches 100 MB, the log file is rotated out and archived. If
-the log messages are configured to be picked up by Local UI, they will show up in Local UI. You can also download all
-log files in the `/var/log/` file from Local UI, including files that are older than a year, as well as files that
-were not configured to be displayed by Local UI.
+logs. After a year, or when the file size reaches 100 MB, the log file is rotated out and archived. If the log messages
+are configured to be picked up by Local UI, they will show up in Local UI.
+
+You can also download log files less than three years old in the `/var/log/` file from Local UI. This includes the log
+entries that were not configured to be displayed in Local UI.
 
 ### Prerequisites
 

--- a/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
@@ -7,7 +7,7 @@ sidebar_position: 110
 tags: ["edge"]
 ---
 
-On any operational Edge host, many services write events, logs, and any other applicable audit log to the
+On any operational Edge host, many services write events, logs, and any other applicable audit logs to the
 `/var/log/stylus-audit.log` file. If you have application workloads on your cluster, you can also configure them to
 write audit logs to the same file. This allows you to keep all audit logs in a single location for easy management and
 retrieval. Audit logs written to the `/var/log/stylus-audit.log` file can be downloaded from Local UI.
@@ -17,14 +17,14 @@ retrieval. Audit logs written to the `/var/log/stylus-audit.log` file can be dow
 You can configure your own application to write log entries to the `/var/log/stylus-audit.log` file by setting up the
 applications to write to `syslog` and configure your `syslog` daemon to direct the logs to the file. The exact steps to
 do this vary by application, but the log entries must conform to the expected schema. In addition, you can also direct
-Palette agent's logs to be directed to another file if you want to collect the logs in a different file.
+Palette agent's logs to another file if you want to collect the logs in a different file.
 
 By default, you can view one year's worth of audit logs in Local UI. Log files past the one year mark will be rotated
 out and archived. You can still download your log files from any period, but they will not be viewable in Local UI.
 
 ### Limitations
 
-- This feature is available to airgapped Edge hosts without a connection to Palette only.
+- This feature is only available to airgapped Edge hosts without a connection to Palette.
 
 ### Prerequisites
 
@@ -63,8 +63,8 @@ out and archived. You can still download your log files from any period, but the
     git clone https://github.com/spectrocloud/CanvOS.git
    ```
 
-2. Create a file at the path `overlay/files/etc/rsyslog.d/48-audit.conf`. You can change the filename, but it must be a
-   `conf` file and sort alphanumerically before `49-stylus-audit.conf`. For example, `30-my-log.conf`.
+2. Create a file at the path `overlay/files/etc/rsyslog.d/48-audit.conf`. You can change the file name, but it must be a
+   `conf` file and sorted alphanumerically before `49-stylus-audit.conf`. For example, `30-my-log.conf`.
 
 <Tabs>
 
@@ -92,7 +92,7 @@ out and archived. You can still download your log files from any period, but the
 
    Ensure your logs follow the RFC 5424 Syslog protocol, with the message in JSON format. The JSON object must contain
    the following keys: `edgeHostId`, `contentMsg`, `action`, `actor`, `actorType`, `resourceId`, `resourceName`,
-   `resourceKind`. If your log entries do not follow this RFE 5424 Syslog protocol, or do not contain the necessary
+   `resourceKind`. If your log entries do not follow the RFE 5424 Syslog protocol, or do not contain the necessary
    keys, they will still be logged, but will not show up in Local UI.
 
 </TabItem>
@@ -109,7 +109,8 @@ out and archived. You can still download your log files from any period, but the
    if ($syslogfacility-text == 'local7' and $syslogseverity-text == 'notice' and $syslogtag contains 'stylus-audit') then {
         action(
             type="omfile"
-            file="/var/log/your-file"
+            // highlight-next-line
+            file="</var/log/your-file>"
             FileCreateMode="0600"
             fileowner="root"
             template="ForwardFormat"
@@ -124,7 +125,7 @@ out and archived. You can still download your log files from any period, but the
 
 </Tabs>
 
-4. Follow [Build Edge Installer ISO](../../edgeforge-workflow/palette-canvos/build-installer-iso.md) to build an Edge
+4. Follow the [Build Edge Installer ISO](../../edgeforge-workflow/palette-canvos/build-installer-iso.md) guide to build an Edge
    installer ISO and install an Edge host. Then follow the relevant guides in
    [Deployment](../../site-deployment/site-deployment.md) to deploy a cluster with your application workloads.
 
@@ -137,14 +138,14 @@ out and archived. You can still download your log files from any period, but the
 ## View and Download Log File from Local UI
 
 Log files are stored in the `/var/log/` folder. The active log file `stylus-audit.log` stores up to one year's worth of
-logs. When the one period is reached, or when the file size reaches 100 MB, the log file is rotated out and archived. If
+logs. After a year, or when the file size reaches 100 MB, the log file is rotated out and archived. If
 the log messages are configured to be picked up by Local UI, they will show up in Local UI. You can also download all
-log files in the `/var/log/` file from Local UI, including files that are older than one-year old, as well as files that
+log files in the `/var/log/` file from Local UI, including files that are older than a year, as well as files that
 were not configured to be displayed by Local UI.
 
 ### Prerequisites
 
-- An active Edge host installed in the `airgap` installation mode.
+- An active Edge host installed in the `airgap` mode.
 
 ### Procedure
 
@@ -154,7 +155,7 @@ were not configured to be displayed by Local UI.
    this page. Local UI will display log entries dated up to one year ago.
 
 3. To download the log files, click the **Download** button in the upper-right corner. This will download all files in
-   the `/var/log` folder, including archived old log files as well as any additional log files you configured to be
+   the `/var/log` folder, including the archived log files as well as any additional log files you configured to be
    stored in the directory.
 
 ### Validate

--- a/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
@@ -132,11 +132,11 @@ out and archived. You can still download your log files from any period, but the
 
 ## View and Download Log File from Local UI
 
-Log files are stored in the `/var/log/` folder. By default, the active log file `stylus-audit.log` stores up to one
-year's worth of logs. When the one period is reached, or when the file size reaches 100 MB, the log file is rotated out
-and archived. If the log messages are configured to be picked up by Local UI, they will show up in Local UI. You can
-also download all log files in the `/var/log/` file from Local UI, including files that are older than one-year old, as
-well as files that were not configured to be displayed by Local UI.
+Log files are stored in the `/var/log/` folder. The active log file `stylus-audit.log` stores up to one year's worth of
+logs. When the one period is reached, or when the file size reaches 100 MB, the log file is rotated out and archived. If
+the log messages are configured to be picked up by Local UI, they will show up in Local UI. You can also download all
+log files in the `/var/log/` file from Local UI, including files that are older than one-year old, as well as files that
+were not configured to be displayed by Local UI.
 
 ### Prerequisites
 
@@ -146,11 +146,11 @@ well as files that were not configured to be displayed by Local UI.
 
 1. Log in to Local UI. For more information, refer to [Access Local UI Console](access-console.md).
 
-2. In the left **Main Menu**, click **Audit Log**. You can view all audit log entries on this page. By default, local UI
-   will display log entries dated up to one year ago.
+2. In the left **Main Menu**, click **Diagnostics**. Then click the **Logs** tab. You can view all audit log entries on
+   this page. Local UI will display log entries dated up to one year ago.
 
-3. To download the log files, click the **Download Logs** button in the upper-right corner. This will download all files
-   in the `/var/log` folder, including archived old log files as well as any additional log files you configured to be
+3. To download the log files, click the **Download** button in the upper-right corner. This will download all files in
+   the `/var/log` folder, including archived old log files as well as any additional log files you configured to be
    stored in the directory.
 
 ### Validate

--- a/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/audit-logs.md
@@ -64,7 +64,7 @@ out and archived. You can still download your log files from any period, but the
 
 <Tabs>
 
-<TabItem label="Send Application Logs to Palette Log File">
+<TabItem value="Send Application Logs to Palette Log File">
 
 3. Populate the file with the following configuration. Replace `your-tag` with the tag you configured for the logs of
    your own application. If you changed the facility or the severity level from the suggested values, replace them with
@@ -93,7 +93,7 @@ out and archived. You can still download your log files from any period, but the
 
 </TabItem>
 
-<TabItem label="Send Palette Logs to Another File">
+<TabItem value="Send Palette Logs to Another File">
 
 3. Populate the file with the following configuration. Replace `your-file` with the name of your log file.
 

--- a/docs/docs-content/clusters/edge/local-ui/host-management/host-management.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/host-management.md
@@ -23,4 +23,10 @@ Refer to the following resources to learn how to configure your Edge host using 
 
 - [Configure HTTP Proxy](./configure-proxy.md)
 
+- [Add Custom Links](./custom-link.md)
+
+- [Diagnostic Tools](./diagnostic-tools.md)
+
+- [Configure and Download Audit Logs](./audit-logs.md)
+
 - [Customize Local UI Theme](./theming.md)


### PR DESCRIPTION
## Describe the Change

This PR documents how to configure applications logs to stylus audit log file and how to download logs.

## Changed Pages

💻 [Audit Logs](https://deploy-preview-3564--docs-spectrocloud.netlify.app/clusters/edge/local-ui/host-management/audit-logs/)

## Jira Tickets

🎫 [PE-4732](https://spectrocloud.atlassian.net/browse/PE-4732)

## Backports

Can this PR be backported?

- [ ] No. 


[PE-4732]: https://spectrocloud.atlassian.net/browse/PE-4732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ