### PR TITLE
[version-3-4] docs: fix broken crossplane URL (#4678)

### DIFF
--- a/docs/docs-content/automation/automation.md
+++ b/docs/docs-content/automation/automation.md
@@ -18,8 +18,8 @@ This section contains documentation and guides for tools essential in automating
 - Palette Terraform Provider - Allows users to use [Terraform](https://www.terraform.io) for automating the deployment
   and management of Palette resources such as cluster profiles, cloud accounts, clusters, and more.
 
-- Palette Crossplane Provider - It allows users to use [Crossplane](https://docs.crossplane.io/v1.15/) to provision and
-  manage Palette resources through standard Kubernetes APIs.
+- Palette Crossplane Provider - Allows users to use [Crossplane](https://docs.crossplane.io/) to provision and manage
+  Palette resources through standard Kubernetes APIs.
 
 ## Resources
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-3-4`:
 - [docs: fix broken crossplane URL (#4678)](https://github.com/spectrocloud/librarium/pull/4678)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)