### PR TITLE
docs: remove tech preview banner from microk8s PCP-4016

### DIFF
--- a/docs/docs-content/integrations/kubernetes-microk8s.md
+++ b/docs/docs-content/integrations/kubernetes-microk8s.md
@@ -16,10 +16,6 @@ We support different Kubernetes distributions, such as MicroK8s, K3s, and RKE2, 
 The EOL is set by the respective owner. Once we stop supporting the minor version, we initiate the deprecation process.
 Refer to the [Kubernetes Support Lifecycle](kubernetes-support.md#other-kubernetes-distributions) guide to learn more.
 
-:::preview
-
-:::
-
 ## Versions Supported
 
 <Tabs queryString="parent">


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the tech preview banner from the microk8s pack. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [MicroK8s](https://deploy-preview-5493--docs-spectrocloud.netlify.app/integrations/packs/?pack=kubernetes-microk8s&version=1.28&parent=1.28.x&tab=custom)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PCP-4016](https://spectrocloud.atlassian.net/browse/PCP-4016)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._


[PCP-4016]: https://spectrocloud.atlassian.net/browse/PCP-4016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ