### PR TITLE
[version-4-0] docs: add safeguard against undefined pack versions DOC-1583 (#5350)

### DIFF
--- a/plugins/packs-integrations.js
+++ b/plugins/packs-integrations.js
@@ -189,16 +189,16 @@ function getAggregatedVersions(registries, repositories, packUidMap) {
           const previousVersiontagdata = previousVersions.find(
             (prevVersion) => prevVersion.title === commonVersion.title
           );
-          const previousVersionChildrenSet = new Set(
-            (previousVersiontagdata.children || []).map((verssion) => verssion.title)
-          );
-          const commonComputedChildren = commonVersion.children.filter((child) =>
+          const previousVersionChildrenSet = new Set(previousVersiontagdata.children.map((verssion) => verssion.title));
+          // Ensure that children are never undefined.
+          const commonVersionChildren = commonVersion.children || [];
+          const commonComputedChildren = commonVersionChildren.filter((child) =>
             previousVersionChildrenSet.has(child.title)
           );
           if (commonComputedChildren.length) {
             //merge non overlapping children in each parent version
             const mergedNonOverlappingChildren = [
-              ...commonVersion.children.filter((child) => !previousVersionChildrenSet.has(child.title)),
+              ...commonVersionChildren.filter((child) => !previousVersionChildrenSet.has(child.title)),
               ...previousVersiontagdata.children.filter((child) => !previousVersionChildrenSet.has(child.title)),
             ];
             commonComputedChildren.forEach((childComputedVersion) => {
@@ -216,7 +216,7 @@ function getAggregatedVersions(registries, repositories, packUidMap) {
             //merging non-overlapping children with the previous version children
             previousVersiontagdata.children = [...previousVersiontagdata.children, ...mergedNonOverlappingChildren];
           } else {
-            previousVersiontagdata.children = [...previousVersiontagdata.children, ...commonVersion.children];
+            previousVersiontagdata.children = [...previousVersiontagdata.children, ...commonVersionChildren];
           }
         });
         //merging the non-overlapping tags with the previous Versions

--- a/static/packs-data/exclude_packs.json
+++ b/static/packs-data/exclude_packs.json
@@ -11,5 +11,6 @@
   "ubuntu-coxedge",
   "edge-os",
   "spectro-zen-of-k8s",
-  "spectro-mgmt"
+  "spectro-mgmt",
+  "virtual-machine-orchestrator"
 ]


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-0`:
 - [docs: add safeguard against undefined pack versions DOC-1583 (#5350)](https://github.com/spectrocloud/librarium/pull/5350)

<!--- Backport version: 9.5.1 -->