### PR TITLE
docs: fix broken crossplane URL

### DIFF
--- a/docs/docs-content/automation/automation.md
+++ b/docs/docs-content/automation/automation.md
@@ -21,8 +21,8 @@ This section contains documentation and guides for tools essential in automating
 - Palette Terraform Provider - Allows users to use [Terraform](https://www.terraform.io) for automating the deployment
   and management of Palette resources such as cluster profiles, cloud accounts, clusters, and more.
 
-- Palette Crossplane Provider - Allows users to use [Crossplane](https://docs.crossplane.io/) to provision and
-  manage Palette resources through standard Kubernetes APIs.
+- Palette Crossplane Provider - Allows users to use [Crossplane](https://docs.crossplane.io/) to provision and manage
+  Palette resources through standard Kubernetes APIs.
 
 ## Resources
 

--- a/docs/docs-content/automation/automation.md
+++ b/docs/docs-content/automation/automation.md
@@ -21,7 +21,7 @@ This section contains documentation and guides for tools essential in automating
 - Palette Terraform Provider - Allows users to use [Terraform](https://www.terraform.io) for automating the deployment
   and management of Palette resources such as cluster profiles, cloud accounts, clusters, and more.
 
-- Palette Crossplane Provider - Allows users to use [Crossplane](https://docs.crossplane.io/v1.15/) to provision and
+- Palette Crossplane Provider - Allows users to use [Crossplane](https://docs.crossplane.io/) to provision and
   manage Palette resources through standard Kubernetes APIs.
 
 ## Resources


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the crossplane URL link as it will point at the latest crossplane version of the docs.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Automation](https://deploy-preview-4678--docs-spectrocloud.netlify.app/automation/)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
