### PR TITLE
docs: update supplemental packs pages DOC-1599

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/airgap/supplemental-packs.md
+++ b/docs/docs-content/enterprise-version/install-palette/airgap/supplemental-packs.md
@@ -11,28 +11,93 @@ keywords: ["self-hosted", "enterprise"]
 
 Review the following table to determine which pack binaries you need to download and upload to your OCI registry.
 
-| File Name                                          | URL                                                                                                     |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `airgap-pack-byoi-agent-mode-1.0.0.bin`            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-byoi-agent-mode-1.0.0.bin            |
-| `airgap-pack-cni-calico-3.29.0.bin`                | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-calico-3.29.0.bin                |
-| `airgap-pack-cni-calico-azure-3.29.0.bin`          | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-calico-azure-3.29.0.bin          |
-| `airgap-pack-cni-cilium-oss-1.15.7.bin`            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-cilium-oss-1.15.7.bin            |
-| `airgap-pack-cni-cilium-oss-1.16.3.bin`            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-cilium-oss-1.16.3.bin            |
-| `airgap-pack-cni-flannel-0.26.1.bin`               | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-flannel-0.26.1.bin               |
-| `airgap-pack-csi-portworx-generic-3.2.0.bin`       | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-portworx-generic-3.2.0.bin       |
-| `airgap-pack-csi-rook-ceph-1.15.3.bin`             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-1.15.3.bin             |
-| `airgap-pack-csi-rook-ceph-addon-1.15.3.bin`       | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-addon-1.15.3.bin       |
-| `airgap-pack-csi-rook-ceph-helm-1.14.9.bin`        | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-helm-1.14.9.bin        |
-| `airgap-pack-csi-rook-ceph-helm-addon-1.14.9.bin`  | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-helm-addon-1.14.9.bin  |
-| `airgap-pack-custom-cni-1.0.0.bin`                 | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-custom-cni-1.0.0.bin                 |
-| `airgap-pack-custom-csi-1.0.0.bin`                 | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-custom-csi-1.0.0.bin                 |
-| `airgap-pack-nginx-1.11.2.bin`                     | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-nginx-1.11.2.bin                     |
-| `airgap-pack-nginx-1.11.3.bin`                     | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-nginx-1.11.3.bin                     |
-| `airgap-pack-prometheus-operator-65.3.1.bin`       | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-prometheus-operator-65.3.1.bin       |
-| `airgap-pack-spectro-proxy-1.5.4.bin`              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-spectro-proxy-1.5.4.bin              |
-| `airgap-pack-vault-0.28.1.bin`                     | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vault-0.28.1.bin                     |
-| `airgap-pack-vault-0.29.1.bin`                     | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vault-0.29.1.bin                     |
-| `airgap-pack-volume-snapshot-controller-8.1.0.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-volume-snapshot-controller-8.1.0.bin |
+| File Name                                                      | URL                                                                                                                 |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `airgap-pack-byoi-agent-mode-1.0.0.bin`                        | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-byoi-agent-mode-1.0.0.bin                        |
+| `airgap-pack-cni-calico-3.29.0.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-calico-3.29.0.bin                            |
+| `airgap-pack-cni-calico-3.29.1.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-calico-3.29.1.bin                            |
+| `airgap-pack-cni-calico-azure-3.29.0.bin`                      | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-calico-azure-3.29.0.bin                      |
+| `airgap-pack-cni-cilium-oss-1.15.7.bin`                        | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-cilium-oss-1.15.7.bin                        |
+| `airgap-pack-cni-cilium-oss-1.16.3.bin`                        | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-cilium-oss-1.16.3.bin                        |
+| `airgap-pack-cni-flannel-0.26.1.bin`                           | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-flannel-0.26.1.bin                           |
+| `airgap-pack-csi-local-path-provisioner-0.0.30.bin`            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-local-path-provisioner-0.0.30.bin            |
+| `airgap-pack-csi-local-path-provisioner-addon-0.0.30.bin`      | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-local-path-provisioner-addon-0.0.30.bin      |
+| `airgap-pack-csi-portworx-generic-3.2.0.bin`                   | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-portworx-generic-3.2.0.bin                   |
+| `airgap-pack-csi-rook-ceph-1.15.3.bin`                         | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-1.15.3.bin                         |
+| `airgap-pack-csi-rook-ceph-1.15.6.bin`                         | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-1.15.6.bin                         |
+| `airgap-pack-csi-rook-ceph-addon-1.15.3.bin`                   | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-addon-1.15.3.bin                   |
+| `airgap-pack-csi-rook-ceph-addon-1.15.6.bin`                   | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-addon-1.15.6.bin                   |
+| `airgap-pack-csi-rook-ceph-helm-1.14.9.bin`                    | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-helm-1.14.9.bin                    |
+| `airgap-pack-csi-rook-ceph-helm-addon-1.14.9.bin`              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-rook-ceph-helm-addon-1.14.9.bin              |
+| `airgap-pack-custom-cni-1.0.0.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-custom-cni-1.0.0.bin                             |
+| `airgap-pack-custom-csi-1.0.0.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-custom-csi-1.0.0.bin                             |
+| `airgap-pack-edge-k3s-1.28.14.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.28.14.bin                             |
+| `airgap-pack-edge-k3s-1.29.9.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.29.9.bin                              |
+| `airgap-pack-edge-k3s-1.30.5.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.30.5.bin                              |
+| `airgap-pack-edge-k3s-1.28.15.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.28.15.bin                             |
+| `airgap-pack-edge-k3s-1.29.10.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.29.10.bin                             |
+| `airgap-pack-edge-k3s-1.30.6.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.30.6.bin                              |
+| `airgap-pack-edge-k3s-1.31.1.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.31.1.bin                              |
+| `airgap-pack-edge-k3s-1.29.12.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.29.12.bin                             |
+| `airgap-pack-edge-k3s-1.30.8.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.30.8.bin                              |
+| `airgap-pack-edge-k3s-1.31.4.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k3s-1.31.4.bin                              |
+| `airgap-pack-edge-k8s-1.28.14.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.28.14.bin                             |
+| `airgap-pack-edge-k8s-1.29.9.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.29.9.bin                              |
+| `airgap-pack-edge-k8s-1.30.5.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.30.5.bin                              |
+| `airgap-pack-edge-k8s-1.28.15.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.28.15.bin                             |
+| `airgap-pack-edge-k8s-1.29.10.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.29.10.bin                             |
+| `airgap-pack-edge-k8s-1.30.6.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.30.6.bin                              |
+| `airgap-pack-edge-k8s-1.29.12.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.29.12.bin                             |
+| `airgap-pack-edge-k8s-1.30.8.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.30.8.bin                              |
+| `airgap-pack-edge-k8s-1.31.1.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.31.1.bin                              |
+| `airgap-pack-edge-k8s-1.31.4.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-k8s-1.31.4.bin                              |
+| `airgap-pack-edge-native-byoi-2.1.0.bin`                       | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-native-byoi-2.1.0.bin                       |
+| `airgap-pack-edge-rke2-1.28.13.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.28.13.bin                            |
+| `airgap-pack-edge-rke2-1.29.8.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.29.8.bin                             |
+| `airgap-pack-edge-rke2-1.30.4.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.30.4.bin                             |
+| `airgap-pack-edge-rke2-1.28.14.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.28.14.bin                            |
+| `airgap-pack-edge-rke2-1.29.9.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.29.9.bin                             |
+| `airgap-pack-edge-rke2-1.30.5.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.30.5.bin                             |
+| `airgap-pack-edge-rke2-1.28.15.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.28.15.bin                            |
+| `airgap-pack-edge-rke2-1.29.10.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.29.10.bin                            |
+| `airgap-pack-edge-rke2-1.30.6.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.30.6.bin                             |
+| `airgap-pack-edge-rke2-1.31.1.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.31.1.bin                             |
+| `airgap-pack-edge-rke2-1.29.12.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.29.12.bin                            |
+| `airgap-pack-edge-rke2-1.30.8.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.30.8.bin                             |
+| `airgap-pack-edge-rke2-1.31.4.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-edge-rke2-1.31.4.bin                             |
+| `airgap-pack-kong-2.45.0.bin`                                  | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kong-2.45.0.bin                                  |
+| `airgap-pack-kubernetes-1.28.14.bin`                           | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.28.14.bin                           |
+| `airgap-pack-kubernetes-1.29.9.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.29.9.bin                            |
+| `airgap-pack-kubernetes-1.30.5.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.30.5.bin                            |
+| `airgap-pack-kubernetes-1.24.16.bin`                           | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.24.16.bin                           |
+| `airgap-pack-kubernetes-1.28.15.bin`                           | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.28.15.bin                           |
+| `airgap-pack-kubernetes-1.29.10.bin`                           | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.29.10.bin                           |
+| `airgap-pack-kubernetes-1.30.6.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.30.6.bin                            |
+| `airgap-pack-kubernetes-1.31.1.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.31.1.bin                            |
+| `airgap-pack-kubernetes-1.29.12.bin`                           | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.29.12.bin                           |
+| `airgap-pack-kubernetes-1.30.8.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.30.8.bin                            |
+| `airgap-pack-kubernetes-1.31.4.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-1.31.4.bin                            |
+| `airgap-pack-kubernetes-rke2-1.28.13-rke2r1-build20240815.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.28.13-rke2r1-build20240815.bin |
+| `airgap-pack-kubernetes-rke2-1.29.8-rke2r1-build20240815.bin`  | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.29.8-rke2r1-build20240815.bin  |
+| `airgap-pack-kubernetes-rke2-1.30.4-rke2r1-build20240815.bin`  | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.30.4-rke2r1-build20240815.bin  |
+| `airgap-pack-kubernetes-rke2-1.28.14-rke2r1-build20240912.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.28.14-rke2r1-build20240912.bin |
+| `airgap-pack-kubernetes-rke2-1.29.9-rke2r1-build20240912.bin`  | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.29.9-rke2r1-build20240912.bin  |
+| `airgap-pack-kubernetes-rke2-1.30.5-rke2r1-build20240912.bin`  | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.30.5-rke2r1-build20240912.bin  |
+| `airgap-pack-kubernetes-rke2-1.28.15-rke2r1-build20241023.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.28.15-rke2r1-build20241023.bin |
+| `airgap-pack-kubernetes-rke2-1.29.10-rke2r1-build20241023.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.29.10-rke2r1-build20241023.bin |
+| `airgap-pack-kubernetes-rke2-1.30.6-rke2r1-build20241023.bin`  | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.30.6-rke2r1-build20241023.bin  |
+| `airgap-pack-kubernetes-rke2-1.29.12-rke2r1-build20241212.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.29.12-rke2r1-build20241212.bin |
+| `airgap-pack-kubernetes-rke2-1.31.4-rke2r1-build20241212.bin`  | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-kubernetes-rke2-1.31.4-rke2r1-build20241212.bin  |
+| `airgap-pack-lb-metallb-helm-0.14.9.bin`                       | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-lb-metallb-helm-0.14.9.bin                       |
+| `airgap-pack-nginx-1.11.2.bin`                                 | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-nginx-1.11.2.bin                                 |
+| `airgap-pack-nginx-1.11.3.bin`                                 | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-nginx-1.11.3.bin                                 |
+| `airgap-pack-prometheus-operator-65.3.1.bin`                   | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-prometheus-operator-65.3.1.bin                   |
+| `airgap-pack-prometheus-operator-67.5.0.bin`                   | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-prometheus-operator-67.5.0.bin                   |
+| `airgap-pack-reloader-1.2.0.bin`                               | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-reloader-1.2.0.bin                               |
+| `airgap-pack-spectro-proxy-1.5.4.bin`                          | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-spectro-proxy-1.5.4.bin                          |
+| `airgap-pack-vault-0.28.1.bin`                                 | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vault-0.28.1.bin                                 |
+| `airgap-pack-vault-0.29.1.bin`                                 | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vault-0.29.1.bin                                 |
+| `airgap-pack-volume-snapshot-controller-8.1.0.bin`             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-volume-snapshot-controller-8.1.0.bin             |
 
 ## Download Instructions
 
@@ -112,13 +177,17 @@ use for the workload clusters.
 | Kubernetes 1.28.12     | u-2204-0-k-12812-0.ova      | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12812-0.ova`      |
 | Kubernetes 1.28.13     | u-2204-0-k-12813-0.ova      | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12813-0.ova`      |
 | Kubernetes 1.28.14     | u-2204-0-k-12814-0.ova      | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12814-0.ova`      |
+| Kubernetes 1.28.15     | u-2204-0-k-12815-0.ova      | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12815-0.ova`      |
 | Kubernetes 1.29.4      | u-2204-0-k-1294-0.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1294-0.ova`       |
 | Kubernetes 1.29.6      | u-2204-0-k-1296-0.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1296-0.ova`       |
 | Kubernetes 1.29.7      | u-2204-0-k-1297-0.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1297-0.ova`       |
 | Kubernetes 1.29.8      | u-2204-0-k-1298-0.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1298-0.ova`       |
 | Kubernetes 1.29.9      | u-2204-0-k-1299-0.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1299-0.ova`       |
+| Kubernetes 1.29.10     | u-2204-0-k-12910-0.ova      | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-12910-0.ova`      |
 | Kubernetes 1.30.4      | u-2204-0-k-1304-0.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1304-0.ova`       |
 | Kubernetes 1.30.5      | u-2204-0-k-1305-0.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1305-0.ova`       |
+| Kubernetes 1.30.6      | u-2204-0-k-1306-0.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1306-0.ova`       |
+| Kubernetes 1.31.1      | u-2204-0-k-1311-0.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1311-0.ova`       |
 | RKE2 1.27.11           | u-2204-0-k-rke2-12711-0.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-12711-0.ova` |
 | RKE2 1.27.13           | u-2204-0-k-rke2-12713-0.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-12713-0.ova` |
 | RKE2 1.27.14           | u-2204-0-k-rke2-12714-0.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-12714-0.ova` |
@@ -128,11 +197,15 @@ use for the workload clusters.
 | RKE2 1.28.11           | u-2204-0-k-rke2-12811-0.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-12811-0.ova` |
 | RKE2 1.28.12           | u-2204-0-k-rke2-12812-0.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-12812-0.ova` |
 | RKE2 1.28.13           | u-2204-0-k-rke2-12813-0.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-12813-0.ova` |
+| RKE2 1.28.14           | u-2204-0-k-rke2-12814-0.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-12814-0.ova` |
+| RKE2 1.28.15           | u-2204-0-k-rke2-12815-0.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-12815-0.ova` |
 | RKE2 1.29.4            | u-2204-0-k-rke2-1294-0.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-1294-0.ova`  |
 | RKE2 1.29.5            | u-2204-0-k-rke2-1295-0.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-1295-0.ova`  |
 | RKE2 1.29.6            | u-2204-0-k-rke2-1296-0.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-1296-0.ova`  |
 | RKE2 1.29.7            | u-2204-0-k-rke2-1297-0.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-1297-0.ova`  |
 | RKE2 1.29.8            | u-2204-0-k-rke2-1298-0.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-1298-0.ova`  |
+| RKE2 1.29.9            | u-2204-0-k-rke2-1299-0.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-1299-0.ova`  |
+| RKE2 1.29.10           | u-2204-0-k-rke2-12910-0.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-12910-0.ova` |
 | RKE2 1.30.3            | u-2204-0-k-rke2-1303-0.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-1303-0.ova`  |
 | RKE2 1.30.4            | u-2204-0-k-rke2-1304-0.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-1304-0.ova`  |
 | RKE2 1.30.5            | u-2204-0-k-rke2-1305-0.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-rke2-1305-0.ova`  |

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/supplemental-packs.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/supplemental-packs.md
@@ -14,20 +14,62 @@ Review the following table to determine which pack binaries you need to download
 | **File Name**                                                         | **Download URL**                                                                                                                  |
 | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `airgap-vertex-pack-cni-calico-3.29.0.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-3.29.0.bin                            |
+| `airgap-vertex-pack-cni-calico-3.29.1.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-3.29.1.bin                            |
 | `airgap-vertex-pack-cni-calico-azure-fips-3.29.0.bin`                 | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-azure-fips-3.29.0.bin                 |
 | `airgap-vertex-pack-cni-cilium-fips-1.16.0.bin`                       | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-cilium-fips-1.16.0.bin                       |
+| `airgap-vertex-pack-csi-longhorn-addon-fips-1.7.2.bin`                | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-csi-longhorn-addon-fips-1.7.2.bin                |
+| `airgap-vertex-pack-csi-longhorn-fips-1.7.2.bin`                      | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-csi-longhorn-fips-1.7.2.bin                      |
+| `airgap-vertex-pack-csi-rook-ceph-1.15.3.bin`                         | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-csi-rook-ceph-1.15.3.bin                         |
+| `airgap-vertex-pack-csi-rook-ceph-addon-1.15.3.bin`                   | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-csi-rook-ceph-addon-1.15.3.bin                   |
 | `airgap-vertex-pack-edge-k8s-1.28.14.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.28.14.bin                             |
 | `airgap-vertex-pack-edge-k8s-1.29.9.bin`                              | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.29.9.bin                              |
 | `airgap-vertex-pack-edge-k8s-1.30.5.bin`                              | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.30.5.bin                              |
+| `airgap-vertex-pack-edge-k8s-1.28.15.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.28.15.bin                             |
+| `airgap-vertex-pack-edge-k8s-1.29.10.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.29.10.bin                             |
+| `airgap-vertex-pack-edge-k8s-1.30.6.bin`                              | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.30.6.bin                              |
+| `airgap-vertex-pack-edge-k8s-1.29.12.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.29.12.bin                             |
+| `airgap-vertex-pack-edge-k8s-1.30.8.bin`                              | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.30.8.bin                              |
+| `airgap-vertex-pack-edge-k8s-1.31.1.bin`                              | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.31.1.bin                              |
+| `airgap-vertex-pack-edge-k8s-1.31.4.bin`                              | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-k8s-1.31.4.bin                              |
+| `airgap-vertex-pack-edge-native-byoi-2.1.0.bin`                       | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-native-byoi-2.1.0.bin                       |
 | `airgap-vertex-pack-edge-rke2-1.28.13.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.28.13.bin                            |
 | `airgap-vertex-pack-edge-rke2-1.29.8.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.29.8.bin                             |
 | `airgap-vertex-pack-edge-rke2-1.30.4.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.30.4.bin                             |
+| `airgap-vertex-pack-edge-rke2-1.28.14.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.28.14.bin                            |
+| `airgap-vertex-pack-edge-rke2-1.29.9.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.29.9.bin                             |
+| `airgap-vertex-pack-edge-rke2-1.30.5.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.30.5.bin                             |
+| `airgap-vertex-pack-edge-rke2-1.28.15.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.28.15.bin                            |
+| `airgap-vertex-pack-edge-rke2-1.29.10.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.29.10.bin                            |
+| `airgap-vertex-pack-edge-rke2-1.30.6.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.30.6.bin                             |
+| `airgap-vertex-pack-edge-rke2-1.31.1.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.31.1.bin                             |
+| `airgap-vertex-pack-edge-rke2-1.29.12.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.29.12.bin                            |
+| `airgap-vertex-pack-edge-rke2-1.30.8.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.30.8.bin                             |
+| `airgap-vertex-pack-edge-rke2-1.31.4.bin`                             | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-edge-rke2-1.31.4.bin                             |
 | `airgap-vertex-pack-kubernetes-1.28.14.bin`                           | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.28.14.bin                           |
 | `airgap-vertex-pack-kubernetes-1.29.9.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.29.9.bin                            |
 | `airgap-vertex-pack-kubernetes-1.30.5.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.30.5.bin                            |
+| `airgap-vertex-pack-kubernetes-1.28.15.bin`                           | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.28.15.bin                           |
+| `airgap-vertex-pack-kubernetes-1.29.10.bin`                           | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.29.10.bin                           |
+| `airgap-vertex-pack-kubernetes-1.30.6.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.30.6.bin                            |
+| `airgap-vertex-pack-kubernetes-1.31.1.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.31.1.bin                            |
+| `airgap-vertex-pack-kubernetes-1.29.12.bin`                           | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.29.12.bin                           |
+| `airgap-vertex-pack-kubernetes-1.30.5.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.30.5.bin                            |
+| `airgap-vertex-pack-kubernetes-1.30.6.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.30.6.bin                            |
+| `airgap-vertex-pack-kubernetes-1.30.8.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.30.8.bin                            |
+| `airgap-vertex-pack-kubernetes-1.31.1.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.31.1.bin                            |
+| `airgap-vertex-pack-kubernetes-1.31.4.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-1.31.4.bin                            |
 | `airgap-vertex-pack-kubernetes-rke2-1.28.13-rke2r1-build20240815.bin` | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.28.13-rke2r1-build20240815.bin |
+| `airgap-vertex-pack-kubernetes-rke2-1.28.14-rke2r1-build20240912.bin` | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.28.14-rke2r1-build20240912.bin |
+| `airgap-vertex-pack-kubernetes-rke2-1.28.15-rke2r1-build20241023.bin` | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.28.15-rke2r1-build20241023.bin |
 | `airgap-vertex-pack-kubernetes-rke2-1.29.8-rke2r1-build20240815.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.29.8-rke2r1-build20240815.bin  |
+| `airgap-vertex-pack-kubernetes-rke2-1.29.9-rke2r1-build20240912.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.29.9-rke2r1-build20240912.bin  |
+| `airgap-vertex-pack-kubernetes-rke2-1.29.10-rke2r1-build20241023.bin` | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.29.10-rke2r1-build20241023.bin |
+| `airgap-vertex-pack-kubernetes-rke2-1.29.12-rke2r1-build20241212.bin` | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.29.12-rke2r1-build20241212.bin |
 | `airgap-vertex-pack-kubernetes-rke2-1.30.4-rke2r1-build20240815.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.30.4-rke2r1-build20240815.bin  |
+| `airgap-vertex-pack-kubernetes-rke2-1.30.5-rke2r1-build20240912.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.30.5-rke2r1-build20240912.bin  |
+| `airgap-vertex-pack-kubernetes-rke2-1.30.6-rke2r1-build20241023.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.30.6-rke2r1-build20241023.bin  |
+| `airgap-vertex-pack-kubernetes-rke2-1.30.8-rke2r1-build20241212.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.30.8-rke2r1-build20241212.bin  |
+| `airgap-vertex-pack-kubernetes-rke2-1.31.4-rke2r1-build20241212.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.31.4-rke2r1-build20241212.bin  |
 
 ### Usage Instructions
 
@@ -104,13 +146,17 @@ want to use for your workload clusters.
 | Kubernetes 1.28.12     | u-2004-0-k-12812-fips.ova      | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12812-fips.ova`      |
 | Kubernetes 1.28.13     | u-2004-0-k-12813-fips.ova      | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12813-fips.ova`      |
 | Kubernetes 1.28.14     | u-2004-0-k-12814-fips.ova      | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12814-fips.ova`      |
+| Kubernetes 1.28.15     | u-2004-0-k-12815-fips.ova      | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12815-fips.ova`      |
 | Kubernetes 1.29.4      | u-2004-0-k-1294-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1294-fips.ova`       |
 | Kubernetes 1.29.6      | u-2004-0-k-1296-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1296-fips.ova`       |
 | Kubernetes 1.29.7      | u-2004-0-k-1297-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1297-fips.ova`       |
 | Kubernetes 1.29.8      | u-2004-0-k-1298-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1298-fips.ova`       |
 | Kubernetes 1.29.9      | u-2004-0-k-1299-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`       |
+| Kubernetes 1.29.10     | u-2004-0-k-1299-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-12910-fips.ova`      |
 | Kubernetes 1.30.4      | u-2004-0-k-1304-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1304-fips.ova`       |
 | Kubernetes 1.30.5      | u-2004-0-k-1305-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1305-fips.ova`       |
+| Kubernetes 1.30.6      | u-2004-0-k-1306-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1306-fips.ova`       |
+| Kubernetes 1.31.1      | u-2004-0-k-1311-fips.ova       | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1311-fips.ova`       |
 | RKE2 1.27.11           | u-2004-0-k-rke2-12711-fips.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-12711-fips.ova` |
 | RKE2 1.27.13           | u-2004-0-k-rke2-12713-fips.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-12713-fips.ova` |
 | RKE2 1.27.14           | u-2004-0-k-rke2-12714-fips.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-12714-fips.ova` |
@@ -120,14 +166,19 @@ want to use for your workload clusters.
 | RKE2 1.28.11           | u-2004-0-k-rke2-12811-fips.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-12811-fips.ova` |
 | RKE2 1.28.12           | u-2004-0-k-rke2-12812-fips.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-12812-fips.ova` |
 | RKE2 1.28.13           | u-2004-0-k-rke2-12813-fips.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-12813-fips.ova` |
+| RKE2 1.28.14           | u-2004-0-k-rke2-12814-fips.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-12814-fips.ova` |
+| RKE2 1.28.15           | u-2004-0-k-rke2-12815-fips.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-12815-fips.ova` |
 | RKE2 1.29.4            | u-2004-0-k-rke2-1294-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1294-fips.ova`  |
 | RKE2 1.29.5            | u-2004-0-k-rke2-1295-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1295-fips.ova`  |
 | RKE2 1.29.6            | u-2004-0-k-rke2-1296-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1296-fips.ova`  |
 | RKE2 1.29.7            | u-2004-0-k-rke2-1297-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1297-fips.ova`  |
 | RKE2 1.29.8            | u-2004-0-k-rke2-1298-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1298-fips.ova`  |
+| RKE2 1.29.9            | u-2004-0-k-rke2-1299-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1299-fips.ova`  |
+| RKE2 1.29.10           | u-2004-0-k-rke2-12910-fips.ova | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-12910-fips.ova` |
 | RKE2 1.30.3            | u-2004-0-k-rke2-1303-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1303-fips.ova`  |
 | RKE2 1.30.4            | u-2004-0-k-rke2-1304-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1304-fips.ova`  |
 | RKE2 1.30.5            | u-2004-0-k-rke2-1305-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1305-fips.ova`  |
+| RKE2 1.30.6            | u-2004-0-k-rke2-1306-fips.ova  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-rke2-1306-fips.ova`  |
 
 ### Usage Instructions
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the supplemental pages for Palette and Vertex. Updates binaries and OVAs. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Palette Supplemental Packs](https://deploy-preview-5478--docs-spectrocloud.netlify.app/enterprise-version/install-palette/airgap/supplemental-packs/)
💻 [VerteX Supplemental Packs](https://deploy-preview-5478--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/airgap/supplemental-packs/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1599](https://spectrocloud.atlassian.net/browse/DOC-1599)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1599]: https://spectrocloud.atlassian.net/browse/DOC-1599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ