### PR TITLE
Fix Production Issue with Packs List

### DIFF
--- a/src/components/Technologies/PackCardIcon.tsx
+++ b/src/components/Technologies/PackCardIcon.tsx
@@ -12,21 +12,27 @@ interface PackCardIconProps {
 
 export default function PackCardIcon({ appType, logoUrl, type, className }: PackCardIconProps) {
   const [icon, setIcon] = useState<ReactElement | null>(null);
+
   useEffect(() => {
-    if (logoUrl) {
-      try {
-        if (appType === "app") {
-          setIcon(<img src={logoUrl} />);
-        } else {
-          setIcon(<Image img={import(`/static/img/packs/${logoUrl}`)} />);
+    const loadImage = async () => {
+      if (logoUrl) {
+        try {
+          if (appType === "app") {
+            setIcon(<img src={logoUrl} />);
+          } else {
+            const img = (await import(`/static/img/packs/${logoUrl}`)).default;
+            setIcon(<Image img={img} />);
+          }
+        } catch (e) {
+          console.error(e);
+          type = type ? setIcon(<IconMapper type={type} />) : setIcon(null);
         }
-      } catch (e) {
-        console.error(e);
+      } else {
         type = type ? setIcon(<IconMapper type={type} />) : setIcon(null);
       }
-    } else {
-      type = type ? setIcon(<IconMapper type={type} />) : setIcon(null);
-    }
+    };
+
+    loadImage();
   }, [logoUrl]);
 
   return <div className={`${className} ${styles.imageWrapper}`}>{icon}</div>;

--- a/src/components/Technologies/PackCardIcon.tsx
+++ b/src/components/Technologies/PackCardIcon.tsx
@@ -10,6 +10,10 @@ interface PackCardIconProps {
   className?: any;
 }
 
+type ImageModule = {
+  default: string;
+};
+
 export default function PackCardIcon({ appType, logoUrl, type, className }: PackCardIconProps) {
   const [icon, setIcon] = useState<ReactElement | null>(null);
 
@@ -22,8 +26,8 @@ export default function PackCardIcon({ appType, logoUrl, type, className }: Pack
 
       if (logoUrl) {
         try {
-          const img = (await import(`/static/img/packs/${logoUrl}`)).default;
-          setIcon(<Image img={img} />);
+          const module: ImageModule = await import(`/static/img/packs/${logoUrl}`);
+          setIcon(<Image img={module.default} />);
           return;
         } catch (e) {
           console.error(e);
@@ -37,7 +41,8 @@ export default function PackCardIcon({ appType, logoUrl, type, className }: Pack
       }
     };
 
-    loadIcon();
+    // Explicitly mark the promise as intentionally unhandled
+    void loadIcon();
   }, [logoUrl, appType, type]);
 
   return <div className={`${className} ${styles.imageWrapper}`}>{icon}</div>;

--- a/src/components/Technologies/PackCardIcon.tsx
+++ b/src/components/Technologies/PackCardIcon.tsx
@@ -14,26 +14,31 @@ export default function PackCardIcon({ appType, logoUrl, type, className }: Pack
   const [icon, setIcon] = useState<ReactElement | null>(null);
 
   useEffect(() => {
-    const loadImage = async () => {
+    const loadIcon = async () => {
+      if (logoUrl && appType === "app") {
+        setIcon(<img src={logoUrl} />);
+        return;
+      }
+
       if (logoUrl) {
         try {
-          if (appType === "app") {
-            setIcon(<img src={logoUrl} />);
-          } else {
-            const img = (await import(`/static/img/packs/${logoUrl}`)).default;
-            setIcon(<Image img={img} />);
-          }
+          const img = (await import(`/static/img/packs/${logoUrl}`)).default;
+          setIcon(<Image img={img} />);
+          return;
         } catch (e) {
           console.error(e);
-          type = type ? setIcon(<IconMapper type={type} />) : setIcon(null);
         }
+      }
+
+      if (type) {
+        setIcon(<IconMapper type={type} />);
       } else {
-        type = type ? setIcon(<IconMapper type={type} />) : setIcon(null);
+        setIcon(null);
       }
     };
 
-    loadImage();
-  }, [logoUrl]);
+    loadIcon();
+  }, [logoUrl, appType, type]);
 
   return <div className={`${className} ${styles.imageWrapper}`}>{icon}</div>;
 }


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes a bug introduced by PR #3522. The import statement was missing the `await` keyword and access to the default object returned by the import. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page](https://deploy-preview-3648--docs-spectrocloud.netlify.app/integrations/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1350](https://spectrocloud.atlassian.net/browse/DOC-1350)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1350]: https://spectrocloud.atlassian.net/browse/DOC-1350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ