### PR TITLE
[version-4-2] chore: bump docker/metadata-action from 5.5.1 to 5.6.1 (#4841)

### DIFF
--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5.3.0
+        uses: docker/metadata-action@v5.6.1
         with:
           images: ghcr.io/${{ github.repository }}:nightly
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the backport issues from PR #4841 
