### PR TITLE
docs: confirm cert renewal by looking at expiry date

### DIFF
--- a/docs/docs-content/clusters/edge/cluster-management/certificate-renewal.md
+++ b/docs/docs-content/clusters/edge/cluster-management/certificate-renewal.md
@@ -123,4 +123,4 @@ Management API.
 
 In **Overview**, click **View Certificates** in the **Kubernetes Certificates** row. This will display all the
 certificates currently in use by your cluster. You can confirm that the certificates have been renewed by looking at the
-expiry date of certificates.
+_expiry_ date of certificates. The issue date of the certificates will not change after cluster renewal.

--- a/docs/docs-content/clusters/edge/cluster-management/certificate-renewal.md
+++ b/docs/docs-content/clusters/edge/cluster-management/certificate-renewal.md
@@ -123,4 +123,4 @@ Management API.
 
 In **Overview**, click **View Certificates** in the **Kubernetes Certificates** row. This will display all the
 certificates currently in use by your cluster. You can confirm that the certificates have been renewed by looking at the
-issue date of certificates.
+expiry date of certificates.


### PR DESCRIPTION
## Describe the Change
The existing doc sentence here is misleading.

This will display all the certificates currently in use by your cluster. You can confirm that the certificates have been renewed by looking at the issue date of certificates.

it should instead be 

This will display all the certificates currently in use by your cluster. You can confirm that the certificates have been renewed by looking at the expiry date of certificates.



## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets
https://spectrocloud.atlassian.net/browse/PE-5011


🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
