### PR TITLE
Read .env for Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ docker-image: ## Build the docker image
 	docker build -t $(IMAGE) .
 
 docker-start: docker-image ## Start a local development container
-	docker run --rm -it -v $(CURDIR)/docs:/librarium/docs/ -p 9000:9000 $(IMAGE)
+	docker run --env-file=.env --rm -it -v $(CURDIR)/docs:/librarium/docs/ -p 9000:9000 $(IMAGE)
 
 
 ##@ Writing Checks


### PR DESCRIPTION
## Describe the Change

Fixes `make docker-start` to actually read the values from the `.env` file
