### PR TITLE
docs: slack notification for release to production (gh-action)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,8 +47,8 @@ jobs:
 
       - name: Force Failure
         run: | 
-        echo "CURRENT_STEP=Force Failure" >> $GITHUB_ENV
-        exit 1
+          echo "CURRENT_STEP=Force Failure" >> $GITHUB_ENV
+          exit 1
 
       - name: Checkout Repository
         run: echo "CURRENT_STEP=Checkout Repository" >> $GITHUB_ENV
@@ -132,7 +132,7 @@ jobs:
 
       - name: Versions
         run: |
-        echo "CURRENT_STEP=Versions" >> $GITHUB_ENV
+          echo "CURRENT_STEP=Versions" >> $GITHUB_ENV
       
       - name: Build
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,11 +44,6 @@ jobs:
     name: Build Website (Self-Hosted Runner)
     runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
     steps:
-
-      - name: Force Failure
-        run: exit 1
-
-
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,7 +164,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
         run: npx semantic-release
 
-      - name: Slack Notification
+      - name: Slack Notification on Failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2.3.2
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,9 +119,6 @@ jobs:
           echo "CURRENT_STEP=npm ci" >> $GITHUB_ENV
           npm ci
 
-      - name: Versions
-        run: |
-          echo "CURRENT_STEP=Versions" >> $GITHUB_ENV
       
       - name: Build
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,6 @@ jobs:
           exit 1
 
       - name: Checkout Repository
-        run: echo "CURRENT_STEP=Checkout Repository" >> $GITHUB_ENV
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -59,7 +58,6 @@ jobs:
 
 
       - name: Setup Node.js environment
-        run: echo "CURRENT_STEP=Setup Node.js environment" >> $GITHUB_ENV
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -78,7 +76,6 @@ jobs:
       
       - name: Build with cached packs
         if: ${{ env.BUILD_EXIT_CODE == '5' }}
-        run: echo "CURRENT_STEP=Build with cached packs" >> $GITHUB_ENV
         uses: ./.github/actions/build-cached-packs
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
@@ -112,7 +109,6 @@ jobs:
       labels: docbot
     steps:
       - name: Checkout Repository
-        run: echo "CURRENT_STEP=Checkout Repository" >> $GITHUB_ENV
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -120,7 +116,6 @@ jobs:
 
 
       - name: Setup Node.js environment
-        run: echo "CURRENT_STEP=Setup Node.js environment" >> $GITHUB_ENV
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -142,7 +137,6 @@ jobs:
           make build-ci
       
       - name: Build with cached packs
-        run: echo "CURRENT_STEP=Build with cached packs" >> $GITHUB_ENV
         if: ${{ env.BUILD_EXIT_CODE == '5' }}
         uses: ./.github/actions/build-cached-packs
         with:
@@ -175,14 +169,12 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        run: echo "CURRENT_STEP=Checkout Repository" >> $GITHUB_ENV
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Retrieve Credentials
-        run: echo "CURRENT_STEP=Retrieve Credentials" >> $GITHUB_ENV
         id: import-secrets
         uses: hashicorp/vault-action@v3.0.0
         with:
@@ -193,7 +185,6 @@ jobs:
           secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
 
       - name: Setup Nodejs
-        run: echo "CURRENT_STEP=Setup Nodejs" >> $GITHUB_ENV
         uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,12 +44,6 @@ jobs:
     name: Build Website (Self-Hosted Runner)
     runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
     steps:
-
-      - name: Force Failure
-        run: | 
-          echo "CURRENT_STEP=Force Failure" >> $GITHUB_ENV
-          exit 1
-
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,11 @@ jobs:
     name: Build Website (Self-Hosted Runner)
     runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
     steps:
+
+      - name: Force Failure
+        run: exit 1
+
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
@@ -158,3 +163,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
         run: npx semantic-release
+
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2.3.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
+          SLACK_USERNAME: "spectromate"
+          SLACK_ICON_EMOJI: ":robot_panic:"
+          SLACK_COLOR: "danger"
+          SLACKIFY_MARKDOWN: true
+          ENABLE_ESCAPES: true
+          SLACK_MESSAGE: "The release build for `${{ github.workflow }}` in `${{ github.repository }}` failed. `<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>`."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
   build-self-hosted-runner:
     if: ${{ github.event.inputs.useGitHubHostedLargeRunner != 'true' || github.event_name == 'schedule' }}
     name: Build Website (Self-Hosted Runner)
-    runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
+    runs-on: ["ubuntu-latest"]
     steps:
 
       - name: Force Failure

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,8 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The self-hosted runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>."
+          SLACK_MESSAGE: "The self-hosted runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
 
 #  Use this workflow if you want to use the GitHub-hosted large runner. Useful for scenarios when you need a change to deploy faster than the self-hosted runner can build it.
   build-large-runner:
@@ -148,7 +149,7 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The large runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>."
+          SLACK_MESSAGE: "The large runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
   release:
     name: "Release"
@@ -197,4 +198,4 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>."
+          SLACK_MESSAGE: "The release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
   build-self-hosted-runner:
     if: ${{ github.event.inputs.useGitHubHostedLargeRunner != 'true' || github.event_name == 'schedule' }}
     name: Build Website (Self-Hosted Runner)
-    runs-on: ["ubuntu-latest"]
+    runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
     steps:
 
       - name: Force Failure
@@ -92,7 +92,7 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The self-hosted runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. `<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>`."
+          SLACK_MESSAGE: "The self-hosted runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>."
 
 #  Use this workflow if you want to use the GitHub-hosted large runner. Useful for scenarios when you need a change to deploy faster than the self-hosted runner can build it.
   build-large-runner:
@@ -148,7 +148,7 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The large runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. `<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>`."
+          SLACK_MESSAGE: "The large runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>."
 
   release:
     name: "Release"
@@ -197,4 +197,4 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. `<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>`."
+          SLACK_MESSAGE: "The release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,6 +82,18 @@ jobs:
           aws s3 sync --cache-control 'public, max-age=0, s-maxage=604800' build/ s3://docs.spectrocloud.com --delete
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
 
+      - name: Slack Notification on Failure
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2.3.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
+          SLACK_USERNAME: "spectromate"
+          SLACK_ICON_EMOJI: ":robot_panic:"
+          SLACK_COLOR: "danger"
+          SLACKIFY_MARKDOWN: true
+          ENABLE_ESCAPES: true
+          SLACK_MESSAGE: "The self-hosted runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. `<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>`."
+
 #  Use this workflow if you want to use the GitHub-hosted large runner. Useful for scenarios when you need a change to deploy faster than the self-hosted runner can build it.
   build-large-runner:
     if: ${{ github.event.inputs.useGitHubHostedLargeRunner == 'true' && github.event_name != 'schedule' }}
@@ -126,6 +138,17 @@ jobs:
           aws s3 sync --cache-control 'public, max-age=0, s-maxage=604800' build/ s3://docs.spectrocloud.com --delete
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
 
+      - name: Slack Notification on Failure
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2.3.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
+          SLACK_USERNAME: "spectromate"
+          SLACK_ICON_EMOJI: ":robot_panic:"
+          SLACK_COLOR: "danger"
+          SLACKIFY_MARKDOWN: true
+          ENABLE_ESCAPES: true
+          SLACK_MESSAGE: "The large runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. `<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>`."
 
   release:
     name: "Release"
@@ -174,4 +197,4 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The release build for `${{ github.workflow }}` in `${{ github.repository }}` failed. `<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>`."
+          SLACK_MESSAGE: "The release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. `<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>`."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,14 @@ jobs:
     name: Build Website (Self-Hosted Runner)
     runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
     steps:
+
+      - name: Force Failure
+        run: | 
+        echo "CURRENT_STEP=Force Failure" >> $GITHUB_ENV
+        exit 1
+
       - name: Checkout Repository
+        run: echo "CURRENT_STEP=Checkout Repository" >> $GITHUB_ENV
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -52,27 +59,33 @@ jobs:
 
 
       - name: Setup Node.js environment
+        run: echo "CURRENT_STEP=Setup Node.js environment" >> $GITHUB_ENV
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
 
-      - run: npm ci
-      
+      - run: |
+          echo "CURRENT_STEP=npm ci" >> $GITHUB_ENV
+          npm ci
+
       - name: Build
         run: |
+          echo "CURRENT_STEP=Build" >> $GITHUB_ENV
           touch .env
           make versions-ci
           make build-ci
       
       - name: Build with cached packs
         if: ${{ env.BUILD_EXIT_CODE == '5' }}
+        run: echo "CURRENT_STEP=Build with cached packs" >> $GITHUB_ENV
         uses: ./.github/actions/build-cached-packs
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload to AWS
         run: |
+          echo "CURRENT_STEP=Upload to AWS" >> $GITHUB_ENV
           aws s3 sync --cache-control 'public, max-age=604800' --exclude '*.html' --exclude '*.xml' --exclude build/scripts/ build/ s3://docs.spectrocloud.com --delete
           aws s3 sync --cache-control 'public, max-age=0, s-maxage=604800' build/ s3://docs.spectrocloud.com --delete
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
@@ -87,7 +100,7 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The self-hosted runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          SLACK_MESSAGE: "The self-hosted runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed at step: `${{ env.CURRENT_STEP }}`. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
 
 #  Use this workflow if you want to use the GitHub-hosted large runner. Useful for scenarios when you need a change to deploy faster than the self-hosted runner can build it.
@@ -99,6 +112,7 @@ jobs:
       labels: docbot
     steps:
       - name: Checkout Repository
+        run: echo "CURRENT_STEP=Checkout Repository" >> $GITHUB_ENV
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -106,23 +120,29 @@ jobs:
 
 
       - name: Setup Node.js environment
+        run: echo "CURRENT_STEP=Setup Node.js environment" >> $GITHUB_ENV
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
 
-      - run: npm ci
+      - run: |
+          echo "CURRENT_STEP=npm ci" >> $GITHUB_ENV
+          npm ci
 
       - name: Versions
         run: |
+        echo "CURRENT_STEP=Versions" >> $GITHUB_ENV
       
       - name: Build
         run: |
+          echo "CURRENT_STEP=Build" >> $GITHUB_ENV
           touch .env
           make versions-ci
           make build-ci
       
       - name: Build with cached packs
+        run: echo "CURRENT_STEP=Build with cached packs" >> $GITHUB_ENV
         if: ${{ env.BUILD_EXIT_CODE == '5' }}
         uses: ./.github/actions/build-cached-packs
         with:
@@ -130,6 +150,7 @@ jobs:
 
       - name: Upload to AWS
         run: |
+          echo "CURRENT_STEP=Upload to AWS" >> $GITHUB_ENV
           aws s3 sync --cache-control 'public, max-age=604800' --exclude '*.html' --exclude '*.xml' --exclude build/scripts/ build/ s3://docs.spectrocloud.com --delete
           aws s3 sync --cache-control 'public, max-age=0, s-maxage=604800' build/ s3://docs.spectrocloud.com --delete
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
@@ -144,7 +165,7 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The large runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          SLACK_MESSAGE: "The large runner release job for `${{ github.workflow }}` in `${{ github.repository }}` failed at step: `${{ env.CURRENT_STEP }}`. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
 
   release:
     name: "Release"
@@ -154,12 +175,14 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
+        run: echo "CURRENT_STEP=Checkout Repository" >> $GITHUB_ENV
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Retrieve Credentials
+        run: echo "CURRENT_STEP=Retrieve Credentials" >> $GITHUB_ENV
         id: import-secrets
         uses: hashicorp/vault-action@v3.0.0
         with:
@@ -170,18 +193,23 @@ jobs:
           secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
 
       - name: Setup Nodejs
+        run: echo "CURRENT_STEP=Setup Nodejs" >> $GITHUB_ENV
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          echo "CURRENT_STEP=Install dependencies" >> $GITHUB_ENV
+          npm ci
 
       - name: "release"
         env:
           GITHUB_TOKEN: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: |
+          echo "CURRENT_STEP=release" >> $GITHUB_ENV
+          npx semantic-release
 
       - name: Slack Notification on Failure
         if: ${{ failure() }}
@@ -193,4 +221,4 @@ jobs:
           SLACK_COLOR: "danger"
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "The release job for `${{ github.workflow }}` in `${{ github.repository }}` failed. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          SLACK_MESSAGE: "The release job for `${{ github.workflow }}` in `${{ github.repository }}` failed at step: `${{ env.CURRENT_STEP }}`. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a Slack notification for when the release to production build fails.

It was tested with a force failure step that successfully outputted a message to the Doc Team private slack channel: https://github.com/spectrocloud/librarium/actions/runs/12379389068/job/34553410821

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1499](https://spectrocloud.atlassian.net/browse/DOC-1499)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1499]: https://spectrocloud.atlassian.net/browse/DOC-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ