### PR TITLE
docs: add nil guards to render pack versions DOC-1583

### DIFF
--- a/src/components/PacksReadme/PacksReadme.tsx
+++ b/src/components/PacksReadme/PacksReadme.tsx
@@ -96,19 +96,29 @@ function compareVersions(v1: string, v2: string): number {
   return 0;
 }
 
+function sortChildren(tagVersion: Version) {
+  const children = tagVersion.children || []
+  return children
+        .sort((a, b) => compareVersions(a.title, b.title))
+        .map((child) => ({
+          value: `${child.title}===${child.packUid}`,
+          title: <span>{child.title}</span>,
+        }))
+}
+
 function renderVersionOptions(packData: PackData) {
-  return packData.versions
+  // If there are no versions, we exit immediately
+  const versions = packData.versions
+  if (versions === undefined) {
+    return;
+  }
+  return versions
     .sort((a, b) => compareVersions(a.title, b.title))
     .map((tagVersion) => ({
       value: tagVersion.title,
       title: tagVersion.title,
       selectable: false,
-      children: tagVersion.children
-        .sort((a, b) => compareVersions(a.title, b.title))
-        .map((child) => ({
-          value: `${child.title}===${child.packUid}`,
-          title: <span>{child.title}</span>,
-        })),
+      children: sortChildren(tagVersion),
     }));
 }
 

--- a/src/components/PacksReadme/PacksReadme.tsx
+++ b/src/components/PacksReadme/PacksReadme.tsx
@@ -97,18 +97,18 @@ function compareVersions(v1: string, v2: string): number {
 }
 
 function sortChildren(tagVersion: Version) {
-  const children = tagVersion.children || []
+  const children = tagVersion.children || [];
   return children
-        .sort((a, b) => compareVersions(a.title, b.title))
-        .map((child) => ({
-          value: `${child.title}===${child.packUid}`,
-          title: <span>{child.title}</span>,
-        }))
+    .sort((a, b) => compareVersions(a.title, b.title))
+    .map((child) => ({
+      value: `${child.title}===${child.packUid}`,
+      title: <span>{child.title}</span>,
+    }));
 }
 
 function renderVersionOptions(packData: PackData) {
   // If there are no versions, we exit immediately
-  const versions = packData.versions
+  const versions = packData.versions;
   if (versions === undefined) {
     return;
   }

--- a/src/constants/packs.ts
+++ b/src/constants/packs.ts
@@ -41,7 +41,6 @@ export const cloudProviderTypes = [
   { name: "aks", displayName: "Azure AKS" },
   { name: "gcp", displayName: "GCP IaaS" },
   { name: "gke", displayName: "GCP GKE" },
-  { name: "tke", displayName: "TKE" },
   { name: "vsphere", displayName: "VMware" },
   { name: "openstack", displayName: "OpenStack" },
   { name: "maas", displayName: "MAAS" },
@@ -76,7 +75,6 @@ export const cloudDisplayNames = {
   vsphere: "VMware",
   openstack: "OpenStack",
   maas: "MAAS",
-  tke: "Tencent",
   "edge-native": "Edge",
   custom: "Custom",
 } as const;

--- a/static/packs-data/exclude_packs.json
+++ b/static/packs-data/exclude_packs.json
@@ -12,8 +12,8 @@
   "edge-os",
   "spectro-zen-of-k8s",
   "spectro-mgmt",
-  "csi-tke", 
-  "kubernetes-tke", 
-  "tke-managed-os", 
+  "csi-tke",
+  "kubernetes-tke",
+  "tke-managed-os",
   "cni-tke-global-router"
 ]

--- a/static/packs-data/exclude_packs.json
+++ b/static/packs-data/exclude_packs.json
@@ -12,5 +12,8 @@
   "edge-os",
   "spectro-zen-of-k8s",
   "spectro-mgmt",
-  "virtual-machine-orchestrator"
+  "csi-tke", 
+  "kubernetes-tke", 
+  "tke-managed-os", 
+  "cni-tke-global-router"
 ]


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds: 
- Guards for undefined children versions
- removes vmo from exclusion list 
- removes tencent from various places

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [VMO pack](https://deploy-preview-5366--docs-spectrocloud.netlify.app/integrations/packs/?pack=virtual-machine-orchestrator&version=4.5.5&parent=4.5.x&tab=main)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1583](https://spectrocloud.atlassian.net/browse/DOC-1583)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1583]: https://spectrocloud.atlassian.net/browse/DOC-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ