### PR TITLE
docs: PLT-1407

### DIFF
--- a/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
+++ b/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
@@ -22,11 +22,6 @@ from VMware vSphere to Palette VMO.
 - Only VMs whose operating systems are included under
   [`virt-v2v` supported guest systems](https://libguestfs.org/virt-v2v-support.1.html) can be migrated.
 
-- The network type <VersionedLink text="Multus CNI" url="/integrations/packs/?pack=cni-multus" /> requires a Network
-  Attachment Definition (NAD) to exist in the migration target namespace in the destination cluster. The NAD name must
-  also match the name assigned to the migration. The migration name is assigned during the wizard, which is started by
-  the Palette CLI's `vmo migrate-vm` command.
-
 ## Prerequisites
 
 - A Healthy VMO cluster. Refer to the [Create a VMO Profile](../../create-vmo-profile.md) for further guidance.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the limitation that required VMO migrations using Multus CNI to have NAD in the target cluster's migration namespace.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PLT-1407](https://spectrocloud.atlassian.net/browse/PLT-1407)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

This is a release PR. 


[PLT-1407]: https://spectrocloud.atlassian.net/browse/PLT-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ