### PR TITLE
docs: PE-5647: Allow skipping of node drains when running cluster upgrades for single-node clusters.

### DIFF
--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -3,7 +3,7 @@ sidebar_label: "Upgrade Palette Agent on Airgap Clusters"
 title: "Upgrade Palette Agent on Airgap Clusters"
 description: "Learn how to upgrade the Palette agent on airgap clusters. "
 hide_table_of_contents: false
-sidebar_position: 80
+sidebar_position: 30
 tags: ["edge", "architecture"]
 ---
 

--- a/docs/docs-content/clusters/edge/cluster-management/certificate-renewal.md
+++ b/docs/docs-content/clusters/edge/cluster-management/certificate-renewal.md
@@ -3,7 +3,7 @@ sidebar_label: "Renew Certificates for Airgap Clusters"
 title: "Renew Certificates for Airgap Clusters"
 description: "Learn how to renew certificates for different Kubernetes components in your cluster."
 hide_table_of_contents: false
-sidebar_position: 80
+sidebar_position: 20
 tags: ["edge", "architecture"]
 ---
 

--- a/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
+++ b/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
@@ -1,0 +1,64 @@
+---
+sidebar_label: "Skip Node Draining During Upgrades"
+title: "Skip Node Draining During Upgrades"
+description: "Learn how to skip node draining during cluster upgrades. "
+icon: ""
+sidebar_position: 40
+hide_table_of_contents: false
+tags: ["edge"]
+---
+
+When you apply a new cluster profile to your cluster, depending on your settings, the cluster may drain each node as it
+updates the pods on that node. This is helpful in multi-node clusters as it allow you to avoid or minimize application
+downtime.
+
+However, the benefits of draining a node in a single-node cluster are minimal because there are no other nodes to
+schedule the workloads onto. In addition, if system-critical workloads are drained, the cluster may get stuck in an
+unmanageable state. You can configure your cluster to skip node draining to avoid such outcomes.
+
+## Prerequisites
+
+- A Palette account. If you do not have one, you can register an account on [Palette](https://console.spectrocloud.com).
+
+- An Edge-type cluster profile.
+
+- An Edge device registered with your Palette account or an existing Edge cluster. For more information, refer to
+  [Edge Host Registration](../site-deployment/site-installation/edge-host-registration.md) and
+  [Deployment](../site-deployment/site-deployment.md).
+
+## Skip Node Draining During Upgrades
+
+1. Log in to [Palette](https://console.spectrocloud.com).
+
+2. From the left **Main Menu**, click **Profiles**.
+
+3. Select the cluster profile you use to provision the clusters for which you want to skip node draining during
+   upgrades.
+
+4. Select the operating system layer of your profile, and add the following lines.
+
+   ```yaml
+   pack:
+     drainOnUpgrade: false
+     drainPodSelector: upgrade.cattle.io/plan!=control-plan,upgrade.cattle.io/plan!=worker-plan,app!=spectro,app!=spectro-proxy,app!=palette-webhook
+   ```
+
+   The following table provides a brief description of the parameters.
+
+   | Parameter          | Description                                                                                                                                                                                                                                                                    | Default                                                                                                                         |
+   | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+   | `drainOnUpgrade`   | Controls the node drain behavior during a cluster upgrade. `true` means nodes will be drained. `false` means nodes will not be drained. `auto` means nodes will only be drained for multi-node clusters, while single-node clusters will not drain nodes during an upgrade.    | `auto`                                                                                                                          |
+   | `drainPodSelector` | If `drainOnUpgrade` is set to `true` for either single-node or multi-node clusters, or set to `auto` for multi-node clusters, only pods matching the selectors will be drained. The default value avoids draining pods related to planning, or any critical Palette workloads. | `upgrade.cattle.io/plan!=control-plan,upgrade.cattle.io/plan!=worker-plan,app!=spectro,app!=spectro-proxy,app!=palette-webhook` |
+
+5. Create a new cluster with the updated cluster profile, or update an existing cluster to use the new cluster profile.
+   For more information, refer to [Create a Cluster](../site-deployment/cluster-deployment.md) or
+   [Update a Cluster](../../cluster-management/cluster-updates.md).
+
+## Validate
+
+1. Update the cluster to use a new version of a cluster profile. For more information, refer to
+   [Update a Cluster](../../cluster-management/cluster-updates.md).
+
+2. After the upgrade is completed, use `kubectl logs` to check on a pod for which you skipped pod draining. Confirm that
+   you do not see any messages that look like `Evicting pod <pod-name> as part of upgrade plan`. The absence of such
+   messages means that the pods were not drained during the upgrade.

--- a/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
+++ b/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
@@ -79,5 +79,5 @@ will apply to both appliance mode and [agent mode](../../../deployment-modes/age
    [Edge Cluster Upgrade Behavior](../cluster-management/upgrade-behavior.md).
 
 2. After the upgrade is completed, use `kubectl logs` to check on a node for which you skipped pod draining. Confirm
-   that you do not see any messages that look like `Evicting pod <pod-name> as part of upgrade plan`. The absence of
+   that no messages that look like `Evicting pod <pod-name> as part of upgrade plan` are displayed. The absence of
    such messages means that the pods were not drained during the upgrade.

--- a/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
+++ b/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
@@ -14,7 +14,8 @@ downtime.
 
 However, the benefits of draining a node in a single-node cluster are minimal because there are no other nodes to
 schedule the workloads onto. In addition, if system-critical workloads are drained, the cluster may get stuck in an
-unmanageable state. You can configure your cluster to skip node draining to avoid such outcomes.
+unmanageable state. You can configure your cluster to skip node draining to avoid such outcomes. These configurations
+will apply to both appliance mode and [agent mode](../../../deployment-modes/agent-mode/agent-mode.md) deployments.
 
 ## Prerequisites
 

--- a/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
+++ b/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
@@ -37,27 +37,33 @@ unmanageable state. You can configure your cluster to skip node draining to avoi
 
 4. Select the operating system layer of your profile, and add the following lines.
 
-   ```yaml
+   ```yaml {2,3}
    pack:
-     drainOnUpgrade: false
-     drainPodSelector: upgrade.cattle.io/plan!=control-plan,upgrade.cattle.io/plan!=worker-plan,app!=spectro,app!=spectro-proxy,app!=palette-webhook
+     drainPods: false
+     podSelector: upgrade.cattle.io/plan!=control-plan,upgrade.cattle.io/plan!=worker-plan,app!=spectro,app!=spectro-proxy,app!=palette-webhook
    ```
 
    The following table provides a brief description of the parameters.
 
-   | Parameter          | Description                                                                                                                                                                                                                                                                    | Default                                                                                                                         |
-   | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-   | `drainOnUpgrade`   | Controls the node drain behavior during a cluster upgrade. `true` means nodes will be drained. `false` means nodes will not be drained. `auto` means nodes will only be drained for multi-node clusters, while single-node clusters will not drain nodes during an upgrade.    | `auto`                                                                                                                          |
-   | `drainPodSelector` | If `drainOnUpgrade` is set to `true` for either single-node or multi-node clusters, or set to `auto` for multi-node clusters, only pods matching the selectors will be drained. The default value avoids draining pods related to planning, or any critical Palette workloads. | `upgrade.cattle.io/plan!=control-plan,upgrade.cattle.io/plan!=worker-plan,app!=spectro,app!=spectro-proxy,app!=palette-webhook` |
+   | Parameter     | Description                                                                                                                                                                                                                                                                 | Default                                                                                                                         |
+   | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+   | `drainPods`   | Controls the node drain behavior during a cluster upgrade. `true` means nodes will be drained. `false` means nodes will not be drained. `auto` means nodes will only be drained for multi-node clusters, while single-node clusters will not drain nodes during an upgrade. | `auto`                                                                                                                          |
+   | `podSelector` | If `drainPods` is set to `true` for either single-node or multi-node clusters, or set to `auto` for multi-node clusters, only pods matching the selectors will be drained. The default value avoids draining pods related to planning, or any critical Palette workloads.   | `upgrade.cattle.io/plan!=control-plan,upgrade.cattle.io/plan!=worker-plan,app!=spectro,app!=spectro-proxy,app!=palette-webhook` |
 
 5. Create a new cluster with the updated cluster profile, or update an existing cluster to use the new cluster profile.
    For more information, refer to [Create a Cluster](../site-deployment/cluster-deployment.md) or
    [Update a Cluster](../../cluster-management/cluster-updates.md).
 
+   For existing clusters, when you update the profile without changing the `system.uri` parameter, these changes alone
+   will take effect and will not trigger any reboot or repave. The next time you made a change to the cluster profile
+   that will trigger a repave or reboot, the new draining settings will apply. For more information about cluster
+   behavior during upgrades, refer to [Edge Cluster Upgrade Behavior](../cluster-management/upgrade-behavior.md).
+
 ## Validate
 
-1. Update the cluster to use a new version of a cluster profile. For more information, refer to
-   [Update a Cluster](../../cluster-management/cluster-updates.md).
+1. Update the cluster to use a new version of a cluster profile. Ensure that your change will trigger a reboot or
+   repave. For more information, refer to [Update a Cluster](../../cluster-management/cluster-updates.md) and
+   [Edge Cluster Upgrade Behavior](../cluster-management/upgrade-behavior.md).
 
 2. After the upgrade is completed, use `kubectl logs` to check on a pod for which you skipped pod draining. Confirm that
    you do not see any messages that look like `Evicting pod <pod-name> as part of upgrade plan`. The absence of such

--- a/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
+++ b/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
@@ -8,9 +8,10 @@ hide_table_of_contents: false
 tags: ["edge"]
 ---
 
-When you apply a new cluster profile to your cluster, depending on your settings, the cluster may drain each node as it
-updates the pods on that node. This is helpful in multi-node clusters as it allows you to avoid or minimize application
-downtime.
+When you apply a new cluster profile to your cluster with changes that require node reboot or repave, the cluster may
+drain each node as it updates the pods on that node. This is helpful in multi-node clusters as it allows you to avoid or
+minimize application downtime. For more information what changes will cause reboot or repave, refer to
+[Edge Cluster Upgrade Behavior](../cluster-management/upgrade-behavior.md).
 
 However, the benefits of draining a node in a single-node cluster are minimal because there are no other nodes to
 schedule the workloads onto. In addition, if system-critical workloads are drained, the cluster may get stuck in an
@@ -46,10 +47,10 @@ will apply to both appliance mode and [agent mode](../../../deployment-modes/age
 
    The following table provides a brief description of the parameters.
 
-   | Parameter     | Description                                                                                                                                                                                                                                                                                                                                                                              | Default |
-   | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-   | `drainPods`   | Controls the node drain behavior during a cluster upgrade. `true` means nodes will be drained. `false` means nodes will not be drained. `auto` means nodes will only be drained for multi-node clusters, while single-node clusters will not drain nodes during an upgrade.                                                                                                              | `auto`  |
-   | `podSelector` | If `drainPods` is set to `true` for either single-node or multi-node clusters, or set to `auto` for multi-node clusters, only pods matching the selectors will be drained. Pods with any of the following labels are always protected from draining: `upgrade.cattle.io/plan=control-plan`,`upgrade.cattle.io/plan=worker-plan`,`app=spectro`,`app=spectro-proxy` ,`app=palette-webhook` | None    |
+   | Parameter     | Description                                                                                                                                                                                                                                                                                                                                                                                            | Default |
+   | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+   | `drainPods`   | Controls the node drain behavior during a cluster upgrade. `true` means nodes will be drained. `false` means nodes will not be drained. `auto` means nodes will only be drained for multi-node clusters, while single-node clusters will not drain nodes during an upgrade.                                                                                                                            | `auto`  |
+   | `podSelector` | If `drainPods` is set to `true` for either single-node or multi-node clusters, or set to `auto` for multi-node clusters, only pods matching the selectors will be drained. <br /> <br /> Pods with any of the following labels are always protected from draining: `upgrade.cattle.io/plan=control-plan`,`upgrade.cattle.io/plan=worker-plan`,`app=spectro`,`app=spectro-proxy` ,`app=palette-webhook` | None    |
 
    :::warning
 
@@ -67,7 +68,7 @@ will apply to both appliance mode and [agent mode](../../../deployment-modes/age
    [Update a Cluster](../../cluster-management/cluster-updates.md).
 
    For existing clusters, when you update the profile without changing the `system.uri` parameter, these changes alone
-   will take effect and will not trigger any reboot or repave. The next time you made a change to the cluster profile
+   will take effect and will not trigger any reboot or repave. The next time you make a change to the cluster profile
    that will trigger a repave or reboot, the new draining settings will apply. For more information about cluster
    behavior during upgrades, refer to [Edge Cluster Upgrade Behavior](../cluster-management/upgrade-behavior.md).
 
@@ -77,6 +78,6 @@ will apply to both appliance mode and [agent mode](../../../deployment-modes/age
    repave. For more information, refer to [Update a Cluster](../../cluster-management/cluster-updates.md) and
    [Edge Cluster Upgrade Behavior](../cluster-management/upgrade-behavior.md).
 
-2. After the upgrade is completed, use `kubectl logs` to check on a pod for which you skipped pod draining. Confirm that
-   you do not see any messages that look like `Evicting pod <pod-name> as part of upgrade plan`. The absence of such
-   messages means that the pods were not drained during the upgrade.
+2. After the upgrade is completed, use `kubectl logs` to check on a node for which you skipped pod draining. Confirm
+   that you do not see any messages that look like `Evicting pod <pod-name> as part of upgrade plan`. The absence of
+   such messages means that the pods were not drained during the upgrade.

--- a/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
+++ b/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
@@ -23,7 +23,7 @@ will apply to both appliance mode and [agent mode](../../../deployment-modes/age
 
 - An Edge-type cluster profile.
 
-- An Edge device registered with your Palette account or an existing Edge cluster. For more information, refer to
+- An host registered with your Palette account or an existing Edge-type cluster. For more information, refer to
   [Edge Host Registration](../site-deployment/site-installation/edge-host-registration.md) and
   [Deployment](../site-deployment/site-deployment.md).
 
@@ -50,6 +50,17 @@ will apply to both appliance mode and [agent mode](../../../deployment-modes/age
    | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
    | `drainPods`   | Controls the node drain behavior during a cluster upgrade. `true` means nodes will be drained. `false` means nodes will not be drained. `auto` means nodes will only be drained for multi-node clusters, while single-node clusters will not drain nodes during an upgrade. | `auto`                                                                                                                          |
    | `podSelector` | If `drainPods` is set to `true` for either single-node or multi-node clusters, or set to `auto` for multi-node clusters, only pods matching the selectors will be drained. The default value avoids draining pods related to planning, or any critical Palette workloads.   | `upgrade.cattle.io/plan!=control-plan,upgrade.cattle.io/plan!=worker-plan,app!=spectro,app!=spectro-proxy,app!=palette-webhook` |
+
+   :::warning
+
+   In single-node clusters, disabling node draining means normal workloads and the upgrade process happen in parallel.
+   This will increase memory usage, and may cause problems if your host is memory-constrained.
+
+   In such cases, you may set the `pack.drainPods` parameter to `true`, and set `pack.disableEviction` to `true`. This
+   will prevent the drain process from hanging indefinitely due to `PodDisruptionBudget` constraints, while the default
+   `podSelector` will protect most critical pods.
+
+   :::
 
 5. Create a new cluster with the updated cluster profile, or update an existing cluster to use the new cluster profile.
    For more information, refer to [Create a Cluster](../site-deployment/cluster-deployment.md) or

--- a/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
+++ b/docs/docs-content/clusters/edge/cluster-management/skip-draining.md
@@ -9,7 +9,7 @@ tags: ["edge"]
 ---
 
 When you apply a new cluster profile to your cluster, depending on your settings, the cluster may drain each node as it
-updates the pods on that node. This is helpful in multi-node clusters as it allow you to avoid or minimize application
+updates the pods on that node. This is helpful in multi-node clusters as it allows you to avoid or minimize application
 downtime.
 
 However, the benefits of draining a node in a single-node cluster are minimal because there are no other nodes to
@@ -46,15 +46,15 @@ will apply to both appliance mode and [agent mode](../../../deployment-modes/age
 
    The following table provides a brief description of the parameters.
 
-   | Parameter     | Description                                                                                                                                                                                                                                                                 | Default                                                                                                                         |
-   | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-   | `drainPods`   | Controls the node drain behavior during a cluster upgrade. `true` means nodes will be drained. `false` means nodes will not be drained. `auto` means nodes will only be drained for multi-node clusters, while single-node clusters will not drain nodes during an upgrade. | `auto`                                                                                                                          |
-   | `podSelector` | If `drainPods` is set to `true` for either single-node or multi-node clusters, or set to `auto` for multi-node clusters, only pods matching the selectors will be drained. The default value avoids draining pods related to planning, or any critical Palette workloads.   | `upgrade.cattle.io/plan!=control-plan,upgrade.cattle.io/plan!=worker-plan,app!=spectro,app!=spectro-proxy,app!=palette-webhook` |
+   | Parameter     | Description                                                                                                                                                                                                                                                                                                                                                                              | Default |
+   | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+   | `drainPods`   | Controls the node drain behavior during a cluster upgrade. `true` means nodes will be drained. `false` means nodes will not be drained. `auto` means nodes will only be drained for multi-node clusters, while single-node clusters will not drain nodes during an upgrade.                                                                                                              | `auto`  |
+   | `podSelector` | If `drainPods` is set to `true` for either single-node or multi-node clusters, or set to `auto` for multi-node clusters, only pods matching the selectors will be drained. Pods with any of the following labels are always protected from draining: `upgrade.cattle.io/plan=control-plan`,`upgrade.cattle.io/plan=worker-plan`,`app=spectro`,`app=spectro-proxy` ,`app=palette-webhook` | None    |
 
    :::warning
 
    In single-node clusters, disabling node draining means normal workloads and the upgrade process happen in parallel.
-   This will increase memory usage, and may cause problems if your host is memory-constrained.
+   This will increase memory usage, and may cause your node to become unresponsive if your host is memory-constrained.
 
    In such cases, you may set the `pack.drainPods` parameter to `true`, and set `pack.disableEviction` to `true`. This
    will prevent the drain process from hanging indefinitely due to `PodDisruptionBudget` constraints, while the default

--- a/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
@@ -3,7 +3,7 @@ sidebar_label: "Edge Cluster Upgrade Behavior"
 title: "Edge Cluster Upgrade Behavior"
 description: "Learn about how Palette Edge responds to upgrades of the cluster profile."
 hide_table_of_contents: false
-sidebar_position: 80
+sidebar_position: 10
 tags: ["edge", "architecture"]
 ---
 


### PR DESCRIPTION
## Describe the Change

This PR adds instructions on how to skip node draining when running cluster upgrades. 

## Changed Pages

💻 [Preview URL for Page](https://deploy-preview-4851--docs-spectrocloud.netlify.app/clusters/edge/cluster-management/skip-draining/)

## Jira Tickets

🎫 [PE-5647](https://spectrocloud.atlassian.net/issues/PE-5647?filter=11884)

## Backports

Can this PR be backported?

- [ ] No. _Please leave a short comment below about why this PR cannot be backported._Release PR. 


[PE-5647]: https://spectrocloud.atlassian.net/browse/PE-5647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ