### PR TITLE
chore: update filters

### DIFF
--- a/src/components/CveReportsTable/CveReportsTable.tsx
+++ b/src/components/CveReportsTable/CveReportsTable.tsx
@@ -51,6 +51,7 @@ interface MinimizedCve {
     cvssScore: number;
     cvePublishedTimestamp: string;
     cveLastModifiedTimestamp: string;
+    advLastModifiedTimestamp: string;
   };
   spec: {
     assessment: {
@@ -99,6 +100,7 @@ export default function CveReportsTable() {
         cvssScore: entry.metadata.cvssScore,
         cvePublishedTimestamp: entry.metadata.cvePublishedTimestamp,
         cveLastModifiedTimestamp: entry.metadata.cveLastModifiedTimestamp,
+        advLastModifiedTimestamp: entry.metadata.advLastModifiedTimestamp,
       },
       spec: {
         assessment: {
@@ -160,12 +162,12 @@ export default function CveReportsTable() {
       },
       {
         title: "Modified Date",
-        dataIndex: ["metadata", "cveLastModifiedTimestamp"],
-        key: "modifiedDateTime",
+        dataIndex: ["metadata", "advLastModifiedTimestamp"],
+        key: "advLastModifiedTimestamp",
         sorter: (a, b) =>
-          new Date(a.metadata.cveLastModifiedTimestamp).getTime() -
-          new Date(b.metadata.cveLastModifiedTimestamp).getTime(),
-        render: (text: string) => new Date(text).toLocaleDateString(),
+          new Date(a.metadata.advLastModifiedTimestamp).getTime() -
+          new Date(b.metadata.advLastModifiedTimestamp).getTime(),
+        render: (value: string) => (value ? new Date(value).toLocaleDateString() : "N/A"),
         defaultSortOrder: "descend",
       },
       {

--- a/utils/cves/index.js
+++ b/utils/cves/index.js
@@ -58,7 +58,7 @@ async function generateCVEs() {
           },
           {
             field: "status.state",
-            options: ["Analyzed", "Modified"],
+            options: ["Analyzed", "Modified", "Awaiting Analyses", "Reopened"],
             operator: "in",
           },
         ],
@@ -80,7 +80,7 @@ async function generateCVEs() {
           },
           {
             field: "status.state",
-            options: ["Analyzed", "Modified"],
+            options: ["Analyzed", "Modified", "Awaiting Analyses", "Reopened"],
             operator: "in",
           },
         ],
@@ -102,7 +102,7 @@ async function generateCVEs() {
           },
           {
             field: "status.state",
-            options: ["Analyzed", "Modified"],
+            options: ["Analyzed", "Modified", "Awaiting Analyses", "Reopened"],
             operator: "in",
           },
         ],
@@ -124,7 +124,7 @@ async function generateCVEs() {
           },
           {
             field: "status.state",
-            options: ["Analyzed", "Modified"],
+            options: ["Analyzed", "Modified", "Awaiting Analyses", "Reopened"],
             operator: "in",
           },
         ],


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the filters for the security bulletin filters. It also includes an update to the field used for the last modified column. Switching to `advLastModifiedTimestamp` per the security team's guidance.

## Changes

💻 [Preview URL](https://deploy-preview-4878--docs-spectrocloud.netlify.app/security-bulletins/reports/#palette)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
