### PR TITLE
docs: add message brokers section PEM-6141

### DIFF
--- a/docs/docs-content/architecture/architecture-overview.md
+++ b/docs/docs-content/architecture/architecture-overview.md
@@ -87,3 +87,29 @@ be optionally downloaded from a self-hosted private repository instead of pullin
 repository.
 
 ![Self-hosted Palette architecture diagram](/architecture_architecture-on-prem-detailed.webp)
+
+### Message Brokers
+
+Palette requires reliable, scalable and secure communication. The internal microservices use a Publish-Subscribe pattern
+implemented with [gRPC](https://grpc.io/) to achieve this. In order to support this communication pattern, a message
+broker service acts as the central hub for message exchange. Palette message brokers are automatically scaled, ensuring
+that a quorum is available for each cluster. The broker system is designed to provide the following functionality.
+
+1. It efficiently distributes incoming gRPC requests across multiple replicas of the message broker to optimize resource
+   usage and platform performance. This capability supports Palette's ability to manage large, enterprise Kubernetes
+   clusters.
+2. It provides high availability by enabling clients to failover to alternative replicas in the case of a pod failure.
+   By default, two replicas of the message broker are created in each cluster.
+3. It automatically adjusts to changes in the number of broker replicas without manual reconfiguration, ensuring that
+   the platform dynamically scales in response to load changes.
+4. It enforces message authentication and security by generating secondary certificates used for broker to broker
+   communication. This provides security in depth.
+
+Any Enterprise and VerteX Palette cluster will have a message broker that you can inspect. First, ensure that you can
+connect to the cluster. Refer to the
+[Access Cluster with CLI](../clusters/cluster-management/palette-webctl.md#access-cluster-with-cli) guide for further
+infomation. You can then view your message broker by executing the following command.
+
+```bash
+kubectl get statefulset msgbroker --namespace hubble-system
+```

--- a/docs/docs-content/architecture/architecture-overview.md
+++ b/docs/docs-content/architecture/architecture-overview.md
@@ -90,10 +90,11 @@ repository.
 
 ### Message Brokers
 
-Palette requires reliable, scalable, and secure communication. The internal microservices use a Publish-Subscribe pattern
-implemented with [gRPC](https://grpc.io/) to achieve this. In order to support this communication pattern, a message
-broker service acts as the central hub for message exchange. Palette message brokers are automatically scaled, ensuring
-that a quorum is available for each cluster. The broker system is designed to provide the following functionality.
+Palette requires reliable, scalable, and secure communication. The internal microservices use a Publish-Subscribe
+pattern implemented with [gRPC](https://grpc.io/) to achieve this. In order to support this communication pattern, a
+message broker service acts as the central hub for message exchange. Palette message brokers are automatically scaled,
+ensuring that a quorum is available for each cluster. The broker system is designed to provide the following
+functionality.
 
 1. It efficiently distributes incoming gRPC requests across multiple replicas of the message broker to optimize resource
    usage and platform performance. This capability supports Palette's ability to manage large enterprise Kubernetes

--- a/docs/docs-content/architecture/architecture-overview.md
+++ b/docs/docs-content/architecture/architecture-overview.md
@@ -90,13 +90,13 @@ repository.
 
 ### Message Brokers
 
-Palette requires reliable, scalable and secure communication. The internal microservices use a Publish-Subscribe pattern
+Palette requires reliable, scalable, and secure communication. The internal microservices use a Publish-Subscribe pattern
 implemented with [gRPC](https://grpc.io/) to achieve this. In order to support this communication pattern, a message
 broker service acts as the central hub for message exchange. Palette message brokers are automatically scaled, ensuring
 that a quorum is available for each cluster. The broker system is designed to provide the following functionality.
 
 1. It efficiently distributes incoming gRPC requests across multiple replicas of the message broker to optimize resource
-   usage and platform performance. This capability supports Palette's ability to manage large, enterprise Kubernetes
+   usage and platform performance. This capability supports Palette's ability to manage large enterprise Kubernetes
    clusters.
 2. It provides high availability by enabling clients to fail over to alternative replicas in the case of a pod failure.
    By default, two replicas of the message broker are created in each cluster.

--- a/docs/docs-content/architecture/architecture-overview.md
+++ b/docs/docs-content/architecture/architecture-overview.md
@@ -93,21 +93,21 @@ repository.
 Palette requires reliable, scalable, and secure communication. The internal microservices use a Publish-Subscribe
 pattern implemented with [gRPC](https://grpc.io/) to achieve this. In order to support this communication pattern, a
 message broker service acts as the central hub for message exchange. Palette message brokers are automatically scaled,
-ensuring that a quorum is available for each cluster. The broker system is designed to provide the following
-functionality.
+ensuring that a quorum is available for each management plane cluster. The broker system is designed to provide the
+following functionality.
 
 1. It efficiently distributes incoming gRPC requests across multiple replicas of the message broker to optimize resource
    usage and platform performance. This capability supports Palette's ability to manage large enterprise Kubernetes
-   clusters.
+   clusters, which are often distributed across numerous Kubernetes clusters.
 2. It provides high availability by enabling clients to fail over to alternative replicas in the case of a pod failure.
-   By default, two replicas of the message broker are created in each cluster.
+   By default, two replicas of the message broker are created in each management plane cluster.
 3. It automatically adjusts to changes in the number of broker replicas without manual reconfiguration, ensuring that
    the platform dynamically scales in response to load changes.
 4. It enforces message authentication and security by generating secondary certificates used for broker to broker
    communication. This provides security in depth.
 
 Any Enterprise and VerteX Palette cluster will have a message broker that you can inspect. First, ensure that you can
-connect to the cluster. Refer to the
+connect to the management plane cluster. Refer to the
 [Access Cluster with CLI](../clusters/cluster-management/palette-webctl.md#access-cluster-with-cli) guide for further
 information. You can then view your message broker by executing the following command.
 

--- a/docs/docs-content/architecture/architecture-overview.md
+++ b/docs/docs-content/architecture/architecture-overview.md
@@ -98,7 +98,7 @@ that a quorum is available for each cluster. The broker system is designed to pr
 1. It efficiently distributes incoming gRPC requests across multiple replicas of the message broker to optimize resource
    usage and platform performance. This capability supports Palette's ability to manage large, enterprise Kubernetes
    clusters.
-2. It provides high availability by enabling clients to failover to alternative replicas in the case of a pod failure.
+2. It provides high availability by enabling clients to fail over to alternative replicas in the case of a pod failure.
    By default, two replicas of the message broker are created in each cluster.
 3. It automatically adjusts to changes in the number of broker replicas without manual reconfiguration, ensuring that
    the platform dynamically scales in response to load changes.
@@ -108,7 +108,7 @@ that a quorum is available for each cluster. The broker system is designed to pr
 Any Enterprise and VerteX Palette cluster will have a message broker that you can inspect. First, ensure that you can
 connect to the cluster. Refer to the
 [Access Cluster with CLI](../clusters/cluster-management/palette-webctl.md#access-cluster-with-cli) guide for further
-infomation. You can then view your message broker by executing the following command.
+information. You can then view your message broker by executing the following command.
 
 ```bash
 kubectl get statefulset msgbroker --namespace hubble-system


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a message brokers section explaining the HA and scaling of Palette message brokers.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Architecture](https://deploy-preview-4818--docs-spectrocloud.netlify.app/architecture/architecture-overview/#message-brokers)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-6141](https://spectrocloud.atlassian.net/browse/PEM-6141)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] No. _Please leave a short comment below about why this PR cannot be backported._
Merging to release branch.


[PEM-6141]: https://spectrocloud.atlassian.net/browse/PEM-6141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ