### PR TITLE
docs: add api breaking change

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -61,6 +61,10 @@ tags: ["release-notes"]
   to the [Edge Installer User Data Configuration](../clusters/edge/edge-configuration/edge-configuration.md) reference
   page for more information.
 
+- A change in the Palette API affects Edge clusters deployed with Terraform or the Palette API. The `type` parameter in
+  the `controlPlaneEndpoint` for Edge clusters no longer accepts IP addresses. The accepted values are now `VIP`,
+  `External`, and `DDNS`.
+
 #### Features
 
 - You can now configure the Maximum Transmission Unit (MTU) for network interface configured for discovery though


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a new breaking change to the 4.4.18 release notes.

The `type` parameter in the `controlPlaneEndpoint` for Edge clusters no longer accepts IP addresses. The accepted values are now `VIP`, `External`, and `DDNS`.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-3942--docs-spectrocloud.netlify.app/release-notes/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
