### PR TITLE
docs: change pack information for Portworx DOC-1521

### DIFF
--- a/static/packs-data/packs_information.json
+++ b/static/packs-data/packs_information.json
@@ -241,7 +241,7 @@
   },
   {
     "name": "csi-portworx-generic",
-    "description": "The Portworx CSI Driver provides a standardized way to manage storage resources in containerized environments. This driver supports the full range of Portworx features and most of the CSI specifications, facilitating seamless integration and management of storage across different platforms."
+    "description": "Portworx Enterprise provides a standardized way to manage storage resources in containerized environments. This driver supports the full range of Portworx features and most of the CSI specifications, facilitating seamless integration and management of storage across different platforms."
   },
   {
     "name": "csi-portworx-vsphere",
@@ -261,7 +261,7 @@
   },
   {
     "name": "portworx-add-on",
-    "description": "The Portworx CSI Driver provides a standardized way to manage storage resources in containerized environments. This driver supports the full range of Portworx features and most of the CSI specifications, facilitating seamless integration and management of storage across different platforms."
+    "description": "Portworx Enterprise provides a standardized way to manage storage resources in containerized environments. This driver supports the full range of Portworx features and most of the CSI specifications, facilitating seamless integration and management of storage across different platforms."
   },
   {
     "name": "csi-rook-ceph",


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR changes the Pack information for Portworx packs to mention Portworx Enterprise instead of CSI Driver. 
As part of this work, we have also raised https://github.com/spectrocloud/pax/pull/2422 which fixes up the readme formats for Portworx Generic and Generic AddOn packs. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Portworx Generic](https://deploy-preview-5200--docs-spectrocloud.netlify.app/integrations/packs/?pack=csi-portworx-generic)
💻 [Portworx Generic AddOn](https://deploy-preview-5200--docs-spectrocloud.netlify.app/integrations/packs/?pack=portworx-add-on)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1521](https://spectrocloud.atlassian.net/browse/DOC-1521)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._

[DOC-1521]: https://spectrocloud.atlassian.net/browse/DOC-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ