### PR TITLE
docs: disable webhook 

### DIFF
--- a/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
@@ -216,7 +216,7 @@ registry. If you find this redirect behavior to be limiting, you can disable the
 
 | Parameter                            | Description                                            | Default |
 | ------------------------------------ | ------------------------------------------------------ | ------- |
-| `stylus.imageRedirectWebhook.enable` | Whether to enable the webhook to redirect image pulls. | None    |
+| `stylus.imageRedirectWebhook.enable` | Whether to enable the webhook to redirect image pulls. | `True`    |
 
 ## Install Parameters
 

--- a/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
@@ -208,6 +208,16 @@ For example, if you have a Python script that returns the following JSON output:
 You can configure `stylus.site.tagsFromScript` to point to the script, and it will add the tags `owner:p78125d` and
 `department: sales` to the Edge host.
 
+### Site Registry Parameters
+
+Palette uses a webhook to redirect image pulls when you have specified an external registry or use a local Harbor
+registry. If you find this redirect behavior to be limiting, you can disable the webhook. For more information, refer to
+[Disable Webhook to Customize Image Pull Behavior](../site-deployment/deploy-custom-registries/webhook-disable.md).
+
+| Parameter                            | Description                                            | Default |
+| ------------------------------------ | ------------------------------------------------------ | ------- |
+| `stylus.imageRedirectWebhook.enable` | Whether to enable the webhook to redirect image pulls. | None    |
+
 ## Install Parameters
 
 The `install` block allows you to configure the installer to make bind mounts and disk partitions on the Edge host. In

--- a/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
@@ -216,7 +216,7 @@ registry. If you find this redirect behavior to be limiting, you can disable the
 
 | Parameter                            | Description                                            | Default |
 | ------------------------------------ | ------------------------------------------------------ | ------- |
-| `stylus.imageRedirectWebhook.enable` | Whether to enable the webhook to redirect image pulls. | `True`    |
+| `stylus.imageRedirectWebhook.enable` | Whether to enable the webhook to redirect image pulls. | `True`  |
 
 ## Install Parameters
 

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
@@ -422,4 +422,4 @@ source code for the credential provider on GitHub.
 
 2. Create a cluster profile that references the image registries you configured.
 
-3. Deploy a cluster with the cluster profile.
+3. Deploy a cluster with the cluster profile. Confirm that the cluster is able to download the necessary images.

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
@@ -15,7 +15,7 @@ appropriate locations depending on your configuration.
 
 While the webhook makes using an external registry or the local Harbor registry more streamlined, it can limit your
 flexibility to configure your own image pull behavior. This guide guides you through how to disable the Palette agent
-webhook and provides a few example configurations to customize image pull for your cluster.
+webhook and provides an example custom image pull configuration.
 
 ## What Happens When You Disable the Webhook
 
@@ -105,8 +105,6 @@ The process to redirect image pulls vary by Kubernetes distribution as well as y
 provides an example that shows how you might customize the image pull behavior of your Edge cluster. The example shows
 how you can configure a PXK-E Edge cluster to pull from multiple authenticated registries.
 
-The example shown in this section uses containerd's registry configuration to redirect image pulls. It uses PXK-E
-
 6. Log in to [Palette](https://console.spectrocloud.com).
 
 7. From the left **Main Menu**, click **Profiles**. Click on the profile you use to deploy your Edge cluster.
@@ -175,7 +173,7 @@ If your registries require authentication, you will need to provide credentials 
 an open-source generic Kubernetes credentials provider to provide the resources. There are other resources that you can
 take advantage of to provide registry credentials, including using a `registry.yaml` file in K3s or RKE2. However, the
 advantage of the approach used in this example is that after installation, you will not need to restart your cluster to
-rewrite the registry paths or provide the registry credentials if you use K3S or RKE2.
+rewrite the registry paths or provide the registry credentials.
 
 :::info
 
@@ -396,7 +394,9 @@ code for the credential provider on GitHub.
     :::warning
 
     Avoid entering sensitive information like passwords directly into your cluster profile in plain text. Instead, you
-    can either use a cluster profile variable or a macro.
+    can either use a cluster profile variable or a macro. For more information, refer to
+    [Macros](../../../cluster-management/macros.md) and
+    [Define and Manage Profile Variables](../../../../profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md).
 
     :::
 
@@ -408,4 +408,6 @@ code for the credential provider on GitHub.
 1. Use the ISO to install Palette Edge on an Edge host. For more information, refer to
    [Installation](../site-installation/site-installation.md).
 
-2. Create a cluster profile and include **Harbor Edge-Native Config** pack.
+2. Create a cluster profile that references the image registries you configured.
+
+3. Deploy a cluster with the cluster profile.

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
@@ -1,0 +1,10 @@
+---
+sidebar_label: "Disable Webhook to Customize Registry Behavior"
+title: "Disable Webhook to Customize Registry Behavior"
+description: "Learn how to disable the Palette agent webhook to give you greater freedom in designing registry image
+  pull behavior.
+  "
+hide_table_of_contents: false
+sidebar_position: 80
+tags: ["edge"]
+---

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
@@ -146,9 +146,13 @@ provides an example that shows how you might customize the image pull behavior o
    :::
 
 9. In the Kubernetes layer of the profile, include the following lines in the reconcile stage. For more information,
-   refer to [Cloud-init Stages](../../edge-configuration/cloud-init.md).
+   refer to [Cloud-init Stages](../../edge-configuration/cloud-init.md). Replace the server address and the host address
+   with your registry and its mirror. Since you are only editing the reconcile stage, this will not result in a reboot
+   or service restart for your cluster.
 
-   ```yaml
+   The following example will redirect image pulls for `https://gcr.io` to `https://gcr-io-mirror.company.local`.
+
+   ```yaml {9-11}
    stages:
     reconcile:
         - name: "Redirect registries"
@@ -161,9 +165,6 @@ provides an example that shows how you might customize the image pull behavior o
                 [host."https://gcr-io-mirror.company.local"]
                     capabilities = ["pull", "resolve"]
    ```
-
-   This will redirect image pulls for `https://gcr.io` to `https://gcr-io-mirror.company.local`. Since you are only
-   editing the reconcile stage, this will not result in a reboot or service restart for your cluster.
 
 ### Provide Registry Credentials
 
@@ -337,8 +338,9 @@ source code for the credential provider on GitHub.
                 image-credential-provider-config: /opt/kubernetes/generic-credential-provider-config.json
     ```
 
-14. Use a `reconcile` stage to define the JSON file with the `CredentialProviderConfig` for Kubelet. This configuration
-    specifies the registries that will use the credential provider.
+14. In the Kubernetes or OS layoer of your cluster profile, use a `reconcile` stage to define the JSON file with the
+    `CredentialProviderConfig` for Kubelet. This configuration specifies the registries that will use the credential
+    provider.
 
     ```yaml {17,18}
     stages:

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
@@ -251,7 +251,7 @@ source code for the credential provider on GitHub.
                           # Create the output JSON response
                           output_json = {
                               "kind": "CredentialProviderResponse",
-                              "apiVersion": "credentialprovider.kubelet.k8s.io/v1",
+                              "apiVersion": "credentialprovider.Kubelet.k8s.io/v1",
                               "cacheKeyType": "Registry",
                               "cacheDuration": duration,
                               "auth": {
@@ -317,27 +317,27 @@ source code for the credential provider on GitHub.
 
      </details>
 
-13. In the Kubernetes layer of your cluster, add the following lines to the `kubeadmconfig.kubeletExtraArgs` field. This
+13. In the Kubernetes layer of your cluster, add the following lines to the `kubeadmconfig.KubeletExtraArgs` field. This
     tells Kubernetes to use the credential provider you installed in the previous step.
 
     ```yaml
-    kubeletExtraArgs:
+    KubeletExtraArgs:
       cluster:
         config: |
           initConfiguration:
             nodeRegistration:
-              kubeletExtraArgs:
+              KubeletExtraArgs:
                 image-credential-provider-bin-dir: /usr/local/bin
                 image-credential-provider-config: /opt/kubernetes/generic-credential-provider-config.json
           joinConfiguration:
             discovery: {}
             nodeRegistration:
-              kubeletExtraArgs:
+              KubeletExtraArgs:
                 image-credential-provider-bin-dir: /usr/local/bin
                 image-credential-provider-config: /opt/kubernetes/generic-credential-provider-config.json
     ```
 
-14. Use a `reconcile` stage to define the JSON file with the `CredentialProviderConfig` for kubelet. This configuration
+14. Use a `reconcile` stage to define the JSON file with the `CredentialProviderConfig` for Kubelet. This configuration
     specifies the registries that will use the credential provider.
 
     ```yaml {17,18}
@@ -351,7 +351,7 @@ source code for the credential provider on GitHub.
               permissions: 0644
               content: |-
                 {
-                  "apiVersion": "kubelet.config.k8s.io/v1",
+                  "apiVersion": "Kubelet.config.k8s.io/v1",
                   "kind": "CredentialProviderConfig",
                   "providers": [
                     {
@@ -361,7 +361,7 @@ source code for the credential provider on GitHub.
                         "*.*.io"
                       ],
                       "defaultCacheDuration": "5m",
-                      "apiVersion": "credentialprovider.kubelet.k8s.io/v1"
+                      "apiVersion": "credentialprovider.Kubelet.k8s.io/v1"
                     }
                   ]
                 }
@@ -369,12 +369,12 @@ source code for the credential provider on GitHub.
 
     Registry URLs that match the patterns in the `mathImages` field will use this provider for credentials. For example,
     `*.io` would match `docker.io`, `quay.io`, `gcr.io` and `*.*.io` would cover URLs like `us.gcr.io`. Refer to
-    [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/#configure-a-kubelet-credential-provider)
-    about the parameters you can use to configure credential providers for kubelet.
+    [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/Kubelet-credential-provider/#configure-a-Kubelet-credential-provider)
+    about the parameters you can use to configure credential providers for Kubelet.
 
     :::tip
 
-    We suggest that you define a broad pattern, as updating this file requires kubelet to restart. There are no adverse
+    We suggest that you define a broad pattern, as updating this file requires Kubelet to restart. There are no adverse
     effects when the pattern matches a registry URL for which there is no defined credentials: the Palette agent will
     still perform the image pull, but it will not use the credential provider.
 

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: "Disable Webhook to Customize Registry Behavior"
-title: "Disable Webhook to Customize Registry Behavior"
+sidebar_label: "Disable Webhook to Customize Image Pull Behavior"
+title: "Disable Webhook to Customize Image Pull Behavior"
 description: "Learn how to disable the Palette agent webhook to give you greater freedom in designing registry image
   pull behavior.
   "
@@ -8,3 +8,105 @@ hide_table_of_contents: false
 sidebar_position: 80
 tags: ["edge"]
 ---
+
+Palette Edge allows you to deploy clusters to an external registry and use a local Harbor registry without manually
+configuring rewrites. This is possible because the Palette agent uses a webhook to redirect image pulls to the
+appropriate locations depending on your configuration.
+
+While the webhook makes using an external registry or the local Harbor registry more streamlined, it can limit your
+flexibility to configure your own image pull behavior. This guide guides you through how to disable the Palette agent
+webhook and provides a few example configurations to customize image pull for your cluster.
+
+## What Happens When You Disable the Webhook
+
+When the agent webhook is disabled, the Palette agent will not redirect any image pull operation by default. This means
+that even if you specify an external registry in the **user-data**, the Palette agent will not pull images from that
+registry unless it is otherwise configured to do so. This also means that the Palette agent will not pull images from
+the local Harbor registry, even if the images are downloaded and stored in the registry, unless it is otherwise
+configured to do so. Disabling the webhook removes restrictions, but does place the burden of ensuring that images are
+pulled from the correct locations on yourself.
+
+You may consider disabling the webhook if you want to configure your cluster to pull images from multiple authenticated
+registries, or you simply do not want the default behavior that forces image pulls to be redirected to the local Harbor
+registry. Once the webhook is disabled, you can then take advantage of the rewrite features of some Kubernetes
+distributions such as K3s and RKE2, or other redirect mechanism that you implement on your own to customize the image
+pull behavior.
+
+## Prerequisites
+
+- The process to disable webhook is based on the EdgeForge process. We recommend that you familiarize yourself with
+  [EdgeForge](../../edgeforge-workflow/edgeforge-workflow.md) and the process to build Edge artifacts.
+
+- A physical or virtual Linux machine with _AMD64_ (also known as _x86_64_) processor architecture to build the Edge
+  artifacts. You can issue the following command in the terminal to check your processor architecture.
+
+  ```bash
+  uname -m
+  ```
+
+- Minimum hardware configuration of the Linux machine:
+
+  - 4 CPU
+  - 8 GB memory
+  - 150 GB storage
+
+- [Git](https://git-scm.com/downloads). You can ensure git installation by issuing the `git --version` command.
+
+- [Docker Engine](https://docs.docker.com/engine/install/) version 18.09.x or later. You can use the `docker --version`
+  command to view the existing Docker version. You should have root-level or `sudo` privileges on your Linux machine to
+  create privileged containers.
+
+- A [Spectro Cloud](https://console.spectrocloud.com) account. If you have not signed up, you can sign up for a
+  [free trial](https://www.spectrocloud.com/free-tier/).
+
+## Procedure
+
+### Disable Webhook
+
+1. Clone the **CanvOS** repository.
+
+   ```shell
+   git clone https://github.com/spectrocloud/CanvOS.git
+   ```
+
+2. Change into the **CanvOS** directory.
+
+   ```shell
+   cd CanvOS
+   ```
+
+3. View the available tags and use the latest available tag. This guide uses `v4.5.0` as an example.
+
+   ```shell
+   git tag
+   git checkout v4.5.0
+   ```
+
+4. In your **user-data** file, set `stylus.webhook.enable` to `false`.
+
+   ```yaml {7}
+   #cloud-config
+   stylus:
+     site:
+       edgeHostToken: XXXXXXXXXXXXXX
+       paletteEndpoint: XXXXXX
+       projectUid: XXXXXX
+     imageRedirectWebhook:
+       enable: false
+   ```
+
+5. Follow the rest of the [Build Edge Artifact](../../edgeforge-workflow/palette-canvos/palette-canvos.md) guide and
+   build the Installer ISO with the user data configurations. The Edge clusters provisioned with the ISO will no longer
+   automatically redirect image pull requests to the external registry or the local Harbor registry.
+
+   From this point on, you can customize redirect behavior yourself. The process to redirect image pulls vary by
+   Kubernetes distribution as well as your registry setup.
+
+## Validate
+
+1. Use the ISO to install Palette Edge on an Edge host. For more information, refer to
+   [Installation](../site-installation/site-installation.md).
+
+2. Create a cluster profile and include **Harbor Edge-Native Config** pack.
+
+3.


### PR DESCRIPTION
## Describe the Change

This PR adds the instructions for how to disable Palette Edge agent webhook. 

## Changed Pages

💻 [Image Pull Customizations](https://deploy-preview-4098--docs-spectrocloud.netlify.app/clusters/edge/site-deployment/deploy-custom-registries/webhook-disable/)

## Jira Tickets

🎫  [PE-4883](https://spectrocloud.atlassian.net/browse/PE-4883)


Can this PR be backported?

- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[PE-4883]: https://spectrocloud.atlassian.net/browse/PE-4883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ