### PR TITLE
[version-4-4] chore: bump @ant-design/icons from 4.8.3 to 5.5.1 (#4136)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "spectro-cloud-docs",
       "version": "4.4.0",
       "dependencies": {
-        "@ant-design/icons": "^4.8.3",
-        "@commitlint/cli": "^19.3.0",
+        "@ant-design/icons": "^5.5.1",
+        "@commitlint/cli": "^19.4.1",
         "@commitlint/config-conventional": "^19.2.2",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/plugin-client-redirects": "^3.5.2",
@@ -443,15 +443,15 @@
       "license": "MIT"
     },
     "node_modules/@ant-design/icons": {
-      "version": "4.8.3",
-      "license": "MIT",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.5.1.tgz",
+      "integrity": "sha512-0UrM02MA2iDIgvLatWrj6YTCYe0F/cwXvVE0E2SqGrL7PZireQwgEKTKBisWpZyal5eXZLvuM98kju6YtYne8w==",
       "dependencies": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons-svg": "^4.3.0",
-        "@babel/runtime": "^7.11.2",
+        "@ant-design/colors": "^7.0.0",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@babel/runtime": "^7.24.8",
         "classnames": "^2.2.6",
-        "lodash": "^4.17.15",
-        "rc-util": "^5.9.4"
+        "rc-util": "^5.31.1"
       },
       "engines": {
         "node": ">=8"
@@ -464,13 +464,6 @@
     "node_modules/@ant-design/icons-svg": {
       "version": "4.4.2",
       "license": "MIT"
-    },
-    "node_modules/@ant-design/icons/node_modules/@ant-design/colors": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@ctrl/tinycolor": "^3.4.0"
-      }
     },
     "node_modules/@ant-design/react-slick": {
       "version": "1.0.2",
@@ -2602,8 +2595,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.6",
-      "license": "MIT",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
+      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -10703,24 +10697,6 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/antd/node_modules/@ant-design/icons": {
-      "version": "5.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "@ant-design/colors": "^7.0.0",
-        "@ant-design/icons-svg": "^4.4.0",
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.31.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/any-promise": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "react-live": ">=3.1.1 <4.0.0"
   },
   "dependencies": {
-    "@ant-design/icons": "^4.8.3",
-    "@commitlint/cli": "^19.3.0",
+    "@ant-design/icons": "^5.5.1",
+    "@commitlint/cli": "^19.4.1",
     "@commitlint/config-conventional": "^19.2.2",
     "@docusaurus/core": "^3.5.2",
     "@docusaurus/plugin-client-redirects": "^3.5.2",


### PR DESCRIPTION


This PR fixes the backport issue from PR #4136 


