### PR TITLE
docs: fix stork links for portworx

### DIFF
--- a/docs/deprecated/integrations/portworx.md
+++ b/docs/deprecated/integrations/portworx.md
@@ -72,7 +72,7 @@ The default installation of Portworx will deploy the following components in the
 - [Lighthouse](https://portworx.com/blog/manage-portworx-clusters-using-lighthouse/)
 
 - [Stork](https://github.com/libopenstorage/stork) and
-  [Stork on Portworx](https://docs.portworx.com/portworx-enterprise/platform/openshift/ocp-gcp/operations/storage-operations/stork.html)
+  [Stork on Portworx](https://docs.portworx.com/portworx-enterprise/platform/openshift/ocp-gcp/operations/storage-operations/stateful-applications/stork)
 
 - Storage class making use of portworx-volume provisioner.
 

--- a/docs/deprecated/integrations/portworx_operator.md
+++ b/docs/deprecated/integrations/portworx_operator.md
@@ -89,7 +89,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 - `StorageClass` resource for dynamic provisioning of `PersistentVolumes`` using the `pxd.portworx.com` provisioner.
 
-- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html).
+- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stateful-applications/stork).
   Portworx's storage scheduler for Kubernetes.
 
 <!-- Optionally for Portworx 2.x, you can enable Lighthouse for basic monitoring of the Portworx cluster. -->
@@ -762,7 +762,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 - `StorageClass` resource for dynamic provisioning of `PersistentVolumes`` using the `pxd.portworx.com` provisioner.
 
-- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html).
+- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stateful-applications/stork).
   Portworx's storage scheduler for Kubernetes.
 
 - [Lighthouse](https://portworx.com/blog/manage-portworx-clusters-using-lighthouse/). Portworx's monitoring and alerting
@@ -1351,7 +1351,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 - `StorageClass` resource for dynamic provisioning of `PersistentVolumes`` using the `pxd.portworx.com` provisioner.
 
-- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html).
+- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stateful-applications/stork).
   Portworx's storage scheduler for Kubernetes.
 
 - [Lighthouse](https://portworx.com/blog/manage-portworx-clusters-using-lighthouse/). Portworx's monitoring and alerting
@@ -1906,7 +1906,7 @@ data "spectrocloud_pack_simple" "portworx-operator" {
 
 - [Portworx Supported Kubernetes versions](https://docs.portworx.com/portworx-enterprise/install-portworx/prerequisites#supported-kubernetes-versions)
 
-- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html)
+- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stateful-applications/stork)
 
 - [Portworx Central](https://docs.portworx.com/portworx-central-on-prem/install/px-central.html)
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

Fix some broken stork links. They were correctly redirecting after removing the `.hmtl`, but setting to correct full URL.

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
