### PR TITLE
Remove Ansible Roles in Pack Documentation

### DIFF
--- a/docs/docs-content/registries-and-packs/add-custom-packs.md
+++ b/docs/docs-content/registries-and-packs/add-custom-packs.md
@@ -20,8 +20,8 @@ to a custom registry.
 
 The following items are required to create a custom pack.
 
-- [ORAS CLI](https://oras.land/docs/installation) v1.0.0 or the [Spectro Cloud CLI](spectro-cli-reference.md) if you
-  using the legacy Spectro Rgistry. We recommend using Oras CLI with an Open Container Initiative (OCI) compliant
+- [ORAS CLI](https://oras.land/docs/installation) v1.0.0 or the [Spectro Cloud CLI](spectro-cli-reference.md) if you are
+  using the legacy Spectro Registry. We recommend using Oras CLI with an Open Container Initiative (OCI) compliant
   registry.
 - A custom Pack registry registered in Palette. Check out the following guides for additional help on how to set up a
   custom pack registry:

--- a/docs/docs-content/registries-and-packs/add-custom-packs.md
+++ b/docs/docs-content/registries-and-packs/add-custom-packs.md
@@ -20,7 +20,7 @@ to a custom registry.
 
 The following items are required to create a custom pack.
 
-- [Oras CLI](https://oras.land/docs/installation) v1.0.0 or the [Spectro Cloud CLI](spectro-cli-reference.md) if you
+- [ORAS CLI](https://oras.land/docs/installation) v1.0.0 or the [Spectro Cloud CLI](spectro-cli-reference.md) if you
   using the legacy Spectro Rgistry. We recommend using Oras CLI with an Open Container Initiative (OCI) compliant
   registry.
 - A custom Pack registry registered in Palette. Check out the following guides for additional help on how to set up a

--- a/docs/docs-content/registries-and-packs/add-custom-packs.md
+++ b/docs/docs-content/registries-and-packs/add-custom-packs.md
@@ -7,18 +7,27 @@ hide_table_of_contents: false
 sidebar_position: 20
 ---
 
-# Add a Custom Pack
+You can add a custom pack to Palette to add new integrations or applications to your cluster profiles.
 
-Custom packs are built by users and deployed to custom registries using the Spectro Cloud CLI tool. To get started with
-Spectro Cloud CLI, review the Spectro Cloud CLI installation [instructions](spectro-cli-reference.md).
+:::further
+
+Check out the tutorial [Deploy a Custom Pack](../tutorials/profiles/deploy-pack.md) to learn how to deploy a custom pack
+to a custom registry.
+
+:::
 
 ## Prerequsites
 
 The following items are required to create a custom pack.
 
-- [Spectro Cloud CLI](spectro-cli-reference.md)
-- A Spectro Cloud [account](https://www.spectrocloud.com/)
-- [Custom Pack registry](adding-a-custom-registry.md)
+- [Oras CLI](https://oras.land/docs/installation) v1.0.0 or the [Spectro Cloud CLI](spectro-cli-reference.md) if you
+  using the legacy Spectro Rgistry. We recommend using Oras CLI with an Open Container Initiative (OCI) compliant
+  registry.
+- A custom Pack registry registered in Palette. Check out the following guides for additional help on how to set up a
+  custom pack registry:
+  - [OCI Pack Registry](./registries/oci-registry/add-pack-oci/add-pack-oci-basic.md)
+  - [AWS ECR Pack Registry](./registries/oci-registry/add-pack-oci/add-pack-oci-ecr.md)
+  - [Legacy Spectro Pack Registry](./adding-a-custom-registry.md)
 
 ## JSON Schema
 

--- a/docs/docs-content/registries-and-packs/add-custom-packs.md
+++ b/docs/docs-content/registries-and-packs/add-custom-packs.md
@@ -32,18 +32,14 @@ attributes.
 | layer         | String    | True     | Relevant layer that this pack should be part of; such as os, k8s, cni, csi, addon                                                                                                                                                                                                                                                         |
 | addonType     | String    | False    | Addon-type must be set for packs that have the layer set to Addon. The value must be one of the following: logging, monitoring, load balancer, authentication, ingress, security. Setting a relevant correct addon type ensures packs are organized correctly on the management console making it easy for profile authors to find packs. |
 | version       | String    | True     | A Semantic version for the pack. It is recommended that the pack version be the same as the underlying integration it is being created for. For example, the version for the pack that will install Prometheus 2.3.4, should set to 2.3.4.                                                                                                |
-| cloudTypes    | Array     | True     | You can provide one or more types for a pack. Supported values are as follows: <br /><br />**all**, **aws**, **azure**, **gcp**, **tencent**, **vsphere**, **openstack**, **baremetal**, **maas**, **aks**, **eks**, **tke**, **edge**, **edge-native**, **coxedge**, and **libvirt** (virtualized edge).                                 |
+| cloudTypes    | Array     | True     | You can provide one or more types for a pack. Supported values are as follows: **all**, **aws**, **azure**, **gcp**, **tencent**, **vsphere**, **openstack**, **baremetal**, **maas**, **aks**, **eks**, **tke**, **edge**, **edge-native**, **coxedge**, and **libvirt** (virtualized edge).                                             |
 | group         | String    | False    | Optional categorization of packs. For example, LTS can be set for Ubuntu OS packs.                                                                                                                                                                                                                                                        |
 | annotations   | Array     | False    | Optional key-value pairs required during pack installation. Typically, custom packs do not need to set annotations. Some packs like the ones for OS require annotations that need to be set with an image id.                                                                                                                             |
 | eol           | String    | False    | End of life date for integration.                                                                                                                                                                                                                                                                                                         |
 | KubeManifests | Array     | False    | Relative path to Kubernetes manifest yaml files.                                                                                                                                                                                                                                                                                          |
-| ansibleRoles  | Array     | False    | Relative part to the Ansible role folders. These folders should contain all the artifacts required by Ansible. Please refer to the Ansible documentation for more details on how Ansible roles are constructed.                                                                                                                           |
-|               |           |          | In Palette, Ansible roles are used to customize the OS image used for cluster nodes. Typically, these are roles that perform tasks like hardening the OS, installing monitoring agents, etc.                                                                                                                                              |
 | charts        | Array     | False    | Relative path to the helm chart archives.                                                                                                                                                                                                                                                                                                 |
 
 The following is the JSON schema for packs. Review the schema to ensure your JSON configuration is defined correctly.
-
-<br />
 
 ```json
 {
@@ -118,12 +114,6 @@ The following is the JSON schema for packs. Review the schema to ensure your JSO
     },
     "addonSubType": {
       "type": "string"
-    },
-    "ansibleRoles": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
     },
     "charts": {
       "type": "array",
@@ -251,7 +241,6 @@ Follow the steps below to create a custom pack.
      "annotations": {
        "name": "value"
      },
-     "ansibleRoles": [],
      "displayName": "<PACK_DISPLAY_NAME>",
      "eol": "2028-04-30",
      "group": "<PACK_GROUP>",
@@ -322,8 +311,6 @@ The OS is one of the Core Layers in a cluster profile. An OS pack can be built t
 nodes. This might be desirable if an organization wants to use an approved hardened OS image for their infrastructure.
 There are typically the following two scenarios for the OS image:
 
-<br />
-
 1. **Pre-Installed Kubernetes** - The OS image has the desired version of Kubernetes components like kubelet, kubectl,
    etc installed.
 
@@ -358,7 +345,6 @@ profile. If Kubernetes is pre-installed in the image, set the flag `skipK8sInsta
       "sshUsername": "centos",
       "skipK8sInstall": "false",
     },
-  "ansibleRoles": ["harden_os"],
   "cloudTypes": ["aws"],
   "displayName": "CentOS",
   "eol": "2024-06-30",
@@ -388,7 +374,6 @@ profile. If Kubernetes is pre-installed in the image, set the flag `skipK8sInsta
       "sshUsername": "centos",
       "skipK8sInstall": "true",
     },
-  "ansibleRoles": ["harden_os"],
   "cloudTypes": ["azure"],
   "displayName": "CentOS",
   "eol": "2024-06-30",
@@ -418,7 +403,6 @@ profile. If Kubernetes is pre-installed in the image, set the flag `skipK8sInsta
       "sshUsername": "root",
       "skipK8sInstall": "false",
     },
-  "ansibleRoles": ["harden_os"],
   "cloudTypes": ["vsphere"],
   "displayName": "CentOS",
   "eol": "2024-06-30",
@@ -443,7 +427,6 @@ profile. If Kubernetes is pre-installed in the image, set the flag `skipK8sInsta
       "sshUsername": "ubuntu",
       "skipK8sInstall": "false",
     },
-  "ansibleRoles": ["harden_os"],
   "cloudTypes": ["vsphere"],
   "displayName": "Ubuntu",
   "eol": "2028-04-30",
@@ -458,31 +441,3 @@ profile. If Kubernetes is pre-installed in the image, set the flag `skipK8sInsta
 </TabItem>
 
 </Tabs>
-
-## Ansible Roles
-
-In all the previous examples, additional customization in the form of an Ansible role called `harden_os` is specified in
-the pack manifest. The tasks and other files for the implementation of this role need to be included in the pack. The
-final directory structure of for the pack would be as follows:
-
-```
-./pack.json
-./logo.png
-./values.yaml
-./harden_os
-./harden_os/tasks
-./harden_os/tasks/main.yml
-./harden_os/files
-./harden_os/files/sec_harden.sh
-```
-
-Ansible roles are optional and only required if additional runtime customization is required. Once an OS pack is
-constructed, push it to the pack registry using the Spectro CLI tool.
-
-:::warning
-
-During the image customization phase of a cluster deployment, failures related to missing packages or package version
-mismatch could occur when using a custom OS pack. These errors are presented on the console. The image needs to be
-updated to resolve any such issues.
-
-:::

--- a/docs/docs-content/registries-and-packs/adding-add-on-packs.md
+++ b/docs/docs-content/registries-and-packs/adding-add-on-packs.md
@@ -42,7 +42,6 @@ the Spectro Cloud CLI:
    {
      "addonType": "monitoring",
      "annotations": {},
-     "ansibleRoles": [],
      "cloudTypes": ["all"],
      "displayName": "Prometheus-Grafana",
      "eol": " ",

--- a/docs/docs-content/registries-and-packs/registries-and-packs.md
+++ b/docs/docs-content/registries-and-packs/registries-and-packs.md
@@ -35,15 +35,14 @@ Each pack is a collection of files such as manifests, helm charts, Ansible roles
 roles, if provided, are used to customize cluster VM images, whereas Kubernetes manifests and Helm charts are applied to
 the Kubernetes clusters after deployment. The following is a typical pack structure:
 
-| **Pack Name**   | **Requirement** | **Description**                                                                                                 |
-| --------------- | --------------- | --------------------------------------------------------------------------------------------------------------- |
-| `pack.json`     | mandatory       | Pack metadata.                                                                                                  |
-| `values.yaml`   | mandatory       | Pack configuration, parameters exposed from the underlying charts, and templated parameters from Ansible roles. |
-| `charts/`       | mandatory       | Mandatory for Helm chart-based packs. Contains the Helm charts to be deployed for the pack.                     |
-| `manifests/`    | mandatory       | Mandatory for Manifest-based packs. Contains the manifest files to be deployed for the pack.                    |
-| `ansible-roles` | optional        | Ansible roles used to install the pack.                                                                         |
-| `logo.png`      | optional        | Contains the pack logo.                                                                                         |
-| `README.md`     | optional        | The pack description.                                                                                           |
+| **Pack Name** | **Requirement** | **Description**                                                                                                 |
+| ------------- | --------------- | --------------------------------------------------------------------------------------------------------------- |
+| `pack.json`   | mandatory       | Pack metadata.                                                                                                  |
+| `values.yaml` | mandatory       | Pack configuration, parameters exposed from the underlying charts, and templated parameters from Ansible roles. |
+| `charts/`     | mandatory       | Mandatory for Helm chart-based packs. Contains the Helm charts to be deployed for the pack.                     |
+| `manifests/`  | mandatory       | Mandatory for Manifest-based packs. Contains the manifest files to be deployed for the pack.                    |
+| `logo.png`    | optional        | Contains the pack logo.                                                                                         |
+| `README.md`   | optional        | The pack description.                                                                                           |
 
 Let's look at the examples below to better understand pack structure.
 

--- a/docs/docs-content/tutorials/profiles/deploy-pack.md
+++ b/docs/docs-content/tutorials/profiles/deploy-pack.md
@@ -310,34 +310,19 @@ you want to use.
 
 <Tabs groupId="registry-server">
 
-<TabItem label="Spectro Registry" value="Spectro_Registry">
+<TabItem label="Basic" value="Basic_Registry">
 
-Start the registry server by issuing the following command from the tutorial container bash session initialized in the
-[Set Up the Tutorial Environment](#set-up-the-tutorial-environment) section.
+Once you have an active Harbor registry server, access its domain on your web browser and log in using your Harbor
+credentials. If you have kept the default credentials, the username and password are **admin** and **Harbor12345**,
+respectively.
 
-```bash
-registry serve /etc/spectro/config.yml > /var/log/registry.log 2>&1 &
-```
+![Screenshot of Harbor login](/tutorials/deploy-pack/registries-and-packs_deploy-pack_harbor-login.webp)
 
-The registry server starts in HTTP mode. If you want to deploy an HTTPS registry server, refer to the
-[Add a Custom Registry](../../registries-and-packs/adding-a-custom-registry.md) guide.
+In the **Projects** section, click on **New Project**. A project in Harbor contains all repositories of an application.
+This tutorial uses **spectro-oci-registry** as the project name. Keep the default settings for the remaining
+configuration options and proceed by clicking **OK**.
 
-Next, make the registry server accessible to the public using [Ngrok](https://ngrok.com/) reverse proxy so that you can
-configure it later in Palette. Execute the command below to expose the registry server listening on port 5000 via an
-HTTP tunnel.
-
-```bash
-ngrok http 5000 --log-level debug
-```
-
-This command reserves the current bash session and displays the status of each HTTP request made to the Ngrok server.
-The image below shows the registry server successfully exposed via Ngrok.
-
-![Screenshot of registry server exposed via ngrok](/tutorials/deploy-pack/registries-and-packs_deploy-pack_ngrok-start.webp)
-
-Check if the registry server is accessible from outside the tutorial container by visiting the `/health` endpoint. Open
-your browser and go to `https://Your-URL-Here/health`, replacing the base URL with the Ngrok URL output. You should get
-a `{"status":"UP"}` response.
+![Screenshot of Harbor project](/tutorials/deploy-pack/registries-and-packs_deploy-pack_harbor-project.webp)
 
 </TabItem>
 
@@ -401,19 +386,34 @@ Registry.
 
 </TabItem>
 
-<TabItem label="Basic" value="Basic_Registry">
+<TabItem label="Spectro Registry" value="Spectro_Registry">
 
-Once you have an active Harbor registry server, access its domain on your web browser and log in using your Harbor
-credentials. If you have kept the default credentials, the username and password are **admin** and **Harbor12345**,
-respectively.
+Start the registry server by issuing the following command from the tutorial container bash session initialized in the
+[Set Up the Tutorial Environment](#set-up-the-tutorial-environment) section.
 
-![Screenshot of Harbor login](/tutorials/deploy-pack/registries-and-packs_deploy-pack_harbor-login.webp)
+```bash
+registry serve /etc/spectro/config.yml > /var/log/registry.log 2>&1 &
+```
 
-In the **Projects** section, click on **New Project**. A project in Harbor contains all repositories of an application.
-This tutorial uses **spectro-oci-registry** as the project name. Keep the default settings for the remaining
-configuration options and proceed by clicking **OK**.
+The registry server starts in HTTP mode. If you want to deploy an HTTPS registry server, refer to the
+[Add a Custom Registry](../../registries-and-packs/adding-a-custom-registry.md) guide.
 
-![Screenshot of Harbor project](/tutorials/deploy-pack/registries-and-packs_deploy-pack_harbor-project.webp)
+Next, make the registry server accessible to the public using [Ngrok](https://ngrok.com/) reverse proxy so that you can
+configure it later in Palette. Execute the command below to expose the registry server listening on port 5000 via an
+HTTP tunnel.
+
+```bash
+ngrok http 5000 --log-level debug
+```
+
+This command reserves the current bash session and displays the status of each HTTP request made to the Ngrok server.
+The image below shows the registry server successfully exposed via Ngrok.
+
+![Screenshot of registry server exposed via ngrok](/tutorials/deploy-pack/registries-and-packs_deploy-pack_ngrok-start.webp)
+
+Check if the registry server is accessible from outside the tutorial container by visiting the `/health` endpoint. Open
+your browser and go to `https://Your-URL-Here/health`, replacing the base URL with the Ngrok URL output. You should get
+a `{"status":"UP"}` response.
 
 </TabItem>
 
@@ -422,6 +422,66 @@ configuration options and proceed by clicking **OK**.
 ### Log in to the Registry Server
 
 <Tabs groupId="registry-server">
+
+<TabItem label="Basic" value="Basic_Registry">
+
+After creating the projects, proceed with the Harbor authentication. In the tutorial container bash session, export the
+`HARBOR_ADDRESS` variable, which will store your Harbor address. Do not include the "https://" prefix.
+
+```bash
+export HARBOR_ADDRESS=<Your_Harbor_Address>
+```
+
+Now, issue the command `oras login`. [ORAS](https://oras.land/docs/) is a CLI tool to push and pull OCI artifacts to and
+from OCI registries.
+
+:::warning
+
+If you are not using the tutorial container, ensure you have ORAS version `1.0.0` installed. This version is explicitly
+required for pushing packs to OCI registries.
+
+:::
+
+```bash
+oras login $HARBOR_ADDRESS
+```
+
+You will be prompted for your Harbor username and password. If the login is successful, you will receive the following
+confirmation message.
+
+```hideClipboard
+Username: admin
+Password:
+Login Succeeded
+```
+
+</TabItem>
+
+<TabItem label="ECR" value="ECR_Registry">
+
+After you have created the repositories, authenticate to your ECR registry using the `aws ecr get-login-password`
+command. The ECR authorization token is then passed to the `oras login` command with **AWS** as username and the
+registry Uniform Resource Identifier (URI). [ORAS](https://oras.land/docs/) is a CLI tool to push and pull OCI artifacts
+to and from OCI registries.
+
+:::warning
+
+If you are not using the tutorial container, ensure you have ORAS version `1.0.0` installed. This version is explicitly
+required for pushing packs to OCI registries.
+
+:::
+
+```bash
+aws ecr get-login-password --region $AWS_DEFAULT_REGION | oras login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
+```
+
+If the login is successful, you will receive the following confirmation message.
+
+```hideClipboard
+Login Succeeded
+```
+
+</TabItem>
 
 <TabItem label="Spectro Registry" value="Spectro_Registry">
 
@@ -475,148 +535,11 @@ Login Succeeded
 
 </TabItem>
 
-<TabItem label="ECR" value="ECR_Registry">
-
-After you have created the repositories, authenticate to your ECR registry using the `aws ecr get-login-password`
-command. The ECR authorization token is then passed to the `oras login` command with **AWS** as username and the
-registry Uniform Resource Identifier (URI). [ORAS](https://oras.land/docs/) is a CLI tool to push and pull OCI artifacts
-to and from OCI registries.
-
-:::warning
-
-If you are not using the tutorial container, ensure you have ORAS version `1.0.0` installed. This version is explicitly
-required for pushing packs to OCI registries.
-
-:::
-
-```bash
-aws ecr get-login-password --region $AWS_DEFAULT_REGION | oras login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
-```
-
-If the login is successful, you will receive the following confirmation message.
-
-```hideClipboard
-Login Succeeded
-```
-
-</TabItem>
-
-<TabItem label="Basic" value="Basic_Registry">
-
-After creating the projects, proceed with the Harbor authentication. In the tutorial container bash session, export the
-`HARBOR_ADDRESS` variable, which will store your Harbor address. Do not include the "https://" prefix.
-
-```bash
-export HARBOR_ADDRESS=<Your_Harbor_Address>
-```
-
-Now, issue the command `oras login`. [ORAS](https://oras.land/docs/) is a CLI tool to push and pull OCI artifacts to and
-from OCI registries.
-
-:::warning
-
-If you are not using the tutorial container, ensure you have ORAS version `1.0.0` installed. This version is explicitly
-required for pushing packs to OCI registries.
-
-:::
-
-```bash
-oras login $HARBOR_ADDRESS
-```
-
-You will be prompted for your Harbor username and password. If the login is successful, you will receive the following
-confirmation message.
-
-```hideClipboard
-Username: admin
-Password:
-Login Succeeded
-```
-
-</TabItem>
-
 </Tabs>
 
 ### Push the Pack to the Registry Server
 
 <Tabs groupId="registry-server">
-
-<TabItem label="Spectro Registry" value="Spectro_Registry">
-
-Once you are logged in, push the pack to the registry server using the following command.
-
-```bash
-spectro pack push /packs/hello-universe-pack/
-```
-
-To confirm that the pack is now in the registry, use the `ls` command. This command lists all packs available in the
-registry.
-
-```bash
-spectro pack ls
-```
-
-Check if the pushed pack is listed, as shown in the image below.
-
-![Screenshot of spectro pack ls](/tutorials/deploy-pack/registries-and-packs_deploy-pack_pack-push.webp)
-
-For assistance with Spectro CLI commands, refer to the
-[Spectro CLI Commands](../../registries-and-packs/spectro-cli-reference.md#commands) guide.
-
-</TabItem>
-
-<TabItem label="ECR" value="ECR_Registry">
-
-Once you are authenticated to your ECR registry, navigate to the **packs** directory, which contains the pack folder,
-**hello-universe-pack**.
-
-```bash
-cd /packs
-```
-
-Before pushing the pack to the registry, compress the contents of the pack folder into an archive file. Issue the
-command below to create the archive file.
-
-```bash
-tar -czvf $NAME-$VERSION.tar.gz hello-universe-pack
-```
-
-Now, proceed to push the **Hello Universe** pack to the ECR registry.
-
-```bash
-oras push $ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$REGISTRY_NAME/spectro-packs/archive/$NAME:$VERSION $NAME-$VERSION.tar.gz
-```
-
-You can use the `aws ecr describe-images` command to check if the pushed pack is listed in your ECR repository.
-
-```bash
-aws ecr describe-images --repository-name $REGISTRY_NAME/spectro-packs/archive/$NAME --region $AWS_DEFAULT_REGION
-```
-
-The snippet below displays the output of the `aws ecr describe-images` command, confirming the presence of the Hello
-Universe pack in the repository.
-
-```plainText {5-8} hideClipboard
-{
-    "imageDetails": [
-        {
-            "registryId": "<YourRegistryId>
-            "repositoryName": "spectro-oci-registry/spectro-packs/archive/hellouniverse",
-            "imageDigest": "sha256:<YourImageSha>",
-            "imageTags": [
-                "1.0.0"
-	        ],
-            "imageSizeInBytes": 19059,
-            "imagePushedAt": "2023-11-06T11:19:48+00:00",
-            "imageManifestMediaType": "application/vnd.oci.image.manifest.v1+json",
-            "artifactMediaType": "application/vnd.unknown.config.v1+json",
-            "lastRecordedPullTime": "2023-11-17T00:00:48.649000+00:00"
-		    }
-	  ]
-}
-```
-
-</TabItem>
 
 <TabItem label="Basic" value="Basic_Registry">
 
@@ -675,45 +598,119 @@ in the image below.
 
 </TabItem>
 
+<TabItem label="ECR" value="ECR_Registry">
+
+Once you are authenticated to your ECR registry, navigate to the **packs** directory, which contains the pack folder,
+**hello-universe-pack**.
+
+```bash
+cd /packs
+```
+
+Before pushing the pack to the registry, compress the contents of the pack folder into an archive file. Issue the
+command below to create the archive file.
+
+```bash
+tar -czvf $NAME-$VERSION.tar.gz hello-universe-pack
+```
+
+Now, proceed to push the **Hello Universe** pack to the ECR registry.
+
+```bash
+oras push $ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$REGISTRY_NAME/spectro-packs/archive/$NAME:$VERSION $NAME-$VERSION.tar.gz
+```
+
+You can use the `aws ecr describe-images` command to check if the pushed pack is listed in your ECR repository.
+
+```bash
+aws ecr describe-images --repository-name $REGISTRY_NAME/spectro-packs/archive/$NAME --region $AWS_DEFAULT_REGION
+```
+
+The snippet below displays the output of the `aws ecr describe-images` command, confirming the presence of the Hello
+Universe pack in the repository.
+
+```plainText {5-8} hideClipboard
+{
+    "imageDetails": [
+        {
+            "registryId": "<YourRegistryId>
+            "repositoryName": "spectro-oci-registry/spectro-packs/archive/hellouniverse",
+            "imageDigest": "sha256:<YourImageSha>",
+            "imageTags": [
+                "1.0.0"
+	        ],
+            "imageSizeInBytes": 19059,
+            "imagePushedAt": "2023-11-06T11:19:48+00:00",
+            "imageManifestMediaType": "application/vnd.oci.image.manifest.v1+json",
+            "artifactMediaType": "application/vnd.unknown.config.v1+json",
+            "lastRecordedPullTime": "2023-11-17T00:00:48.649000+00:00"
+		    }
+	  ]
+}
+```
+
+</TabItem>
+
+<TabItem label="Spectro Registry" value="Spectro_Registry">
+
+Once you are logged in, push the pack to the registry server using the following command.
+
+```bash
+spectro pack push /packs/hello-universe-pack/
+```
+
+To confirm that the pack is now in the registry, use the `ls` command. This command lists all packs available in the
+registry.
+
+```bash
+spectro pack ls
+```
+
+Check if the pushed pack is listed, as shown in the image below.
+
+![Screenshot of spectro pack ls](/tutorials/deploy-pack/registries-and-packs_deploy-pack_pack-push.webp)
+
+For assistance with Spectro CLI commands, refer to the
+[Spectro CLI Commands](../../registries-and-packs/spectro-cli-reference.md#commands) guide.
+
+</TabItem>
+
 </Tabs>
 
 ### Configure the Registry Server in Palette
 
 <Tabs groupId="registry-server">
 
-<TabItem label="Spectro Registry" value="Spectro_Registry">
+<TabItem label="Basic" value="Basic_Registry">
 
-After pushing the pack to the registry server, follow the next steps to log in to Palette and add the registry server to
+After pushing the pack to the Harbor registry, follow the next steps to log in to Palette and add the Harbor registry to
 it.
 
 Log in to [Palette](https://console.spectrocloud.com) and switch to the **Tenant Admin** view.
 
 ![Screenshot of Palette tenant settings.](/tutorials/deploy-pack/registries-and-packs_deploy-pack_tenant-admin.webp)
 
-Navigate to the **Tenant Settings** > **Registries** > **Pack Registries** section and click on **Add New Pack
-Registry**. Palette will open a pop-up window prompting you for the required fields to configure a custom pack registry.
+Navigate to the **Tenant Settings** > **Registries** > **OCI Registries** section and click on **Add New OCI Registry**.
+Palette will open a pop-up window prompting you for the required fields to configure an OCI registry.
 
-![A screenshot highlighting the fields to configure a custom pack registry. ](/tutorials/deploy-pack/registries-and-packs_adding-a-custom-registry-tls_certificate.webp)
+![A screenshot highlighting the fields to configure an OCI registry.](/tutorials/deploy-pack/registries-and-packs_deploy-pack_basic-oci-registry.webp)
 
-Provide the pack registry name, endpoint, and user credentials in the pop-up window. For consistency, we suggest using
-the registry name **spectro-pack-registry**. Use your Ngrok URL as the pack registry endpoint. Ensure to add "https://"
-as the prefix in the pack registry endpoint. Set both the username and password as **admin**.
+Provide the registry name. For consistency, we suggest using the registry name **harbor-registry**. Choose **Pack** as
+the provider and select **Basic** as the OCI authentication type. Complete the **Endpoint** field with your Harbor
+registry address. Ensure to include "https://" as the prefix.
 
-In the **TLS Configuration** section, select the **Insecure Skip TLS Verify** checkbox. This tutorial does not establish
-a secure HTTPS connection between Palette and your pack registry server. Therefore, you can skip the TLS verification.
-Instead, this tutorial uses an unencrypted HTTP connection. However, in a production environment, you can upload your
-certificate in the **TLS Configuration** section if you need Palette to establish a secure HTTPS connection while
-communicating with the pack registry server.
+Next, set the base content path as **spectro-oci-registry**, which corresponds to your Harbor project name. Then, enter
+your Harbor credentials in the **Username** and **Password** fields.
 
-Click on **Validate** to ensure the provided URL and credentials are correct, then click on **Confirm** to finish the
-registry server configuration.
+Last, click on **Validate** to ensure the provided URL and credentials are correct. After validation, click on
+**Confirm** to complete the Harbor registry configuration.
 
-![Screenshot of registry server edit option in Palette tenant settings.](/tutorials/deploy-pack/registries-and-packs_deploy-pack_registry-edit.webp)
+![Screenshot of OCI registry fields in Palette tenant settings.](/tutorials/deploy-pack/registries-and-packs_deploy-pack_basic-oci-registry-edit.webp)
 
-Palette automatically syncs the registry server. However, you can sync it manually by clicking the **three-dot Menu**
-next to the registry server name and selecting **Sync**.
+Palette automatically syncs the registry. However, you can sync it manually by clicking the **three-dot Menu** next to
+the registry name and selecting **Sync**.
 
-![Screenshot of registry server sync in Palette](/tutorials/deploy-pack/registries-and-packs_deploy-pack_registry-sync.webp)
+![Screenshot of OCI registry sync in Palette](/tutorials/deploy-pack/registries-and-packs_deploy-pack_basic-oci-registry-sync.webp)
 
 </TabItem>
 
@@ -750,36 +747,39 @@ the registry name and selecting **Sync**.
 
 </TabItem>
 
-<TabItem label="Basic" value="Basic_Registry">
+<TabItem label="Spectro Registry" value="Spectro_Registry">
 
-After pushing the pack to the Harbor registry, follow the next steps to log in to Palette and add the Harbor registry to
+After pushing the pack to the registry server, follow the next steps to log in to Palette and add the registry server to
 it.
 
 Log in to [Palette](https://console.spectrocloud.com) and switch to the **Tenant Admin** view.
 
 ![Screenshot of Palette tenant settings.](/tutorials/deploy-pack/registries-and-packs_deploy-pack_tenant-admin.webp)
 
-Navigate to the **Tenant Settings** > **Registries** > **OCI Registries** section and click on **Add New OCI Registry**.
-Palette will open a pop-up window prompting you for the required fields to configure an OCI registry.
+Navigate to the **Tenant Settings** > **Registries** > **Pack Registries** section and click on **Add New Pack
+Registry**. Palette will open a pop-up window prompting you for the required fields to configure a custom pack registry.
 
-![A screenshot highlighting the fields to configure an OCI registry.](/tutorials/deploy-pack/registries-and-packs_deploy-pack_basic-oci-registry.webp)
+![A screenshot highlighting the fields to configure a custom pack registry. ](/tutorials/deploy-pack/registries-and-packs_adding-a-custom-registry-tls_certificate.webp)
 
-Provide the registry name. For consistency, we suggest using the registry name **harbor-registry**. Choose **Pack** as
-the provider and select **Basic** as the OCI authentication type. Complete the **Endpoint** field with your Harbor
-registry address. Ensure to include "https://" as the prefix.
+Provide the pack registry name, endpoint, and user credentials in the pop-up window. For consistency, we suggest using
+the registry name **spectro-pack-registry**. Use your Ngrok URL as the pack registry endpoint. Ensure to add "https://"
+as the prefix in the pack registry endpoint. Set both the username and password as **admin**.
 
-Next, set the base content path as **spectro-oci-registry**, which corresponds to your Harbor project name. Then, enter
-your Harbor credentials in the **Username** and **Password** fields.
+In the **TLS Configuration** section, select the **Insecure Skip TLS Verify** checkbox. This tutorial does not establish
+a secure HTTPS connection between Palette and your pack registry server. Therefore, you can skip the TLS verification.
+Instead, this tutorial uses an unencrypted HTTP connection. However, in a production environment, you can upload your
+certificate in the **TLS Configuration** section if you need Palette to establish a secure HTTPS connection while
+communicating with the pack registry server.
 
-Last, click on **Validate** to ensure the provided URL and credentials are correct. After validation, click on
-**Confirm** to complete the Harbor registry configuration.
+Click on **Validate** to ensure the provided URL and credentials are correct, then click on **Confirm** to finish the
+registry server configuration.
 
-![Screenshot of OCI registry fields in Palette tenant settings.](/tutorials/deploy-pack/registries-and-packs_deploy-pack_basic-oci-registry-edit.webp)
+![Screenshot of registry server edit option in Palette tenant settings.](/tutorials/deploy-pack/registries-and-packs_deploy-pack_registry-edit.webp)
 
-Palette automatically syncs the registry. However, you can sync it manually by clicking the **three-dot Menu** next to
-the registry name and selecting **Sync**.
+Palette automatically syncs the registry server. However, you can sync it manually by clicking the **three-dot Menu**
+next to the registry server name and selecting **Sync**.
 
-![Screenshot of OCI registry sync in Palette](/tutorials/deploy-pack/registries-and-packs_deploy-pack_basic-oci-registry-sync.webp)
+![Screenshot of registry server sync in Palette](/tutorials/deploy-pack/registries-and-packs_deploy-pack_registry-sync.webp)
 
 </TabItem>
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the mention of Ansible roles in Packs. The order of registries in the Add a Custom Pack tutorial has also been updated to start with Basic, followed by ECR, and Spectro Registry.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add a Custom Pack Page](https://deploy-preview-4719--docs-spectrocloud.netlify.app/registries-and-packs/add-custom-packs/)

💻 [Tutorial](https://deploy-preview-4719--docs-spectrocloud.netlify.app/tutorials/profiles/deploy-pack/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1485](https://spectrocloud.atlassian.net/browse/DOC-1485)
🎫 [DOC-1487](https://spectrocloud.atlassian.net/browse/DOC-1487)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1485]: https://spectrocloud.atlassian.net/browse/DOC-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-1487]: https://spectrocloud.atlassian.net/browse/DOC-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ