### PR TITLE
docs: add ip tables as a prerequisite

### DIFF
--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -63,7 +63,7 @@ Palette. You will then create a cluster profile and use the registered host to d
 
   - [jq](https://jqlang.github.io/jq/download/)
   - [Zstandard](https://facebook.github.io/zstd/)
-  - [Rsync](https://github.com/RsyncProject/rsync)
+  - [rsync](https://github.com/RsyncProject/rsync)
   - [systemd-timesyncd](https://www.freedesktop.org/software/systemd/man/latest/systemd-timesyncd.service.html)
   - [conntrack](https://conntrack-tools.netfilter.org/downloads.html). This requirement is specific for clusters that
     use PXKE as the Kubernetes layer.

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -64,9 +64,10 @@ Palette. You will then create a cluster profile and use the registered host to d
   - [jq](https://jqlang.github.io/jq/download/)
   - [Zstandard](https://facebook.github.io/zstd/)
   - [Rsync](https://github.com/RsyncProject/rsync)
-  - [`systemd-timesyncd`](https://www.freedesktop.org/software/systemd/man/latest/systemd-timesyncd.service.html)
+  - [systemd-timesyncd](https://www.freedesktop.org/software/systemd/man/latest/systemd-timesyncd.service.html)
   - [conntrack](https://conntrack-tools.netfilter.org/downloads.html). This requirement is specific for clusters that
     use PXKE as the Kubernetes layer.
+  - [iptables](https://linux.die.net/man/8/iptables)
   - (Airgap only) [Crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) is installed and
     available.
   - (Airgap only) [Palette Edge CLI](../../spectro-downloads.md#palette-edge-cli) is installed and available.

--- a/docs/docs-content/deployment-modes/controller-mode.md
+++ b/docs/docs-content/deployment-modes/controller-mode.md
@@ -42,12 +42,11 @@ You can deploy clusters in controller mode across a range of environments to mee
 table below provides an overview of the different use cases and the corresponding supported environments for controller
 mode deployments.
 
-| Use Case          | Supported Environments                                                                                                                           |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Public Cloud**  | [AWS](../clusters/public-cloud/aws/aws.md)<br />[Azure](../clusters/public-cloud/azure/azure.md)<br />[GCP](../clusters/public-cloud/gcp/gcp.md) |
-| **Data Center**   | [VMware vSphere](../clusters/data-center/vmware/vmware.md)                                                                                       |
-| **Bare Metal**    | [MAAS](../clusters/data-center/maas/maas.md)                                                                                                     |
-| **Private Cloud** | [Nutanix](../clusters/data-center/nutanix/nutanix.md)<br />[Openstack](../clusters/data-center/openstack.md)                                     |
+| Use Case         | Supported Environments                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Public Cloud** | [AWS](../clusters/public-cloud/aws/aws.md)<br />[Azure](../clusters/public-cloud/azure/azure.md)<br />[GCP](../clusters/public-cloud/gcp/gcp.md)                                |
+| **Data Center**  | [VMware vSphere](../clusters/data-center/vmware/vmware.md) <br /> [Nutanix](../clusters/data-center/nutanix/nutanix.md) <br />[Openstack](../clusters/data-center/openstack.md) |
+| **Bare Metal**   | [MAAS](../clusters/data-center/maas/maas.md)                                                                                                                                    |
 
 ## Resources
 


### PR DESCRIPTION
## Describe the Change

This PR adds iptables as a prerequisite for agent mode. 

## Changed Pages

💻 [Add Preview URL for Page]()

## Jira Tickets

🎫 [DOC-1509](https://spectrocloud.atlassian.net/browse/DOC-1509)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1509]: https://spectrocloud.atlassian.net/browse/DOC-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ