### PR TITLE
[version-4-0] docs: remove airgap instructions from non-airgap guides (#3934)

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -96,7 +96,7 @@ Use the following steps to install Palette.
 1.  Log in to your vCenter environment.
 
 2.  Create a vSphere VM and Template folder with the name `spectro-templates`. Ensure this folder is accessible by the
-    user account you will use to deploy the airgap VerteX installation.
+    user account you will use to deploy the Palette installation.
 
 3.  Use the URL below to import the Operating System and Kubernetes distribution OVA required for the install. Place the
     OVA in the `spectro-templates` folder.
@@ -133,26 +133,10 @@ Use the following steps to install Palette.
 7.  Type `y` if you want to use Ubuntu Pro. Otherwise, type `n`. If you choose to use Ubuntu Pro, you will be prompted
     to enter your Ubuntu Pro token.
 
-8.  Depending on that type of install of Palette you are using, the Spectro Cloud repository URL value will be
-    different.
-
-    - Non-Airgap: `https://saas-repo.console.spectrocloud.com`
-    - Airgap: The URL or IP address of the Spectro Cloud Repository that is provided to you by the airgap setup script
-
-    <br />
-
-    :::info
-
-    If you are using the Palette CLI from inside an [airgap support VM](./airgap-install/airgap-install.md), the CLI
-    will automatically detect the airgap environment and prompt you to **Use local, air-gapped Spectro Cloud Artifact
-    Repository (SCAR) configuration**. Type `y` to use the local resources and skip filling in the repository URL and
-    credentials.
-
-    :::
+8.  Provide `https://saas-repo.console.spectrocloud.com` as the URL for the Spectro Cloud repository.
 
 9.  Enter the repository credentials. Our support team provides the credentials you need to access the public Spectro
-    Cloud repository. Airgap installations, provide the credentials to your private repository provided to you by the
-    airgap setup script .
+    Cloud repository.
 
 10. Choose `VMware vSphere` as the cloud type. This is the default.
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -9,9 +9,9 @@ tags: ["vertex", "vmware"]
 keywords: ["self-hosted", "vertex"]
 ---
 
-You install Palette VerteX in an airgap environment through the Palette Command Line Interface (CLI). The CLI provides
-you with an interactive experience that guides you through the installation process. You can invoke the Palette CLI on
-any Linux x86-64 system with the Docker daemon installed and connectivity to the VMware vSphere environment where
+You can install Palette VerteX in a connected environment using the Palette Command Line Interface (CLI). The CLI
+provides you with an interactive experience that guides you through the installation process. You can invoke the Palette
+CLI on any Linux x86-64 system with the Docker daemon installed and connectivity to the VMware vSphere environment where
 Palette VerteX will be deployed.
 
 ## Prerequisites
@@ -78,10 +78,10 @@ Palette VerteX will be deployed.
 
 :::info
 
-Self-hosted Palette VerteX installations provide a system Private Cloud Gateway (PCG) out-of-the-box and typically do
-not require a separate, user-installed PCG. However, you can create additional PCGs as needed to support provisioning
-into remote data centers that do not have a direct incoming connection from the Palette console. To learn how to install
-a PCG on VMware, check out the [Deploy to VMware vSphere](../../../clusters/pcg/deploy-pcg/vmware.md) guide.
+Palette VerteX installations provide a system Private Cloud Gateway (PCG) out-of-the-box and typically do not require a
+separate, user-installed PCG. However, you can create additional PCGs as needed to support provisioning into remote data
+centers that do not have a direct incoming connection from the Palette console. To learn how to install a PCG on VMware,
+check out the [Deploy to VMware vSphere](../../../clusters/pcg/deploy-pcg/vmware.md) guide.
 
 :::
 
@@ -99,7 +99,7 @@ Use the following steps to install Palette VerteX.
 1.  Log in to your vCenter environment.
 
 2.  Create a vSphere VM and Template folder with the name `spectro-templates`. Ensure this folder is accessible by the
-    user account you will use to deploy the airgap VerteX installation.
+    user account you will use to deploy the VerteX installation.
 
 3.  Use the URL below to import the Operating System and Kubernetes distribution OVA required for the install. Place the
     OVA in the `spectro-templates` folder. Refer to the
@@ -146,8 +146,7 @@ Use the following steps to install Palette VerteX.
 8.  The Spectro Cloud repository URL is `https://saas-repo-fips.console.spectrocloud.com`.
 
 9.  Enter the repository credentials. Our support team provides the credentials you need to access the public Spectro
-    Cloud repository. Airgap installations, provide the credentials to your private repository provided to you by the
-    airgap setup script .
+    Cloud repository.
 
 10. Choose `VMware vSphere` as the cloud type. This is the default.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR backports PR #3934 from master to version-4-0.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Self-hosted Palette Non-Airgap Installation](https://deploy-preview-3941--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/install/)
💻 [VerteX Non-Airgap Installation](https://deploy-preview-3941--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/install/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._Backport PR.
