### PR TITLE
docs: add limitation on version skipping during upgrades

### DIFF
--- a/docs/docs-content/clusters/cluster-management/cluster-updates.md
+++ b/docs/docs-content/clusters/cluster-management/cluster-updates.md
@@ -37,6 +37,10 @@ upgrading, you review the information provided in the
   instead. For more information about creating an Edge cluster, refer to
   [Create Cluster Definition](../edge/site-deployment/cluster-deployment.md).
 
+- Avoid skipping minor versions when upgrading the Kubernetes version of a cluster. Refer to the documentation of your
+  Kubernetes distribution for upgrade guidance and follow the recommended upgrade paths. For PXK abd PXK-E, refer to
+  [Upgrade Kubeadm Clusters](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
+
 ## Prerequisites
 
 - An active Kubernetes cluster in Palette.

--- a/docs/docs-content/clusters/cluster-management/cluster-updates.md
+++ b/docs/docs-content/clusters/cluster-management/cluster-updates.md
@@ -40,7 +40,7 @@ upgrading, you review the information provided in the
 - Avoid skipping minor versions when upgrading the Kubernetes version of a cluster. Refer to the documentation of your
   Kubernetes distribution for upgrade guidance and follow the recommended upgrade paths.
 
-  - For PXK abd PXK-E, refer to
+  - For PXK and PXK-E, refer to
     [Upgrade Kubeadm Clusters](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
   - For K3s, refer to [K3s Upgrades](https://docs.k3s.io/upgrades#version-specific-caveats)
   - For RKE2, refer to [RKE2 Manual Upgrades](https://docs.rke2.io/upgrade/manual_upgrade)

--- a/docs/docs-content/clusters/cluster-management/cluster-updates.md
+++ b/docs/docs-content/clusters/cluster-management/cluster-updates.md
@@ -38,8 +38,12 @@ upgrading, you review the information provided in the
   [Create Cluster Definition](../edge/site-deployment/cluster-deployment.md).
 
 - Avoid skipping minor versions when upgrading the Kubernetes version of a cluster. Refer to the documentation of your
-  Kubernetes distribution for upgrade guidance and follow the recommended upgrade paths. For PXK abd PXK-E, refer to
-  [Upgrade Kubeadm Clusters](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
+  Kubernetes distribution for upgrade guidance and follow the recommended upgrade paths.
+
+  - For PXK abd PXK-E, refer to
+    [Upgrade Kubeadm Clusters](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
+  - For K3s, refer to [K3s Upgrades](https://docs.k3s.io/upgrades#version-specific-caveats)
+  - For RKE2, refer to [RKE2 Manual Upgrades](https://docs.rke2.io/upgrade/manual_upgrade)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Describe the Change

This PR adds the limitation that version skipping during K8s upgrades are not supported. 

## Changed Pages

💻 [Add Preview URL for Page]()

## Jira Tickets

🎫 [PE-5494](https://spectrocloud.atlassian.net/browse/PE-5494)

## Backports


Can this PR be backported?

- [ ] Yes. 


[PE-5494]: https://spectrocloud.atlassian.net/browse/PE-5494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ