### PR TITLE
docs: fix image tag

### DIFF
--- a/docs/docs-content/byoos/capi-image-builder/build-image-vmware/airgap-build/rhel-capi-airgap.md
+++ b/docs/docs-content/byoos/capi-image-builder/build-image-vmware/airgap-build/rhel-capi-airgap.md
@@ -395,14 +395,14 @@ Enterprise Linux (RHEL) image with <VersionedLink text="Palette eXtended Kuberne
             <TabItem value="Docker" label="Docker">
 
              ```bash
-             BUILD_ID_CAPI=$(docker run --net=host --volume /home/ubuntu/output:/home/imagebuilder/output  --detach  gcr.io/spectro-images-public/imagebuilder/capi-builder:v1.5.0)
+             BUILD_ID_CAPI=$(docker run --net=host --volume /root/output:/home/imagebuilder/output --detach gcr.io/spectro-images-public/imagebuilder/capi-builder:v4.4.4)
              ```
             </TabItem>
 
             <TabItem value="Podman" label="Podman">
 
              ```bash
-             BUILD_ID_CAPI=$(podman run --net=host --volume /home/ubuntu/output:/home/imagebuilder/output  --detach  gcr.io/spectro-images-public/imagebuilder/capi-builder:v1.5.0)
+             BUILD_ID_CAPI=$(podman run --net=host --volume /root/output:/home/imagebuilder/output --detach gcr.io/spectro-images-public/imagebuilder/capi-builder:v4.4.4)
              ```
 
             </TabItem>

--- a/docs/docs-content/byoos/capi-image-builder/build-image-vmware/airgap-build/rocky-capi-airgap.md
+++ b/docs/docs-content/byoos/capi-image-builder/build-image-vmware/airgap-build/rocky-capi-airgap.md
@@ -390,14 +390,14 @@ This guide teaches you how to use the [CAPI Image Builder](../../capi-image-buil
             <TabItem value="Docker" label="Docker">
 
              ```bash
-             BUILD_ID_CAPI=$(docker run --net=host --volume /home/ubuntu/output:/home/imagebuilder/output  --detach  gcr.io/spectro-images-public/imagebuilder/capi-builder:v1.5.0)
+             BUILD_ID_CAPI=$(docker run --net=host --volume /root/output:/home/imagebuilder/output --detach gcr.io/spectro-images-public/imagebuilder/capi-builder:v4.4.4)
              ```
             </TabItem>
 
             <TabItem value="Podman" label="Podman">
 
              ```bash
-             BUILD_ID_CAPI=$(podman run --net=host --volume /home/ubuntu/output:/home/imagebuilder/output  --detach  gcr.io/spectro-images-public/imagebuilder/capi-builder:v1.5.0)
+             BUILD_ID_CAPI=$(podman run --net=host --volume /root/output:/home/imagebuilder/output --detach gcr.io/spectro-images-public/imagebuilder/capi-builder:v4.4.4)
              ```
 
             </TabItem>


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the capi image builder tag in one of the commands of the airgap guides.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [RHEL and PXK](https://deploy-preview-4352--docs-spectrocloud.netlify.app/byoos/capi-image-builder/build-image-vmware/airgap-build/rhel-capi-airgap/)
💻 [Rocky and PXK](https://deploy-preview-4352--docs-spectrocloud.netlify.app/byoos/capi-image-builder/build-image-vmware/airgap-build/rocky-capi-airgap/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1434](https://spectrocloud.atlassian.net/browse/DOC-1434)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1434]: https://spectrocloud.atlassian.net/browse/DOC-1434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ