### PR TITLE
fix: move VM folder to spectro role, correct folder conditions

### DIFF
--- a/_partials/permissions/_vsphere-permissions.mdx
+++ b/_partials/permissions/_vsphere-permissions.mdx
@@ -34,6 +34,7 @@ https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-ED56F3C4-77D
 | **Network**             | Assign network                                 |
 | **Sessions**            | Validate session                               |
 | **Storage Views**       | View                                           |
+| **System**              | Anonymous<br />Read<br />View                  |
 | **VM Storage Policies** | View VM storage policies                       |
 | **vSphere Tagging**     | Create vSphere Tag<br />Edit vSphere Tag       |
 
@@ -54,6 +55,7 @@ https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GU
 | **Profile-driven Storage** | View                                           |
 | **Sessions**               | Validate session                               |
 | **Storage Views**          | View                                           |
+| **System**                 | Anonymous<br />Read<br />View                  |
 | **vSphere Tagging**        | Create vSphere Tag<br />Edit vSphere Tag       |
 
 </TabItem>
@@ -69,6 +71,7 @@ https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GU
 | **Profile-driven Storage** | View                                           |
 | **Sessions**               | Validate session                               |
 | **Storage Views**          | View                                           |
+| **System**                 | Anonymous<br />Read<br />View                  |
 | **vSphere Tagging**        | Create vSphere Tag<br />Edit vSphere Tag       |
 
 </TabItem>
@@ -87,8 +90,15 @@ https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GU
     - `Sessions.ValidateSession`
     - `StorageProfile.View`
     - `StorageViews.View`
+    - `System.Anonymous`
+    - `System.Read`
+    - `System.View`
 
 </details>
+
+> [!NOTE]
+>
+> The `System.*` privileges are [added to all custom vSphere roles by default](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html).
 
 ### Spectro Root Role Assignments
 
@@ -130,6 +140,7 @@ Select the tab for the vSphere version you are using to view the required privil
 | **Resource**              | Apply recommendation<br />Assign virtual machine to resource pool<br />Migrate powered off virtual machine<br />Migrate powered on virtual machine<br />Query vMotion |
 | **Sessions**              | Validate session                                                                                                                                                      |
 | **Storage Views**         | View                                                                                                                                                                  |
+| **System**                | Anonymous<br />Read<br />View                                                                                                                                         |
 | **Tasks**                 | Create task<br />Update task                                                                                                                                          |
 | **vApp**                  | Import<br />View OVF environment<br />vApp application configuration<br />vApp instance configuration                                                                 |
 | **VM Storage Policies**   | View VM storage policies                                                                                                                                              |
@@ -165,6 +176,7 @@ Virtual Machines.
 | **Profile-driven Storage** | View                                                                                                                                                                  |
 | **Sessions**               | Validate session                                                                                                                                                      |
 | **Storage Views**          | View                                                                                                                                                                  |
+| **System**                 | Anonymous<br />Read<br />View                                                                                                                                         |
 | **Tasks**                  | Create task<br />Update task                                                                                                                                          |
 | **vApp**                   | Import<br />View OVF environment<br />vApp application configuration<br />vApp instance configuration                                                                 |
 | **vSphere Tagging**        | Assign or Unassign vSphere Tag<br />Create vSphere Tag<br />Delete vSphere Tag<br />Edit vSphere Tag                                                                  |
@@ -198,6 +210,7 @@ Virtual Machines.
 | **Profile-driven Storage** | View                                                                                                                                                                  |
 | **Sessions**               | Validate session                                                                                                                                                      |
 | **Storage Views**          | View                                                                                                                                                                  |
+| **System**                 | Anonymous<br />Read<br />View                                                                                                                                         |
 | **Tasks**                  | Create task<br />Update task                                                                                                                                          |
 | **vApp**                   | Import<br />View OVF environment<br />vApp application configuration<br />vApp instance configuration                                                                 |
 | **vSphere Tagging**        | Assign or Unassign vSphere Tag<br />Create vSphere Tag<br />Delete vSphere Tag<br />Edit vSphere Tag                                                                  |
@@ -248,6 +261,9 @@ Virtual Machines.
     - `Sessions.ValidateSession`
     - `StorageProfile.View`
     - `StorageViews.View`
+    - `System.Anonymous`
+    - `System.Read`
+    - `System.View`
     - `Task.Create`
     - `Task.Update`
     - `VApp.ApplicationConfig`
@@ -326,6 +342,10 @@ Virtual Machines.
 
 </details>
 
+> [!NOTE]
+>
+> The `System.*` privileges are [added to all custom vSphere roles by default](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html).
+
 ### Spectro Role Assignments
 
 The privileges associated with the _Spectro role_ must be granted via role assignments on specific vSphere objects for
@@ -335,8 +355,9 @@ required privileges on all required objects.
 | **vSphere Object**                           | **Propagation** | **Role**       | **Condition**                                                                                                                                 |
 | -------------------------------------------- | --------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Target Network**                           | Yes             | _Spectro role_ |                                                                                                                                               |
-| **Target Datastore**                         | Yes             | _Spectro role_ |                                                                                                                                               |
+| **Target Cluster**                           | No              | _Spectro role_ | Required if using a cluster's default `Resources` resource pool.                                                                              |
+| **Target Resource Pool**                     | Yes             | _Spectro role_ | Required if using a non-default resource pool.                                                                                                |
 | **All ESXi hosts within the Target Cluster** | No              | _Spectro role_ |                                                                                                                                               |
+| **Target Datastore**                         | Yes             | _Spectro role_ |                                                                                                                                               |
 | **spectro-templates Folder**                 | Yes             | _Spectro role_ | Must be manually created in advance, assigned permissions, and populated with Spectro Cloud VM Templates.                                     |
 | **Target VM Folder**                         | Yes             | _Spectro role_ | For air-gapped installs, it must be manually created in advance and permissions assigned. For connected installs it is created automatically. |
-| **Target Resource Pool**                     | Yes             | _Spectro role_ |                                                                                                                                               |

--- a/_partials/permissions/_vsphere-permissions.mdx
+++ b/_partials/permissions/_vsphere-permissions.mdx
@@ -108,7 +108,6 @@ propagated to a child object, the child object inherits the permission from the 
 | **vCenter Root**       | No              | _Spectro root role_ |                                                   |
 | **Target Datacenter**  | No              | _Spectro root role_ |                                                   |
 | **Target Cluster**     | No              | _Spectro root role_ |                                                   |
-| **Target VM Folder**   | Yes             | _Spectro root role_ |                                                   |
 | **Distributed Switch** | No              | _Spectro root role_ | If the Target Network is a Distributed Port Group |
 
 ### Spectro Role Privileges
@@ -333,10 +332,11 @@ The privileges associated with the _Spectro role_ must be granted via role assig
 either the user or a group containing the user. Review the required role assignments to ensure that your user has all
 required privileges on all required objects.
 
-| **vSphere Object**                           | **Propagation** | **Role**       | **Condition**                                                                                                                             |
-| -------------------------------------------- | --------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Target Network**                           | Yes             | _Spectro role_ |                                                                                                                                           |
-| **Target Datastore**                         | Yes             | _Spectro role_ |                                                                                                                                           |
-| **All ESXi hosts within the Target Cluster** | No              | _Spectro role_ |                                                                                                                                           |
-| **spectro-templates Folder**                 | Yes             | _Spectro role_ | For airgap installs, it must be manually created in advance and permissions assigned. For connected installs it is created automatically. |
-| **Target Resource Pool**                     | Yes             | _Spectro role_ |                                                                                                                                           |
+| **vSphere Object**                           | **Propagation** | **Role**       | **Condition**                                                                                                                                 |
+| -------------------------------------------- | --------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Target Network**                           | Yes             | _Spectro role_ |                                                                                                                                               |
+| **Target Datastore**                         | Yes             | _Spectro role_ |                                                                                                                                               |
+| **All ESXi hosts within the Target Cluster** | No              | _Spectro role_ |                                                                                                                                               |
+| **spectro-templates Folder**                 | Yes             | _Spectro role_ | Must be manually created in advance, assigned permissions, and populated with Spectro Cloud VM Templates.                                     |
+| **Target VM Folder**                         | Yes             | _Spectro role_ | For air-gapped installs, it must be manually created in advance and permissions assigned. For connected installs it is created automatically. |
+| **Target Resource Pool**                     | Yes             | _Spectro role_ |                                                                                                                                               |

--- a/_partials/permissions/_vsphere-permissions.mdx
+++ b/_partials/permissions/_vsphere-permissions.mdx
@@ -13,6 +13,13 @@ A _Spectro root role_ must be created that contains each privilege in the follow
 
 Select the tab for the vSphere version you are using to view the required privileges.
 
+
+:::info
+
+The `System.*` privileges are added to all [custom vSphere roles](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html) by default.
+
+:::
+
 <!--
 VMware vSphere Privilege ID Mapping
 https://gist.github.com/pljoel/98842cf88d78872bed891bba14a44ab8
@@ -96,9 +103,6 @@ https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GU
 
 </details>
 
-> [!NOTE]
->
-> The `System.*` privileges are [added to all custom vSphere roles by default](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html).
 
 ### Spectro Root Role Assignments
 
@@ -342,9 +346,12 @@ Virtual Machines.
 
 </details>
 
-> [!NOTE]
->
-> The `System.*` privileges are [added to all custom vSphere roles by default](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html).
+
+:::info
+
+The `System.*` privileges are added to all [custom vSphere roles](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html) by default.
+
+:::
 
 ### Spectro Role Assignments
 

--- a/docs/docs-content/clusters/data-center/vmware/create-manage-vmware-clusters.md
+++ b/docs/docs-content/clusters/data-center/vmware/create-manage-vmware-clusters.md
@@ -17,6 +17,23 @@ Before you begin, ensure that you have the following prerequisites:
 - A VMware vSphere user account with the necessary permissions to create and manage clusters. Refer to the
   [Required Permissions](./permissions.md) page for more information.
 
+- Ensure your vSphere environment contains the Kubernetes OVA for the desired Kubernetes version. Such as
+  `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1294-0.ova`. Speak to your assigned support
+  representative to get the link to other versions. Append an `r_` prefix to the OVA name and remove the `.ova` suffix
+  after the import. For example, the final output should look like `r_u-2204-0-k-12813-0`. This naming convention is
+  required for the install process to identify the OVA. The OVA must be converted to a template in the
+  `spectro-templates` folder.
+
+  :::tip
+
+  You can also use the **Deploy OVF Template** wizard in vSphere to make the OVA available in the `spectro-templates`
+  folder. Append the `r_` prefix, and remove the `.ova` suffix when assigning a name and target location. You can
+  terminate the deployment after the OVA is available in the `spectro-templates` folder. Refer to the
+  [Deploy an OVF or OVA Template](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vm-administration/GUID-AFEDC48B-C96F-4088-9C1F-4F0A30E965DE.html)
+  guide for more information about deploying an OVA in vCenter.
+
+  :::
+
 - A VMware account registered in Palette. VMware accounts are automatically registered when you deploy a Private Cloud
   Gateway (PCG) in Palette. Check out the [Deploy a PCG](../../pcg/deploy-pcg/vmware.md) guide to learn how to deploy a
   PCG.

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
@@ -97,11 +97,11 @@ Use the following steps to install Palette.
     OVA in the `spectro-templates` folder.
 
     ```url
-     https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2204-0-k-12711-0.ova
+    https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova
     ```
 
 4.  Append an `r_` prefix to the OVA name and remove the `.ova` suffix after the import. For example, the final output
-    should look like `r_u-2204-0-k-12711-0`. This naming convention is required for the install process to identify the
+    should look like `r_u-2204-0-k-12813-0`. This naming convention is required for the install process to identify the
     OVA. Refer to the [Supplement Packs](../../airgap/supplemental-packs.md#additional-ovas) page for a list of
     additional OVAs you can download and upload to your vCenter environment.
 

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -101,11 +101,11 @@ Use the following steps to install Palette.
     OVA in the `spectro-templates` folder.
 
     ```url
-     https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2204-0-k-12711-0.ova
+    https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova
     ```
 
 4.  Append an `r_` prefix to the OVA name and remove the `.ova` suffix after the import. For example, the final output
-    should look like `r_u-2204-0-k-12711-0`. This naming convention is required for the install process to identify the
+    should look like `r_u-2204-0-k-12813-0`. This naming convention is required for the install process to identify the
     OVA. Refer to the [Supplement Packs](../airgap/supplemental-packs.md#additional-ovas) page for a list of additional
     OVAs you can download and upload to your vCenter environment.
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
@@ -124,11 +124,11 @@ Use the following steps to install Palette VerteX.
     guide for information about importing an OVA in vCenter.
 
     ```url
-     https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2204-0-k-12711-0.ova
+    https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova
     ```
 
 4.  Append an `r_` prefix to the OVA name and remove the `.ova` suffix after the import. For example, the final output
-    should look like `r_u-2204-0-k-12711-0`. This naming convention is required for the install process to identify the
+    should look like `r_u-2204-0-k-12813-0`. This naming convention is required for the install process to identify the
     OVA. Refer to the [Supplement Packs](../../airgap/supplemental-packs.md#additional-ovas) page for a list of
     additional OVAs you can download and upload to your vCenter environment.
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -127,11 +127,11 @@ Use the following steps to install Palette VerteX.
     guide for information about importing an OVA in vCenter.
 
     ```url
-     https://vmwaregoldenimage-console.s3.us-east-2.amazonaws.com/u-2204-0-k-12711-0.ova
+     https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova
     ```
 
 4.  Append an `r_` prefix to the OVA name and remove the `.ova` suffix after the import. For example, the final output
-    should look like `r_u-2204-0-k-12711-0`. This naming convention is required for the install process to identify the
+    should look like `r_u-2204-0-k-12813-0`. This naming convention is required for the install process to identify the
     OVA. Refer to the [Supplement Packs](../airgap/supplemental-packs.md#additional-ovas) page for a list of additional
     OVAs you can download and upload to your vCenter environment.
 


### PR DESCRIPTION
## Describe the Change

- Fix the role assignment / privileges for the Enterprise Cluster's VM Folder
- Correct the conditions for VM Folder and `spectro-templates` folder
- Add `System.*` privileges just to be explicit
- Document conditionality around spectro privileges on Cluster vs. non-default Resource Pool

During installation, palette (controller, not product) creates the VM Folder, but only in connected mode. The `spectro-templates` folder is always created in advance.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
