### PR TITLE
Packs fix

### DIFF
--- a/plugins/packs-integrations.js
+++ b/plugins/packs-integrations.js
@@ -341,37 +341,6 @@ async function write(res, packName, logoUrlMap) {
   });
 }
 
-// async function getLogoUrl(packsAllData, logoUrlMap) {
-//   for (let j = 0; j < packsAllData.length; j++) {
-//     const registries = packsAllData[j].spec.registries;
-//     const packName = packsAllData[j].spec.name;
-//     for (let i = 0; i < registries.length; i++) {
-//       const registry = registries[i];
-//       try {
-//         let url = registry.logoUrl;
-//         if (!url) {
-//           url = `${BASE_URL}/v1/packs/${registry.latestPackUid}/logo`;
-//         } else {
-//           url = url.startsWith("https") ? url : url.startsWith("/") ? `${BASE_URL}${url}` : `${BASE_URL}/${url}`;
-//         }
-//         if (!Object.hasOwnProperty.call(logoUrlMap, packName)) {
-//           options.headers["Accept"] = "image/png";
-//           const res = await fetch(url, options);
-//           await write(res, packName, logoUrlMap);
-//           counter++;
-//           if (counter % 10 === 0) {
-//             await setTimeout(1000);
-//           }
-//         }
-//       } catch (e) {
-//         // Intentionally ignoring errors here to continue processing other logos
-//         // Enable the below line to log the error, if needed, for debugging.
-//         logger.error(e);
-//       }
-//     }
-//   }
-// }
-
 async function getLogoUrl(packsAllData, logoUrlMap) {
   for (let j = 0; j < packsAllData.length; j++) {
     const { registries, name: packName } = packsAllData[j].spec;

--- a/plugins/packs-integrations.js
+++ b/plugins/packs-integrations.js
@@ -355,6 +355,7 @@ async function getLogoUrl(packsAllData, logoUrlMap) {
           url = url.startsWith("https") ? url : url.startsWith("/") ? `${BASE_URL}${url}` : `${BASE_URL}/${url}`;
         }
         if (!Object.hasOwnProperty.call(logoUrlMap, packName)) {
+          options.headers["Accept"] = "image/png";
           const res = await fetch(url, options);
           await write(res, packName, logoUrlMap);
           counter++;
@@ -365,7 +366,7 @@ async function getLogoUrl(packsAllData, logoUrlMap) {
       } catch (e) {
         // Intentionally ignoring errors here to continue processing other logos
         // Enable the below line to log the error, if needed, for debugging.
-        // logger.error(e);
+        logger.error(e);
       }
     }
   }

--- a/plugins/packs-integrations.js
+++ b/plugins/packs-integrations.js
@@ -341,32 +341,70 @@ async function write(res, packName, logoUrlMap) {
   });
 }
 
+// async function getLogoUrl(packsAllData, logoUrlMap) {
+//   for (let j = 0; j < packsAllData.length; j++) {
+//     const registries = packsAllData[j].spec.registries;
+//     const packName = packsAllData[j].spec.name;
+//     for (let i = 0; i < registries.length; i++) {
+//       const registry = registries[i];
+//       try {
+//         let url = registry.logoUrl;
+//         if (!url) {
+//           url = `${BASE_URL}/v1/packs/${registry.latestPackUid}/logo`;
+//         } else {
+//           url = url.startsWith("https") ? url : url.startsWith("/") ? `${BASE_URL}${url}` : `${BASE_URL}/${url}`;
+//         }
+//         if (!Object.hasOwnProperty.call(logoUrlMap, packName)) {
+//           options.headers["Accept"] = "image/png";
+//           const res = await fetch(url, options);
+//           await write(res, packName, logoUrlMap);
+//           counter++;
+//           if (counter % 10 === 0) {
+//             await setTimeout(1000);
+//           }
+//         }
+//       } catch (e) {
+//         // Intentionally ignoring errors here to continue processing other logos
+//         // Enable the below line to log the error, if needed, for debugging.
+//         logger.error(e);
+//       }
+//     }
+//   }
+// }
+
 async function getLogoUrl(packsAllData, logoUrlMap) {
   for (let j = 0; j < packsAllData.length; j++) {
-    const registries = packsAllData[j].spec.registries;
-    const packName = packsAllData[j].spec.name;
+    const { registries, name: packName } = packsAllData[j].spec;
+
     for (let i = 0; i < registries.length; i++) {
       const registry = registries[i];
-      try {
-        let url = registry.logoUrl;
-        if (!url) {
-          url = `${BASE_URL}/v1/packs/${registry.latestPackUid}/logo`;
-        } else {
-          url = url.startsWith("https") ? url : url.startsWith("/") ? `${BASE_URL}${url}` : `${BASE_URL}/${url}`;
-        }
-        if (!Object.hasOwnProperty.call(logoUrlMap, packName)) {
+      let url = registry.logoUrl || `${BASE_URL}/v1/packs/${registry.latestPackUid}/logo`;
+
+      url =
+        url.startsWith("http://") || url.startsWith("https://")
+          ? url
+          : url.startsWith("/")
+            ? `${BASE_URL}${url}`
+            : `${BASE_URL}/${url}`;
+
+      if (!logoUrlMap.hasOwnProperty(packName)) {
+        try {
           options.headers["Accept"] = "image/png";
           const res = await fetch(url, options);
+
+          if (!res.ok) {
+            throw new Error(`Failed to fetch logo for ${packName} from ${url}. Got status ${res.status}`);
+          }
+
           await write(res, packName, logoUrlMap);
           counter++;
+
           if (counter % 10 === 0) {
             await setTimeout(1000);
           }
+        } catch (e) {
+          logger.error(e);
         }
-      } catch (e) {
-        // Intentionally ignoring errors here to continue processing other logos
-        // Enable the below line to log the error, if needed, for debugging.
-        logger.error(e);
       }
     }
   }


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR addresses issues with bad pack data values or bad server requests from the Palette API.  The changes include:
- Error output for when pack's data download fails
- When a logo download requests fails
-  Improved logo URL handling. In the past, multiple `404` entries were returned due to poor URL value handling.  Below are all the URL requests which are no longer failing.

```shell
[ERROR] Failed to fetch logo for permission-manager from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974835827ad/logo. Got status 404
[ERROR] EError: Failed to fetch logo for permission-manager from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974835827ad/logo. Got status 404:
[ERROR] Failed to fetch logo for cni-calico from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec7d13c20505505fdc98/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cni-calico from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec7d13c20505505fdc98/logo. Got status 404:
[ERROR] Failed to fetch logo for csi-aws from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297b7b30407e/logo. Got status 404
[ERROR] EError: Failed to fetch logo for csi-aws from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297b7b30407e/logo. Got status 404:
[ERROR] Failed to fetch logo for istio from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/661cc67e0aa79b9585d589cd/logo. Got status 404
[ERROR] EError: Failed to fetch logo for istio from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/661cc67e0aa79b9585d589cd/logo. Got status 404:
[ERROR] Failed to fetch logo for kubewatch from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974b490fb30/logo. Got status 404
[ERROR] EError: Failed to fetch logo for kubewatch from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974b490fb30/logo. Got status 404:
[ERROR] Failed to fetch logo for wordpress-chart from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/65ef9cf3af52cae61b0e6d16/logo. Got status 404
[ERROR] EError: Failed to fetch logo for wordpress-chart from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/65ef9cf3af52cae61b0e6d16/logo. Got status 404:
[ERROR] Failed to fetch logo for registry-creds from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979b683b769/logo. Got status 404
[ERROR] EError: Failed to fetch logo for registry-creds from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979b683b769/logo. Got status 404:
[ERROR] Failed to fetch logo for centos-azure from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297d0aa4cf5d/logo. Got status 404
[ERROR] EError: Failed to fetch logo for centos-azure from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297d0aa4cf5d/logo. Got status 404:
[ERROR] Failed to fetch logo for outcold-monitoring from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff673040297449538e3d/logo. Got status 404
[ERROR] EError: Failed to fetch logo for outcold-monitoring from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff673040297449538e3d/logo. Got status 404:
[ERROR] Failed to fetch logo for splunk from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974956e836e/logo. Got status 404
[ERROR] EError: Failed to fetch logo for splunk from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974956e836e/logo. Got status 404:
[ERROR] Failed to fetch logo for cni-aws-vpc-eks from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297a60850f3f/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cni-aws-vpc-eks from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297a60850f3f/logo. Got status 404:
[ERROR] Failed to fetch logo for aws-ssm-agent from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297cb2415fca/logo. Got status 404
[ERROR] EError: Failed to fetch logo for aws-ssm-agent from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297cb2415fca/logo. Got status 404:
[ERROR] Failed to fetch logo for spectro-rbac from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297a6cedcf41/logo. Got status 404
[ERROR] EError: Failed to fetch logo for spectro-rbac from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297a6cedcf41/logo. Got status 404:
[ERROR] Failed to fetch logo for cni-kubenet from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979e80b42b3/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cni-kubenet from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979e80b42b3/logo. Got status 404:
[ERROR] Failed to fetch logo for cni-azure from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297d86b40266/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cni-azure from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297d86b40266/logo. Got status 404:
[ERROR] Failed to fetch logo for minio from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297a8c338c9a/logo. Got status 404
[ERROR] EError: Failed to fetch logo for minio from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297a8c338c9a/logo. Got status 404:
[ERROR] Failed to fetch logo for velero from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297e59828491/logo. Got status 404
[ERROR] EError: Failed to fetch logo for velero from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297e59828491/logo. Got status 404:
[ERROR] Failed to fetch logo for ubuntu-edge from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297ffe712e54/logo. Got status 404
[ERROR] EError: Failed to fetch logo for ubuntu-edge from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297ffe712e54/logo. Got status 404:
[ERROR] Failed to fetch logo for konvoy-defaultstorageclass from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c6665f5ae/logo. Got status 404
[ERROR] EError: Failed to fetch logo for konvoy-defaultstorageclass from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c6665f5ae/logo. Got status 404:
[ERROR] Failed to fetch logo for cni-tke-global-router from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c30b73cec/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cni-tke-global-router from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c30b73cec/logo. Got status 404:
[ERROR] Failed to fetch logo for csi-rook-ceph from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec6e13c20504ffb5f0b7/logo. Got status 404
[ERROR] EError: Failed to fetch logo for csi-rook-ceph from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec6e13c20504ffb5f0b7/logo. Got status 404:
[ERROR] Failed to fetch logo for opensuse-k3s from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297ca7e691ed/logo. Got status 404
[ERROR] EError: Failed to fetch logo for opensuse-k3s from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297ca7e691ed/logo. Got status 404:
[ERROR] Failed to fetch logo for triliovault from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297b775cd38b/logo. Got status 404
[ERROR] EError: Failed to fetch logo for triliovault from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297b775cd38b/logo. Got status 404:
[ERROR] Failed to fetch logo for kubevious from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff673040297436b73cea/logo. Got status 404
[ERROR] EError: Failed to fetch logo for kubevious from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff673040297436b73cea/logo. Got status 404:
[ERROR] Failed to fetch logo for elastic-fluentd-kibana from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297af675f917/logo. Got status 404
[ERROR] EError: Failed to fetch logo for elastic-fluentd-kibana from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297af675f917/logo. Got status 404:
[ERROR] Failed to fetch logo for thanos from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974d85d24ec/logo. Got status 404
[ERROR] EError: Failed to fetch logo for thanos from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974d85d24ec/logo. Got status 404:
[ERROR] Failed to fetch logo for edge-native-ubuntu from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c23bc17ff/logo. Got status 404
[ERROR] EError: Failed to fetch logo for edge-native-ubuntu from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c23bc17ff/logo. Got status 404:
[ERROR] Failed to fetch logo for ubuntu-aws from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979c852deb5/logo. Got status 404
[ERROR] EError: Failed to fetch logo for ubuntu-aws from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979c852deb5/logo. Got status 404:
[ERROR] Failed to fetch logo for csi-gcp-driver from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e823465fd845b7aca6f5c/logo. Got status 404
[ERROR] EError: Failed to fetch logo for csi-gcp-driver from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e823465fd845b7aca6f5c/logo. Got status 404:
[ERROR] Failed to fetch logo for edge-native-byoi from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297e3d0e2011/logo. Got status 404
[ERROR] EError: Failed to fetch logo for edge-native-byoi from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297e3d0e2011/logo. Got status 404:
[ERROR] Failed to fetch logo for ubuntu-azure from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979f0981ef5/logo. Got status 404
[ERROR] EError: Failed to fetch logo for ubuntu-azure from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979f0981ef5/logo. Got status 404:
[ERROR] Failed to fetch logo for ubuntu-maas from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c8c564fd6/logo. Got status 404
[ERROR] EError: Failed to fetch logo for ubuntu-maas from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c8c564fd6/logo. Got status 404:
[ERROR] Failed to fetch logo for volume-snapshot-controller from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979e475536c/logo. Got status 404
[ERROR] EError: Failed to fetch logo for volume-snapshot-controller from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979e475536c/logo. Got status 404:
[ERROR] Failed to fetch logo for flux-cd from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d1f0e79ec6b03e579d0/logo. Got status 404
[ERROR] EError: Failed to fetch logo for flux-cd from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d1f0e79ec6b03e579d0/logo. Got status 404:
[ERROR] Failed to fetch logo for cni-vpc-native-gke from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297a6496c26f/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cni-vpc-native-gke from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297a6496c26f/logo. Got status 404:
[ERROR] Failed to fetch logo for csi-topolvm from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297e1f5f1c0e/logo. Got status 404
[ERROR] EError: Failed to fetch logo for csi-topolvm from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297e1f5f1c0e/logo. Got status 404:
[ERROR] Failed to fetch logo for spectro-k8s-dashboard from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c888a6e8d/logo. Got status 404
[ERROR] EError: Failed to fetch logo for spectro-k8s-dashboard from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00163040297c888a6e8d/logo. Got status 404:
[ERROR] Failed to fetch logo for stormforge-optimize-live from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974995829d2/logo. Got status 404
[ERROR] EError: Failed to fetch logo for stormforge-optimize-live from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff6730402974995829d2/logo. Got status 404:
[ERROR] Failed to fetch logo for stormforge-optimize-live from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979ba092c78/logo. Got status 404
[ERROR] EError: Failed to fetch logo for stormforge-optimize-live from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb001530402979ba092c78/logo. Got status 404:
[ERROR] Failed to fetch logo for pfsense-vm-vsphere from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/6535b918852d1cfb34f8e58f/logo. Got status 404
[ERROR] EError: Failed to fetch logo for pfsense-vm-vsphere from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/6535b918852d1cfb34f8e58f/logo. Got status 404:
[ERROR] Failed to fetch logo for cost-analyzer from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff673040297464766404/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cost-analyzer from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff673040297464766404/logo. Got status 404:
[ERROR] Failed to fetch logo for local-ai from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297b44e638fe/logo. Got status 404
[ERROR] EError: Failed to fetch logo for local-ai from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00153040297b44e638fe/logo. Got status 404:
[ERROR] Failed to fetch logo for ubuntu-aks from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297f633d40ca/logo. Got status 404
[ERROR] EError: Failed to fetch logo for ubuntu-aks from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eb00173040297f633d40ca/logo. Got status 404:
[ERROR] Failed to fetch logo for csi-trident-addon from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/65540a7ea63fa3c4ed56dbae/logo. Got status 404
[ERROR] EError: Failed to fetch logo for csi-trident-addon from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/65540a7ea63fa3c4ed56dbae/logo. Got status 404:
[ERROR] Failed to fetch logo for argo-cd from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d290e79ec6b4a8a82c2/logo. Got status 404
[ERROR] EError: Failed to fetch logo for argo-cd from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d290e79ec6b4a8a82c2/logo. Got status 404:
[ERROR] Failed to fetch logo for argo-cd from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff67304029746f14e5f7/logo. Got status 404
[ERROR] EError: Failed to fetch logo for argo-cd from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/64eaff67304029746f14e5f7/logo. Got status 404:
[ERROR] Failed to fetch logo for harbor-edge-native-config from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d2d0e79ec6b68dcdc77/logo. Got status 404
[ERROR] EError: Failed to fetch logo for harbor-edge-native-config from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d2d0e79ec6b68dcdc77/logo. Got status 404:
[ERROR] Failed to fetch logo for image-swap from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d160e79ec6ac9486c62/logo. Got status 404
[ERROR] EError: Failed to fetch logo for image-swap from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d160e79ec6ac9486c62/logo. Got status 404:
[ERROR] Failed to fetch logo for spotinst-kubernetes-cluster-controller from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d1d0e79ec6af52d7747/logo. Got status 404
[ERROR] EError: Failed to fetch logo for spotinst-kubernetes-cluster-controller from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/659b3d1d0e79ec6af52d7747/logo. Got status 404:
[ERROR] Failed to fetch logo for hello-universe from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/65e0f8bd80d43b8e8a76dcc6/logo. Got status 404
[ERROR] EError: Failed to fetch logo for hello-universe from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/65e0f8bd80d43b8e8a76dcc6/logo. Got status 404:
[ERROR] Failed to fetch logo for hello-universe from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66a82d732ac255d651223f13/logo. Got status 404
[ERROR] EError: Failed to fetch logo for hello-universe from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66a82d732ac255d651223f13/logo. Got status 404:
[ERROR] Failed to fetch logo for spegel from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/65fccaa6d1db6bd34f82b33f/logo. Got status 404
[ERROR] EError: Failed to fetch logo for spegel from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/65fccaa6d1db6bd34f82b33f/logo. Got status 404:
[ERROR] Failed to fetch logo for csi-local-path-provisioner from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/661cc6510aa79b917f3a80ea/logo. Got status 404
[ERROR] EError: Failed to fetch logo for csi-local-path-provisioner from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/661cc6510aa79b917f3a80ea/logo. Got status 404:
[ERROR] Failed to fetch logo for kubernetes-konvoy from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/661cc6700aa79b944149eff9/logo. Got status 404
[ERROR] EError: Failed to fetch logo for kubernetes-konvoy from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/661cc6700aa79b944149eff9/logo. Got status 404:
[ERROR] Failed to fetch logo for nginx from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e823765fd845ba86254e9/logo. Got status 404
[ERROR] EError: Failed to fetch logo for nginx from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e823765fd845ba86254e9/logo. Got status 404:
[ERROR] Failed to fetch logo for oam-app-controller from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/665e5a8324f0a42d877c7ed8/logo. Got status 404
[ERROR] EError: Failed to fetch logo for oam-app-controller from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/665e5a8324f0a42d877c7ed8/logo. Got status 404:
[ERROR] Failed to fetch logo for csm-operator-addon from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/6624576b6f2877853a158643/logo. Got status 404
[ERROR] EError: Failed to fetch logo for csm-operator-addon from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/6624576b6f2877853a158643/logo. Got status 404:
[ERROR] Failed to fetch logo for unctl from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551ebe00e41bea37122c77/logo. Got status 404
[ERROR] EError: Failed to fetch logo for unctl from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551ebe00e41bea37122c77/logo. Got status 404:
[ERROR] Failed to fetch logo for elastic-operator from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551ec400e41bea3db67b19/logo. Got status 404
[ERROR] EError: Failed to fetch logo for elastic-operator from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551ec400e41bea3db67b19/logo. Got status 404:
[ERROR] Failed to fetch logo for elastic-stack from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551ec700e41bea41888377/logo. Got status 404
[ERROR] EError: Failed to fetch logo for elastic-stack from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551ec700e41bea41888377/logo. Got status 404:
[ERROR] Failed to fetch logo for cisco-appdynamics-collectors from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551eca00e41bea497a1757/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cisco-appdynamics-collectors from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551eca00e41bea497a1757/logo. Got status 404:
[ERROR] Failed to fetch logo for cisco-appdynamics-operators from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551ece00e41bea4d64b759/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cisco-appdynamics-operators from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66551ece00e41bea4d64b759/logo. Got status 404:
[ERROR] Failed to fetch logo for k8gb from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66679455d361fb6ec31bc691/logo. Got status 404
[ERROR] EError: Failed to fetch logo for k8gb from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66679455d361fb6ec31bc691/logo. Got status 404:
[ERROR] Failed to fetch logo for aws-alb from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e822865fd845ad3a53671/logo. Got status 404
[ERROR] EError: Failed to fetch logo for aws-alb from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e822865fd845ad3a53671/logo. Got status 404:
[ERROR] Failed to fetch logo for cni-flannel from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e823365fd845b67cb4559/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cni-flannel from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e823365fd845b67cb4559/logo. Got status 404:
[ERROR] Failed to fetch logo for kubernetes-aks from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e823865fd845bbb2b8aaa/logo. Got status 404
[ERROR] EError: Failed to fetch logo for kubernetes-aks from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/666e823865fd845bbb2b8aaa/logo. Got status 404:
[ERROR] Failed to fetch logo for strimzi-kafka from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/6670cf89c97b6e78bbafdc36/logo. Got status 404
[ERROR] EError: Failed to fetch logo for strimzi-kafka from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/6670cf89c97b6e78bbafdc36/logo. Got status 404:
[ERROR] Failed to fetch logo for ceph-rbd from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/668c7dc32c715ec9fd963216/logo. Got status 404
[ERROR] EError: Failed to fetch logo for ceph-rbd from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/668c7dc32c715ec9fd963216/logo. Got status 404:
[ERROR] Failed to fetch logo for ceph-rbd-addon from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/668c7dc52c715eca018ffd43/logo. Got status 404
[ERROR] EError: Failed to fetch logo for ceph-rbd-addon from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/668c7dc52c715eca018ffd43/logo. Got status 404:
[ERROR] Failed to fetch logo for edge-k3s from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec8113c2050565afcfb8/logo. Got status 404
[ERROR] EError: Failed to fetch logo for edge-k3s from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec8113c2050565afcfb8/logo. Got status 404:
[ERROR] Failed to fetch logo for kong from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec8313c2050572c08c75/logo. Got status 404
[ERROR] EError: Failed to fetch logo for kong from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec8313c2050572c08c75/logo. Got status 404:
[ERROR] Failed to fetch logo for reloader from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec6b13c20504edec62c6/logo. Got status 404
[ERROR] EError: Failed to fetch logo for reloader from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec6b13c20504edec62c6/logo. Got status 404:
[ERROR] Failed to fetch logo for spectro-proxy from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec7513c2050524b326cd/logo. Got status 404
[ERROR] EError: Failed to fetch logo for spectro-proxy from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/669bec7513c2050524b326cd/logo. Got status 404:
[ERROR] Failed to fetch logo for cni-aws-vpc-eks-helm from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c0c921cd3c682a49507a74/logo. Got status 404
[ERROR] EError: Failed to fetch logo for cni-aws-vpc-eks-helm from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c0c921cd3c682a49507a74/logo. Got status 404:
[ERROR] Failed to fetch logo for csi-azure from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c0c92bcd3c682a7803e42c/logo. Got status 404
[ERROR] EError: Failed to fetch logo for csi-azure from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c0c92bcd3c682a7803e42c/logo. Got status 404:
[ERROR] Failed to fetch logo for edge-k8s from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c0c924cd3c682a57e7be57/logo. Got status 404
[ERROR] EError: Failed to fetch logo for edge-k8s from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c0c924cd3c682a57e7be57/logo. Got status 404:
[ERROR] Failed to fetch logo for edge-rke2 from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c0c925cd3c682a5c23e498/logo. Got status 404
[ERROR] EError: Failed to fetch logo for edge-rke2 from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c0c925cd3c682a5c23e498/logo. Got status 404:
[ERROR] Failed to fetch logo for kyverno from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c3dce050f9acc21f453468/logo. Got status 404
[ERROR] EError: Failed to fetch logo for kyverno from http://api.spectrocloud.com/http://api.spectrocloud.com/v1/packs/66c3dce050f9acc21f453468/logo. Got status 404:
[INFO] Completed fetching all pack logos
```

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page](https://deploy-preview-3676--docs-spectrocloud.netlify.app/integrations/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1355](https://spectrocloud.atlassian.net/browse/DOC-1355)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1355]: https://spectrocloud.atlassian.net/browse/DOC-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ