### PR TITLE
Rewrote MAAS custom endpoint docs

### DIFF
--- a/docs/deprecated/integrations/kubernetes.md
+++ b/docs/deprecated/integrations/kubernetes.md
@@ -431,7 +431,7 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
 control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
-Kubernetes pack allows you configure a custom API server endpoint for your cluster instead. This feature is only
+Kubernetes pack allows you to configure a custom API server endpoint for your cluster instead. This feature is only
 supported in Palette eXtended Kubernetes (PXK).
 
 :::warning
@@ -462,7 +462,7 @@ cloud:
 
 In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
 recommend to use a system macro to automatically populate the cluster name. This approach allows the cluster profile to
-dynamically populate the endpoint name, without requiring the user to do it manually. The following snippet demonstrates
+dynamically populate the endpoint name without requiring the user to do it manually. The following snippet demonstrates
 how to use macros for endpoint specification.
 
 ```yaml hideClipboard {10-14}
@@ -822,7 +822,7 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
 control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
-Kubernetes pack allows you configure a custom API server endpoint for your cluster instead. This feature is only
+Kubernetes pack allows you to configure a custom API server endpoint for your cluster instead. This feature is only
 supported in Palette eXtended Kubernetes (PXK).
 
 :::warning
@@ -853,7 +853,7 @@ cloud:
 
 In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
 recommend to use a system macro to automatically populate the cluster name. This approach allows the cluster profile to
-dynamically populate the endpoint name, without requiring the user to do it manually. The following snippet demonstrates
+dynamically populate the endpoint name without requiring the user to do it manually. The following snippet demonstrates
 how to use macros for endpoint specification.
 
 ```yaml hideClipboard {10-14}

--- a/docs/deprecated/integrations/kubernetes.md
+++ b/docs/deprecated/integrations/kubernetes.md
@@ -427,29 +427,25 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ![A subject of the type group is assigned as the subject in a RoleBinding](/clusters_cluster-management_cluster-rbac_cluster-subject-group.webp)
 
-### Custom API server endpoint for MAAS clusters
+### Custom API Server Endpoint for MAAS Clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
-control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
-Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is
-only supported in Palette eXtended Kubernetes (PXK).
-
-When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used
-instead. If you use this option, you are responsible for:
-
-- Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
-- Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
-  - pointing directly to the IP address(es) of your control plane node(s), or
-  - pointing to a load balancer that balances traffic to your control plane node(s)
+By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
+control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
+Kubernetes pack allows you configure a custom API server endpoint for your cluster instead. This feature is only
+supported in Palette eXtended Kubernetes (PXK).
 
 :::warning
 
-This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able
-to connect to the cluster API endpoint.
+The custom API server endpoint must exist before the cluster gets deployed. Otherwise, your cluster deployment will fail
+as components will not be able to connect to the cluster API endpoint.
+
+When you configure a custom endpoint, a DNS record will not be created in MAAS and the configured endpoint will be used
+instead. If you use this option, you are responsible for ensuring the Full Qualified Domain Name (FQDN) of the endpoint
+can be resolved by your DNS infrastructure and that it can connect to the API server port on your control plane nodes.
 
 :::
 
-The following example shows how to specify a custom API server endpoint in the Kubernetes pack. Make sure the
+The following snippet demonstrates how to specify a custom API server endpoint in the Kubernetes pack. Note that the
 `cloud.maas` section is at the same level as the `pack` section.
 
 ```yaml hideClipboard {10-14}
@@ -464,8 +460,10 @@ cloud:
     customEndpointPort: "6443"
 ```
 
-In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is
-recommend to use a system macro to automatically populate the cluster name:
+In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
+recommend to use a system macro to automatically populate the cluster name. This approach allows the cluster profile to
+dynamically populate the endpoint name, without requiring the user to do it manually. The following snippet demonstrates
+how to use macros for endpoint specification.
 
 ```yaml hideClipboard {10-14}
 pack:
@@ -478,8 +476,6 @@ cloud:
     customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
     customEndpointPort: "6443"
 ```
-
-That way the profile can dynamically populate the endpoint name, without requiring the user to do it manually.
 
 </TabItem>
 
@@ -822,29 +818,25 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ![A subject of the type group is assigned as the subject in a RoleBinding](/clusters_cluster-management_cluster-rbac_cluster-subject-group.webp)
 
-### Custom API server endpoint for MAAS clusters
+### Custom API Server Endpoint for MAAS Clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
-control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
-Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is
-only supported in Palette eXtended Kubernetes (PXK).
-
-When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used
-instead. If you use this option, you are responsible for:
-
-- Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
-- Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
-  - pointing directly to the IP address(es) of your control plane node(s), or
-  - pointing to a load balancer that balances traffic to your control plane node(s)
+By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
+control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
+Kubernetes pack allows you configure a custom API server endpoint for your cluster instead. This feature is only
+supported in Palette eXtended Kubernetes (PXK).
 
 :::warning
 
-This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able
-to connect to the cluster API endpoint.
+The custom API server endpoint must exist before the cluster gets deployed. Otherwise, your cluster deployment will fail
+as components will not be able to connect to the cluster API endpoint.
+
+When you configure a custom endpoint, a DNS record will not be created in MAAS and the configured endpoint will be used
+instead. If you use this option, you are responsible for ensuring the Full Qualified Domain Name (FQDN) of the endpoint
+can be resolved by your DNS infrastructure and that it can connect to the API server port on your control plane nodes.
 
 :::
 
-The following example shows how to specify a custom API server endpoint in the Kubernetes pack. Make sure the
+The following snippet demonstrates how to specify a custom API server endpoint in the Kubernetes pack. Note that the
 `cloud.maas` section is at the same level as the `pack` section.
 
 ```yaml hideClipboard {10-14}
@@ -859,8 +851,10 @@ cloud:
     customEndpointPort: "6443"
 ```
 
-In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is
-recommend to use a system macro to automatically populate the cluster name:
+In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
+recommend to use a system macro to automatically populate the cluster name. This approach allows the cluster profile to
+dynamically populate the endpoint name, without requiring the user to do it manually. The following snippet demonstrates
+how to use macros for endpoint specification.
 
 ```yaml hideClipboard {10-14}
 pack:
@@ -873,8 +867,6 @@ cloud:
     customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
     customEndpointPort: "6443"
 ```
-
-That way the profile can dynamically populate the endpoint name, without requiring the user to do it manually.
 
 </TabItem>
 

--- a/docs/deprecated/integrations/kubernetes.md
+++ b/docs/deprecated/integrations/kubernetes.md
@@ -429,17 +429,23 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ### Custom API server endpoint for MAAS clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is only supported in Palette eXtended Kubernetes (PXK).
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
+control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
+Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is
+only supported in Palette eXtended Kubernetes (PXK).
 
-When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used instead. If you use this option, you are responsible for:
-* Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
-* Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
-  * pointing directly to the IP address(es) of your control plane node(s), or
-  * pointing to a load balancer that balances traffic to your control plane node(s)
+When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used
+instead. If you use this option, you are responsible for:
+
+- Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
+- Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
+  - pointing directly to the IP address(es) of your control plane node(s), or
+  - pointing to a load balancer that balances traffic to your control plane node(s)
 
 :::warning
 
-This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able to connect to the cluster API endpoint.
+This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able
+to connect to the cluster API endpoint.
 
 :::
 
@@ -458,7 +464,8 @@ cloud:
     customEndpointPort: "6443"
 ```
 
-In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is recommend to use a system macro to automatically populate the cluster name:
+In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is
+recommend to use a system macro to automatically populate the cluster name:
 
 ```yaml hideClipboard {10-14}
 pack:
@@ -817,17 +824,23 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ### Custom API server endpoint for MAAS clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is only supported in Palette eXtended Kubernetes (PXK).
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
+control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
+Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is
+only supported in Palette eXtended Kubernetes (PXK).
 
-When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used instead. If you use this option, you are responsible for:
-* Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
-* Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
-  * pointing directly to the IP address(es) of your control plane node(s), or
-  * pointing to a load balancer that balances traffic to your control plane node(s)
+When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used
+instead. If you use this option, you are responsible for:
+
+- Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
+- Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
+  - pointing directly to the IP address(es) of your control plane node(s), or
+  - pointing to a load balancer that balances traffic to your control plane node(s)
 
 :::warning
 
-This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able to connect to the cluster API endpoint.
+This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able
+to connect to the cluster API endpoint.
 
 :::
 
@@ -846,7 +859,8 @@ cloud:
     customEndpointPort: "6443"
 ```
 
-In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is recommend to use a system macro to automatically populate the cluster name:
+In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is
+recommend to use a system macro to automatically populate the cluster name:
 
 ```yaml hideClipboard {10-14}
 pack:

--- a/docs/deprecated/integrations/kubernetes.md
+++ b/docs/deprecated/integrations/kubernetes.md
@@ -427,14 +427,23 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ![A subject of the type group is assigned as the subject in a RoleBinding](/clusters_cluster-management_cluster-rbac_cluster-subject-group.webp)
 
-### Custom MAAS Endpoint
+### Custom API server endpoint for MAAS clusters
 
-You can specify a custom MAAS endpoint and port that instructs Palette to direct all MAAS API requests to the provided
-endpoint URL. Use the `cloud.maas.customEndpoint` and `cloud.maas.customEndpointPort` parameters to specify the custom
-MAAS API URL and port. This is useful in scenarios where the MAAS API endpoint is not resolvable outside of the MAAS
-network.
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is only supported in Palette eXtended Kubernetes (PXK).
 
-The following example shows how to specify a custom MAAS endpoint and port in the Kubernetes YAML file. Make sure the
+When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used instead. If you use this option, you are responsible for:
+* Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
+* Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
+  * pointing directly to the IP address(es) of your control plane node(s), or
+  * pointing to a load balancer that balances traffic to your control plane node(s)
+
+:::warning
+
+This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able to connect to the cluster API endpoint.
+
+:::
+
+The following example shows how to specify a custom API server endpoint in the Kubernetes pack. Make sure the
 `cloud.maas` section is at the same level as the `pack` section.
 
 ```yaml hideClipboard {10-14}
@@ -442,16 +451,28 @@ pack:
   k8sHardening: True
   podCIDR: "192.168.0.0/16"
   serviceClusterIpRange: "10.96.0.0/12"
-  palette:
-    config:
-      dashboard:
-        identityProvider: palette
 
 cloud:
   maas:
-    customEndpoint: "maas-api.example.maas.org"
+    customEndpoint: "cluster-123.baremetal.company.com"
     customEndpointPort: "6443"
 ```
+
+In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is recommend to use a system macro to automatically populate the cluster name:
+
+```yaml hideClipboard {10-14}
+pack:
+  k8sHardening: True
+  podCIDR: "192.168.0.0/16"
+  serviceClusterIpRange: "10.96.0.0/12"
+
+cloud:
+  maas:
+    customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
+    customEndpointPort: "6443"
+```
+
+That way the profile can dynamically populate the endpoint name, without requiring the user to do it manually.
 
 </TabItem>
 
@@ -794,14 +815,23 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ![A subject of the type group is assigned as the subject in a RoleBinding](/clusters_cluster-management_cluster-rbac_cluster-subject-group.webp)
 
-### Custom MAAS Endpoint
+### Custom API server endpoint for MAAS clusters
 
-You can specify a custom MAAS endpoint and port that instructs Palette to direct all MAAS API requests to the provided
-endpoint URL. Use the `cloud.maas.customEndpoint` and `cloud.maas.customEndpointPort` parameters to specify the custom
-MAAS API URL and port. This is useful in scenarios where the MAAS API endpoint is not resolvable outside of the MAAS
-network.
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is only supported in Palette eXtended Kubernetes (PXK).
 
-The following example shows how to specify a custom MAAS endpoint and port in the Kubernetes YAML file. Make sure the
+When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used instead. If you use this option, you are responsible for:
+* Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
+* Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
+  * pointing directly to the IP address(es) of your control plane node(s), or
+  * pointing to a load balancer that balances traffic to your control plane node(s)
+
+:::warning
+
+This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able to connect to the cluster API endpoint.
+
+:::
+
+The following example shows how to specify a custom API server endpoint in the Kubernetes pack. Make sure the
 `cloud.maas` section is at the same level as the `pack` section.
 
 ```yaml hideClipboard {10-14}
@@ -809,16 +839,28 @@ pack:
   k8sHardening: True
   podCIDR: "192.168.0.0/16"
   serviceClusterIpRange: "10.96.0.0/12"
-  palette:
-    config:
-      dashboard:
-        identityProvider: palette
 
 cloud:
   maas:
-    customEndpoint: "maas-api.example.maas.org"
+    customEndpoint: "cluster-123.baremetal.company.com"
     customEndpointPort: "6443"
 ```
+
+In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is recommend to use a system macro to automatically populate the cluster name:
+
+```yaml hideClipboard {10-14}
+pack:
+  k8sHardening: True
+  podCIDR: "192.168.0.0/16"
+  serviceClusterIpRange: "10.96.0.0/12"
+
+cloud:
+  maas:
+    customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
+    customEndpointPort: "6443"
+```
+
+That way the profile can dynamically populate the endpoint name, without requiring the user to do it manually.
 
 </TabItem>
 

--- a/docs/docs-content/clusters/data-center/maas/architecture.md
+++ b/docs/docs-content/clusters/data-center/maas/architecture.md
@@ -37,7 +37,7 @@ Refer to the [PCG Architecture](../../pcg/architecture.md) section to learn more
 
 By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
 control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
-Kubernetes pack allows you configure a custom API server endpoint for your cluster instead.
+Kubernetes pack allows you to configure a custom API server endpoint for your cluster instead.
 
 <!-- prettier-ignore-start -->
 

--- a/docs/docs-content/clusters/data-center/maas/architecture.md
+++ b/docs/docs-content/clusters/data-center/maas/architecture.md
@@ -33,12 +33,18 @@ using Canonical MAAS. Refer to the PCG deployment options section below to learn
 
 Refer to the [PCG Architecture](../../pcg/architecture.md) section to learn more about the PCG architecture.
 
-## Custom API server endpoint for MAAS clusters
+## Custom API Server Endpoint for MAAS Clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
-control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
-Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead.
+By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
+control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
+Kubernetes pack allows you configure a custom API server endpoint for your cluster instead.
 
-This feature is only supported in Palette eXtended Kubernetes (PKX). For more information, refer to the
-[Custom API server endpoint for MAAS clusters](../../../integrations/kubernetes.md#custom-api-server-endpoint-for-maas-clusters)
-section of the PXK reference page.
+<!-- prettier-ignore-start -->
+
+This feature is only supported in Palette eXtended Kubernetes (PXK). Refer to the <VersionedLink
+  text="Custom API Server Endpoint for MAAS Clusters"
+  url="/integrations/packs/?pack=kubernetes#custom-api-server-endpoint-for-maas-clusters"
+/>
+section for further guidance.
+
+<!-- prettier-ignore-end -->

--- a/docs/docs-content/clusters/data-center/maas/architecture.md
+++ b/docs/docs-content/clusters/data-center/maas/architecture.md
@@ -33,9 +33,10 @@ using Canonical MAAS. Refer to the PCG deployment options section below to learn
 
 Refer to the [PCG Architecture](../../pcg/architecture.md) section to learn more about the PCG architecture.
 
-## Custom MAAS Endpoint
+## Custom API server endpoint for MAAS clusters
 
-If the MAAS API server URL is not resolvable outside of the MAAS environment, you can specify a different URL in the
-cluster profile's Kubernetes YAML. This feature is only supported in Palette eXtented Kubernetes (PKX). For more
-information, refer to the [Custom MAAS Endpoint](../../../integrations/kubernetes.md#custom-maas-endpoint) section of
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead.
+
+This feature is only supported in Palette eXtended Kubernetes (PKX). For more
+information, refer to the [Custom API server endpoint for MAAS clusters](../../../integrations/kubernetes.md#custom-api-server-endpoint-for-maas-clusters) section of
 the PXK reference page.

--- a/docs/docs-content/clusters/data-center/maas/architecture.md
+++ b/docs/docs-content/clusters/data-center/maas/architecture.md
@@ -35,8 +35,10 @@ Refer to the [PCG Architecture](../../pcg/architecture.md) section to learn more
 
 ## Custom API server endpoint for MAAS clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead.
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
+control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
+Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead.
 
-This feature is only supported in Palette eXtended Kubernetes (PKX). For more
-information, refer to the [Custom API server endpoint for MAAS clusters](../../../integrations/kubernetes.md#custom-api-server-endpoint-for-maas-clusters) section of
-the PXK reference page.
+This feature is only supported in Palette eXtended Kubernetes (PKX). For more information, refer to the
+[Custom API server endpoint for MAAS clusters](../../../integrations/kubernetes.md#custom-api-server-endpoint-for-maas-clusters)
+section of the PXK reference page.

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
@@ -33,7 +33,7 @@ create a Kubernetes cluster in MAAS that is managed by Palette.
 
 By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
 control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
-Kubernetes pack allows you configure a custom API server endpoint for your cluster instead.
+Kubernetes pack allows you to configure a custom API server endpoint for your cluster instead.
 
 <!-- prettier-ignore-start -->
 

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
@@ -31,11 +31,13 @@ create a Kubernetes cluster in MAAS that is managed by Palette.
 
 :::warning
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead.
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
+control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
+Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead.
 
-This feature is only supported in Palette eXtended Kubernetes (PXK). For more
-information, refer to the [Custom API server endpoint for MAAS clusters](../../../integrations/kubernetes.md#custom-api-server-endpoint-for-maas-clusters) section of
-the PXK reference page.
+This feature is only supported in Palette eXtended Kubernetes (PXK). For more information, refer to the
+[Custom API server endpoint for MAAS clusters](../../../integrations/kubernetes.md#custom-api-server-endpoint-for-maas-clusters)
+section of the PXK reference page.
 
 :::
 

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
@@ -31,9 +31,10 @@ create a Kubernetes cluster in MAAS that is managed by Palette.
 
 :::warning
 
-If the MAAS API server URL is not resolvable outside of the MAAS environment, you can specify a different URL in the
-cluster profile's Kubernetes YAML. This feature is only supported in Palette eXtented Kubernetes (PXK). For more
-information, refer to the [Custom MAAS Endpoint](../../../integrations/kubernetes.md#custom-maas-endpoint) section of
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead.
+
+This feature is only supported in Palette eXtended Kubernetes (PXK). For more
+information, refer to the [Custom API server endpoint for MAAS clusters](../../../integrations/kubernetes.md#custom-api-server-endpoint-for-maas-clusters) section of
 the PXK reference page.
 
 :::

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
@@ -29,15 +29,21 @@ create a Kubernetes cluster in MAAS that is managed by Palette.
   your MAAS environment. Review the [How to use standard images](https://maas.io/docs/how-to-use-standard-images) for
   guidance on downloading OS images for MAAS.
 
-:::warning
+:::info
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
-control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
-Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead.
+By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
+control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
+Kubernetes pack allows you configure a custom API server endpoint for your cluster instead.
 
-This feature is only supported in Palette eXtended Kubernetes (PXK). For more information, refer to the
-[Custom API server endpoint for MAAS clusters](../../../integrations/kubernetes.md#custom-api-server-endpoint-for-maas-clusters)
-section of the PXK reference page.
+<!-- prettier-ignore-start -->
+
+This feature is only supported in Palette eXtended Kubernetes (PXK). Refer to the <VersionedLink
+  text="Custom API Server Endpoint for MAAS Clusters"
+  url="/integrations/packs/?pack=kubernetes#custom-api-server-endpoint-for-maas-clusters"
+/>
+section for further guidance.
+
+<!-- prettier-ignore-end -->
 
 :::
 

--- a/docs/docs-content/integrations/kubernetes.md
+++ b/docs/docs-content/integrations/kubernetes.md
@@ -402,29 +402,25 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ![A subject of the type group is assigned as the subject in a RoleBinding](/clusters_cluster-management_cluster-rbac_cluster-subject-group.webp)
 
-### Custom API server endpoint for MAAS clusters
+### Custom API Server Endpoint for MAAS Clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
-control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
-Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is
-only supported in Palette eXtended Kubernetes (PXK).
-
-When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used
-instead. If you use this option, you are responsible for:
-
-- Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
-- Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
-  - pointing directly to the IP address(es) of your control plane node(s), or
-  - pointing to a load balancer that balances traffic to your control plane node(s)
+By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
+control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
+Kubernetes pack allows you configure a custom API server endpoint for your cluster instead. This feature is only
+supported in Palette eXtended Kubernetes (PXK).
 
 :::warning
 
-This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able
-to connect to the cluster API endpoint.
+The custom API server endpoint must exist before the cluster gets deployed. Otherwise, your cluster deployment will fail
+as components will not be able to connect to the cluster API endpoint.
+
+When you configure a custom endpoint, a DNS record will not be created in MAAS and the configured endpoint will be used
+instead. If you use this option, you are responsible for ensuring the Full Qualified Domain Name (FQDN) of the endpoint
+can be resolved by your DNS infrastructure and that it can connect to the API server port on your control plane nodes.
 
 :::
 
-The following example shows how to specify a custom API server endpoint in the Kubernetes pack. Make sure the
+The following snippet demonstrates how to specify a custom API server endpoint in the Kubernetes pack. Note that the
 `cloud.maas` section is at the same level as the `pack` section.
 
 ```yaml hideClipboard {10-14}
@@ -439,8 +435,10 @@ cloud:
     customEndpointPort: "6443"
 ```
 
-In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is
-recommend to use a system macro to automatically populate the cluster name:
+In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
+recommend to use a system macro to automatically populate the cluster name. This approach allows the cluster profile to
+dynamically populate the endpoint name, without requiring the user to do it manually. The following snippet demonstrates
+how to use macros for endpoint specification.
 
 ```yaml hideClipboard {10-14}
 pack:
@@ -453,8 +451,6 @@ cloud:
     customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
     customEndpointPort: "6443"
 ```
-
-That way the profile can dynamically populate the endpoint name, without requiring the user to do it manually.
 
 </TabItem>
 
@@ -763,29 +759,25 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ![A subject of the type group is assigned as the subject in a RoleBinding](/clusters_cluster-management_cluster-rbac_cluster-subject-group.webp)
 
-### Custom API server endpoint for MAAS clusters
+### Custom API Server Endpoint for MAAS Clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
-control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
-Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is
-only supported in Palette eXtended Kubernetes (PXK).
-
-When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used
-instead. If you use this option, you are responsible for:
-
-- Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
-- Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
-  - pointing directly to the IP address(es) of your control plane node(s), or
-  - pointing to a load balancer that balances traffic to your control plane node(s)
+By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
+control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
+Kubernetes pack allows you configure a custom API server endpoint for your cluster instead. This feature is only
+supported in Palette eXtended Kubernetes (PXK).
 
 :::warning
 
-This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able
-to connect to the cluster API endpoint.
+The custom API server endpoint must exist before the cluster gets deployed. Otherwise, your cluster deployment will fail
+as components will not be able to connect to the cluster API endpoint.
+
+When you configure a custom endpoint, a DNS record will not be created in MAAS and the configured endpoint will be used
+instead. If you use this option, you are responsible for ensuring the Full Qualified Domain Name (FQDN) of the endpoint
+can be resolved by your DNS infrastructure and that it can connect to the API server port on your control plane nodes.
 
 :::
 
-The following example shows how to specify a custom API server endpoint in the Kubernetes pack. Make sure the
+The following snippet demonstrates how to specify a custom API server endpoint in the Kubernetes pack. Note that the
 `cloud.maas` section is at the same level as the `pack` section.
 
 ```yaml hideClipboard {10-14}
@@ -800,8 +792,10 @@ cloud:
     customEndpointPort: "6443"
 ```
 
-In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is
-recommend to use a system macro to automatically populate the cluster name:
+In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
+recommend to use a system macro to automatically populate the cluster name. This approach allows the cluster profile to
+dynamically populate the endpoint name, without requiring the user to do it manually. The following snippet demonstrates
+how to use macros for endpoint specification.
 
 ```yaml hideClipboard {10-14}
 pack:
@@ -814,8 +808,6 @@ cloud:
     customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
     customEndpointPort: "6443"
 ```
-
-That way the profile can dynamically populate the endpoint name, without requiring the user to do it manually.
 
 </TabItem>
 

--- a/docs/docs-content/integrations/kubernetes.md
+++ b/docs/docs-content/integrations/kubernetes.md
@@ -402,14 +402,23 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ![A subject of the type group is assigned as the subject in a RoleBinding](/clusters_cluster-management_cluster-rbac_cluster-subject-group.webp)
 
-### Custom MAAS Endpoint
+### Custom API server endpoint for MAAS clusters
 
-You can specify a custom MAAS endpoint and port that instructs Palette to direct all MAAS API requests to the provided
-endpoint URL. Use the `cloud.maas.customEndpoint` and `cloud.maas.customEndpointPort` parameters to specify the custom
-MAAS API URL and port. This is useful in scenarios where the MAAS API endpoint is not resolvable outside of the MAAS
-network.
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is only supported in Palette eXtended Kubernetes (PXK).
 
-The following example shows how to specify a custom MAAS endpoint and port in the Kubernetes YAML file. Make sure the
+When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used instead. If you use this option, you are responsible for:
+* Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
+* Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
+  * pointing directly to the IP address(es) of your control plane node(s), or
+  * pointing to a load balancer that balances traffic to your control plane node(s)
+
+:::warning
+
+This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able to connect to the cluster API endpoint.
+
+:::
+
+The following example shows how to specify a custom API server endpoint in the Kubernetes pack. Make sure the
 `cloud.maas` section is at the same level as the `pack` section.
 
 ```yaml hideClipboard {10-14}
@@ -417,16 +426,28 @@ pack:
   k8sHardening: True
   podCIDR: "192.168.0.0/16"
   serviceClusterIpRange: "10.96.0.0/12"
-  palette:
-    config:
-      dashboard:
-        identityProvider: palette
 
 cloud:
   maas:
-    customEndpoint: "maas-api.example.maas.org"
+    customEndpoint: "cluster-123.baremetal.company.com"
     customEndpointPort: "6443"
 ```
+
+In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is recommend to use a system macro to automatically populate the cluster name:
+
+```yaml hideClipboard {10-14}
+pack:
+  k8sHardening: True
+  podCIDR: "192.168.0.0/16"
+  serviceClusterIpRange: "10.96.0.0/12"
+
+cloud:
+  maas:
+    customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
+    customEndpointPort: "6443"
+```
+
+That way the profile can dynamically populate the endpoint name, without requiring the user to do it manually.
 
 </TabItem>
 
@@ -735,14 +756,23 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ![A subject of the type group is assigned as the subject in a RoleBinding](/clusters_cluster-management_cluster-rbac_cluster-subject-group.webp)
 
-### Custom MAAS Endpoint
+### Custom API server endpoint for MAAS clusters
 
-You can specify a custom MAAS endpoint and port that instructs Palette to direct all MAAS API requests to the provided
-endpoint URL. Use the `cloud.maas.customEndpoint` and `cloud.maas.customEndpointPort` parameters to specify the custom
-MAAS API URL and port. This is useful in scenarios where the MAAS API endpoint is not resolvable outside of the MAAS
-network.
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is only supported in Palette eXtended Kubernetes (PXK).
 
-The following example shows how to specify a custom MAAS endpoint and port in the Kubernetes YAML file. Make sure the
+When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used instead. If you use this option, you are responsible for:
+* Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
+* Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
+  * pointing directly to the IP address(es) of your control plane node(s), or
+  * pointing to a load balancer that balances traffic to your control plane node(s)
+
+:::warning
+
+This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able to connect to the cluster API endpoint.
+
+:::
+
+The following example shows how to specify a custom API server endpoint in the Kubernetes pack. Make sure the
 `cloud.maas` section is at the same level as the `pack` section.
 
 ```yaml hideClipboard {10-14}
@@ -750,16 +780,28 @@ pack:
   k8sHardening: True
   podCIDR: "192.168.0.0/16"
   serviceClusterIpRange: "10.96.0.0/12"
-  palette:
-    config:
-      dashboard:
-        identityProvider: palette
 
 cloud:
   maas:
-    customEndpoint: "maas-api.example.maas.org"
+    customEndpoint: "cluster-123.baremetal.company.com"
     customEndpointPort: "6443"
 ```
+
+In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is recommend to use a system macro to automatically populate the cluster name:
+
+```yaml hideClipboard {10-14}
+pack:
+  k8sHardening: True
+  podCIDR: "192.168.0.0/16"
+  serviceClusterIpRange: "10.96.0.0/12"
+
+cloud:
+  maas:
+    customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
+    customEndpointPort: "6443"
+```
+
+That way the profile can dynamically populate the endpoint name, without requiring the user to do it manually.
 
 </TabItem>
 

--- a/docs/docs-content/integrations/kubernetes.md
+++ b/docs/docs-content/integrations/kubernetes.md
@@ -404,17 +404,23 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ### Custom API server endpoint for MAAS clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is only supported in Palette eXtended Kubernetes (PXK).
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
+control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
+Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is
+only supported in Palette eXtended Kubernetes (PXK).
 
-When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used instead. If you use this option, you are responsible for:
-* Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
-* Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
-  * pointing directly to the IP address(es) of your control plane node(s), or
-  * pointing to a load balancer that balances traffic to your control plane node(s)
+When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used
+instead. If you use this option, you are responsible for:
+
+- Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
+- Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
+  - pointing directly to the IP address(es) of your control plane node(s), or
+  - pointing to a load balancer that balances traffic to your control plane node(s)
 
 :::warning
 
-This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able to connect to the cluster API endpoint.
+This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able
+to connect to the cluster API endpoint.
 
 :::
 
@@ -433,7 +439,8 @@ cloud:
     customEndpointPort: "6443"
 ```
 
-In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is recommend to use a system macro to automatically populate the cluster name:
+In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is
+recommend to use a system macro to automatically populate the cluster name:
 
 ```yaml hideClipboard {10-14}
 pack:
@@ -758,17 +765,23 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 ### Custom API server endpoint for MAAS clusters
 
-By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is only supported in Palette eXtended Kubernetes (PXK).
+By default, Palette will register a DNS record in MAAS for the deployed cluster, linking it to the IP address(es) of the
+control plane node(s) of the cluster. However you may not want to depend on MAAS for your cluster DNS record. The
+Kubernetes pack provides an option to configure a custom API server endpoint for your cluster instead. This feature is
+only supported in Palette eXtended Kubernetes (PXK).
 
-When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used instead. If you use this option, you are responsible for:
-* Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
-* Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
-  * pointing directly to the IP address(es) of your control plane node(s), or
-  * pointing to a load balancer that balances traffic to your control plane node(s)
+When you configure this option, a DNS record will not be created in MAAS and the configured endpoint will be used
+instead. If you use this option, you are responsible for:
+
+- Ensuring the endpoint FQDN can be resolved by your DNS infrastructure
+- Ensuring the endpoint connects to the API server port on your control plane node(s), by either:
+  - pointing directly to the IP address(es) of your control plane node(s), or
+  - pointing to a load balancer that balances traffic to your control plane node(s)
 
 :::warning
 
-This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able to connect to the cluster API endpoint.
+This endpoint must exist before the cluster gets deployed, otherwise deployment will fail as components will not be able
+to connect to the cluster API endpoint.
 
 :::
 
@@ -787,7 +800,8 @@ cloud:
     customEndpointPort: "6443"
 ```
 
-In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is recommend to use a system macro to automatically populate the cluster name:
+In order to prevent needing per-cluster profile adjustments (which can become difficult to deal with at scale), it is
+recommend to use a system macro to automatically populate the cluster name:
 
 ```yaml hideClipboard {10-14}
 pack:

--- a/docs/docs-content/integrations/kubernetes.md
+++ b/docs/docs-content/integrations/kubernetes.md
@@ -406,7 +406,7 @@ In this example, Palette is used as the IDP, and all users in the `dev-east-2` w
 
 By default, Palette registers a DNS record in MAAS for the deployed cluster and links it to the IP addresses of the
 control plane nodes of the cluster. However, you may choose not to depend on MAAS for your cluster DNS record. The
-Kubernetes pack allows you configure a custom API server endpoint for your cluster instead. This feature is only
+Kubernetes pack allows you to configure a custom API server endpoint for your cluster instead. This feature is only
 supported in Palette eXtended Kubernetes (PXK).
 
 :::warning
@@ -437,7 +437,7 @@ cloud:
 
 In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
 recommend to use a system macro to automatically populate the cluster name. This approach allows the cluster profile to
-dynamically populate the endpoint name, without requiring the user to do it manually. The following snippet demonstrates
+dynamically populate the endpoint name without requiring the user to do it manually. The following snippet demonstrates
 how to use macros for endpoint specification.
 
 ```yaml hideClipboard {10-14}
@@ -794,7 +794,7 @@ cloud:
 
 In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
 recommend to use a system macro to automatically populate the cluster name. This approach allows the cluster profile to
-dynamically populate the endpoint name, without requiring the user to do it manually. The following snippet demonstrates
+dynamically populate the endpoint name without requiring the user to do it manually. The following snippet demonstrates
 how to use macros for endpoint specification.
 
 ```yaml hideClipboard {10-14}


### PR DESCRIPTION
## Describe the Change

The documentation on the Custom MAAS Endpoint was wrong. This PR corrects this.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [PXK pack](https://deploy-preview-4302--docs-spectrocloud.netlify.app/integrations/packs/?pack=kubernetes&version=1.30.5&parent=1.30.x)
💻 [MAAS Architecture](https://deploy-preview-4302--docs-spectrocloud.netlify.app/clusters/data-center/maas/architecture/#custom-api-server-endpoint-for-maas-clusters)
💻 [Create and Manage MAAS Clusters](https://deploy-preview-4302--docs-spectrocloud.netlify.app/clusters/data-center/maas/create-manage-maas-clusters/)
