### PR TITLE
docs: update vertex/self-hosted upgrade paths table

### DIFF
--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -34,6 +34,8 @@ minor version available.
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
 |       4.4.14       |       4.4.18       | :white_check_mark: |
+|       4.4.11       |       4.4.18       | :white_check_mark: |
+|       4.3.6        |       4.4.18       | :white_check_mark: |
 |       4.4.11       |       4.4.14       | :white_check_mark: |
 |       4.4.6        |       4.4.14       | :white_check_mark: |
 |       4.3.6        |       4.4.14       | :white_check_mark: |

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -34,6 +34,8 @@ latest minor version available.
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
 |       4.4.14       |       4.4.18       | :white_check_mark: |
+|       4.4.11       |       4.4.18       | :white_check_mark: |
+|       4.3.6        |       4.4.18       | :white_check_mark: |
 |       4.4.11       |       4.4.14       | :white_check_mark: |
 |       4.4.6        |       4.4.14       | :white_check_mark: |
 |       4.3.6        |       4.4.14       | :white_check_mark: |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates VerteX and self-hosted upgrade paths tables.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Self-Hosted Upgrade](https://deploy-preview-3976--docs-spectrocloud.netlify.app/enterprise-version/upgrade/)
💻 [VerteX Upgrade](https://deploy-preview-3976--docs-spectrocloud.netlify.app/vertex/upgrade//)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1386](https://spectrocloud.atlassian.net/browse/DOC-1386)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1386]: https://spectrocloud.atlassian.net/browse/DOC-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ