### PR TITLE
docs: add airgap VMO profile creation PEM-5497

### DIFF
--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -26,13 +26,37 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 ## Prerequisites
 
+<Tabs groupId="environment">
+
+<TabItem value="non-edge" label="Non-edge">
+
 - A Palette permission key `create` for the resource `clusterProfile`.
 
-- If you are creating an Edge cluster profile, your profile must have a Container Storage Interface (CSI) pack.
+</TabItem>
+
+<TabItem value="edge" label="Edge">
+
+- A Palette permission key `create` for the resource `clusterProfile`.
+
+- Your Edge cluster profile must have a Container Storage Interface (CSI) pack.
+
+</TabItem>
+
+<TabItem value="airgap" label="Airgap">
+
+- A Palette permission key `create` for the resource `clusterProfile`.
+
+- Ensure the VMO pack is installed in your airgap environment. Refer to the Install VMO in Airgap Environments guide for
+  further information.
+
+</TabItem>
+
+</Tabs>
 
 ## Create the Profile
 
-<Tabs>
+<Tabs groupId="environment">
+
 <TabItem value="non-edge" label="Non-edge">
 
 1. Log in to [Palette](https://console.spectrocloud.com).
@@ -165,11 +189,68 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 </TabItem>
 
+<TabItem value="airgap" label="Airgap">
+
+1. Log in to Palette using your configured system address.
+
+2. Select **Profiles** in the left **Main Menu** and click the **Add Cluster Profile** button.
+
+3. Enter basic information for the profile: name, version if desired, and optional description.
+
+4. Select type **Add-on**, and click **Next**.
+
+5. In the following screen, click **Add New Pack**.
+
+6. Locate the **Virtual Machine Orchestrator** pack and add it to your profile.
+
+7. Review the **Access** configuration panel at right. The default setting is **Proxied**, which automatically adds the
+   **Spectro Proxy** pack when you create the cluster, allowing access to the Spectro VM Dashboard from anywhere. Check
+   out the <VersionedLink text="Spectro Proxy" url="/integrations/packs/?pack=spectro-proxy" /> guide to learn more.
+   Changing the default may require some additional configuration.
+
+   The **Direct** option is intended for a private configuration where a proxy is not implemented or not desired.
+
+   :::warning
+
+   We recommend using the pack defaults. Default settings provide best practices for your clusters. Changing the default
+   settings can introduce misconfigurations. Carefully review the changes you make to a pack.
+
+   :::
+
+8. Click **Values** in the **Pack Details** section. The pack manifest editor appears.
+
+9. Locate the `pack.cdi` section in the manifest. Set `privateRegistry.enabled` to true, and add
+   `privateRegistry.registryIP` and `privateRegistry.registryBasePath` details according to your environment details.
+   This configures the pack to pull images from the provided private registry.
+
+   ```yaml
+   cdi:
+     privateRegistry:
+       enabled: true
+       registryIP: <REPLACE ME>
+       registryBasePath: <REPLACE ME>
+   ```
+
+10. Click **Confirm & Create**.
+
+11. In the following screen, click **Next**.
+
+12. Review the profile and click **Finish Configuration**.
+
+13. Apply the profile to your cluster. For more information, refer to
+    [Create a Cluster](../clusters/public-cloud/deploy-k8s-cluster.md).
+
+</TabItem>
+
 </Tabs>
 
 ## Validate
 
 You can validate the profile is created.
+
+<Tabs groupId="environment">
+
+<TabItem value="non-edge" label="Non-edge">
 
 1.  Log in to [Palette](https://console.spectrocloud.com).
 
@@ -181,6 +262,40 @@ You can validate the profile is created.
 
 5.  Based on your Single Sign-On (SSO) settings, the **Virtual Machines** tab may display on the **Cluster Overview**
     page, or the **Connect** button may display next to **Virtual Machines Dashboard** in cluster details.
+
+</TabItem>
+
+<TabItem value="edge" label="Edge">
+
+1.  Log in to [Palette](https://console.spectrocloud.com).
+
+2.  Navigate to **Profiles** from the left **Main Menu**.
+
+3.  Locate the newly created profile in the list.
+
+4.  From the left **Main Menu**, click **Clusters** and select your cluster.
+
+5.  Based on your Single Sign-On (SSO) settings, the **Virtual Machines** tab may display on the **Cluster Overview**
+    page, or the **Connect** button may display next to **Virtual Machines Dashboard** in cluster details.
+
+</TabItem>
+
+<TabItem value="airgap" label="Airgap">
+
+1.  Log in to Palette using your configured system address.
+
+2.  Navigate to **Profiles** from the left **Main Menu**.
+
+3.  Locate the newly created profile in the list.
+
+4.  From the left **Main Menu**, click **Clusters** and select your cluster.
+
+5.  Based on your Single Sign-On (SSO) settings, the **Virtual Machines** tab may display on the **Cluster Overview**
+    page, or the **Connect** button may display next to **Virtual Machines Dashboard** in cluster details.
+
+</TabItem>
+
+</Tabs>
 
 ## Next Steps
 

--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -193,7 +193,7 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 1.  Log in to a tenant that belongs to your instance of Palette or Palette VerteX.
 
-2.  In the **left Main Menu**, select **Profiles** and click **Add Cluster Profile**.
+2.  In the left **Main Menu**, select **Profiles** and click **Add Cluster Profile**.
 
 3.  Enter basic information for the profile: name, version if desired, and optional description.
 
@@ -288,7 +288,7 @@ You can validate the profile is created.
 
 <TabItem value="airgap" label="Airgap">
 
-1.  Log in to Palette using your configured system address.
+1.  Log in to a tenant that belongs to your instance of Palette or Palette VerteX.
 
 2.  Navigate to **Profiles** from the left **Main Menu**.
 

--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -219,8 +219,10 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 8. Click **Values** in the **Pack Details** section. The pack manifest editor appears.
 
-9. Locate the `pack.cdi` section in the manifest. Configure the `pack.cdi.privateRegistry` option as in the snippet
-   below. This configures the pack to pull images from your airgap environment private registry.
+9. Locate the `pack.cdi.privateRegistry` section in the manifest. The table below contains a brief description of each
+   field exposed by the private registry. Set the `pack.cdi.privateRegistry.enabled` field to true and fill in the
+   registry IP address and base path according to your environment. This configures the VMO pack to pull images from
+   your airgap environment private registry.
 
    | Field                                       | Description                                                          |
    | ------------------------------------------- | -------------------------------------------------------------------- |

--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -191,9 +191,9 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 <TabItem value="airgap" label="Airgap">
 
-1. Log in to Palette using your configured system address.
+1. Log in to a tenant that belongs to your instance of Palette or Palette VerteX.
 
-2. Select **Profiles** in the left **Main Menu** and click the **Add Cluster Profile** button.
+2. In the **left Main Menu**, select **Profiles** and click **Add Cluster Profile**.
 
 3. Enter basic information for the profile: name, version if desired, and optional description.
 
@@ -203,10 +203,9 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 6. Locate the **Virtual Machine Orchestrator** pack and add it to your profile.
 
-7. Review the **Access** configuration panel at right. The default setting is **Proxied**, which automatically adds the
+7. Review the **Access** configuration panel on the right. The default setting is **Proxied**, which automatically adds the
    **Spectro Proxy** pack when you create the cluster, allowing access to the Spectro VM Dashboard from anywhere. Check
    out the <VersionedLink text="Spectro Proxy" url="/integrations/packs/?pack=spectro-proxy" /> guide to learn more.
-   Changing the default may require some additional configuration.
 
    The **Direct** option is intended for a private configuration where a proxy is not implemented or not desired.
 
@@ -219,7 +218,7 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 8. Click **Values** in the **Pack Details** section. The pack manifest editor appears.
 
-9. Locate the `pack.cdi.privateRegistry` section in the manifest. The table below contains a brief description of each
+ Locate the `pack.cdi.privateRegistry` section in the manifest. The table below contains a brief description of each
    field exposed by the private registry. Set the `pack.cdi.privateRegistry.enabled` field to true and fill in the
    registry IP address and base path according to your environment. This configures the VMO pack to pull images from
    your airgap environment private registry.
@@ -240,7 +239,7 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 10. Click **Confirm & Create**.
 
-11. In the following screen, click **Next**.
+11. On the following screen, click **Next**.
 
 12. Review the profile and click **Finish Configuration**.
 

--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -219,9 +219,14 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 8. Click **Values** in the **Pack Details** section. The pack manifest editor appears.
 
-9. Locate the `pack.cdi` section in the manifest. Set `privateRegistry.enabled` to true, and add
-   `privateRegistry.registryIP` and `privateRegistry.registryBasePath` details according to your environment details.
-   This configures the pack to pull images from the provided private registry.
+9. Locate the `pack.cdi` section in the manifest. Configure the `pack.cdi.privateRegistry` option as in the snippet
+   below. This configures the pack to pull images from your airgap environment private registry.
+
+   | Field                                       | Description                                                          |
+   | ------------------------------------------- | -------------------------------------------------------------------- |
+   | `pack.cdi.privateRegistry.enabled`          | Flag to enable the profile to use the airgap private image registry. |
+   | `pack.cdi.privateRegistry.registryIP`       | The IP address the private image registry.                           |
+   | `pack.cdi.privateRegistry.registryBasePath` | The base path of the private image registry.                         |
 
    ```yaml
    cdi:

--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -203,9 +203,10 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 6. Locate the **Virtual Machine Orchestrator** pack and add it to your profile.
 
-7. Review the **Access** configuration panel on the right. The default setting is **Proxied**, which automatically adds the
-   **Spectro Proxy** pack when you create the cluster, allowing access to the Spectro VM Dashboard from anywhere. Check
-   out the <VersionedLink text="Spectro Proxy" url="/integrations/packs/?pack=spectro-proxy" /> guide to learn more.
+7. Review the **Access** configuration panel on the right. The default setting is **Proxied**, which automatically adds
+   the **Spectro Proxy** pack when you create the cluster, allowing access to the Spectro VM Dashboard from anywhere.
+   Check out the <VersionedLink text="Spectro Proxy" url="/integrations/packs/?pack=spectro-proxy" /> guide to learn
+   more.
 
    The **Direct** option is intended for a private configuration where a proxy is not implemented or not desired.
 
@@ -218,24 +219,24 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 8. Click **Values** in the **Pack Details** section. The pack manifest editor appears.
 
- Locate the `pack.cdi.privateRegistry` section in the manifest. The table below contains a brief description of each
-   field exposed by the private registry. Set the `pack.cdi.privateRegistry.enabled` field to true and fill in the
-   registry IP address and base path according to your environment. This configures the VMO pack to pull images from
-   your airgap environment private registry.
+Locate the `pack.cdi.privateRegistry` section in the manifest. The table below contains a brief description of each
+field exposed by the private registry. Set the `pack.cdi.privateRegistry.enabled` field to true and fill in the registry
+IP address and base path according to your environment. This configures the VMO pack to pull images from your airgap
+environment private registry.
 
-   | Field                                       | Description                                                          |
-   | ------------------------------------------- | -------------------------------------------------------------------- |
-   | `pack.cdi.privateRegistry.enabled`          | Flag to enable the profile to use the airgap private image registry. |
-   | `pack.cdi.privateRegistry.registryIP`       | The IP address the private image registry.                           |
-   | `pack.cdi.privateRegistry.registryBasePath` | The base path of the private image registry.                         |
+| Field                                       | Description                                                          |
+| ------------------------------------------- | -------------------------------------------------------------------- |
+| `pack.cdi.privateRegistry.enabled`          | Flag to enable the profile to use the airgap private image registry. |
+| `pack.cdi.privateRegistry.registryIP`       | The IP address the private image registry.                           |
+| `pack.cdi.privateRegistry.registryBasePath` | The base path of the private image registry.                         |
 
-   ```yaml
-   cdi:
-     privateRegistry:
-       enabled: true
-       registryIP: <REPLACE ME>
-       registryBasePath: <REPLACE ME>
-   ```
+```yaml
+cdi:
+  privateRegistry:
+    enabled: true
+    registryIP: <REPLACE ME>
+    registryBasePath: <REPLACE ME>
+```
 
 10. Click **Confirm & Create**.
 

--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -191,60 +191,59 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 <TabItem value="airgap" label="Airgap">
 
-1. Log in to a tenant that belongs to your instance of Palette or Palette VerteX.
+1.  Log in to a tenant that belongs to your instance of Palette or Palette VerteX.
 
-2. In the **left Main Menu**, select **Profiles** and click **Add Cluster Profile**.
+2.  In the **left Main Menu**, select **Profiles** and click **Add Cluster Profile**.
 
-3. Enter basic information for the profile: name, version if desired, and optional description.
+3.  Enter basic information for the profile: name, version if desired, and optional description.
 
-4. Select type **Add-on**, and click **Next**.
+4.  Select type **Add-on**, and click **Next**.
 
-5. In the following screen, click **Add New Pack**.
+5.  In the following screen, click **Add New Pack**.
 
-6. Locate the **Virtual Machine Orchestrator** pack and add it to your profile.
+6.  Locate the **Virtual Machine Orchestrator** pack and add it to your profile.
 
-7. Review the **Access** configuration panel on the right. The default setting is **Proxied**, which automatically adds
-   the **Spectro Proxy** pack when you create the cluster, allowing access to the Spectro VM Dashboard from anywhere.
-   Check out the <VersionedLink text="Spectro Proxy" url="/integrations/packs/?pack=spectro-proxy" /> guide to learn
-   more.
+7.  Review the **Access** configuration panel on the right. The default setting is **Proxied**, which automatically adds
+    the **Spectro Proxy** pack when you create the cluster, allowing access to the Spectro VM Dashboard from anywhere.
+    Check out the <VersionedLink text="Spectro Proxy" url="/integrations/packs/?pack=spectro-proxy" /> guide to learn
+    more.
 
-   The **Direct** option is intended for a private configuration where a proxy is not implemented or not desired.
+    The **Direct** option is intended for a private configuration where a proxy is not implemented or not desired.
 
-   :::warning
+    :::warning
 
-   We recommend using the pack defaults. Default settings provide best practices for your clusters. Changing the default
-   settings can introduce misconfigurations. Carefully review the changes you make to a pack.
+    We recommend using the pack defaults. Default settings provide best practices for your clusters. Changing the
+    default settings can introduce misconfigurations. Carefully review the changes you make to a pack.
 
-   :::
+    :::
 
-8. Click **Values** in the **Pack Details** section. The pack manifest editor appears.
+8.  Click **Values** in the **Pack Details** section. The pack manifest editor appears. Locate the
+    `pack.cdi.privateRegistry` section in the manifest. The table below contains a brief description of each field
+    exposed by the private registry. Set the `pack.cdi.privateRegistry.enabled` field to true and fill in the registry
+    IP address and base path according to your environment. This configures the VMO pack to pull images from your airgap
+    environment private registry.
 
-Locate the `pack.cdi.privateRegistry` section in the manifest. The table below contains a brief description of each
-field exposed by the private registry. Set the `pack.cdi.privateRegistry.enabled` field to true and fill in the registry
-IP address and base path according to your environment. This configures the VMO pack to pull images from your airgap
-environment private registry.
+        | Field                                       | Description                                                          |
+        | ------------------------------------------- | -------------------------------------------------------------------- |
+        | `pack.cdi.privateRegistry.enabled`          | Flag to enable the profile to use the airgap private image registry. |
+        | `pack.cdi.privateRegistry.registryIP`       | The IP address the private image registry.                           |
+        | `pack.cdi.privateRegistry.registryBasePath` | The base path of the private image registry.                         |
 
-| Field                                       | Description                                                          |
-| ------------------------------------------- | -------------------------------------------------------------------- |
-| `pack.cdi.privateRegistry.enabled`          | Flag to enable the profile to use the airgap private image registry. |
-| `pack.cdi.privateRegistry.registryIP`       | The IP address the private image registry.                           |
-| `pack.cdi.privateRegistry.registryBasePath` | The base path of the private image registry.                         |
+        ```yaml
+        cdi:
+          privateRegistry:
+            enabled: true
+            registryIP: <REPLACE ME>
+            registryBasePath: <REPLACE ME>
+        ```
 
-```yaml
-cdi:
-  privateRegistry:
-    enabled: true
-    registryIP: <REPLACE ME>
-    registryBasePath: <REPLACE ME>
-```
+9.  Click **Confirm & Create**.
 
-10. Click **Confirm & Create**.
+10. On the following screen, click **Next**.
 
-11. On the following screen, click **Next**.
+11. Review the profile and click **Finish Configuration**.
 
-12. Review the profile and click **Finish Configuration**.
-
-13. Apply the profile to your cluster. For more information, refer to
+12. Apply the profile to your cluster. For more information, refer to
     [Create a Cluster](../clusters/public-cloud/deploy-k8s-cluster.md).
 
 </TabItem>

--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -46,8 +46,8 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 - A Palette permission key `create` for the resource `clusterProfile`.
 
-- Ensure the VMO pack is installed in your airgap environment. Refer to the Install VMO in Airgap Environments guide for
-  further information.
+- Ensure the VMO pack is installed in your airgap environment. Refer to the
+  [Install VMO in Airgap Environments](./install-vmo-in-airgap.md) guide for further information.
 
 </TabItem>
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds airgap tabs to the Create VMO Profile page.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Create a VMO Profile](https://deploy-preview-3583--docs-spectrocloud.netlify.app/vm-management/create-vmo-profile/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-5497](https://spectrocloud.atlassian.net/browse/PEM-5497)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[PEM-5497]: https://spectrocloud.atlassian.net/browse/PEM-5497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ