### PR TITLE
docs: node pool repave workaround adjustments

### DIFF
--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
@@ -355,7 +355,8 @@ Use the following steps to manually trigger a repave on a hybrid node pool.
    The key value you enter for the node label does not affect your hybrid node pool's functionality, but any addition or
    change to the Kubelet config will trigger the required repave.
 
-   If you need to trigger a repave again, you can modify the key value to something else, such as `--node-labels=repave2=true`.
+   If you need to trigger a repave again, you can modify the key value to something else, such as
+   `--node-labels=repave2=true`.
 
    :::
 

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
@@ -300,8 +300,6 @@ nodes. Before proceeding, consider the following points:
 
 ## When to Manually Repave Hybrid Node Pools
 
-<!-- This section may be removed as the workaround is not currently working. There may also be repave logic included to resolve this for 4.5.c. -->
-
 Your hybrid node pools require manual repaving in these scenarios:
 
 - After modifying the **Access Management** settings of your Amazon EKS cluster in Palette. Refer to steps 11 through 13
@@ -334,19 +332,32 @@ Use the following steps to manually trigger a repave on a hybrid node pool.
 
    ![Edit Hybrid Profile](/aws_eks-hybrid_create-hybrid-node-pools_in-use-clusters.webp)
 
-5. Click on the **cni-custom 0.1.0** network layer to view the **Edit Pack** page.
+5. Click on the **edge-nodeadm x.y.z** network layer to view the **Edit Pack** page.
 
-6. In the YAML editor on the right, change the value for `manifests.byo-cni.contents.data.custom-cni` to something
-   different.
+6. In the YAML editor on the right, add an arbitrary node label to `cluster.config.kubelet.flags`.
 
    Example.
 
-   ```yaml
-   custom-cni: "dummy-repave-1"
+   ```yaml {9} hideClipboard
+   pack:
+     content: {}
+   cluster:
+     config: |
+       kubelet:
+         config:
+          shutdownGracePeriod: 30s
+         flags:
+         - --node-labels=repave1=true
    ```
 
-   As mentioned in step 14 during the [Create Profile](#create-profile) steps, the specific value you enter does not
-   affect your hybrid node pool's functionality, but any change to this field will trigger the required repave.
+   :::info
+
+   The key value you enter for the node label does not affect your hybrid node pool's functionality, but any addition or
+   change to the kubelet config will trigger the required repave.
+
+   If you need to trigger a repave again, you can simply modify the key value to something else, such as `--node-labels=repave2=true`.
+
+   :::
 
 7. Click **Confirm Updates** when done, then click **Save Changes**.
 
@@ -360,7 +371,7 @@ Use the following steps to manually trigger a repave on a hybrid node pool.
     **Node Pool Updates** in the banner.
 
 12. On the **Pool changes summary** pop-up window, click the checkbox next to **Upcoming changes in hybridPoolName
-    configuration**. Click **Confirm** afterward.
+    configuration**. Click **Confirm** afterwards.
 
 13. On the **Review update changes** window, review your changes and click **Confirm** to start the repave.
 

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
@@ -345,9 +345,9 @@ Use the following steps to manually trigger a repave on a hybrid node pool.
      config: |
        kubelet:
          config:
-          shutdownGracePeriod: 30s
+           shutdownGracePeriod: 30s
          flags:
-         - --node-labels=repave1=true
+           - --node-labels=repave1=true
    ```
 
    :::info

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
@@ -353,9 +353,9 @@ Use the following steps to manually trigger a repave on a hybrid node pool.
    :::info
 
    The key value you enter for the node label does not affect your hybrid node pool's functionality, but any addition or
-   change to the kubelet config will trigger the required repave.
+   change to the Kubelet config will trigger the required repave.
 
-   If you need to trigger a repave again, you can simply modify the key value to something else, such as `--node-labels=repave2=true`.
+   If you need to trigger a repave again, you can modify the key value to something else, such as `--node-labels=repave2=true`.
 
    :::
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adjusts the existing node pool repave workaround after testing confirmed this behaviour. The new steps are also more arbitrary.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Create Hybrid Node Pools](https://deploy-preview-5229--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools/#trigger-repave-on-hybrid-node-pool)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1511](https://spectrocloud.atlassian.net/browse/DOC-1511)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Merge to feature branch.

[DOC-1511]: https://spectrocloud.atlassian.net/browse/DOC-1511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ