### PR TITLE
docs: document node drain configmap PCP-3323

### DIFF
--- a/docs/docs-content/clusters/cluster-management/os-patching.md
+++ b/docs/docs-content/clusters/cluster-management/os-patching.md
@@ -20,12 +20,16 @@ cluster nodes.
 
 The following options are available for OS patching:
 
-- Patch OS on boot
-- Enable scheduled patching
-- Patch OS on-demand
+- [Patch OS on boot](#patch-os-on-boot)
+- [Enable scheduled patching](#enable-scheduled-patching)
+- [Patch OS on-demand](#perform-on-demand-patching)
 
 You can use a combination of these options to patch the operating system to the latest version. For example, you can
 patch OS on boot, set up scheduled patching every month, and also perform on-demand patches at any given point in time.
+
+Palette provides the option to provide custom node drain configuration, which gives you fine-grained control of drain
+behaviour during updates. Refer to the [Configure OS Patching Drain Policy](#configure-os-patching-drain-policy)
+for further information.
 
 ## Patch OS on Boot
 
@@ -154,15 +158,15 @@ updates.
   - For EKS clusters, you can trigger OS updates from Palette. This would request AWS to update cluster node groups to
     the latest patch version.
 
-### Prerequisite
+### Prerequisites
 
 - An active cluster in Palette.
 
-### Instructions
+### Enablement
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
-2. From the left **Main Menu**, click **Cluster**. Select the cluster you want to patch to view cluster details.
+2. From the left **Main Menu**, click **Clusters**. Select the cluster you want to patch to view cluster details.
 
 3. In the upper-right corner, click on **Settings** and select **On-Demand Update**. This will trigger an OS update
    immediately if a newer version is available.
@@ -180,3 +184,111 @@ updates.
    | ----------------------- | --------------------------------------- |
    | Last Applied Patch Time | The date and time of the last OS patch. |
    | Patched Version         | The latest patched version.             |
+
+## Configure OS Patching Drain Policy
+
+Palette provides the ability to configure the drain policy during on boot, scheduled and on-demand OS patching. This
+capability can also be useful during node maintenance. Users can specify a node drain policy using a ConfigMap, which
+can be applied to deployed clusters using a cluster profile or through `kubectl`.
+
+### Limitations
+
+- This operation is not available for existing Kubernetes clusters imported into Palette.
+- This operation is not available for managed Kubernetes Services such as EKS and AKS.
+  - For EKS clusters, you can trigger OS updates from Palette. This would request AWS to update cluster node groups to
+    the latest patch version.
+
+### Prerequisites
+
+- An active cluster in Palette.
+
+### Enablement
+
+1. Log in to [Palette](https://console.spectrocloud.com).
+
+2. From the left **Main Menu**, click **Profiles**. Then, click **Add Cluster Profile**. The cluster profile creation
+   wizard appears.
+
+3. Fill in a name in the **Name** field. Optionally, add a description in the **Description** field. Select the
+   **Add-on** box for the **Type**. Click **Next**.
+
+4. Click **Add Manifest**. The manifest editor appears.
+
+5. Add a name in the **Layer Name** field. Then, click **New manifest**. Assign a name to the internal manifest and
+   click on the blue button. An empty editor displays on the right side of the screen.
+
+6. Paste the snippet below into the empty editor. This snippet uses a ConfigMap to control the drain policy of the
+   cluster. The ConfigMap provides the following drain configuration parameters.
+
+   | **Parameter**                         | **Description**                                                                                                                                                 | **Value Type**       | **Default Value** |
+   | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ----------------- |
+   | `data.profiling`                      | Flag to indicate whether the profiling server should capture profiling data. If enabled, the port `8082` should be exposed to the profiling server.             | `enable` / `disable` | `disable`         |
+   | `data.feature.workloads`              | Flag to indicate whether to push workload metadata to the Palette server.                                                                                       | `enable` /`disable`  | `enable`          |
+   | `data.drain.timeout`                  | The length of time, specified in nanoseconds, to wait for the drain operation to complete. There is no configured timeout if set to zero.                       | Duration             | `unset`           |
+   | `data.drain.gracePeriod`              | The period of time, specified in seconds, to wait for each pod to terminate gracefully. The value provided by the pods will be usef if set to a negative value. | Integer              | `-1`              |
+   | `data.drain.deleteLocalData`          | Flag to indicate whether to continue if one or more affected pods do not have specified volumes, resulting in the deletion of their local data.                 | Boolean              | `false`           |
+   | `data.drain.ignoreDaemonSets`         | Flag to indicate whether to ignore DaemonSet managed pods.                                                                                                      | Boolean              | `false`           |
+   | `data.drain.force`                    | Flag to indicate whether to continue if one or more affected pods do not have a declared controller.                                                            | Boolean              | `false`           |
+   | `data.drain.disableEviction`          | Flag to indicate whether to force drain to use delete operations.                                                                                               | Boolean              | `false`           |
+   | `data.drain.skipWaitForDeleteTimeout` | The length of time, in seconds, to wait for pod deletion to complete. If the time elapses, the drain will continue.                                             | Integer              | `0`               |
+
+   ```yaml
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+   name: palette-agent-config
+   namespace: "cluster-{{ .spectro.system.cluster.uid }}"
+   data:
+   profiling: disable
+   feature.workloads: enable
+   drain: |
+     {
+        "timeout": 600000000,
+        "gracePeriod": 600,
+        "deleteLocalData": true,
+        "ignoreDaemonSets": true,
+        "force": true,
+        "disableEviction": false,
+        "skipWaitForDeleteTimeout": 600
+     }
+   ```
+
+   :::info
+
+   You can also specify the drain ConfigMap directly on the cluster by using `kubectl`. Download the
+   [Kubeconfig](./kubeconfig.md) file to connect to the cluster and issue the
+   `kubectl create configmap palette-agent-config --namespace <cluster-id>` command. Then, execute the command
+   `kubectl edit configmap palette-agent-config --namespace <cluster-id>` command and paste the configuration provided.
+
+   :::
+
+7. Click **Confirm & Create** to save the manifest. The manifest editor closes.
+
+8. Click **Next**. The summary of your Add-on cluster profile appears. Then, click **Finish Configuration** to complete
+   the cluster profile creation flow. The list of cluster profiles displays.
+
+9. From the left **Main Menu**, click **Clusters**. Select the cluster you want to patch to view cluster details.
+
+10. Select the **Profile** tab. Then, click `+` next to **Addon Layers**, then select the Add-on profile you created
+    previously. Click **Confirm**, then click **Save**. Wait for Palette to apply this manifest to your cluster.
+
+11. In the upper-right corner, click on **Settings** and select **On-Demand Update**. This will trigger an OS update
+    immediately if a newer version is available.
+
+### Validate
+
+1. Log in to [Palette](https://console.spectrocloud.com).
+
+2. Click on the cluster you patched to view cluster details.
+
+3. Click on the **Nodes** tab of the cluster details page. You can find the current OS version and when the most recent
+   patch was applied.
+
+   | **Field**               | **Description**                         |
+   | ----------------------- | --------------------------------------- |
+   | Last Applied Patch Time | The date and time of the last OS patch. |
+   | Patched Version         | The latest patched version.             |
+
+4. Select the **Workloads** tab. The list of namespaces appears. Then, select the **Pods** tab. The list of deployed
+   pods and their details appears. The **Age** column of the pods shows that they were migrated, not restarted, during
+   cluster patching.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR documents usage of ConfigMap to specify node drain behaviour during OS patching. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PCP-3323](https://spectrocloud.atlassian.net/browse/PCP-3323)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x ] No. _Please leave a short comment below about why this PR cannot be backported._
