### PR TITLE
[version-4-1] chore: bump sigstore/cosign-installer from 3.5.0 to 3.6.0 (#3770)

### DIFF
--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -67,7 +67,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:nightly
           labels: ${{ steps.meta.outputs.labels }}
 
-      - uses: sigstore/cosign-installer@v3.3.0
+      - uses: sigstore/cosign-installer@v3.6.0
 
       - name: Image Signing
         run: |


### PR DESCRIPTION

## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the backport issues from PR #3770 