### PR TITLE
docs: DOC-1372

### DIFF
--- a/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/vertex-helm-ref.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/vertex-helm-ref.md
@@ -450,7 +450,7 @@ ui-system:
       mapBoxStyledLayerID: ""
 ```
 
-### Reach System
+## Reach System
 
 You can configure VerteX to use a proxy server to access the internet. Set the parameter `reach-system.enabled` to
 `true` to enable the proxy server. Proxy settings are configured in the `reach-system.proxySettings` section.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes a minor indentation issue on the VerteX Helm Install Reference page. The heading Reach System was  using `###` and H3 instead of an H2.

![CleanShot 2024-09-09 at 14 58 18](https://github.com/user-attachments/assets/f7fd18bd-b6e6-464a-bef3-b573758b056f)


## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1372](https://spectrocloud.atlassian.net/browse/DOC-1372)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1372]: https://spectrocloud.atlassian.net/browse/DOC-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ