### PR TITLE
docs: DOC-1577: Add projectName prereq to Palette Agent

### DIFF
--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -70,9 +70,9 @@ Palette. You will then create a cluster profile and use the registered host to d
   - [iptables](https://linux.die.net/man/8/iptables)
   - (Airgap only) [Crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) is installed and
     available.
-  - (Airgap only) [Palette Edge CLI](../../spectro-downloads.md#palette-edge-cli) is installed and available
+  - (Airgap only) [Palette Edge CLI](../../spectro-downloads.md#palette-edge-cli) is installed and available.
 
-  <br></br>
+  <br />
 
   :::warning
 
@@ -139,7 +139,7 @@ Palette. You will then create a cluster profile and use the registered host to d
      [registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) has a
      Default Project set.
 
-   <br></br>
+   <br />
 
    ```shell
    cat << EOF > user-data

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -125,16 +125,18 @@ Palette. You will then create a cluster profile and use the registered host to d
 
    :::
 
-   The following configuration includes a Palette registration token and the default Palette endpoint, specifies the Palette project, and sets up the `kairos`
-   user. The host will not shut down and will reboot after the agent installation, with
-   [kube-vip](../../clusters/edge/networking/kubevip.md) enabled, as this is required for bare metal and VMware vSphere
-   deployments. If your environment does not require kube-vip, set `skipKubeVip:` to `true`. Refer to the
-   [Prepare User Data](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) guide to learn more about user data
-   configuration.
+   The following configuration includes a Palette registration token and the default Palette endpoint, specifies the
+   Palette project, and sets up the `kairos` user. The host will not shut down and will reboot after the agent
+   installation, with [kube-vip](../../clusters/edge/networking/kubevip.md) enabled, as this is required for bare metal
+   and VMware vSphere deployments. If your environment does not require kube-vip, set `skipKubeVip:` to `true`. Refer to
+   the [Prepare User Data](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) guide to learn more about user
+   data configuration.
 
    :::info
 
-   The `projectName` parameter is not required if the associated Palette [registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) has a Default Project set.
+   The `projectName` parameter is not required if the associated Palette
+   [registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) has a
+   Default Project set.
 
    :::
 

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -134,7 +134,7 @@ Palette. You will then create a cluster profile and use the registered host to d
 
    :::info
 
-   The `projectName` parameter is not required if your Palette [registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) has a Default Project set.
+   The `projectName` parameter is not required if the associated Palette [registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) has a Default Project set.
 
    :::
 

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -125,12 +125,18 @@ Palette. You will then create a cluster profile and use the registered host to d
 
    :::
 
-   The following configuration includes the default Palette endpoint, a registration token, and sets up the `kairos`
+   The following configuration includes a Palette registration token and the default Palette endpoint, specifies the Palette project, and sets up the `kairos`
    user. The host will not shut down and will reboot after the agent installation, with
    [kube-vip](../../clusters/edge/networking/kubevip.md) enabled, as this is required for bare metal and VMware vSphere
    deployments. If your environment does not require kube-vip, set `skipKubeVip:` to `true`. Refer to the
    [Prepare User Data](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) guide to learn more about user data
    configuration.
+
+   :::info
+
+   The `projectName` parameter is not required if your Palette [registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) has a Default Project set.
+
+   :::
 
    ```shell
    cat << EOF > user-data
@@ -144,6 +150,7 @@ Palette. You will then create a cluster profile and use the registered host to d
      site:
        edgeHostToken: $TOKEN
        paletteEndpoint: api.spectrocloud.com
+       projectName: Default
    stages:
      initramfs:
        - users:

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -71,15 +71,14 @@ Palette. You will then create a cluster profile and use the registered host to d
   - (Airgap only) [Crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) is installed and
     available.
   - (Airgap only) [Palette Edge CLI](../../spectro-downloads.md#palette-edge-cli) is installed and available
-  
-  <br>
-  </br>
+
+  <br></br>
 
   :::warning
-  
+
   Avoid installing Docker on the host where you want to install the agent. Docker is a heavyweight tool that could
   interfere with the Palette agent.
-  
+
   :::
 
 ## Install Palette Agent
@@ -130,16 +129,17 @@ Palette. You will then create a cluster profile and use the registered host to d
 
    The following configuration includes a Palette registration token and the default Palette endpoint, specifies a
    Palette project, and sets up the `kairos` user. Note the following:
-   - The host will not shut down and will instead reboot after the agent is installed, with [kube-vip](../../clusters/edge/networking/kubevip.md) enabled, as this is required for bare metal
-   and VMware vSphere deployments. If your environment does not require kube-vip, set `skipKubeVip` to `true`. Refer to
-   the [Prepare User Data](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) guide to learn more about user
-   data configuration.
+
+   - The host will not shut down and will instead reboot after the agent is installed, with
+     [kube-vip](../../clusters/edge/networking/kubevip.md) enabled, as this is required for bare metal and VMware
+     vSphere deployments. If your environment does not require kube-vip, set `skipKubeVip` to `true`. Refer to the
+     [Prepare User Data](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) guide to learn more about user
+     data configuration.
    - The `projectName` parameter is not required if the associated Palette
-   [registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) has a
-   Default Project set.
- 
-   <br>
-   </br>
+     [registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) has a
+     Default Project set.
+
+   <br></br>
 
    ```shell
    cat << EOF > user-data

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -183,6 +183,7 @@ Palette. You will then create a cluster profile and use the registered host to d
      site:
        edgeHostToken: ****************
        paletteEndpoint: api.spectrocloud.com
+       projectName: Default
    stages:
      initramfs:
        - users:

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -70,13 +70,16 @@ Palette. You will then create a cluster profile and use the registered host to d
   - [iptables](https://linux.die.net/man/8/iptables)
   - (Airgap only) [Crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) is installed and
     available.
-  - (Airgap only) [Palette Edge CLI](../../spectro-downloads.md#palette-edge-cli) is installed and available.
+  - (Airgap only) [Palette Edge CLI](../../spectro-downloads.md#palette-edge-cli) is installed and available
+  
+  <br>
+  </br>
 
   :::warning
-
+  
   Avoid installing Docker on the host where you want to install the agent. Docker is a heavyweight tool that could
   interfere with the Palette agent.
-
+  
   :::
 
 ## Install Palette Agent
@@ -125,20 +128,18 @@ Palette. You will then create a cluster profile and use the registered host to d
 
    :::
 
-   The following configuration includes a Palette registration token and the default Palette endpoint, specifies the
-   Palette project, and sets up the `kairos` user. The host will not shut down and will reboot after the agent
-   installation, with [kube-vip](../../clusters/edge/networking/kubevip.md) enabled, as this is required for bare metal
-   and VMware vSphere deployments. If your environment does not require kube-vip, set `skipKubeVip:` to `true`. Refer to
+   The following configuration includes a Palette registration token and the default Palette endpoint, specifies a
+   Palette project, and sets up the `kairos` user. Note the following:
+   - The host will not shut down and will instead reboot after the agent is installed, with [kube-vip](../../clusters/edge/networking/kubevip.md) enabled, as this is required for bare metal
+   and VMware vSphere deployments. If your environment does not require kube-vip, set `skipKubeVip` to `true`. Refer to
    the [Prepare User Data](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) guide to learn more about user
    data configuration.
-
-   :::info
-
-   The `projectName` parameter is not required if the associated Palette
+   - The `projectName` parameter is not required if the associated Palette
    [registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) has a
    Default Project set.
-
-   :::
+ 
+   <br>
+   </br>
 
    ```shell
    cat << EOF > user-data


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the user-data config with the `projectName` parameter. It also clarifies that `projectName` is not required if a Default Project is set in the associated registration token.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Install Palette Agent](https://deploy-preview-5417--docs-spectrocloud.netlify.app/deployment-modes/agent-mode/install-agent-host/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1577](https://spectrocloud.atlassian.net/browse/DOC-1577)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1577]: https://spectrocloud.atlassian.net/browse/DOC-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ