### PR TITLE
PEM-6153-fixed the fragment url to follow the actual content

### DIFF
--- a/src/components/PacksReadme/PacksReadme.tsx
+++ b/src/components/PacksReadme/PacksReadme.tsx
@@ -110,7 +110,7 @@ function renderVersionOptions(packData: PackData) {
     }));
 }
 
-function renderTabs(selectedPackUid: string, packData: PackData, customReadme: ReactElement<any, any> | null) {
+function renderTabs(selectedPackUid: string, packData: PackData, customReadme: ReactElement<any, any> | null, fragmentIdentifier: string) {
   const empty_icon_light = useBaseUrl("/img/empty_icon_table_light.svg");
   const empty_icon_dark = useBaseUrl("/img/empty_icon_table_dark.svg");
   const readme = selectedPackUid ? packData.packUidMap[selectedPackUid]?.readme : "";
@@ -129,7 +129,7 @@ function renderTabs(selectedPackUid: string, packData: PackData, customReadme: R
 
   if (tabs.length > 1) {
     return (
-      <Tabs defaultActiveKey="1">
+      <Tabs defaultActiveKey={fragmentIdentifier ? "2" : "1"}>
         {tabs.map((item) => (
           <Tabs.TabPane tab={item.label} key={item.key}>
             {item.children}
@@ -186,7 +186,7 @@ function getRegistries(packData: PackData, selectedVersion: string, selectedPack
 export default function PacksReadme() {
   try {
     const { packs, repositories } = usePluginData("plugin-packs-integrations") as PacksIntegrationsPluginData;
-
+    const [fragmentIdentifier, setFragmentIdentifier] = useState<string>("");
     const [customReadme, setCustomReadme] = useState<ReactElement<any, any> | null>(null);
     const [packName, setPackName] = useState<string>("");
     const [selectedPackUid, setSelectedPackUid] = useState<string>("");
@@ -197,6 +197,7 @@ export default function PacksReadme() {
 
     useEffect(() => {
       const searchParams = window ? new URLSearchParams(window.location.search) : null;
+      const hashLocationValue = window ? window.location.hash : "";
       const pckName = searchParams?.get("pack") || "";
       setPackName(pckName);
       const importComponent = async () => {
@@ -208,6 +209,9 @@ export default function PacksReadme() {
               <PackReadMeComponent />
             </div>
           );
+          if (hashLocationValue) {
+            setFragmentIdentifier(hashLocationValue);
+          }
         } catch (error) {
           console.error("Error importing custom readme component for pack. Additional information follows: \n", error);
           setCustomReadme(null);
@@ -217,6 +221,14 @@ export default function PacksReadme() {
         console.error("Error importing custom readme component for pack. Additional information follows: \n", e);
       });
     }, []);
+
+    useEffect(() => {
+      if (document && fragmentIdentifier) {
+        const elementId = fragmentIdentifier.replace("#", "");
+        const parent = document.getElementById?.(elementId);
+        parent?.querySelector?.("a")?.click();
+      }
+    }, [fragmentIdentifier]);
 
     const packData: PackData = useMemo(() => {
       const pack = packs.find((pack) => pack.name === packName);
@@ -322,7 +334,7 @@ export default function PacksReadme() {
         </div>
         <div className={styles.tabPane}>
           <ConfigProvider theme={{ algorithm: colorMode === "dark" ? darkAlgorithm : defaultAlgorithm }}>
-            {renderTabs(selectedPackUid, packData, customReadme)}
+            {renderTabs(selectedPackUid, packData, customReadme, fragmentIdentifier)}
           </ConfigProvider>
         </div>
       </div>


### PR DESCRIPTION
## Describe the Change

The change made as part of this PR is, when we load the packs doc page with fragment identifier (followed by "#"), it takes to the exact fragment in the "Additional Details"

## Changed Pages

No access to netify, but, it doesnt impact on the design , in the packs page, go to pack detail page of any packs.
or directly hit the url,
http://localhost:3000/integrations/packs/?pack=kubernetes-tke&version=1.24.4&parent=1.24.x#change-cluster-dns-service-domain
the control goes to the fragement anchor change-cluster-dns-service-domain

## Jira Tickets

https://spectrocloud.atlassian.net/browse/PEM-6153

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
