### PR TITLE
docs: change from provider images to edgeforge

### DIFF
--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/architecture.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/architecture.md
@@ -119,8 +119,9 @@ If you want to use your edge hosts as Amazon EKS Hybrid Nodes, they must have be
 methods:
 
 - [Agent Mode](../../../../deployment-modes/agent-mode/agent-mode.md)
-- [Provider images](../../../edge/edgeforge-workflow/palette-canvos/build-provider-images.md)
-  - Provider images are [Kairos-based images](https://kairos.io/) containing the OS and the desired Kubernetes versions.
+- [EdgeForge Workflow](../../../edge/edgeforge-workflow/edgeforge-workflow.md)
+  - Part of the EdgeForge Workflow is to create [Kairos-based images](https://kairos.io/) containing the OS and the
+    desired Kubernetes versions. These are also named provider images.
 
 :::warning
 
@@ -140,8 +141,8 @@ Adjust to your operating system and package manager on your edge hosts.
 
 ### Build Provider Images with Specific Arguments
 
-If using provider images, you must include the following in your `.arg` file during the
-[build steps](../../../edge/edgeforge-workflow/palette-canvos/build-provider-images.md#build-provider-images).
+If using the EdgeForge Workflow, you must include the following in your `.arg` file during the
+[build steps for provider images](../../../edge/edgeforge-workflow/palette-canvos/build-provider-images.md#build-provider-images).
 
 ```shell
 K8S_DISTRIBUTION=nodeadm

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/architecture.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/architecture.md
@@ -121,7 +121,7 @@ methods:
 - [Agent Mode](../../../../deployment-modes/agent-mode/agent-mode.md)
 - [EdgeForge Workflow](../../../edge/edgeforge-workflow/edgeforge-workflow.md)
   - Part of the EdgeForge Workflow is to create [Kairos-based images](https://kairos.io/) containing the OS and the
-    desired Kubernetes versions. These are also named provider images.
+    desired Kubernetes versions. These are named provider images.
 
 :::warning
 

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
@@ -40,7 +40,7 @@ You must then configure your networking to allow traffic to reach the pods on yo
 6. Select your base OS pack depending on how you will register your edge hosts.
 
    - For Agent Mode, select **BYOS - Agent Mode**.
-   - For provider images, select **BYOS - Edge OS**.
+   - For EdgeForge Workflow, select **BYOS - Edge OS**.
 
 7. If selecting **BYOS - Agent Mode**, on the **Configure Pack** page, click **Values** under **Pack Details**. Then,
    click on **Presets** on the right-hand side, and select **Agent Mode**.
@@ -98,13 +98,13 @@ Your cluster profile for hybrid nodes is now created and can be used in the
   [Import EKS Cluster and Enable Hybrid Mode](./import-eks-cluster-enable-hybrid-mode.md) for guidance.
 
 - Edge hosts have been registered with Palette through
-  [Agent Mode](../../../../deployment-modes/agent-mode/agent-mode.md) or by using
-  [provider images](../../../edge/edgeforge-workflow/palette-canvos/build-provider-images.md).
+  [Agent Mode](../../../../deployment-modes/agent-mode/agent-mode.md) or
+  [EdgeForge Workflow](../../../edge/edgeforge-workflow/edgeforge-workflow.md).
 
   :::warning
 
-  If using provider images, you must include the following in your `.arg` file during the
-  [build steps](../../../edge/edgeforge-workflow/palette-canvos/build-provider-images.md#build-provider-images).
+  If using the EdgeForge Workflow, you must include the following in your `.arg` file during the
+  [build steps for provider images](../../../edge/edgeforge-workflow/palette-canvos/build-provider-images.md#build-provider-images).
 
   ```shell
   K8S_DISTRIBUTION=nodeadm
@@ -393,6 +393,8 @@ The hybrid node pool repave will now complete. This can take up to one hour.
 ## Resources
 
 - [Agent Mode](../../../../deployment-modes/agent-mode/agent-mode.md)
+
+- [EdgeForge Workflow](../../../edge/edgeforge-workflow/edgeforge-workflow.md)
 
 - [Build Provider Images](../../../edge/edgeforge-workflow/palette-canvos/build-provider-images.md)
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR makes some minor terminology fixes to the EKS Hybrid Nodes docs.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Architecture](https://deploy-preview-5323--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/eks-hybrid-nodes/architecture/#supported-edge-hosts)
💻 [Create Hybrid Node Pools](https://deploy-preview-5323--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools/)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

4.5.c release fix