### PR TITLE
docs: add no proxy list configuration for VMO PEM-5233

### DIFF
--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -250,10 +250,10 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 If you want to use direct access in an environment configured to use an external proxy, you must exclude your cluster's
 load balancer IP range from proxy routing. Expand the following section to learn how you can configure your
-environment's No Proxy list.
+environment's **No Proxy** list.
 
    <details>
-      <summary>Configure the No Proxy list</summary>
+      <summary>Configure the **No Proxy** list</summary>
 
       1. Download the [Kubeconfig](../clusters/cluster-management/kubeconfig.md) file of the airgap support VM.
 

--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -246,6 +246,51 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 12. Apply the profile to your cluster. For more information, refer to
     [Create a Cluster](../clusters/public-cloud/deploy-k8s-cluster.md).
 
+:::info
+
+If you want to use direct access in an environment configured to use an external proxy, you must exclude your cluster's
+load balancer IP range from proxy routing. Expand the following section to learn how you can configure your
+environment's no proxy list.
+
+   <details>
+      <summary>Configure the No Proxy list</summary>
+
+      1. Download the [Kubeconfig](../clusters/cluster-management/kubeconfig.md) file of the airgap support VM.
+
+      2. Open a terminal window and set the environment variable `KUBECONFIG` to point to the file you downloaded.
+
+          ```shell
+          export KUBECONFIG=<path-to-downloaded-kubeconfig-file>
+          ```
+
+      3. Execute the following command to find the namespace which contains your environment proxy configuration. Make a note of the namespace.
+
+          ```shell
+          kubectl get podpreset --all-namespaces --field-selector=metadata.name=proxy
+          ```
+
+      4. Issue following command to edit the pod preset. Replace the placeholder with the namespace you found previously.
+
+          ```shell
+          kubectl edit podpreset proxy --namespace <namespace>
+          ```
+
+      5. Add your load balancer IP range to the `NO_PROXY` configuration under the `spec.env` section.
+
+          ```yaml
+          env:
+            - name: NO_PROXY
+              value: "REPLACE ME"
+          ```
+
+      6. Save your changes and close the editor.
+
+      Your configuration changes are automatically applied.
+
+   </details>
+   
+   :::
+
 </TabItem>
 
 </Tabs>

--- a/docs/docs-content/vm-management/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/create-vmo-profile.md
@@ -250,7 +250,7 @@ profile configuration. To learn about pack components, refer to [Palette VMO](./
 
 If you want to use direct access in an environment configured to use an external proxy, you must exclude your cluster's
 load balancer IP range from proxy routing. Expand the following section to learn how you can configure your
-environment's no proxy list.
+environment's No Proxy list.
 
    <details>
       <summary>Configure the No Proxy list</summary>
@@ -269,7 +269,7 @@ environment's no proxy list.
           kubectl get podpreset --all-namespaces --field-selector=metadata.name=proxy
           ```
 
-      4. Issue following command to edit the pod preset. Replace the placeholder with the namespace you found previously.
+      4. Issue following command to edit the pod preset. Replace the placeholder with the namespace you identified previously.
 
           ```shell
           kubectl edit podpreset proxy --namespace <namespace>

--- a/docs/docs-content/vm-management/install-vmo-in-airgap.md
+++ b/docs/docs-content/vm-management/install-vmo-in-airgap.md
@@ -17,6 +17,14 @@ instance of Palette and Palette VerteX.
   [Self-Hosted Palette Installation](../enterprise-version/install-palette/install-palette.md) and
   [Palette VerteX Installation](../vertex/install-palette-vertex/install-palette-vertex.md) guides for more information.
 
+  :::info
+
+  If your environment is configured to use an external proxy, you can use the **No Proxy** list to exclude any domains
+  or IP addresses from proxying. You have the option to set the No Proxy list during the Palette installation flow. This
+  is useful for scenarios where you know the IP addresses of your VMs load balancers before deployment.
+
+  :::
+
 - At least one tenant created for your airgap instance of Palette or Palette VerteX. Refer to
   [Tenant Management](../enterprise-version/system-management/tenant-management.md) for more information.
 

--- a/docs/docs-content/vm-management/install-vmo-in-airgap.md
+++ b/docs/docs-content/vm-management/install-vmo-in-airgap.md
@@ -20,7 +20,9 @@ instance of Palette and Palette VerteX.
   :::info
 
   If your environment is configured to use an external proxy, you can use the **No Proxy** list to exclude any domains
-  or IP addresses from proxying. You have the option to set the No Proxy list during the Palette installation flow. This is useful in scenarios where you know the IP addresses you want to exclude before deployment, such as load balancer IP addresses.
+  or IP addresses from proxying. You have the option to set the No Proxy list during the Palette installation flow. This
+  is useful in scenarios where you know the IP addresses you want to exclude before deployment, such as load balancer IP
+  addresses.
 
   :::
 

--- a/docs/docs-content/vm-management/install-vmo-in-airgap.md
+++ b/docs/docs-content/vm-management/install-vmo-in-airgap.md
@@ -20,8 +20,7 @@ instance of Palette and Palette VerteX.
   :::info
 
   If your environment is configured to use an external proxy, you can use the **No Proxy** list to exclude any domains
-  or IP addresses from proxying. You have the option to set the No Proxy list during the Palette installation flow. This
-  is useful for scenarios where you know the IP addresses of your VMs load balancers before deployment.
+  or IP addresses from proxying. You have the option to set the No Proxy list during the Palette installation flow. This is useful in scenarios where you know the IP addresses you want to exclude before deployment, such as load balancer IP addresses.
 
   :::
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds the No Proxy list as part of the VMO profile creation and airgap with VMO pages. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Install VMO in Airgap Environments](https://deploy-preview-3586--docs-spectrocloud.netlify.app/vm-management/install-vmo-in-airgap/#prerequisites)
💻 [Create a VMO Profile](https://deploy-preview-3586--docs-spectrocloud.netlify.app/vm-management/create-vmo-profile/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-5233](https://spectrocloud.atlassian.net/browse/PEM-5233)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

[PEM-5233]: https://spectrocloud.atlassian.net/browse/PEM-5233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ