### PR TITLE
docs: add note about vddk secret namespace

### DIFF
--- a/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
+++ b/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
@@ -88,8 +88,8 @@ from VMware vSphere to Palette VMO.
     documentation for guidance.
   - The migration host must have access to your image registry.
   - If you are using a private image registry, you must create a Secret to be used for the migration. The Secret must be
-    in the form of a YAML file and the `metadata.name` value must be `vddk-image-pull-secret`. The `metadata.namespace` value
-    should be left blank, it will be automatically populated by Palette CLI.
+    in the form of a YAML file and the `metadata.name` value must be `vddk-image-pull-secret`. The `metadata.namespace`
+    value should be left blank, it will be automatically populated by Palette CLI.
 
     <!--prettier-ignore-->
     <details>

--- a/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
+++ b/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
@@ -88,7 +88,8 @@ from VMware vSphere to Palette VMO.
     documentation for guidance.
   - The migration host must have access to your image registry.
   - If you are using a private image registry, you must create a Secret to be used for the migration. The Secret must be
-    in the form of a YAML file and the `metadata.name` value must be `vddk-image-pull-secret`.
+    in the form of a YAML file and the `metadata.name` value must be `vddk-image-pull-secret`. The `metadata.namespace` value
+    should be left blank, it will be automatically populated by Palette CLI.
 
     <!--prettier-ignore-->
     <details>
@@ -130,7 +131,7 @@ from VMware vSphere to Palette VMO.
     ```
 
     You can then use this output to create your own Secret manually. Ensure that the `metadata.name` is set to
-    `vddk-image-pull-secret`.
+    `vddk-image-pull-secret` and the `metadata.namespace` is left blank.
 
     Refer to the
     [Pull an Image from a Private Registry documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)

--- a/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
+++ b/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
@@ -89,7 +89,7 @@ from VMware vSphere to Palette VMO.
   - The migration host must have access to your image registry.
   - If you are using a private image registry, you must create a Secret to be used for the migration. The Secret must be
     in the form of a YAML file and the `metadata.name` value must be `vddk-image-pull-secret`. The `metadata.namespace`
-    value should be left blank, it will be automatically populated by Palette CLI.
+    value should be left blank or omitted, as the Palette CLI will automatically populate it.
 
     <!--prettier-ignore-->
     <details>
@@ -131,7 +131,7 @@ from VMware vSphere to Palette VMO.
     ```
 
     You can then use this output to create your own Secret manually. Ensure that the `metadata.name` is set to
-    `vddk-image-pull-secret` and the `metadata.namespace` is left blank.
+    `vddk-image-pull-secret`, and the `metadata.namespace` is left blank or omitted.
 
     Refer to the
     [Pull an Image from a Private Registry documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)


### PR DESCRIPTION
## Describe the Change

This PR adds a note to the page about VM migration to VMO, directing the user to leave `namespace` blank when creating a `vddk-image-pull-secret` yaml.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview](https://deploy-preview-4713--docs-spectrocloud.netlify.app/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt/#prerequisites)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
