### PR TITLE
OIDC userinfo

### DIFF
--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-adfs.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-adfs.md
@@ -49,9 +49,9 @@ standard that Palette employs. You can only use the OIDC-based approach for Micr
   | **Last Name**    | `family_name` | The user's last name.                                  |
   | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
 
-  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
-  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
-  claims from the userinfo endpoint.
+  Change the claim names in your IdP if they are different from the default values. If the OIDC token does not contain
+  these claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the
+  missing claims from the user information endpoint.
 
 ## Enablement
 

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-adfs.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-adfs.md
@@ -40,6 +40,19 @@ standard that Palette employs. You can only use the OIDC-based approach for Micr
   [Matrixpost](https://blog.matrixpost.net/set-up-active-directory-federation-services-ad-fs-5-0-adfs-reverse-proxy-part-2/)
   for additional guidance.
 
+- Palette requires the following claims to be present in the OIDC token:
+
+  | Claim Name       | Default Value | Description                                            |
+  | ---------------- | ------------- | ------------------------------------------------------ |
+  | **Email**        | `email`       | The user's email address.                              |
+  | **First Name**   | `given_name`  | The user's first name.                                 |
+  | **Last Name**    | `family_name` | The user's last name.                                  |
+  | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
+
+  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
+  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
+  claims from the userinfo endpoint.
+
 ## Enablement
 
 ### Create the AD FS Application Group for Palette

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-entra-id.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-entra-id.md
@@ -58,9 +58,9 @@ Use the following steps to enable OIDC SSO in Palette with Microsoft Entra ID.
   | **Last Name**    | `family_name` | The user's last name.                                  |
   | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
 
-  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
-  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
-  claims from the userinfo endpoint.
+  Change the claim names in your IdP if they are different from the default values. If the OIDC token does not contain
+  these claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the
+  missing claims from the user information endpoint.
 
 ### Configure Microsoft Entra ID with Palette
 

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-entra-id.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-entra-id.md
@@ -49,6 +49,19 @@ Use the following steps to enable OIDC SSO in Palette with Microsoft Entra ID.
   need to install [kubelogin](https://github.com/int128/kubelogin) on your local workstation to handle retrieval of
   access tokens for your cluster.
 
+- Palette requires the following claims to be present in the OIDC token:
+
+  | Claim Name       | Default Value | Description                                            |
+  | ---------------- | ------------- | ------------------------------------------------------ |
+  | **Email**        | `email`       | The user's email address.                              |
+  | **First Name**   | `given_name`  | The user's first name.                                 |
+  | **Last Name**    | `family_name` | The user's last name.                                  |
+  | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
+
+  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
+  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
+  claims from the userinfo endpoint.
+
 ### Configure Microsoft Entra ID with Palette
 
 1.  Log in to [Palette](https://console.spectrocloud.com) as a **Tenant Admin**.

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
@@ -53,7 +53,7 @@ up Keycloak as an OIDC provider for Palette.
 
   Change the claim names in your IdP if they are different from the default values. If the OIDC token does not contain
   these claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the
-  missing claims from the userinfo endpoint.
+  missing claims from the user information endpoint.
 
 ## Enable SSO with Keycloak
 

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
@@ -51,9 +51,9 @@ up Keycloak as an OIDC provider for Palette.
   | **Last Name**    | `family_name` | The user's last name.                                  |
   | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
 
-  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
-  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
-  claims from the userinfo endpoint.
+  Change the claim names in your IdP if they are different from the default values. If the OIDC token does not contain
+  these claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the
+  missing claims from the userinfo endpoint.
 
 ## Enable SSO with Keycloak
 

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
@@ -42,6 +42,19 @@ up Keycloak as an OIDC provider for Palette.
 
 - Kubectl installed and configured to access your Kubernetes cluster.
 
+- Palette requires the following claims to be present in the OIDC token:
+
+  | Claim Name       | Default Value | Description                                            |
+  | ---------------- | ------------- | ------------------------------------------------------ |
+  | **Email**        | `email`       | The user's email address.                              |
+  | **First Name**   | `given_name`  | The user's first name.                                 |
+  | **Last Name**    | `family_name` | The user's last name.                                  |
+  | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
+
+  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
+  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
+  claims from the userinfo endpoint.
+
 ## Enable SSO with Keycloak
 
 1. Ensure you can access your Kubernetes cluster using the kubectl CLI. Refer to the

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-okta.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-okta.md
@@ -37,9 +37,9 @@ The following steps will guide you on how to enable Palette SSO with
   | **Last Name**    | `family_name` | The user's last name.                                  |
   | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
 
-  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
-  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
-  claims from the userinfo endpoint.
+  Change the claim names in your IdP if they are different from the default values. If the OIDC token does not contain
+  these claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the
+  missing claims from the user information endpoint.
 
 ## Okta with OIDC
 

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-okta.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-okta.md
@@ -28,6 +28,19 @@ The following steps will guide you on how to enable Palette SSO with
   install [kubelogin](https://github.com/int128/kubelogin) on your local workstation to handle retrieval of access
   tokens for your cluster.
 
+- Palette requires the following claims to be present in the OIDC token:
+
+  | Claim Name       | Default Value | Description                                            |
+  | ---------------- | ------------- | ------------------------------------------------------ |
+  | **Email**        | `email`       | The user's email address.                              |
+  | **First Name**   | `given_name`  | The user's first name.                                 |
+  | **Last Name**    | `family_name` | The user's last name.                                  |
+  | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
+
+  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
+  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
+  claims from the userinfo endpoint.
+
 ## Okta with OIDC
 
 ### Create the Okta Application

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-onelogin.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-onelogin.md
@@ -29,6 +29,19 @@ for OIDC-based SSO in your Kubernetes cluster.
 - For OIDC-based SSO in your Kubernetes cluster, you will need to install
   [kubelogin](https://github.com/int128/kubelogin) on your local workstation to retrieve access tokens for your cluster.
 
+- Palette requires the following claims to be present in the OIDC token:
+
+  | Claim Name       | Default Value | Description                                            |
+  | ---------------- | ------------- | ------------------------------------------------------ |
+  | **Email**        | `email`       | The user's email address.                              |
+  | **First Name**   | `given_name`  | The user's first name.                                 |
+  | **Last Name**    | `family_name` | The user's last name.                                  |
+  | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
+
+  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
+  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
+  claims from the userinfo endpoint.
+
 ## Enable SSO with OneLogin
 
 Use the following steps to configure OneLogin as a third-party IdP in Palette.

--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-onelogin.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-onelogin.md
@@ -38,9 +38,9 @@ for OIDC-based SSO in your Kubernetes cluster.
   | **Last Name**    | `family_name` | The user's last name.                                  |
   | **Spectro Team** | `groups`      | The user's group memberships in the Identity Provider. |
 
-  Change the claim names in IdP if they are different from the default values. If the OIDC token does not contain these
-  claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the missing
-  claims from the userinfo endpoint.
+  Change the claim names in your IdP if they are different from the default values. If the OIDC token does not contain
+  these claims, toggle the **Use userinfo endpoint** option in the OIDC configuration to allow Palette to fetch the
+  missing claims from the user information endpoint.
 
 ## Enable SSO with OneLogin
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds information about the new OIDC capability of extracting required claims from the userinfo endpoint. 

## Changed Pages

Added this prereq to each OIDC guide.

![CleanShot 2024-09-30 at 10 33 46](https://github.com/user-attachments/assets/12e1eca3-5552-4fe0-94a5-434d8942302e)


<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page](https://deploy-preview-4119--docs-spectrocloud.netlify.app/user-management/saml-sso/palette-sso-with-okta/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-5698](https://spectrocloud.atlassian.net/browse/PEM-5698)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release PR

[PEM-5698]: https://spectrocloud.atlassian.net/browse/PEM-5698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ