### PR TITLE
docs: add limitation for external registry + content bundle

### DIFF
--- a/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
@@ -44,8 +44,8 @@ You can point the Edge Installer to a non-default registry to load content from 
 
 If you are using an external registry and want to use content bundles when deploying your Edge cluster, you must also
 enable the local Harbor registry. For more information, refer to
-[Build Content Bundles](../../edgeforge-workflow/palette-canvos/build-content-bundle.md) and
-[Enable Local Harbor Registry](../../site-deployment/deploy-custom-registries/local-registry.md).
+[Build Content Bundles](../edgeforge-workflow/palette-canvos/build-content-bundle.md) and
+[Enable Local Harbor Registry](../site-deployment/deploy-custom-registries/local-registry.md).
 
 | Parameter                                    | Description                                                                                                                                                                                                                                                                                                   | Default |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |

--- a/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
@@ -42,6 +42,11 @@ listed in alphabetical order.
 You can point the Edge Installer to a non-default registry to load content from another source. Use the
 `registryCredentials` parameter object to specify the registry configurations.
 
+If you are using an external registry and want to use content bundles when deploying your Edge cluster, you must also
+enable the local Harbor registry. For more information, refer to
+[Build Content Bundles](../../edgeforge-workflow/palette-canvos/build-content-bundle.md) and
+[Enable Local Harbor Registry](../../site-deployment/deploy-custom-registries/local-registry.md).
+
 | Parameter                                    | Description                                                                                                                                                                                                                                                                                                   | Default |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `stylus.registryCredentials.domain`          | The domain of the registry. You can use an IP address plus the port or a domain name.                                                                                                                                                                                                                         |         |

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
@@ -43,7 +43,7 @@ Creating a content bundle provides several benefits that may address common use 
 
 ## Limitation
 
-- You cannot use content bundles with an external registry if you do not enable a local Harbor registry on your Edge
+- You cannot use content bundles with an external registry if you do not enable the local Harbor registry on your Edge
   host. If you specify a external registry without enabling the local Harbor registry, the images will be downloaded
   from the external registry even if you provide a content bundle, and deployment will fail if the necessary images
   cannot be located in the external registry. For more information, refer to

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
@@ -41,6 +41,15 @@ Creating a content bundle provides several benefits that may address common use 
 - Organizations that want better control over the software used by their Edge hosts can use content bundles to ensure
   that only approved software is consumed.
 
+## Limitation
+
+- You cannot use content bundles with an external registry if you do not enable a local Harbor registry on your Edge
+  host. If you specify a external registry without enabling the local Harbor registry, the images will be downloaded
+  from the external registry even if you provide a content bundle, and deployment will fail if the necessary images
+  cannot be located in the external registry. For more information, refer to
+  [Deploy Cluster with External Registry](../../site-deployment/deploy-custom-registries/deploy-external-registry.md)
+  and [Enable Local Harbor Registry](../../site-deployment/deploy-custom-registries/local-registry.md).
+
 ## Prerequisites
 
 - Linux Machine (Physical or VM) with an AMD64 architecture.

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/deploy-external-registry.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/deploy-external-registry.md
@@ -38,6 +38,13 @@ information, refer to [Enable Local Harbor Registry](./local-registry.md).
 - Palette Edge supports basic username/password authentication. Token authentication schemes used by services such as
   AWS ECR and Google Artifact Registry are not supported.
 
+- You cannot use content bundles with an external registry if you do not enable a local Harbor registry on your Edge
+  host. If you specify a external registry without enabling the local Harbor registry, the images will be downloaded
+  from the external registry even if you provide a content bundle, and deployment will fail if the necessary images
+  cannot be located in the external registry. refer to
+  [Build Content Bundles](../../edgeforge-workflow/palette-canvos/build-content-bundle.md) and
+  [Enable Local Harbor Registry](../../site-deployment/deploy-custom-registries/local-registry.md).
+
 ## Prerequisites
 
 - Specifying the external registry and providing credentials happens during the EdgeForge process. You should become

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/deploy-external-registry.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/deploy-external-registry.md
@@ -38,10 +38,10 @@ information, refer to [Enable Local Harbor Registry](./local-registry.md).
 - Palette Edge supports basic username/password authentication. Token authentication schemes used by services such as
   AWS ECR and Google Artifact Registry are not supported.
 
-- You cannot use content bundles with an external registry if you do not enable a local Harbor registry on your Edge
+- You cannot use content bundles with an external registry if you do not enable the local Harbor registry on your Edge
   host. If you specify a external registry without enabling the local Harbor registry, the images will be downloaded
   from the external registry even if you provide a content bundle, and deployment will fail if the necessary images
-  cannot be located in the external registry. refer to
+  cannot be located in the external registry. For more information, refer to
   [Build Content Bundles](../../edgeforge-workflow/palette-canvos/build-content-bundle.md) and
   [Enable Local Harbor Registry](../../site-deployment/deploy-custom-registries/local-registry.md).
 


### PR DESCRIPTION
## Describe the Change

This PR adds the limitation that you cannot use external registries with content bundles if you don't have harbor. 

## Changed Pages

💻 [Build Content Bundle](https://deploy-preview-4049--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle/)

## Jira Tickets

🎫 [PE-5123](https://spectrocloud.atlassian.net/browse/PE-5123)

## Backports

Can this PR be backported?

- [ ] Yes. 


[PE-5123]: https://spectrocloud.atlassian.net/browse/PE-5123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ