### PR TITLE
docs: remove space from broken URL check DOC-1346

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ verify-security-bulletins-links-ci: ## Check for broken URLs in production in a 
 		--skip "\.(jpg|jpeg|png|gif|webp)$$" \
 		--skip "https:\/\/linux\.die\.net\/man\/.*$$" \
 		--skip "https:\/\/mysql\.com\/.*\.*$$" \
-		--skip "https:\/\/dev\.mysql\.com\/doc\/.*$$" \	
+		--skip "https:\/\/dev\.mysql\.com\/doc\/.*$$" \
 		--format json > temp_sec_bul_report.json
 	@# Use jq to filter out links that do not start with http or https and keep only broken links
 	@jq '[.links[] | select(.url | test("^https?://")) | select(.status >= 400)]' temp_sec_bul_report.json > filtered_sec_bul_report.json


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes a stray space from `verify-security-bulletins-links-ci` make command. 
This is breaking the Github action. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1346](https://spectrocloud.atlassian.net/browse/DOC-1346)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1346]: https://spectrocloud.atlassian.net/browse/DOC-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ