### PR TITLE
[version-4-4] chore: bump typescript from 5.3.3 to 5.7.2 (#5194)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "semantic-release": "^24.1.0",
         "test-links": "^0.0.1",
         "ts-jest": "^29.1.4",
-        "typescript": "^5.1.6",
+        "typescript": "^5.7.2",
         "typescript-plugin-css-modules": "^5.1.0",
         "webpconvert": "^3.0.1",
         "xml2js": "^0.6.2"
@@ -66316,8 +66316,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "license": "Apache-2.0",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "semantic-release": "^24.1.0",
     "test-links": "^0.0.1",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.1.6",
+    "typescript": "^5.7.2",
     "typescript-plugin-css-modules": "^5.1.0",
     "webpconvert": "^3.0.1",
     "xml2js": "^0.6.2"


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This will backport PR #5194  from `master` to `version-4-4`.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._Backport PR
