### PR TITLE
docs: replace cve-reports as skipped path DOC-1503

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ ALOGLIA_CONFIG=$(shell cat docsearch.dev.config.json | jq -r tostring)
 # Remove all /deprecated paths because we don't want to maintain their links
 VERIFY_URL_PATHS=$(shell find ./docs -name "*.md" | cut -c 3- | \
 	sed '/security-bulletins/d' | \
+	sed '/cve-reports/d' | \
 	sed '/oss-licenses/d' | \
 	sed '/deprecated/d' )
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR replaces `cve-reports` as a skipped match, as we want the `unlisted/cve-reports.md` file to be checked by the rate limited job instead. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

No user facing changes. 

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1503](https://spectrocloud.atlassian.net/browse/DOC-1503)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._

[DOC-1503]: https://spectrocloud.atlassian.net/browse/DOC-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ