### PR TITLE
docs: PEM-6611: Cluster Profile Variables Updates

### DIFF
--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
@@ -6,8 +6,8 @@ sidebar_position: 40
 tags: ["profiles", "cluster profiles"]
 ---
 
-Cluster profile variables enable you to create placeholders for parameters in profile layer configurations, which you
-can then populate for individual clusters during deployment. Meaning you can use a single cluster profile to deploy
+Use cluster profile variables to create placeholders for parameters in profile-layer configurations, which you
+can populate for individual clusters during deployment. With cluster profile variables, you can use a single cluster profile to deploy
 multiple clusters with unique requirements for security, networking, resource allocation, and so on.
 
 When defining a cluster profile variable, you can set specific constraints on the expected values, such as format,
@@ -15,16 +15,13 @@ optionality, masking, and so on, to ensure scalable, error-free cluster deployme
 
 :::preview
 
-This is a Tech Preview feature currently available in [Local UI](../../../clusters/edge/local-ui/local-ui.md). Do not
-use this feature in production workloads, as it is subject to change.
-
 :::
 
 You can use profile variables with any number of packs, manifests, and Helm charts, but only in the scope of their
 parent cluster profile. If you want to create placeholders to use across different cluster profiles, consider using
 [Palette Macros](../../../clusters/cluster-management/macros.md).
 
-The following table describes the difference between profile variables and macros.
+The following table describes the differences between profile variables and macros.
 
 | **Capability**                                                            | **Profile Variable** | **Macro** |
 | ------------------------------------------------------------------------- | :------------------: | :-------: |
@@ -39,8 +36,6 @@ This guide explains how you can define and manage cluster profile variables.
 
 ## Limitations
 
-- Cluster profile variables are currently available only in [Local UI](../../../clusters/edge/local-ui/local-ui.md).
-
 - Palette does not support nesting profile variables within macros or other profile variables.
 
 - You cannot define profile variables for the `pack.content` and `system.uri` parameters because the
@@ -48,7 +43,7 @@ This guide explains how you can define and manage cluster profile variables.
 
 - Once you deploy a cluster from a profile with variables, you can neither edit nor delete the profile variables. To
   edit or delete them, [version the cluster profile](../modify-cluster-profiles/version-cluster-profile.md) and update
-  the variables in the new version.
+  the variables in the new version. Enhanced Day-2 operations will be released in a future version.
 
   When you version a cluster profile with variables, the variables are propagated to the new version. However, upon
   versioning, the variables in each version are independent.
@@ -61,16 +56,15 @@ This guide explains how you can define and manage cluster profile variables.
   [Roles and Permissions](../../../user-management/palette-rbac/project-scope-roles-permissions.md#cluster-profile) for
   more information.
 
-- An in-progress or already created cluster profile. The cluster profile must either have the **Edge Native**
-  infrastructure or be an edge-based add-on profile.
+- An in-progress or existing cluster profile.
 
 ### Enablement
 
-You can define profile variables both while creating and for the already created cluster profiles. To define profile
+You can define profile variables when creating cluster profiles and for existing cluster profiles. To define profile
 variables [while creating a cluster profile](../create-cluster-profiles/create-cluster-profiles.md), you need to be at
 the **Profile Layers** stage of cluster profile creation and start following this guide from step three.
 
-1.  Log in to Palette.
+1.  Log in to [Palette](https://console.spectrocloud.com).
 
 2.  Navigate to the cluster profile for which you want to define profile variables.
 
@@ -140,8 +134,8 @@ the **Profile Layers** stage of cluster profile creation and start following thi
 
     :::tip
 
-    To improve navigation, you can change the display order of variables. Select the **Variables three-dot menu**, then
-    select **Reorder variables**, and drag and drop variables to change their display order. Finally, select **Confirm
+    To improve navigation, you can change the display order of variables. Select the **Variables three-dot Menu**,
+    choose **Reorder variables**, and drag and drop variables to change their display order. Finally, select **Confirm
     order**.
 
     :::
@@ -195,7 +189,7 @@ variables in the new version.
 
    :::
 
-3. To edit a profile variable, in the **three-dot menu** of the necessary variable, select **Edit** and make the
+3. To edit a profile variable, in the **three-dot Menu** of the necessary variable, select **Edit** and make the
    necessary changes.
 
 4. To delete a profile variable, navigate to the profile layers that implement this variable and remove it from their

--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
@@ -12,8 +12,8 @@ to deploy multiple clusters with unique requirements for security, networking, r
 also set specific constraints on the expected values, such as format, optionality, and masking to ensure scalable,
 error-free cluster deployments.
 
-Cluster profile variables can be used with any Palette cluster, including public cloud, data center, bare
-metal, and edge clusters, and can also be managed via
+Cluster profile variables can be used with any Palette cluster, including public cloud, data center, bare metal, and
+edge clusters, and can also be managed via
 [Terraform](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs).
 
 :::preview

--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
@@ -30,7 +30,7 @@ The following table describes the differences between profile variables and macr
 | Belongs to the tenant scope                                               |          ❌          |    ✅     |
 | Supports data format restrictions                                         |          ✅          |    ❌     |
 | Supports optionality restrictions                                         |          ✅          |    ❌     |
-| Supports [sprig template functions](https://masterminds.github.io/sprig/) |          ✅          |    ✅     |
+| Supports [sprig template functions](https://masterminds.github.io/sprig/) |          ❌          |    ✅     |
 
 This guide explains how you can define and manage cluster profile variables.
 

--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
@@ -8,16 +8,16 @@ tags: ["profiles", "cluster profiles"]
 
 Use cluster profile variables to create placeholders for parameters in profile-layer configurations, which you
 can populate for individual clusters during deployment. With cluster profile variables, you can use a single cluster profile to deploy
-multiple clusters with unique requirements for security, networking, resource allocation, and so on.
+multiple clusters with unique requirements for security, networking, resource allocation, and more. You can also set specific constraints on the expected values, such as format, optionality, and masking to ensure scalable, error-free cluster deployments.
 
-When defining a cluster profile variable, you can set specific constraints on the expected values, such as format,
-optionality, masking, and so on, to ensure scalable, error-free cluster deployments.
+Cluster profile variables can be used with
+any Palette-connected cluster, including public cloud, data center, bare metal, and edge environments, and can also be managed via [Terraform](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs).
 
 :::preview
 
 :::
 
-You can use profile variables with any number of packs, manifests, and Helm charts, but only in the scope of their
+You can use cluster profile variables with any number of packs, manifests, and Helm charts, but only in the scope of their
 parent cluster profile. If you want to create placeholders to use across different cluster profiles, consider using
 [Palette Macros](../../../clusters/cluster-management/macros.md).
 
@@ -43,7 +43,7 @@ This guide explains how you can define and manage cluster profile variables.
 
 - Once you deploy a cluster from a profile with variables, you can neither edit nor delete the profile variables. To
   edit or delete them, [version the cluster profile](../modify-cluster-profiles/version-cluster-profile.md) and update
-  the variables in the new version. Enhanced Day-2 operations will be released in a future version.
+  the variables in the new version.
 
   When you version a cluster profile with variables, the variables are propagated to the new version. However, upon
   versioning, the variables in each version are independent.
@@ -85,9 +85,9 @@ the **Profile Layers** stage of cluster profile creation and start following thi
 5.  Enter a variable display name that Palette will display during cluster deployment. The display name must be unique
     within the parent cluster.
 
-6.  Optionally, enter the variable description.
+6.  Optionally, enter a variable description.
 
-7.  Select a data format that the variable will expect. The following table describes the available data formats.
+7.  Select the data format for the variable. The following table describes available data formats.
 
     | **Format** | **Description**                                                                                        |
     | ---------- | ------------------------------------------------------------------------------------------------------ |
@@ -116,7 +116,7 @@ the **Profile Layers** stage of cluster profile creation and start following thi
 
     :::
 
-9.  Review the variable definition and behavior under **Preview**, and then select **Create**.
+9.  **Preview** the variable definition and behavior, and **Create** the variable.
 
     ![Palette YAML editor with the added profile variables.](/profiles_create-cluster-profiles_define-profile-variables_variable-preview.webp)
 
@@ -145,7 +145,7 @@ the **Profile Layers** stage of cluster profile creation and start following thi
 
 ### Validation
 
-1. Log in to Palette.
+1. Log in to [Palette](https://console.spectrocloud.com).
 
 2. From the left **Main Menu**, select **Profiles** and navigate to the cluster profile for which you have defined
    profile variables.
@@ -177,7 +177,7 @@ variables in the new version.
 
 ### Enablement
 
-1. Log in to Palette.
+1. Log in to [Palette](https://console.spectrocloud.com).
 
 2. Navigate to the cluster profile for which you want to update profile variables and, in the upper-right corner, click
    **Variables**.
@@ -193,11 +193,11 @@ variables in the new version.
    necessary changes.
 
 4. To delete a profile variable, navigate to the profile layers that implement this variable and remove it from their
-   YAML configuration. Then, in the **three-dot menu** of the necessary variable, select **Delete**.
+   YAML configuration. Then, in the **three-dot Menu** of the necessary variable, select **Delete**.
 
 ### Validation
 
-1. Log in to Palette.
+1. Log in to [Palette](https://console.spectrocloud.com).
 
 2. From the left **Main Menu**, select **Profiles** and navigate to the cluster profile for which you have updated the
    profile variables.

--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
@@ -12,8 +12,8 @@ to deploy multiple clusters with unique requirements for security, networking, r
 also set specific constraints on the expected values, such as format, optionality, and masking to ensure scalable,
 error-free cluster deployments.
 
-Cluster profile variables can be used with any Palette-connected cluster, including public cloud, data center, bare
-metal, and edge environments, and can also be managed via
+Cluster profile variables can be used with any Palette cluster, including public cloud, data center, bare
+metal, and edge clusters, and can also be managed via
 [Terraform](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs).
 
 :::preview

--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md
@@ -6,20 +6,23 @@ sidebar_position: 40
 tags: ["profiles", "cluster profiles"]
 ---
 
-Use cluster profile variables to create placeholders for parameters in profile-layer configurations, which you
-can populate for individual clusters during deployment. With cluster profile variables, you can use a single cluster profile to deploy
-multiple clusters with unique requirements for security, networking, resource allocation, and more. You can also set specific constraints on the expected values, such as format, optionality, and masking to ensure scalable, error-free cluster deployments.
+Use cluster profile variables to create placeholders for parameters in profile-layer configurations, which you can
+populate for individual clusters during deployment. With cluster profile variables, you can use a single cluster profile
+to deploy multiple clusters with unique requirements for security, networking, resource allocation, and more. You can
+also set specific constraints on the expected values, such as format, optionality, and masking to ensure scalable,
+error-free cluster deployments.
 
-Cluster profile variables can be used with
-any Palette-connected cluster, including public cloud, data center, bare metal, and edge environments, and can also be managed via [Terraform](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs).
+Cluster profile variables can be used with any Palette-connected cluster, including public cloud, data center, bare
+metal, and edge environments, and can also be managed via
+[Terraform](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs).
 
 :::preview
 
 :::
 
-You can use cluster profile variables with any number of packs, manifests, and Helm charts, but only in the scope of their
-parent cluster profile. If you want to create placeholders to use across different cluster profiles, consider using
-[Palette Macros](../../../clusters/cluster-management/macros.md).
+You can use cluster profile variables with any number of packs, manifests, and Helm charts, but only in the scope of
+their parent cluster profile. If you want to create placeholders to use across different cluster profiles, consider
+using [Palette Macros](../../../clusters/cluster-management/macros.md).
 
 The following table describes the differences between profile variables and macros.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the Edge limitation for cluster profile variables for 4.5.c. Cluster profile variables can now be used with any Palette-connected cluster. 

Notes:
- Decided to NOT remove tech preview, though I did remove the Local UI mention. [PEM-6535](https://spectrocloud.atlassian.net/browse/PEM-6535) confirms it is not leaving the tech preview phase until 4.6.0.
- Yuliia already leaned into Day-2 variable management with profile versioning. The majority of Day-2 features are coming in 4.6.0 ([PEM-4367](https://spectrocloud.atlassian.net/browse/PEM-4367)).

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Define and Manage Profile Variables](https://deploy-preview-5217--docs-spectrocloud.netlify.app/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-6611](https://spectrocloud.atlassian.net/browse/PEM-6611)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

4.5.c release work.


[PEM-6611]: https://spectrocloud.atlassian.net/browse/PEM-6611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PEM-6535]: https://spectrocloud.atlassian.net/browse/PEM-6535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PEM-4367]: https://spectrocloud.atlassian.net/browse/PEM-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ