### PR TITLE
[version-4-3] docs: add kubernetes requirements to self-hosted, vertex and pcg DOC-1519 (#5056)

### DIFF
--- a/_partials/self-hosted/_kubernetes_palette_versions.mdx
+++ b/_partials/self-hosted/_kubernetes_palette_versions.mdx
@@ -1,0 +1,22 @@
+---
+partial_category: self-hosted
+partial_name: kubernetes-palette-versions
+---
+
+| **Palette Version** | **Kubernetes Version** | **OVA Download URL**                                                        | **FIPS OVA Download URL**                                                      |
+| ------------------- | ---------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| 4.5.11              | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
+| 4.5.10              | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
+| 4.5.8               | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
+| 4.5.5               | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
+| 4.5.4               | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
+| 4.5.3               | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
+| 4.4.20              | 1.28.13                | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova`         | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-12813-fips.ova`         |
+| 4.4.18              | 1.28.13                | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova`         | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-12813-fips.ova`         |
+| 4.4.14              | 1.28.12                | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12812-0.ova`         | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-12812-fips.ova`         |
+| 4.4.11              | 1.28.11                | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1289-0.ova`  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1289-fips.ova`  |
+| 4.4.6               | 1.28.9                 | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1289-0.ova`  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1289-fips.ova`  |
+| 4.3.6               | 1.27.11                | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12711-0.ova` | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12711-fips.ova` |
+| 4.2.13              | 1.26.10                | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12610-0.ova` | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12610-fips.ova` |
+| 4.2.7               | 1.26.10                | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12610-0.ova` | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12610-fips.ova` |
+| 4.1.12              | 1.26.8                 | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1268-0.ova`  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1268-fips.ova`  |

--- a/_partials/self-hosted/_kubernetes_palette_versions.mdx
+++ b/_partials/self-hosted/_kubernetes_palette_versions.mdx
@@ -5,17 +5,6 @@ partial_name: kubernetes-palette-versions
 
 | **Palette Version** | **Kubernetes Version** | **OVA Download URL**                                                        | **FIPS OVA Download URL**                                                      |
 | ------------------- | ---------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| 4.5.11              | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
-| 4.5.10              | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
-| 4.5.8               | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
-| 4.5.5               | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
-| 4.5.4               | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
-| 4.5.3               | 1.29.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1299-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`          |
-| 4.4.20              | 1.28.13                | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova`         | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-12813-fips.ova`         |
-| 4.4.18              | 1.28.13                | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova`         | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-12813-fips.ova`         |
-| 4.4.14              | 1.28.12                | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12812-0.ova`         | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-12812-fips.ova`         |
-| 4.4.11              | 1.28.11                | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1289-0.ova`  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1289-fips.ova`  |
-| 4.4.6               | 1.28.9                 | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1289-0.ova`  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1289-fips.ova`  |
 | 4.3.6               | 1.27.11                | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12711-0.ova` | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12711-fips.ova` |
 | 4.2.13              | 1.26.10                | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12610-0.ova` | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12610-fips.ova` |
 | 4.2.7               | 1.26.10                | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12610-0.ova` | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12610-fips.ova` |

--- a/docs/docs-content/clusters/pcg/deploy-pcg-k8s.md
+++ b/docs/docs-content/clusters/pcg/deploy-pcg-k8s.md
@@ -71,6 +71,9 @@ development and testing environments.
     to the [PCG Sizing](#pcg-sizing) section for more information.
   - A Container Network Interface plugin installed.
   - A Container Storage Interface plugin installed.
+  - The Kubernetes cluster must be set up on a version of Kubernetes that is compatible to your PCG version. Refer to
+    the [Kubernetes Requirements](./pcg.md#kubernetes-requirements) section to find the version required for your
+    Palette installation
 
 - PCG IP address requirements:
 

--- a/docs/docs-content/clusters/pcg/pcg.md
+++ b/docs/docs-content/clusters/pcg/pcg.md
@@ -31,6 +31,21 @@ existing Kubernetes cluster. Refer to the table below to learn more about the su
 | VMware vSphere | ✅                   | The PCG is deployed into a VMware vSphere environment.                                          | [Deploy to VMware vSphere](./deploy-pcg/vmware.md)                    |
 | Other          | ❌                   | The PCG cluster is deployed into an existing Kubernetes cluster that is not managed by Palette. | [Deploy a PCG to an Existing Kubernetes Cluster](./deploy-pcg-k8s.md) |
 
+## Kubernetes Requirements
+
+The following table presents the Kubernetes version corresponding to each Palette version. It provides the download URLs
+for the Operating System and Kubernetes distribution OVA required for the PCG install. Ensure that you use FIPS OVA URL
+if you require a <VersionedLink text="FIPS" url="/vertex/fips/" /> compliant installation.
+
+:::warning
+
+The versions included in the following table apply for PCG installs on VMware vSphere and MAAS. The Kubernetes version
+for OpenStack is 1.24.10 on all the Palette versions included below.
+
+:::
+
+<PartialsComponent category="self-hosted" name="kubernetes-palette-versions" />
+
 ## Resources
 
 - [Architecture](./architecture.md)

--- a/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/airgap-install/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/airgap-install/install.md
@@ -34,7 +34,9 @@ Complete the [Environment Setup](./kubernetes-airgap-instructions.md) steps befo
 
 - Ensure `unzip` or a similar extraction utility is installed on your system.
 
-- The Kubernetes cluster must be set up on a supported version of Kubernetes, which includes versions v1.25 to v1.27.
+- The Kubernetes cluster must be set up on a supported version of Kubernetes. Refer to the
+  [Kubernetes Requirements](../../install-palette.md#kubernetes-requirements) section to find the version required for
+  your Palette installation.
 
 - Ensure the Kubernetes cluster does not have Cert Manager installed. Palette requires a unique Cert Manager
   configuration to be installed as part of the installation process. If Cert Manager is already installed, you must

--- a/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/install.md
@@ -23,7 +23,9 @@ You can use the Palette Helm Chart to install Palette in a multi-node Kubernetes
 
 - Ensure `unzip` or a similar extraction utility is installed on your system.
 
-- The Kubernetes cluster must be set up on a supported version of Kubernetes, which includes versions v1.25 to v1.27.
+- The Kubernetes cluster must be set up on a supported version of Kubernetes. Refer to the
+  [Kubernetes Requirements](../install-palette.md#kubernetes-requirements) section to find the version required for your
+  Palette installation.
 
 - Ensure the Kubernetes cluster does not have Cert Manager installed. Palette requires a unique Cert Manager
   configuration to be installed as part of the installation process. If Cert Manager is already installed, you must

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -365,7 +365,8 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
 23. Right-click on your cluster or resource group and select **Deploy OVF Template**.
 
 24. In the **Deploy OVF Template** wizard, enter the following URL to import the Operating System (OS) and Kubernetes
-    distribution OVA required for the installation. Contact your support representative to learn if the version of
+    distribution OVA required for the installation. Refer to the
+    [Kubernetes Requirements](../../../install-palette.md#kubernetes-requirements) section to learn if the version of
     Palette you are installing requires a new OS and Kubernetes OVA.
 
         Consider the following example for reference.

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -366,7 +366,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
 
 24. In the **Deploy OVF Template** wizard, enter the following URL to import the Operating System (OS) and Kubernetes
     distribution OVA required for the installation. Refer to the
-    [Kubernetes Requirements](../../../install-palette.md#kubernetes-requirements) section to learn if the version of
+    [Kubernetes Requirements](../../install-palette.md#kubernetes-requirements) section to learn if the version of
     Palette you are installing requires a new OS and Kubernetes OVA.
 
         Consider the following example for reference.

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -98,12 +98,10 @@ Use the following steps to install Palette.
 2.  Create a vSphere VM and Template folder with the name `spectro-templates`. Ensure this folder is accessible by the
     user account you will use to deploy the Palette installation.
 
-3.  Use the URL below to import the Operating System and Kubernetes distribution OVA required for the install. Place the
-    OVA in the `spectro-templates` folder.
-
-    ```url
-    https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova
-    ```
+3.  Find the OVA download URL corresponding to your Palette version in the
+    [Kubernetes Requirements](../install-palette.md#kubernetes-requirements) section. Use the identified URL to import
+    the Operating System and Kubernetes distribution OVA required for the install. Place the OVA in the
+    `spectro-templates` folder.
 
 4.  Append an `r_` prefix to the OVA name and remove the `.ova` suffix after the import. For example, the final output
     should look like `r_u-2204-0-k-12813-0`. This naming convention is required for the install process to identify the

--- a/docs/docs-content/enterprise-version/install-palette/install-palette.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-palette.md
@@ -62,6 +62,14 @@ active nodes and pods at any given time.
 | Medium (Recommended) | Up to 3000 Nodes each with 30 Pods (90,000 Pods)  |
 | Large                | Up to 5000 Nodes each with 30 Pods (150,000 Pods) |
 
+## Kubernetes Requirements
+
+The following table presents the Kubernetes version corresponding to each Palette version. It provides the download URLs
+for the Operating System and Kubernetes distribution OVA required for the install. Ensure that you use FIPS OVA URL if
+you require a <VersionedLink text="FIPS" url="/vertex/fips/" /> compliant installation.
+
+<PartialsComponent category="self-hosted" name="kubernetes-palette-versions" />
+
 ## Proxy Requirements
 
 <PartialsComponent category="self-hosted" name="required-domains" edition="Palette" />

--- a/docs/docs-content/enterprise-version/upgrade/upgrade-k8s/airgap.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade-k8s/airgap.md
@@ -45,6 +45,10 @@ Palette upgrade.
 - Access to the latest Palette Helm Chart. Refer to [Access Palette](/enterprise-version/#access-palette) for more
   details.
 
+- The Kubernetes cluster must be set up on a version of Kubernetes that is compatible to your upgraded version. Refer to
+  the [Kubernetes Requirements](../../install-palette/install-palette.md#kubernetes-requirements) section to find the
+  version required for your Palette installation.
+
 ## Upgrade
 
 1.  Log in to the Linux environment from which you can access your self-hosted airgap Palette instance.

--- a/docs/docs-content/enterprise-version/upgrade/upgrade-k8s/non-airgap.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade-k8s/non-airgap.md
@@ -36,6 +36,10 @@ Palette upgrade.
 - Access to the latest Palette Helm Chart. Refer to [Access Palette](/enterprise-version/#access-palette) for more
   details.
 
+- The Kubernetes cluster must be set up on a version of Kubernetes that is compatible to your upgraded version. Refer to
+  the [Kubernetes Requirements](../../install-palette/install-palette.md#kubernetes-requirements) section to find the
+  version required for your Palette installation.
+
 ## Upgrade
 
 :::info

--- a/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/airgap.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/airgap.md
@@ -39,6 +39,10 @@ Palette upgrade.
 
 - A diff or text comparison tool of your choice.
 
+- The Kubernetes cluster must be set up on a version of Kubernetes that is compatible to your upgraded version. Refer to
+  the [Kubernetes Requirements](../../install-palette/install-palette.md#kubernetes-requirements) section to find the
+  version required for your Palette installation.
+
 ## Upgrade
 
 :::info

--- a/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/non-airgap.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/non-airgap.md
@@ -28,6 +28,9 @@ Palette upgrade.
 
 - Access to the Palette system console.
 - A diff or text comparison tool of your choice.
+- The Kubernetes cluster must be set up on a version of Kubernetes that is compatible to your upgraded version. Refer to
+  the [Kubernetes Requirements](../../install-palette/install-palette.md#kubernetes-requirements) section to find the
+  version required for your Palette installation.
 
 ## Upgrade
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/install.md
@@ -34,7 +34,9 @@ Complete the [Environment Setup](./kubernetes-airgap-instructions.md) steps befo
 
 - Ensure `unzip` or a similar extraction utility is installed on your system.
 
-- The Kubernetes cluster must be set up on a supported version of Kubernetes, which includes versions v1.25 to v1.27.
+- The Kubernetes cluster must be set up on a version of Kubernetes that is compatible to your upgraded version. Refer to
+  the [Kubernetes Requirements](../../install-palette-vertex.md#kubernetes-requirements) section to find the version
+  required for your Palette installation.
 
 - Ensure the Kubernetes cluster does not have Cert Manager installed. VerteX requires a unique Cert Manager
   configuration to be installed as part of the installation process. If Cert Manager is already installed, you must

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/install.md
@@ -28,7 +28,9 @@ has the necessary network connectivity for VerteX to operate successfully.
 
 - Ensure `unzip` or a similar extraction utility is installed on your system.
 
-- The Kubernetes cluster must be set up on a supported version of Kubernetes, which includes versions v1.25 to v1.27.
+- The Kubernetes cluster must be set up on a version of Kubernetes that is compatible to your upgraded version. Refer to
+  the [Kubernetes Requirements](../install-palette-vertex.md#kubernetes-requirements) section to find the version
+  required for your Palette installation.
 
 - Ensure the Kubernetes cluster does not have Cert Manager installed. VerteX requires a unique Cert Manager
   configuration to be installed as part of the installation process. If Cert Manager is already installed, you must

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -371,7 +371,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
 
 24. In the **Deploy OVF Template** wizard, enter the following URL to import the Operating System (OS) and Kubernetes
     distribution OVA required for the installation. Refer to the
-    [Kubernetes Requirements](../../../install-palette-vertex.md#kubernetes-requirements) section to learn if the
+    [Kubernetes Requirements](../../install-palette-vertex.md#kubernetes-requirements) section to learn if the
     version of Palette you are installing requires a new OS and Kubernetes OVA.
 
         Consider the following example for reference.

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/vmware-vsphere-airgap-instructions.md
@@ -370,8 +370,9 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
 23. Next, right-click on your cluster or resource group and select **Deploy OVF Template**.
 
 24. In the **Deploy OVF Template** wizard, enter the following URL to import the Operating System (OS) and Kubernetes
-    distribution OVA required for the installation. Contact your support representative to learn if the version of
-    VerteX you are installing requires a new OS and Kubernetes OVA.
+    distribution OVA required for the installation. Refer to the
+    [Kubernetes Requirements](../../../install-palette-vertex.md#kubernetes-requirements) section to learn if the
+    version of Palette you are installing requires a new OS and Kubernetes OVA.
 
         Consider the following example for reference.
 

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -101,14 +101,12 @@ Use the following steps to install Palette VerteX.
 2.  Create a vSphere VM and Template folder with the name `spectro-templates`. Ensure this folder is accessible by the
     user account you will use to deploy the VerteX installation.
 
-3.  Use the URL below to import the Operating System and Kubernetes distribution OVA required for the install. Place the
-    OVA in the `spectro-templates` folder. Refer to the
+3.  Find the OVA download URL corresponding to your Palette VerteX version in the
+    [Kubernetes Requirements](../install-palette-vertex.md#kubernetes-requirements) section. Use the identified URL to
+    import the Operating System and Kubernetes distribution OVA required for the install. Place the OVA in the
+    `spectro-templates` folder. Refer to the
     [Import Items to a Content Library](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vm-administration/GUID-B413FBAE-8FCB-4598-A3C2-8B6DDA772D5C.html?hWord=N4IghgNiBcIJYFsAOB7ATgFwAQYKbIjDwGcQBfIA)
     guide for information about importing an OVA in vCenter.
-
-    ```url
-     https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12813-0.ova
-    ```
 
 4.  Append an `r_` prefix to the OVA name and remove the `.ova` suffix after the import. For example, the final output
     should look like `r_u-2204-0-k-12813-0`. This naming convention is required for the install process to identify the

--- a/docs/docs-content/vertex/install-palette-vertex/install-palette-vertex.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-palette-vertex.md
@@ -64,6 +64,14 @@ number of active nodes and pods at any given time.
 
 <br />
 
+## Kubernetes Requirements
+
+The following table presents the Kubernetes version corresponding to each Palette version. It provides the download URLs
+for the Operating System and Kubernetes distribution OVA required for the install. Ensure that you use FIPS OVA URL if
+you require a <VersionedLink text="FIPS" url="/vertex/fips/" /> compliant installation.
+
+<PartialsComponent category="self-hosted" name="kubernetes-palette-versions" />
+
 ## Proxy Requirements
 
 <PartialsComponent category="self-hosted" name="required-domains" edition="VerteX" />


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-3`:
 - [docs: add kubernetes requirements to self-hosted, vertex and pcg DOC-1519 (#5056)](https://github.com/spectrocloud/librarium/pull/5056)
