### PR TITLE
Fix link to VMO reference architecture

### DIFF
--- a/docs/docs-content/vm-management/architecture.md
+++ b/docs/docs-content/vm-management/architecture.md
@@ -15,7 +15,7 @@ on top of an existing data center or edge cluster.
 ![Diagram that explains the architecture behind Palette VMO.](/vm-management_architecture_vmo-architecture.webp)
 
 For more detailed information about the technical architecture of VMO, refer to the
-[Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center). From the left **navigation Menu**, click
+[Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center). From the left **Main Menu**, click
 on the "virtual machines" topic to find the latest version of the Palette VMO Reference Architecture.
 
 ## Palette VMO Components

--- a/docs/docs-content/vm-management/architecture.md
+++ b/docs/docs-content/vm-management/architecture.md
@@ -15,8 +15,8 @@ on top of an existing data center or edge cluster.
 ![Diagram that explains the architecture behind Palette VMO.](/vm-management_architecture_vmo-architecture.webp)
 
 For more detailed information about the technical architecture of VMO, refer to the
-[Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center). From the left **Main Menu**, click
-on the "virtual machines" topic to find the latest version of the Palette VMO Reference Architecture.
+[Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center). From the left **Main Menu**, click on the
+"virtual machines" topic to find the latest version of the Palette VMO Reference Architecture.
 
 ## Palette VMO Components
 

--- a/docs/docs-content/vm-management/architecture.md
+++ b/docs/docs-content/vm-management/architecture.md
@@ -15,7 +15,7 @@ on top of an existing data center or edge cluster.
 ![Diagram that explains the architecture behind Palette VMO.](/vm-management_architecture_vmo-architecture.webp)
 
 For more detailed information about the technical architecture of VMO, refer to the
-[Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center) and click the "virtual machines" topic to
+[Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center). From the left **navigation Menu**,  click on the "virtual machines" topic to
 find the latest version of the Palette VMO Reference Architecture.
 
 ## Palette VMO Components

--- a/docs/docs-content/vm-management/architecture.md
+++ b/docs/docs-content/vm-management/architecture.md
@@ -14,7 +14,9 @@ on top of an existing data center or edge cluster.
 
 ![Diagram that explains the architecture behind Palette VMO.](/vm-management_architecture_vmo-architecture.webp)
 
-For more detailed information about the technical architecture of VMO, refer to the [Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center) and click the "virtual machines" topic to find the latest version of the Palette VMO Reference Architecture.
+For more detailed information about the technical architecture of VMO, refer to the
+[Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center) and click the "virtual machines" topic to
+find the latest version of the Palette VMO Reference Architecture.
 
 ## Palette VMO Components
 

--- a/docs/docs-content/vm-management/architecture.md
+++ b/docs/docs-content/vm-management/architecture.md
@@ -14,8 +14,7 @@ on top of an existing data center or edge cluster.
 
 ![Diagram that explains the architecture behind Palette VMO.](/vm-management_architecture_vmo-architecture.webp)
 
-For more detailed information about the technical architecture of VMO, refer to
-[Palette VMO Reference Architecture](https://www.spectrocloud.com/resources/whitepaper/vmo-architecture-pdf).
+For more detailed information about the technical architecture of VMO, refer to the [Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center) and click the "virtual machines" topic to find the latest version of the Palette VMO Reference Architecture.
 
 ## Palette VMO Components
 

--- a/docs/docs-content/vm-management/architecture.md
+++ b/docs/docs-content/vm-management/architecture.md
@@ -15,8 +15,8 @@ on top of an existing data center or edge cluster.
 ![Diagram that explains the architecture behind Palette VMO.](/vm-management_architecture_vmo-architecture.webp)
 
 For more detailed information about the technical architecture of VMO, refer to the
-[Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center). From the left **navigation Menu**,  click on the "virtual machines" topic to
-find the latest version of the Palette VMO Reference Architecture.
+[Spectro Cloud Resource Center](https://www.spectrocloud.com/resource-center). From the left **navigation Menu**, click
+on the "virtual machines" topic to find the latest version of the Palette VMO Reference Architecture.
 
 ## Palette VMO Components
 


### PR DESCRIPTION
## Describe the Change

This PR changes the link for the VMO Reference Architecture to the Spectro Cloud Resource Center, instead of linking to a hardcoded PDF file that no longer gets updated.

## Changed Pages

💻 [Add Preview URL for Page]()

## Jira Tickets

None