### PR TITLE
customEndpointPort must be an integer

### DIFF
--- a/docs/deprecated/integrations/kubernetes.md
+++ b/docs/deprecated/integrations/kubernetes.md
@@ -457,7 +457,7 @@ pack:
 cloud:
   maas:
     customEndpoint: "cluster-123.baremetal.company.com"
-    customEndpointPort: "6443"
+    customEndpointPort: 6443
 ```
 
 In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
@@ -474,7 +474,7 @@ pack:
 cloud:
   maas:
     customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
-    customEndpointPort: "6443"
+    customEndpointPort: 6443
 ```
 
 </TabItem>
@@ -848,7 +848,7 @@ pack:
 cloud:
   maas:
     customEndpoint: "cluster-123.baremetal.company.com"
-    customEndpointPort: "6443"
+    customEndpointPort: 6443
 ```
 
 In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
@@ -865,7 +865,7 @@ pack:
 cloud:
   maas:
     customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
-    customEndpointPort: "6443"
+    customEndpointPort: 6443
 ```
 
 </TabItem>

--- a/docs/docs-content/clusters/data-center/maas/architecture.md
+++ b/docs/docs-content/clusters/data-center/maas/architecture.md
@@ -45,6 +45,6 @@ This feature is only supported in Palette eXtended Kubernetes (PXK). Refer to th
   text="Custom API Server Endpoint for MAAS Clusters"
   url="/integrations/packs/?pack=kubernetes"
 />
-section for further guidance.
+section of the pack Additional Guidance for further information.
 
 <!-- prettier-ignore-end -->

--- a/docs/docs-content/clusters/data-center/maas/architecture.md
+++ b/docs/docs-content/clusters/data-center/maas/architecture.md
@@ -43,7 +43,7 @@ Kubernetes pack allows you to configure a custom API server endpoint for your cl
 
 This feature is only supported in Palette eXtended Kubernetes (PXK). Refer to the <VersionedLink
   text="Custom API Server Endpoint for MAAS Clusters"
-  url="/integrations/packs/?pack=kubernetes#custom-api-server-endpoint-for-maas-clusters"
+  url="/integrations/packs/?pack=kubernetes"
 />
 section for further guidance.
 

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
@@ -41,7 +41,7 @@ This feature is only supported in Palette eXtended Kubernetes (PXK). Refer to th
   text="Custom API Server Endpoint for MAAS Clusters"
   url="/integrations/packs/?pack=kubernetes"
 />
-section for further guidance.
+section of the pack Additional Guidance for further information.
 
 <!-- prettier-ignore-end -->
 

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
@@ -39,7 +39,7 @@ Kubernetes pack allows you to configure a custom API server endpoint for your cl
 
 This feature is only supported in Palette eXtended Kubernetes (PXK). Refer to the <VersionedLink
   text="Custom API Server Endpoint for MAAS Clusters"
-  url="/integrations/packs/?pack=kubernetes#custom-api-server-endpoint-for-maas-clusters"
+  url="/integrations/packs/?pack=kubernetes"
 />
 section for further guidance.
 

--- a/docs/docs-content/integrations/kubernetes.md
+++ b/docs/docs-content/integrations/kubernetes.md
@@ -432,7 +432,7 @@ pack:
 cloud:
   maas:
     customEndpoint: "cluster-123.baremetal.company.com"
-    customEndpointPort: "6443"
+    customEndpointPort: 6443
 ```
 
 In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
@@ -449,7 +449,7 @@ pack:
 cloud:
   maas:
     customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
-    customEndpointPort: "6443"
+    customEndpointPort: 6443
 ```
 
 </TabItem>
@@ -789,7 +789,7 @@ pack:
 cloud:
   maas:
     customEndpoint: "cluster-123.baremetal.company.com"
-    customEndpointPort: "6443"
+    customEndpointPort: 6443
 ```
 
 In order to prevent the need for per-cluster profile adjustments which can become difficult to maintain at scale, we
@@ -806,7 +806,7 @@ pack:
 cloud:
   maas:
     customEndpoint: "{{ .spectro.system.cluster.name }}.baremetal.company.com"
-    customEndpointPort: "6443"
+    customEndpointPort: 6443
 ```
 
 </TabItem>


### PR DESCRIPTION
## Describe the Change

This PR fixes an error in the Custom API Server endpoint for MAAS documentation. It turns out the customEndpointPort must be specified as an integer instead of a string, otherwise it does not work and you get the error
```
"failed to get Maas cloud items from pack" "error"="error unmarshaling JSON: json: cannot unmarshal string into Go struct field MaasCloudItems.maas.customEndpointPort of type int"
```

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL](https://deploy-preview-4401--docs-spectrocloud.netlify.app/integrations/packs/?pack=kubernetes#custom-api-server-endpoint-for-maas-clusters)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Please backport this as well.
