### PR TITLE
Updated hello-universe yaml in tutorial

### DIFF
--- a/docs/docs-content/tutorials/cluster-deployment/public-cloud/deploy-k8s-cluster.md
+++ b/docs/docs-content/tutorials/cluster-deployment/public-cloud/deploy-k8s-cluster.md
@@ -634,6 +634,11 @@ In the manifest editor, insert the following content.
 
 ```yaml
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-universe
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: hello-universe-service

--- a/docs/docs-content/tutorials/cluster-deployment/public-cloud/deploy-k8s-cluster.md
+++ b/docs/docs-content/tutorials/cluster-deployment/public-cloud/deploy-k8s-cluster.md
@@ -637,6 +637,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-universe-service
+  namespace: hello-universe
 spec:
   type: LoadBalancer
   ports:
@@ -650,6 +651,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-universe-deployment
+  namespace: hello-universe
 spec:
   replicas: 2
   selector:


### PR DESCRIPTION
## Describe the Change
 
 In the [tutorial to deploy public cloud clusters](https://docs.spectrocloud.com/tutorials/cluster-deployment/public-cloud/deploy-k8s-cluster/#update-cluster-profile), the manifests files in the update cluster profile flow are missing the namespace field, which leads to a reconciliation error when updating the cluster.
 
 Added the namespace which fixes the issue.

