### PR TITLE
ci: fix GitHub action issue

### DIFF
--- a/.github/workflows/packs-data.yaml
+++ b/.github/workflows/packs-data.yaml
@@ -5,6 +5,9 @@ on:
     # Runs at 5 minutes past the hour, every 6 hours.
     - cron: "5 */6 * * *"
   workflow_dispatch:
+  pull_request:
+    branches-ignore: "master"
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY }}

--- a/.github/workflows/packs-data.yaml
+++ b/.github/workflows/packs-data.yaml
@@ -5,7 +5,7 @@ on:
     # Runs at 5 minutes past the hour, every 6 hours.
     - cron: "5 */6 * * *"
   workflow_dispatch:
-  pull_request:
+  push:
     branches-ignore: "master"
 
 env:

--- a/.github/workflows/packs-data.yaml
+++ b/.github/workflows/packs-data.yaml
@@ -5,8 +5,6 @@ on:
     # Runs at 5 minutes past the hour, every 6 hours.
     - cron: "5 */6 * * *"
   workflow_dispatch:
-  push:
-    branches-ignore: "master"
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,14 +42,6 @@ jobs:
         run: |
           gsutil cp gs://docs-education-automation/packs_inventory/packs_report.json  ./packs_report.json
 
-      # - uses: actions-hub/gcloud@master
-      #   env:
-      #     PROJECT_ID: spectro-common-dev
-      #     APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-      #   with:
-      #     args: cp gs://docs-education-automation/packs_inventory/packs_report.json  ./packs_report.json
-      #     cli: gsutil
-
       - name: Upload to S3
         run: |
           aws s3 cp ./packs_report.json s3://docs.spectrocloud.com/packs-data/
@@ -59,12 +49,12 @@ jobs:
           aws s3 cp ./packs_report.json s3://docs-latest.spectrocloud.com/packs-data/
           aws cloudfront create-invalidation --distribution-id ${{ secrets.LATEST_DOCS_DISTRIBUTION_ID }} --paths "/packs-data/packs_report.json"
 
-      # - name: Slack Notification
-      #   if: ${{ failure() }}
-      #   uses: rtCamp/action-slack-notify@v2.3.2
-      #   env:
-      #     SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
-      #     SLACK_USERNAME: "spectromate"
-      #     SLACK_ICON_EMOJI: ":robot:"
-      #     SLACK_COLOR: ${{ job.status }}
-      #     SLACK_MESSAGE: 'The Docs cron job that generates the `packs.json` file failed. Please check the logs for more details.'
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2.3.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
+          SLACK_USERNAME: "spectromate"
+          SLACK_ICON_EMOJI: ":robot:"
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: 'The Deprecated Docs cron job that generates the `packs.json` file failed. Please check the logs for more details.'

--- a/.github/workflows/packs-data.yaml
+++ b/.github/workflows/packs-data.yaml
@@ -26,13 +26,26 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
 
-      - uses: actions-hub/gcloud@master
-        env:
-          PROJECT_ID: spectro-common-dev
-          APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+
+      - uses: 'google-github-actions/auth@v2'
         with:
-          args: cp gs://docs-education-automation/packs_inventory/packs_report.json  ./packs_report.json
-          cli: gsutil
+          project_id: spectro-common-dev
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          cleanup_credentials: true
+
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: '>= 363.0.0'    
+
+      # - uses: actions-hub/gcloud@master
+      #   env:
+      #     PROJECT_ID: spectro-common-dev
+      #     APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+      #   with:
+      #     args: cp gs://docs-education-automation/packs_inventory/packs_report.json  ./packs_report.json
+      #     cli: gsutil
 
       - name: Upload to S3
         run: |

--- a/.github/workflows/packs-data.yaml
+++ b/.github/workflows/packs-data.yaml
@@ -29,18 +29,20 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
 
-
       - uses: 'google-github-actions/auth@v2'
         with:
           project_id: spectro-common-dev
           credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           cleanup_credentials: true
 
-
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
         with:
-          version: '>= 363.0.0'    
+          version: '>= 503.0.0'    
+
+      - name: 'Get Packs Data'
+        run: |
+          gsutil cp gs://docs-education-automation/packs_inventory/packs_report.json  ./packs_report.json
 
       # - uses: actions-hub/gcloud@master
       #   env:
@@ -57,12 +59,12 @@ jobs:
           aws s3 cp ./packs_report.json s3://docs-latest.spectrocloud.com/packs-data/
           aws cloudfront create-invalidation --distribution-id ${{ secrets.LATEST_DOCS_DISTRIBUTION_ID }} --paths "/packs-data/packs_report.json"
 
-      - name: Slack Notification
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
-          SLACK_USERNAME: "spectromate"
-          SLACK_ICON_EMOJI: ":robot:"
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: 'The Docs cron job that generates the `packs.json` file failed. Please check the logs for more details.'
+      # - name: Slack Notification
+      #   if: ${{ failure() }}
+      #   uses: rtCamp/action-slack-notify@v2.3.2
+      #   env:
+      #     SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
+      #     SLACK_USERNAME: "spectromate"
+      #     SLACK_ICON_EMOJI: ":robot:"
+      #     SLACK_COLOR: ${{ job.status }}
+      #     SLACK_MESSAGE: 'The Docs cron job that generates the `packs.json` file failed. Please check the logs for more details.'


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the GitHub Actions issues with the deprecated packs CI action. The former action that was causing the issue is now replaced with official GCP GitHub Actions.

Here is a recent [run](https://github.com/spectrocloud/librarium/actions/runs/12279058543/job/34262200293?pr=4973) with the new steps. 

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1508](https://spectrocloud.atlassian.net/browse/DOC-1508)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1508]: https://spectrocloud.atlassian.net/browse/DOC-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ