### PR TITLE
docs: PCP-3421

### DIFF
--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -61,6 +61,22 @@ cluster repaves.
 
 :::
 
+### Pod Drainage Toleration
+
+Palette will not remove pods with the toleration key `node.kubernetes.io/unschedulable` and the effect `NoSchedule`
+during node draining operations. You can add this toleration to your pods to prevent them from being removed during a
+repave operation.
+
+```yaml
+tolerations:
+  - key: node.kubernetes.io/unschedulable
+    effect: NoSchedule
+    operator: Exists
+```
+
+You can also specify other custom tolerations during the cluster creation process. For more information on adding
+tolerations, refer to the [Taints and Tolerations](./taints.md) guide.
+
 ## Node Pool Configuration Settings
 
 The following tables contain the configuration settings for node pools. Depending on the type of node pool, some of the

--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -74,8 +74,8 @@ tolerations:
     operator: Exists
 ```
 
-You can also specify other custom tolerations during the cluster creation process. For more information on adding
-tolerations, refer to the [Taints and Tolerations](./taints.md) guide.
+You can also specify other tolerations during the cluster creation process. For more information on adding tolerations,
+refer to the [Taints and Tolerations](./taints.md) guide.
 
 ## Node Pool Configuration Settings
 

--- a/docs/docs-content/clusters/cluster-management/taints.md
+++ b/docs/docs-content/clusters/cluster-management/taints.md
@@ -57,6 +57,14 @@ Taints can also be applied to node pools using the Spectro Cloud
    [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) official
    documentation page for more details.
 
+   :::tip
+
+   By default, Palette will not remove pods with the toleration key `node.kubernetes.io/unschedulable` set to
+   `NoSchedule`. For more information, refer to the [Pod Drainage Toleration](./node-pool.md#pod-drainage-toleration)
+   section
+
+   :::
+
    - Specify a custom **key** and custom **value**.
    - Palette supports the `Equal` **operator**.
    - The **effect** defines what will happen to the pods that do not tolerate a taint. Kubernetes provides three taint

--- a/docs/docs-content/profiles/profile-customization.md
+++ b/docs/docs-content/profiles/profile-customization.md
@@ -46,20 +46,3 @@ pack:
     "monitoring": "monitoring.io/enable=true"
     "wordpress-storage": "storage.metrics.io/format=json"
 ```
-
-## Additional Parameters
-
-The following parameters are available to help customize pack configurations.
-
-### Skip Drain Selector
-
-The `skipDrainSelector` parameter is used to skip the drain operation for pack pods that match the specified label. In
-the following example, the `storage: true` label is used to skip the drain operation for pack pods that have the
-`storage: true` label.
-
-```yaml
-pack:
-  skipDrainSelector:
-    labels:
-      storage: true
-```

--- a/docs/docs-content/profiles/profile-customization.md
+++ b/docs/docs-content/profiles/profile-customization.md
@@ -46,3 +46,20 @@ pack:
     "monitoring": "monitoring.io/enable=true"
     "wordpress-storage": "storage.metrics.io/format=json"
 ```
+
+## Additional Parameters
+
+The following parameters are available to help customize pack configurations.
+
+### Skip Drain Selector
+
+The `skipDrainSelector` parameter is used to skip the drain operation for pack pods that match the specified label. In
+the following example, the `storage: true` label is used to skip the drain operation for pack pods that have the
+`storage: true` label.
+
+```yaml
+pack:
+  skipDrainSelector:
+    labels:
+      storage: true
+```


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR captures the ability to leverage a toleration label for avoiding pods getting evicted during a node drainage operation.

- [Node Pools Page](https://deploy-preview-3742--docs-spectrocloud.netlify.app/clusters/cluster-management/node-pool/#pod-drainage-toleration)
- [Taints and Tolerations](https://deploy-preview-3742--docs-spectrocloud.netlify.app/clusters/cluster-management/taints/)

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Taints & Tolerations ](https://deploy-preview-3742--docs-spectrocloud.netlify.app/clusters/cluster-management/taints/)

💻 [Node Pools ](https://deploy-preview-3742--docs-spectrocloud.netlify.app/clusters/cluster-management/node-pool/#pod-drainage-toleration/)


## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PCP-3421](https://spectrocloud.atlassian.net/browse/PCP-3421)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[PCP-3403]: https://spectrocloud.atlassian.net/browse/PCP-3403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PCP-3421]: https://spectrocloud.atlassian.net/browse/PCP-3421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ