### PR TITLE
docs: update cve-2022-32190

### DIFF
--- a/docs/docs-content/security-bulletins/reports/cve-2022-32190.md
+++ b/docs/docs-content/security-bulletins/reports/cve-2022-32190.md
@@ -18,9 +18,9 @@ tags: ["security", "cve"]
 
 ## NIST CVE Summary
 
-JoinPath and URL.JoinPath do not remove ../ path elements appended to a relative path. For example,
-JoinPath("https://go.dev", "../go") returns the URL "https://go.dev/../go", despite the JoinPath documentation stating
-that ../ path elements are removed from the result.
+JoinPath and URL.JoinPath do not remove `../` path elements appended to a relative path. For example,
+JoinPath(`https://go.dev`, `../go`) returns the URL `https://go.dev/../go`, despite the JoinPath documentation stating
+that `../` path elements are removed from the result.
 
 ## Our Official Summary
 

--- a/docs/docs-content/security-bulletins/reports/cve-2022-32190.md
+++ b/docs/docs-content/security-bulletins/reports/cve-2022-32190.md
@@ -19,7 +19,7 @@ tags: ["security", "cve"]
 ## NIST CVE Summary
 
 JoinPath and URL.JoinPath do not remove `../` path elements appended to a relative path. For example,
-JoinPath(`https://go.dev`, `../go`) returns the URL `https://go.dev/../go`, despite the JoinPath documentation stating
+`JoinPath("https://go.dev", "../go")` returns the URL `https://go.dev/../go`, despite the JoinPath documentation stating
 that `../` path elements are removed from the result.
 
 ## Our Official Summary


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR does not fix the link but places the link segments into monospace. This should also stop it being picked up as a broken link (and stop it being created as a hyperlink in Production).

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [cve-2022-32190](https://deploy-preview-4396--docs-spectrocloud.netlify.app/security-bulletins/reports/cve-2022-32190/)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
