### PR TITLE
chore: added filter to exclude cves not ready for publication

### DIFF
--- a/utils/cves/index.js
+++ b/utils/cves/index.js
@@ -56,6 +56,11 @@ async function generateCVEs() {
             field: "spec.impact.impactedDeployments.connected",
             operator: "ex",
           },
+          {
+            field: "status.state",
+            options: ["Analyzed", "Modified"],
+            operator: "in",
+          },
         ],
       });
       const paletteAirgap = await getSecurityBulletins({
@@ -72,6 +77,11 @@ async function generateCVEs() {
           {
             field: "spec.impact.impactedDeployments.airgap",
             operator: "ex",
+          },
+          {
+            field: "status.state",
+            options: ["Analyzed", "Modified"],
+            operator: "in",
           },
         ],
       });
@@ -90,6 +100,11 @@ async function generateCVEs() {
             field: "spec.impact.impactedDeployments.connected",
             operator: "ex",
           },
+          {
+            field: "status.state",
+            options: ["Analyzed", "Modified"],
+            operator: "in",
+          },
         ],
       });
       const vertexAirgap = await getSecurityBulletins({
@@ -106,6 +121,11 @@ async function generateCVEs() {
           {
             field: "spec.impact.impactedDeployments.airgap",
             operator: "ex",
+          },
+          {
+            field: "status.state",
+            options: ["Analyzed", "Modified"],
+            operator: "in",
           },
         ],
       });


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds an additional filter that removes CVE items that are not yet ready for publication.

This is the new filter added to the query payload.
```js
  {
    field: "status.state",
    options: ["Analyzed", "Modified"],
    operator: "in",
  },
```

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page](https://deploy-preview-4869--docs-spectrocloud.netlify.app/security-bulletins/reports/#palette)



## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
