### PR TITLE
Fix Path to airgap-setup.sh in airgap suport VM

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -265,7 +265,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
     - **server.crt**
     - **server.key**
 
-20. Start the airgap initialization process by issuing the following command. The script requires the hostname or IP
+20. Start the airgap initialization process by issuing the following command. The script requires a fully qualified hostname or IP
     address of the airgap support VM. Choose the preferred method for your environment. Be aware that the script will
     generate a self-signed certificate for the value you provide.
 
@@ -273,7 +273,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
         <TabItem label="Domain Name" value="domain">
 
         ```shell
-        /bin/airgap-setup.sh palette.example.com
+        /usr/bin/airgap-setup.sh palette.example.com
         ```
 
         The output of the script will look similar to the example below.
@@ -311,7 +311,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
         <TabItem label="IP Address" value="ip-address">
 
         ```shell
-        /bin/airgap-setup.sh 10.10.1.1
+        /usr/bin/airgap-setup.sh 10.10.1.1
         ```
 
         The output of the script will look similar to the example below.
@@ -385,7 +385,7 @@ Use the following steps to validate that you've successfully completed the airga
     hostname or IP address with the hostname or IP address of the airgap support VM.
 
     ```shell
-    bin/airgap-setup.sh palette.example.com
+    /usr/bin/airgap-setup.sh palette.example.com
     ```
 
 4.  Verify you have the values and credentials in the output.

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -269,7 +269,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
     - **server.crt**
     - **server.key**
 
-20. Start the airgap initialization process by issuing the following command. The script requires the hostname or IP
+20. Start the airgap initialization process by issuing the following command. The script requires a fully qualified hostname or IP
     address of the airgap support VM. Choose the preferred method for your environment. Be aware that the script will
     generate a self-signed certificate for the value you provide.
 
@@ -277,7 +277,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
         <TabItem label="Domain Name" value="domain">
 
         ```shell
-        /bin/airgap-setup.sh vertex.example.com
+        /usr/bin/airgap-setup.sh vertex.example.com
         ```
 
         The output of the script will look similar to the example below.
@@ -315,7 +315,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
         <TabItem label="IP Address" value="ip-address">
 
         ```shell
-        /bin/airgap-setup.sh 10.10.1.1
+        /usr/bin/airgap-setup.sh 10.10.1.1
         ```
 
         The output of the script will look similar to the example below.
@@ -389,7 +389,7 @@ Use the following steps to validate that you've successfully completed the airga
     hostname or IP address with the hostname or IP address of the airgap support VM.
 
     ```shell
-    bin/airgap-setup.sh vertex.example.com
+    /usr/bin/airgap-setup.sh vertex.example.com
     ```
 
 4.  Verify you have the values and credentials in the output.


### PR DESCRIPTION

## Describe the Change

This PR fixes the path to `airgap-setup.sh` within the airgap support VM.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
