### PR TITLE
docs: add safeguard against undefined pack versions DOC-1583

### DIFF
--- a/plugins/packs-integrations.js
+++ b/plugins/packs-integrations.js
@@ -191,7 +191,7 @@ function getAggregatedVersions(registries, repositories, packUidMap) {
           );
           const previousVersionChildrenSet = new Set(previousVersiontagdata.children.map((verssion) => verssion.title));
           // Ensure that children are never undefined.
-          const commonVersionChildren = commonVersion.children || []
+          const commonVersionChildren = commonVersion.children || [];
           const commonComputedChildren = commonVersionChildren.filter((child) =>
             previousVersionChildrenSet.has(child.title)
           );

--- a/plugins/packs-integrations.js
+++ b/plugins/packs-integrations.js
@@ -190,13 +190,15 @@ function getAggregatedVersions(registries, repositories, packUidMap) {
             (prevVersion) => prevVersion.title === commonVersion.title
           );
           const previousVersionChildrenSet = new Set(previousVersiontagdata.children.map((verssion) => verssion.title));
-          const commonComputedChildren = commonVersion.children.filter((child) =>
+          // Ensure that children are never undefined.
+          const commonVersionChildren = commonVersion.children || []
+          const commonComputedChildren = commonVersionChildren.filter((child) =>
             previousVersionChildrenSet.has(child.title)
           );
           if (commonComputedChildren.length) {
             //merge non overlapping children in each parent version
             const mergedNonOverlappingChildren = [
-              ...commonVersion.children.filter((child) => !previousVersionChildrenSet.has(child.title)),
+              ...commonVersionChildren.filter((child) => !previousVersionChildrenSet.has(child.title)),
               ...previousVersiontagdata.children.filter((child) => !previousVersionChildrenSet.has(child.title)),
             ];
             commonComputedChildren.forEach((childComputedVersion) => {
@@ -214,7 +216,7 @@ function getAggregatedVersions(registries, repositories, packUidMap) {
             //merging non-overlapping children with the previous version children
             previousVersiontagdata.children = [...previousVersiontagdata.children, ...mergedNonOverlappingChildren];
           } else {
-            previousVersiontagdata.children = [...previousVersiontagdata.children, ...commonVersion.children];
+            previousVersiontagdata.children = [...previousVersiontagdata.children, ...commonVersionChildren];
           }
         });
         //merging the non-overlapping tags with the previous Versions

--- a/static/packs-data/exclude_packs.json
+++ b/static/packs-data/exclude_packs.json
@@ -11,6 +11,6 @@
   "ubuntu-coxedge",
   "edge-os",
   "spectro-zen-of-k8s",
-  "spectro-mgmt", 
+  "spectro-mgmt",
   "virtual-machine-orchestrator"
 ]

--- a/static/packs-data/exclude_packs.json
+++ b/static/packs-data/exclude_packs.json
@@ -11,5 +11,6 @@
   "ubuntu-coxedge",
   "edge-os",
   "spectro-zen-of-k8s",
-  "spectro-mgmt"
+  "spectro-mgmt", 
+  "virtual-machine-orchestrator"
 ]


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a safeguard against undefined children on pack version reading. This was causing outages on the VMO pack. This safeguards makes the code more robust. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1583](https://spectrocloud.atlassian.net/browse/DOC-1583)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1583]: https://spectrocloud.atlassian.net/browse/DOC-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ