### PR TITLE
docs: DOC-1579

### DIFF
--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/create-addon-profile/create-addon-profile.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/create-addon-profile/create-addon-profile.md
@@ -26,8 +26,8 @@ negative and positive numbers and 0. The default install order value is 0. The i
 which manifests in the profile are applied. The lowest-numbered packs will be installed first. Palette will wait a few
 moments when installing layers to ensure the readiness checks pass.
 
-To set the install order for an add-on pack layer, add the following annotation to the pack layer YAML. Replace the
-number with the desired install order value.
+To set the install order for an add-on pack layer, add the `spectrocloud.com/install-priority` annotation to the pack
+layer YAML. Replace the number with the desired install order value.
 
 ```yaml
 pack:

--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/create-addon-profile/create-addon-profile.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/create-addon-profile/create-addon-profile.md
@@ -26,6 +26,14 @@ negative and positive numbers and 0. The default install order value is 0. The i
 which manifests in the profile are applied. The lowest-numbered packs will be installed first. Palette will wait a few
 moments when installing layers to ensure the readiness checks pass.
 
+To set the install order for an add-on pack layer, add the following annotation to the pack layer YAML. Replace the
+number with the desired install order value.
+
+```yaml
+pack:
+  spectrocloud.com/install-priority: "30"
+```
+
 If a readiness check for an add-on pack layer fails, Palette will keep checking the status every two minutes until the
 check passes. Once the readiness check passes for a pack with a lower priority, add-on layer packs with higher install
 priority will be installed.

--- a/docs/docs-content/profiles/profile-customization.md
+++ b/docs/docs-content/profiles/profile-customization.md
@@ -19,12 +19,13 @@ deployed to or to a specific namespace if specified. You can apply labels and an
 
 The following parameters are available to specify namespace labels and annotations:
 
-| **Parameter**          | **Description**                                                                                      | **Type** |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- | -------- |
-| `namespace`            | The Namespace that the pack is deployed to. If the namespace does not exist, Palette will create it. | string   |
-| `additionalNamespaces` | A list of additional namespaces that Palette will create.                                            | map      |
-| `namespaceLabels`      | A list of key-value pairs for labels applied to the namespace.                                       | map      |
-| `namespaceAnnotations` | A list of key-value pairs for annotations applied to the namespace.                                  | map      |
+| **Parameter**                        | **Description**                                                                                                                                                                                                                          | **Type** |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `namespace`                          | The Namespace that the pack is deployed to. If the namespace does not exist, Palette will create it.                                                                                                                                     | string   |
+| `additionalNamespaces`               | A list of additional namespaces that Palette will create.                                                                                                                                                                                | map      |
+| `namespaceLabels`                    | A list of key-value pairs for labels applied to the namespace.                                                                                                                                                                           | map      |
+| `namespaceAnnotations`               | A list of key-value pairs for annotations applied to the namespace.                                                                                                                                                                      | map      |
+| ` spectrocloud.com/install-priority` | The install order of the pack. The lower the number, the higher the priority. Refer to the [Install Order](./cluster-profiles/create-cluster-profiles/create-addon-profile/create-addon-profile.md#install-order) section to learn more. | string   |
 
 The following example shows how to specify namespace labels and annotations for an add-on pack, a CSI pack, and a CNI
 pack. In the example pack YAML configuration, the `wordpress` namespace is created. An additional namespace titled


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR documents how to modify the Install Order priority of add-on packs through the YAML template. Two main changes were added to this PR:

1. The Install Order section got an example YAML.  This will help the reader better understand how to use the parameter in the Pack YAML.
2. Added a row to the profile customization table with a link to the Install Order section. This will help readers find the information. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Profile Customization Page](https://deploy-preview-5418--docs-spectrocloud.netlify.app/profiles/profile-customization/)

💻 [Install Order Section](https://deploy-preview-5418--docs-spectrocloud.netlify.app/profiles/cluster-profiles/create-cluster-profiles/create-addon-profile/#install-order)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1579](https://spectrocloud.atlassian.net/browse/DOC-1579)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1579]: https://spectrocloud.atlassian.net/browse/DOC-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ