### PR TITLE
docs: remove double slashes from image reference DOC-1232

### DIFF
--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
@@ -126,7 +126,7 @@ up Keycloak as an OIDC provider for Palette.
 
    :::
 
-   ![Keycloak Admin console](/keycloak//user-management_palette-rback_keycloak_login.webp)
+   ![Keycloak Admin console](/keycloak/user-management_palette-rback_keycloak_login.webp)
 
 7. Next, log in to [Palette](https://console.spectrocloud.com), and navigate to the left **Main Menu** and select
    **Tenant Settings**. Next, select **SSO** from the **Tenant Menu** to access the SSO configuration page. Click on the
@@ -200,7 +200,7 @@ Use the following steps to validate the SSO configuration.
 
    ![Image of Palette's main login screen](/keycloak/user-management_saml-sso_keycloak-11-palette-sso.webp "Palette SSO")
 
-   ![Image of the Keycloak Admin console](/keycloak//user-management_palette-rback_keycloak_login.webp)
+   ![Image of the Keycloak Admin console](/keycloak/user-management_palette-rback_keycloak_login.webp)
 
 3. Upon successful authentication, you will be redirected to Palette. You will be logged in to Palette as the admin user
    you created in Keycloak.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the double slashes from the keycloak guide. While this renders correctly, it is wrong syntax and breaks the unused image detection automation.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Keycloak](https://deploy-preview-4429--docs-spectrocloud.netlify.app/user-management/saml-sso/palette-sso-with-keycloak/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1232](https://spectrocloud.atlassian.net/browse/DOC-1232)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1232]: https://spectrocloud.atlassian.net/browse/DOC-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ