### PR TITLE
[version-4-4] docs: fix broken links (#5245)

### DIFF
--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/environment-setup/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/environment-setup/vmware-vsphere-airgap-instructions.md
@@ -409,7 +409,7 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
 
     You may encounter an error message during the OVA deployment stating unable to retrieve manifest or certificate.
     This is a known issue that was fixed in the
-    [VMware vCenter Server 7.0 Update 3q](https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-vcenter-server-70u3q-release-notes/index.html).
+    [VMware vCenter Server 7.0 Update 3q](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/7-0/release-notes/vcenter-server-update-and-patch-releases/vsphere-vcenter-server-70u3q-release-notes.html).
     Reach out to [Broadcom Support](https://support.broadcom.com) if you need further guidance.
 
     :::


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-4`:
 - [docs: fix broken links (#5245)](https://github.com/spectrocloud/librarium/pull/5245)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)