### PR TITLE
docs: add feature gate to the vm clone guide DOC-1491

### DIFF
--- a/docs/docs-content/vm-management/create-manage-vm/clone-vm.md
+++ b/docs/docs-content/vm-management/create-manage-vm/clone-vm.md
@@ -28,8 +28,8 @@ clone a VM for the following reasons:
   Ensure that the **Snapshot** feature gate is enabled in the Virtual Machine Orchestrator (VMO) pack. This is enabled
   by default, but may be modified during cluster profile creation and editing. This feature gate allows Palette to
   access the KubeVirt resources required for correctly cloning your VMs and their data volumes. Learn more about the
-  KubeVirt clone capabilities on the [Clone API](https://kubevirt.io/user-guide/storage/clone_api/#clone-api) page in the
-  official project documentation.
+  KubeVirt clone capabilities on the [Clone API](https://kubevirt.io/user-guide/storage/clone_api/#clone-api) page in
+  the official project documentation.
 
   Select the VMO pack in your cluster profile. Then, click on **Values** under the **Pack Details** section. Verify that
   `Snapshot` is present in the `charts.virtual-machine-orchestrator.kubevirt.kubevirtResources.additionalFeatureGates`
@@ -37,10 +37,10 @@ clone a VM for the following reasons:
 
   ```yaml hideClipboard {5}
   kubevirtResource:
-  name: kubevirt
-  useEmulation: false
-  additionalFeatureGates:
-    - Snapshot
+    name: kubevirt
+    useEmulation: false
+    additionalFeatureGates:
+      - Snapshot
   ```
 
   :::

--- a/docs/docs-content/vm-management/create-manage-vm/clone-vm.md
+++ b/docs/docs-content/vm-management/create-manage-vm/clone-vm.md
@@ -27,8 +27,8 @@ clone a VM for the following reasons:
 
   Ensure that the **Snapshot** feature gate is enabled in the Virtual Machine Orchestrator (VMO) pack. This is enabled
   by default, but may be modified during cluster profile creation and editing. This feature gate allows Palette to
-  access the Kubevirt resources required for correctly cloning your VMs and their data volumes. Learn more about the
-  Kubevirt clone capabilities on the [Clone API](https://kubevirt.io/user-guide/storage/clone_api/#clone-api) page in the
+  access the KubeVirt resources required for correctly cloning your VMs and their data volumes. Learn more about the
+  KubeVirt clone capabilities on the [Clone API](https://kubevirt.io/user-guide/storage/clone_api/#clone-api) page in the
   official project documentation.
 
   Select the VMO pack in your cluster profile. Then, click on **Values** under the **Pack Details** section. Verify that

--- a/docs/docs-content/vm-management/create-manage-vm/clone-vm.md
+++ b/docs/docs-content/vm-management/create-manage-vm/clone-vm.md
@@ -23,6 +23,28 @@ clone a VM for the following reasons:
 
 - An active cluster in Palette with the Virtual Machine Orchestrator (VMO) pack.
 
+  :::warning
+
+  Ensure that the **Snapshot** feature gate is enabled in the Virtual Machine Orchestrator (VMO) pack. This is enabled
+  by default, but may be modified during cluster profile creation and editing. This feature gate allows Palette to
+  access the Kubevirt resources required for correctly cloning your VMs and their data volumes. Learn more about the
+  Kubevirt clone capabilities on the [Clone API](https://kubevirt.io/user-guide/storage/clone_api/#clone-api) page in the
+  official project documentation.
+
+  Select the VMO pack in your cluster profile. Then, click on **Values** under the **Pack Details** section. Verify that
+  `Snapshot` is present in the `charts.virtual-machine-orchestrator.kubevirt.kubevirtResources.additionalFeatureGates`
+  field.
+
+  ```yaml hideClipboard {5}
+  kubevirtResource:
+  name: kubevirt
+  useEmulation: false
+  additionalFeatureGates:
+    - Snapshot
+  ```
+
+  :::
+
 - Outbound internet connectivity for port 443 is allowed so that you and your applications can connect with the Spectro
   Cloud reverse proxy.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a warning for the Snapshot feature gate to the Clone a VM guide. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1491](https://spectrocloud.atlassian.net/browse/DOC-1491)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] No. _Please leave a short comment below about why this PR cannot be backported._
Merge to release branch.


[DOC-1491]: https://spectrocloud.atlassian.net/browse/DOC-1491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ