### PR TITLE
docs: update downloads with new artifacts DOC-1335

### DIFF
--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -25,12 +25,16 @@ the [Palette CLI](./automation/palette-cli/palette-cli.md) document for installa
 
 | Version | Operating System                                                                      | Checksum (SHA256)                                                  |
 | ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 4.4.6   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.4.6/linux/cli/palette) | `36b756afaa8349ff8f44085cd4508dfe990d22f3befeea980a65c4028a584b3f` |
 | 4.4.5   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.4.5/linux/cli/palette) | `d177e996844f72305d2d952e0ecf5893eb5b1a32442543454cb9720e9fa9b935` |
 | 4.4.0   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.4.0/linux/cli/palette) | `9e515f4f78b235a0022d1f10099f0e819fa28ceb356d4a97a34bb4e251a81ea1` |
 
 ## Palette Edge CLI
 
-| Version | Operating System                                                                      | Checksum (SHA256)                                                  |
-| ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 4.4.4   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.4/cli/linux/palette-edge) | `3dae63e503251ff0d8a85c596cddf9c45ac29ca341d0f4d47756c865121fcdb9` |
-| 4.4.2   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.2/cli/linux/palette-edge) | `86d2f9239d2b8517dc6d750631a3a328136a5d49a8ec042899879e9bd25a396e` |
+| Version | Operating System                                                                      | Checksum (SHA256)                                                   |
+| ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| 4.4.8   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.8/cli/linux/palette-edge) | `380df5d7037e962c2984070b54ce005f849158819545a2f25f24b9d2f5dd6cca1` |
+| 4.4.7   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.7/cli/linux/palette-edge) | `fb961fd91cfb2b8235f467dfbc7ee06efe0d94184a42f2f3b9a0c8534ad7b797`  |
+| 4.4.6   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.6/cli/linux/palette-edge) | `6bf798ce0fc1910cfb0ad3b5e2d949d46fa7d1948372120cc82ae323b14898aa`  |
+| 4.4.4   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.4/cli/linux/palette-edge) | `3dae63e503251ff0d8a85c596cddf9c45ac29ca341d0f4d47756c865121fcdb9`  |
+| 4.4.2   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.4.2/cli/linux/palette-edge) | `86d2f9239d2b8517dc6d750631a3a328136a5d49a8ec042899879e9bd25a396e`  |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the downloads page with the newest artifacts and adds the entries from https://github.com/spectrocloud/librarium/pull/3582 as well.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Downloads](https://deploy-preview-3594--docs-spectrocloud.netlify.app/spectro-downloads/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1335](https://spectrocloud.atlassian.net/browse/DOC-1335)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1335]: https://spectrocloud.atlassian.net/browse/DOC-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ