### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/docs-content/tutorials/edge/deploy-cluster-virtualbox.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster-virtualbox.md
@@ -61,7 +61,7 @@ To complete this tutorial, you will need the following prerequisites in place.
     management tools like [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) instead
     of Docker.
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) version 7.0
+  - [VirtualBox](https://www.oracle.com/virtualization/technologies/vm/downloads/virtualbox-downloads.html) version 7.0
 
 ## EdgeForge Workflow
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes a broken link in the Edge tutorial.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Edge Tutorial](https://deploy-preview-5186--docs-spectrocloud.netlify.app/tutorials/edge/deploy-cluster-virtualbox/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1549](https://spectrocloud.atlassian.net/browse/DOC-1549)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1549]: https://spectrocloud.atlassian.net/browse/DOC-1549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ