### PR TITLE
[version-4-1] docs: fix up broken links DOC-1532 (#5155)

### DIFF
--- a/docs/docs-content/clusters/cluster-management/cluster-updates.md
+++ b/docs/docs-content/clusters/cluster-management/cluster-updates.md
@@ -34,7 +34,7 @@ upgrading, you review the information provided in the
   - For PXK and PXK-E, refer to
     [Upgrade Kubeadm Clusters](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
   - For K3s, refer to [K3s Upgrades](https://docs.k3s.io/upgrades#version-specific-caveats)
-  - For RKE2, refer to [RKE2 Manual Upgrades](https://docs.rke2.io/upgrade/manual_upgrade)
+  - For RKE2, refer to [RKE2 Manual Upgrades](https://docs.rke2.io/upgrades/manual_upgrade)
 
 ## Prerequisites
 

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
@@ -96,8 +96,8 @@ To deploy a new MAAS cluster:
         servers to only those that have at least the amount of CPU and Memory selected.
 
       - Tags: Specify the MAAS machine tags so that Palette can deploy nodes onto the MAAS machines that match the
-        provided tags. To learn more about MAAS tags, refer to the [MAAS Tags](https://maas.io/docs/how-to-tag-machines)
-        documentation.
+        provided tags. To learn more about MAAS tags, refer to the
+        [MAAS Tags](https://maas.io/docs/how-to-use-group-machines#p-19384-tags-and-annotations) documentation.
 
 11. You can configure the following cluster management features now if needed, or you can do it later:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-1`:
 - [docs: fix up broken links DOC-1532 (#5155)](https://github.com/spectrocloud/librarium/pull/5155)
