### PR TITLE
[4.4.b] Binaries References and Upgrade Path

### DIFF
--- a/docs/docs-content/automation/palette-cli/install-palette-cli.md
+++ b/docs/docs-content/automation/palette-cli/install-palette-cli.md
@@ -62,7 +62,7 @@ palette version
 ```
 
 ```shell hideClipboard
-Palette CLI version: 4.4.5
+Palette CLI version: 4.4.6
 ```
 
 ## Next Steps

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -32,6 +32,9 @@ Before upgrading Palette to a new major version, you must first update it to the
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.4.11       |       4.4.14       | :white_check_mark: |
+|       4.4.6        |       4.4.14       | :white_check_mark: |
+|       4.3.6        |       4.4.14       | :white_check_mark: |
 |       4.4.6        |       4.4.11       | :white_check_mark: |
 |       4.3.6        |       4.4.11       | :white_check_mark: |
 |       4.3.6        |       4.4.4        | :white_check_mark: |

--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -9,7 +9,7 @@ sidebar_custom_props:
 tags: ["downloads"]
 ---
 
-The following Palette downloads are available:
+The following Palette downloads are available.
 
 ## Self-Hosted
 

--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -9,7 +9,7 @@ sidebar_custom_props:
 tags: ["downloads"]
 ---
 
-The following Palette downloads are available.
+The following Palette downloads are available:
 
 ## Self-Hosted
 

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -32,6 +32,9 @@ Before upgrading Palette VerteX to a new major version, you must first update it
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.4.11       |       4.4.14       | :white_check_mark: |
+|       4.4.6        |       4.4.14       | :white_check_mark: |
+|       4.3.6        |       4.4.14       | :white_check_mark: |
 |       4.4.6        |       4.4.11       | :white_check_mark: |
 |       4.3.6        |       4.4.11       | :white_check_mark: |
 |       4.3.6        |       4.4.x        | :white_check_mark: |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds the new self-hosted and VerteX upgrade paths and updates the Palette CLI references.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Palette CLI: Installation](https://deploy-preview-3595--docs-spectrocloud.netlify.app/automation/palette-cli/install-palette-cli/)
💻 [Self-hosted Upgrade](https://deploy-preview-3595--docs-spectrocloud.netlify.app/enterprise-version/upgrade/)
💻 [VerteX Upgrade](https://deploy-preview-3595--docs-spectrocloud.netlify.app/vertex/upgrade/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1334](https://spectrocloud.atlassian.net/browse/DOC-1334)
🎫 [DOC-1339](https://spectrocloud.atlassian.net/browse/DOC-1339)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [X] No. _Please leave a short comment below about why this PR cannot be backported._This is a release PR.


[DOC-1334]: https://spectrocloud.atlassian.net/browse/DOC-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-1339]: https://spectrocloud.atlassian.net/browse/DOC-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ