### PR TITLE
Fix CVE URL logic

### DIFF
--- a/src/components/CveReportsTable/CveReportsTable.tsx
+++ b/src/components/CveReportsTable/CveReportsTable.tsx
@@ -173,7 +173,7 @@ export default function CveReportsTable() {
         sorter: (a, b) => a.metadata.cve.localeCompare(b.metadata.cve),
         render: (cve: string, record) => {
           return (
-            <Link to={record.metadata.uid} style={{ color: "#1890ff" }}>
+            <Link to={`/security-bulletins/reports/${record.metadata.uid.toLowerCase()}`} style={{ color: "#1890ff" }}>
               {cve}
             </Link>
           );

--- a/utils/cves/index.js
+++ b/utils/cves/index.js
@@ -7,6 +7,7 @@ const { formatDateCveDetails } = require("../helpers/date");
 const { escapeMDXSpecialChars } = require("../helpers/string");
 const { generateMarkdownTable } = require("../helpers/affected-table");
 const { generateRevisionHistory } = require("../helpers/revision-history");
+const { generateCVEOfficialDetailsUrl } = require("../helpers/urls");
 
 async function getSecurityBulletins(payload) {
   const limit = 100;
@@ -269,7 +270,7 @@ tags: ["security", "cve"]
 
 ## CVE Details
 
-[${upperCaseCve}](https://nvd.nist.gov/vuln/detail/${upperCaseCve})
+Visit the official vulnerability details page for [${upperCaseCve}](${generateCVEOfficialDetailsUrl(item.metadata.cve)}) to learn more.
 
 ## Initial Publication
 
@@ -288,7 +289,7 @@ ${escapeMDXSpecialChars(item.metadata.summary)}
 
 ## CVE Severity
 
-${item.metadata.cvssScore}
+[${item.metadata.cvssScore}](${generateCVEOfficialDetailsUrl(item.metadata.cve)})
 
 ## Our Official Summary
 

--- a/utils/helpers/urls.js
+++ b/utils/helpers/urls.js
@@ -1,0 +1,28 @@
+// generateCVEOfficialDetailsUrl returns a URL that is used to link to the official CVE report.
+// The URL is generated based on the cveId.
+// The function checks if the cveId starts with "ghsa" and returns a GitHub Security Advisory URL. Other formal sites can be added in the future.
+// The default URL is the NVD official CVE report.
+function generateCVEOfficialDetailsUrl(cveId) {
+  let url;
+
+  // If cveId is empty, return the default reports page URL
+  if (!cveId) {
+    return "/security-bulletins/reports/";
+  }
+
+  switch (true) {
+    // GitHub Security Advisory
+    case cveId.toLocaleLowerCase().startsWith("ghsa"):
+      url = `https://github.com/advisories/${cveId.toLocaleLowerCase()}`;
+      break;
+    // Default CVE URL
+    default:
+      url = `https://nvd.nist.gov/vuln/detail/${cveId.toLocaleLowerCase()}`;
+  }
+
+  return url;
+}
+
+module.exports = {
+  generateCVEOfficialDetailsUrl,
+};

--- a/utils/helpers/urls.test.ts
+++ b/utils/helpers/urls.test.ts
@@ -1,0 +1,39 @@
+const { generateCVEOfficialDetailsUrl } = require("./urls");
+
+describe("generateCVEOfficialDetailsUrl", () => {
+  it("should generate the GitHub Security Advisory URL for CVEs starting with 'ghsa'", () => {
+    const cveId = "GHSA-27wf-5967-98gx";
+    const result = generateCVEOfficialDetailsUrl(cveId);
+    expect(result).toBe("https://github.com/advisories/ghsa-27wf-5967-98gx");
+  });
+
+  it("should handle 'ghsa' case-insensitively and generate the correct URL", () => {
+    const cveId = "ghsa-27wf-5967-98gx";
+    const result = generateCVEOfficialDetailsUrl(cveId);
+    expect(result).toBe("https://github.com/advisories/ghsa-27wf-5967-98gx");
+  });
+
+  it("should generate the NVD URL for a CVE ID not starting with 'ghsa'", () => {
+    const cveId = "CVE-2020-16156";
+    const result = generateCVEOfficialDetailsUrl(cveId);
+    expect(result).toBe("https://nvd.nist.gov/vuln/detail/cve-2020-16156");
+  });
+
+  it("should generate the NVD URL for another CVE ID not starting with 'ghsa'", () => {
+    const cveId = "CVE-2019-20838";
+    const result = generateCVEOfficialDetailsUrl(cveId);
+    expect(result).toBe("https://nvd.nist.gov/vuln/detail/cve-2019-20838");
+  });
+
+  it("should return the default reports page URL for an empty CVE ID", () => {
+    const cveId = "";
+    const result = generateCVEOfficialDetailsUrl(cveId);
+    expect(result).toBe("/security-bulletins/reports/");
+  });
+
+  it("should return the NVD URL for a CVE ID with mixed case and normalize it", () => {
+    const cveId = "CVE-2020-16156";
+    const result = generateCVEOfficialDetailsUrl(cveId);
+    expect(result).toBe("https://nvd.nist.gov/vuln/detail/cve-2020-16156");
+  });
+});


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes issues with CVE URLs that are not NIST based, such as GitHub security advisories.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page](https://deploy-preview-4936--docs-spectrocloud.netlify.app/security-bulletins/reports/#palette)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
