### PR TITLE
ci: remove package.json prepare

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,4 @@
 [build]
   ignore = "./scripts/netlify.sh"
   command = "npm run build"
-[context.branch-deploy.environment]
-  # Set so that branch deploys (version-x.legacy.docs.spectrocloud.com) contain sitemap.xml
-  NODE_ENV = "production"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@mdx-js/react": "^3.0.1",
         "antd": "^5.6.2",
+        "axios-retry": "^4.5.0",
         "babel-plugin-macros": "^3.1.0",
         "clsx": "^1.2.1",
         "docusaurus-plugin-image-zoom": "^2.0.0",
@@ -29,6 +30,7 @@
         "fuse.js": "^6.6.2",
         "markdown-to-jsx": "^7.0.0",
         "node-fetch": "^3.1.0",
+        "p-ratelimit": "^1.0.1",
         "prism-react-renderer": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.3.1",
@@ -44,16 +46,15 @@
         "@playwright/test": "^1.42.1",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/exec": "^6.0.3",
-        "@semantic-release/git": "*",
-        "@semantic-release/github": "*",
-        "@semantic-release/npm": "*",
+        "@semantic-release/git": "latest",
+        "@semantic-release/github": "latest",
+        "@semantic-release/npm": "latest",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^16.0.1",
         "@tsconfig/docusaurus": "^2.0.3",
         "@types/jest": "^29.5.12",
         "@typescript-eslint/eslint-plugin": "^8.2.0",
         "@typescript-eslint/parser": "^8.2.0",
-        "axios-retry": "^4.5.0",
         "babel-jest": "^29.6.2",
         "dotenv": "^16.3.1",
         "eslint": "^8.45.0",
@@ -73,7 +74,6 @@
         "linkinator": "^6.1.1",
         "lint-staged": "^15.2.10",
         "netlify-cli": "^17.36.3",
-        "p-ratelimit": "^1.0.1",
         "prettier": "3.3.2",
         "semantic-release": "^24.1.0",
         "test-links": "^0.0.1",
@@ -11305,7 +11305,6 @@
     },
     "node_modules/axios": {
       "version": "0.25.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.7"
@@ -11315,7 +11314,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
       "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "is-retry-allowed": "^2.2.0"
@@ -11326,7 +11324,6 @@
     },
     "node_modules/axios-retry/node_modules/is-retry-allowed": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -53379,7 +53376,6 @@
     },
     "node_modules/p-ratelimit": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.23.0"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "lint": "eslint . --ext .js,.ts,.jsx,.tsx",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write \"**/*.{js,jsx,json,ts,tsx,md,mdx,css}\"",
-    "format-check": "prettier . --check",
-    "prepare": "husky install"
+    "format-check": "prettier . --check"
   },
   "lint-staged": {
     "**/*.{js,jsx,json,ts,tsx,md,mdx,css}": "npm run format"
@@ -48,6 +47,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@mdx-js/react": "^3.0.1",
     "antd": "^5.6.2",
+    "axios-retry": "^4.5.0",
     "babel-plugin-macros": "^3.1.0",
     "clsx": "^1.2.1",
     "docusaurus-plugin-image-zoom": "^2.0.0",
@@ -56,6 +56,7 @@
     "fuse.js": "^6.6.2",
     "markdown-to-jsx": "^7.0.0",
     "node-fetch": "^3.1.0",
+    "p-ratelimit": "^1.0.1",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.3.1",
@@ -80,7 +81,6 @@
     "@types/jest": "^29.5.12",
     "@typescript-eslint/eslint-plugin": "^8.2.0",
     "@typescript-eslint/parser": "^8.2.0",
-    "axios-retry": "^4.5.0",
     "babel-jest": "^29.6.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.45.0",
@@ -104,7 +104,6 @@
     "semantic-release": "^24.1.0",
     "test-links": "^0.0.1",
     "ts-jest": "^29.1.4",
-    "p-ratelimit": "^1.0.1",
     "typescript": "^5.1.6",
     "typescript-plugin-css-modules": "^5.1.0",
     "webpconvert": "^3.0.1"


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes a setting that needs more experimentation from Netlify. Two packages were also moved up to dependencies vs devDependencies. `axios` and `p-ratelimit` is needed for the packs download. If the env variable `NODE_ENV` is set to `production` then Netlify will not install dev dependencies. That will cause issues for our pre-build steps that retrieve packs, and security bulletins [future].

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
