### PR TITLE
chore: DOC-1534 update deprecated packs documentation and enhance Pac…

### DIFF
--- a/docs/docs-content/integrations/deprecated-packs.md
+++ b/docs/docs-content/integrations/deprecated-packs.md
@@ -3,7 +3,7 @@ sidebar_label: "Deprecated Packs"
 title: "Deprecated Packs"
 description: "Deprecated Packs"
 icon: ""
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_position: 40
 tags: ["packs", "deprecation"]
 ---

--- a/src/components/PacksTable/PacksTable.module.scss
+++ b/src/components/PacksTable/PacksTable.module.scss
@@ -46,6 +46,31 @@
   }
 }
 
+.tableContainer {
+  margin: 16px 0;
+  overflow: auto;
+
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
+
+  :global {
+    .ant-input-search {
+      margin-bottom: 16px;
+    }
+  }
+}
+
+.tableWrapper {
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 4px;
+  padding: 16px;
+
+  @media screen and (max-width: 768px) {
+    padding: 8px;
+  }
+}
+
 .green {
   background-color: var(--ifm-color-success-contrast-background);
   color: var(--ifm-color-success-contrast-foreground);
@@ -60,32 +85,27 @@
   border-radius: 16px;
 }
 
-.tableWrapper {
-  border: 1px solid var(--ifm-toc-border-color);
-  padding: 16px;
+.disabled,
+.deleted,
+.deprecated {
   padding: 4px 8px;
-  border-radius: 4px;
+  border-radius: 16px;
+  display: inline-block;
 }
 
 .disabled {
   background-color: var(--ifm-color-warning-contrast-background);
   color: var(--ifm-color-warning-contrast-foreground);
-  padding: 4px 8px;
-  border-radius: 16px;
 }
 
 .deleted {
   background-color: var(--ifm-color-danger-contrast-background);
   color: var(--ifm-color-danger-contrast-foreground);
-  padding: 4px 8px;
-  border-radius: 16px;
 }
 
 .deprecated {
   background-color: var(--ifm-color-info-contrast-background);
   color: var(--ifm-color-info-contrast-foreground);
-  padding: 4px 8px;
-  border-radius: 16px;
 }
 
 .error {
@@ -93,5 +113,18 @@
   justify-content: center;
   align-items: center;
   min-height: 400px;
-  color: red;
+  color: var(--ifm-color-danger);
+}
+
+.unsupportedMessage {
+  display: none;
+  margin: 16px 0;
+
+  @media screen and (max-width: 768px) {
+    display: block;
+  }
+}
+
+.searchContainer {
+  margin-bottom: 16px;
 }

--- a/src/components/PacksTable/__mocks__/@docusaurus/theme-common.ts
+++ b/src/components/PacksTable/__mocks__/@docusaurus/theme-common.ts
@@ -1,0 +1,4 @@
+export const useColorMode = () => ({
+  colorMode: "light",
+  setColorMode: jest.fn(),
+});

--- a/src/components/PacksTable/__mocks__/@theme/Admonition.tsx
+++ b/src/components/PacksTable/__mocks__/@theme/Admonition.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function MockAdmonition({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/utils/helpers/affected-table.test.js
+++ b/utils/helpers/affected-table.test.js
@@ -11,8 +11,8 @@ describe("generateMarkdownTable", () => {
 
     const expectedTable = `| Version | Palette Enterprise | Palette Enterprise Airgap | VerteX | VerteX Airgap |
 | - | -------- | -------- | -------- | -------- |
-| 4.5.3 | Impacted | No Impact | No Impact | No Impact |
-| 4.4.20 | Impacted | No Impact | No Impact | No Impact |`;
+| 4.5.3 | ⚠️ Impacted | ✅ No Impact | ✅ No Impact | ✅ No Impact |
+| 4.4.20 | ⚠️ Impacted | ✅ No Impact | ✅ No Impact | ✅ No Impact |`;
 
     expect(generateMarkdownTable(cveImpactMap).replace(/\s+/g, "")).toBe(expectedTable.replace(/\s+/g, ""));
   });


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the Deprecated Packs table. The [current table](https://docs.spectrocloud.com/integrations/deprecated-packs/) has some challenging UI/UX issues that we need to fix. The new changes use Andt and follow the style we spearheaded with the security bulletins work.

### Before

![CleanShot 2024-12-23 at 11 20 03](https://github.com/user-attachments/assets/d6679ed0-19d7-4362-b7ad-0d08a7f4e61c)





### After

![CleanShot 2024-12-23 at 11 21 13](https://github.com/user-attachments/assets/4739f7e5-ffe5-4856-8992-4791e3a41d03)

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Preview URL for Page](https://deploy-preview-5163--docs-spectrocloud.netlify.app/integrations/deprecated-packs/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1534](https://spectrocloud.atlassian.net/browse/DOC-1534)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1534]: https://spectrocloud.atlassian.net/browse/DOC-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ