### PR TITLE
docs: adjust script to handle zero unused images DOC-1232

### DIFF
--- a/.github/workflows/clean-up-unused-images.yaml
+++ b/.github/workflows/clean-up-unused-images.yaml
@@ -49,10 +49,16 @@ jobs:
 
       - name: Create PR with unused images
         run: |
-          unused_image_count=$(wc -l < unused_images.json)
-          if unused_image_count == 0; then
-            "No images found to remove."
-            exit 0
+          file="unused_images.json"
+          if [[ -f "$file" ]]; then
+            unused_image_count=$(wc -l < "$file")
+            if [ "$unused_image_count" -eq 0 ]; then
+              echo "No images found to remove."
+              exit 0
+            fi
+          else
+            echo "File $file not found."
+            exit 1
           fi
 
           # Ensure that we are on master.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes a small bug in the clean up images GH action.  The script contained == instead of the bash `-eq` syntax. An `echo` was also missing.  Added checking that the file exists too and raised an error in case it was not created correctly. 

## Changed Pages

No user-facing changes.

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1232](https://spectrocloud.atlassian.net/browse/DOC-1232)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1232]: https://spectrocloud.atlassian.net/browse/DOC-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ