### PR TITLE
docs: fix third-party references in self-hosted airgap guides

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/checklist.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/checklist.md
@@ -27,7 +27,7 @@ installation. Review this checklist with your Palette support team to ensure you
 - [ ] Review the list of [pack binaries](../../airgap/supplemental-packs.md) to download and upload to your OCI
       registry.
 
-- [ ] Download the required third-party binary that contains the core packs and images required for the installation.
+- [ ] Download the release binary that contains the core packs and images required for the installation.
 
 - [ ] If you have custom SSL certificates you want to include, copy the custom SSL certificates, in base64 PEM format,
       to the support VM. The custom certificates must be placed in the **/opt/spectro/ssl** folder. Include the

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/environment-setup/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/environment-setup/vmware-vsphere-airgap-instructions.md
@@ -31,10 +31,9 @@ Palette.
 
   - The installation OVA that deploys and initializes the airgap support VM. The installation OVA can be either generic
     or release-specific.
-  - If you are using a generic OVA, ensure you download the airgap Palette installation binary for the version of
-    Palette you plan to install.
+  - If you are using a generic OVA, ensure you download the airgap Palette release binary for the version of Palette you
+    plan to install. This binary contains the core packs and images required for the installation.
   - An OVA with the operating system and Kubernetes distribution required for the Palette nodes.
-  - The third-party binary that contains the core packs and images required for the installation.
 
   For sensitive environments, you can download the OVAs to a system with internet access and then transfer them to your
   airgap environment.
@@ -321,24 +320,22 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
         </TabItem>
         </Tabs>
 
-18. The output of the script contains credentials and values you will need when completing the installation with the
+    The output of the script contains credentials and values you will need when completing the installation with the
     Palette CLI. If you need to review this information in the future, invoke the script again.
 
-19. Next, download the third party binary. Your support representative will provide you with credentials to access the
-    third-party binary. Use the following command to download the third-party binary. Replace the `XXXXX` and `YYYYY`
-    placeholders with the credentials provided to you. Replace the `X.X` placeholder with the version of the third-party
-    binary you are downloading. Ask your support representative for the version of the third-party binary you need.
+18. If you have used a release-specific installation OVA, skip this step. Otherwise, if you have used a generic
+    installation OVA, use the following command to start the airgap Palette release binary. The release binary uploads
+    the release-specific packs and images to the registry configured in step **17** of this guide. This process may take
+    some time to complete.
 
     ```shell
-    curl --user XXXXX:YYYYY https://software-private.spectrocloud.com/airgap/thirdparty/airgap-thirdparty-X.X.X.bin \
-    --output airgap-upload.bin
+    chmod +x airgap-<version>.bin && ./airgap-<version>.bin
     ```
 
-20. Use the following command to start the third-party binary. The third-party binary uploads the release-specific packs
-    and images to the registry configured in step **17** of this guide. This process may take some time to complete.
+    Consider the following example for reference.
 
     ```shell
-    chmod +x airgap-upload.bin && ./airgap-upload.bin
+    chmod +x airgap-v4.4.14.bin && ./airgap-v4.4.14.bin
     ```
 
     ```text hideClipboard
@@ -354,17 +351,17 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
 
     Once the airgap binary completes its tasks, you will receive a **Setup Completed** success message.
 
-21. Review the [Additional Packs](../../../airgap/supplemental-packs.md) page and identify any additional packs you want
+19. Review the [Additional Packs](../../../airgap/supplemental-packs.md) page and identify any additional packs you want
     to add to your OCI registry. You can also add additional packs after the installation is complete.
 
-22. Navigate back to the vSphere console and create a vSphere VM and Template folder named `spectro-templates`. Ensure
+20. Navigate back to the vSphere console and create a vSphere VM and Template folder named `spectro-templates`. Ensure
     you can access this folder with the user account you plan to use when deploying the VerteX installation. You can
     choose a different name for the folder if you prefer, but ensure you use the same name when the Palette CLI prompts
     you for the folder name.
 
-23. Right-click on your cluster or resource group and select **Deploy OVF Template**.
+21. Right-click on your cluster or resource group and select **Deploy OVF Template**.
 
-24. In the **Deploy OVF Template** wizard, enter the following URL to import the Operating System (OS) and Kubernetes
+22. In the **Deploy OVF Template** wizard, enter the following URL to import the Operating System (OS) and Kubernetes
     distribution OVA required for the installation. Refer to the
     [Kubernetes Requirements](../../../install-palette.md#kubernetes-requirements) section to learn if the version of
     Palette you are installing requires a new OS and Kubernetes OVA.

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/checklist.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/checklist.md
@@ -34,7 +34,7 @@ installation. Review this checklist with your VerteX support team to ensure you 
 - [ ] Review the list of [pack binaries](../../airgap/supplemental-packs.md) to download and upload to your OCI
       registry.
 
-- [ ] Download the required third-party binary that contains the core packs and images required for the installation.
+- [ ] Download the release binary that contains the core packs and images required for the installation.
 
 - [ ] If you have custom SSL certificates you want to include, copy the custom SSL certificates, in base64 PEM format,
       to the support VM. The custom certificates must be placed in the **/opt/spectro/ssl** folder. Include the

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/environment-setup/vmware-vsphere-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/environment-setup/vmware-vsphere-airgap-instructions.md
@@ -31,10 +31,9 @@ VerteX.
 
   - The installation OVA that deploys and initializes the airgap support VM. The installation OVA can be either generic
     or release-specific.
-  - If you are using a generic OVA, ensure you download the airgap VerteX installation binary for the version of VerteX
-    you plan to install.
+  - If you are using a generic OVA, ensure you download the airgap VerteX release binary for the version of VerteX you
+    plan to install. This binary contains the core packs and images required for the installation.
   - An OVA with the operating system and Kubernetes distribution required for the VerteX nodes.
-  - The third-party binary that contains the core packs and images required for the installation.
 
   For sensitive environments, you can download the OVAs to a system with internet access and then transfer them to your
   airgap environment.
@@ -325,24 +324,22 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
         </TabItem>
         </Tabs>
 
-18. The output of the script contains credentials and values you will need when completing the installation with the
+    The output of the script contains credentials and values you will need when completing the installation with the
     Palette CLI. If you need to review this information in the future, invoke the script again.
 
-19. Next, download the third party binary. Your support representative will provide you with credentials to access the
-    third-party binary. Use the following command to download the third-party binary. Replace the `XXXXX` and `YYYYY`
-    placeholders with the credentials provided to you. Replace the `X.X` placeholder with the version of the third-party
-    binary you are downloading. Ask your support representative for the version of the third-party binary you need.
+18. If you have used a release-specific installation OVA, skip this step. Otherwise, if you have used a generic
+    installation OVA, use the following command to start the airgap VerteX release binary. The release binary uploads
+    the release-specific packs and images to the registry configured in step **17** of this guide. This process may take
+    some time to complete.
 
     ```shell
-    curl --user XXXXX:YYYYY https://software-private.spectrocloud.com/airgap/thirdparty/airgap-thirdparty-X.X.X.bin \
-    --output airgap-upload.bin
+    chmod +x airgap-vertex-<version>.bin && ./airgap-vertex-<version>.bin
     ```
 
-20. Use the following command to start the third-party binary. The third-party binary uploads the release-specific packs
-    and images to the registry configured in step **17** of this guide. This process may take some time to complete.
+    Consider the following example for reference.
 
     ```shell
-    chmod +x airgap-upload.bin && ./airgap-upload.bin
+    chmod +x airgap-vertex-v4.4.14.bin && ./airgap-vertex-v4.4.14.bin
     ```
 
     ```text hideClipboard
@@ -360,17 +357,17 @@ The default container runtime for OVAs is [Podman](https://podman.io/), not Dock
 
     Once the Palette VerteX airgap binary completes its tasks, you will receive a **Setup Completed** success message.
 
-21. Review the [Additional Packs](../../../airgap/supplemental-packs.md) page and identify any additional packs you want
+19. Review the [Additional Packs](../../../airgap/supplemental-packs.md) page and identify any additional packs you want
     to add to your OCI registry. You can also add additional packs after the installation is complete.
 
-22. Navigate back to the vSphere console and create a vSphere VM and Template folder named `spectro-templates`. Ensure
+20. Navigate back to the vSphere console and create a vSphere VM and Template folder named `spectro-templates`. Ensure
     you can access this folder with the user account you plan to use when deploying the VerteX installation. You can
     choose a different name for the folder if you prefer, but ensure you use the same name when the Palette CLI prompts
     you for the folder name.
 
-23. Next, right-click on your cluster or resource group and select **Deploy OVF Template**.
+21. Next, right-click on your cluster or resource group and select **Deploy OVF Template**.
 
-24. In the **Deploy OVF Template** wizard, enter the following URL to import the Operating System (OS) and Kubernetes
+22. In the **Deploy OVF Template** wizard, enter the following URL to import the Operating System (OS) and Kubernetes
     distribution OVA required for the installation. Refer to the
     [Kubernetes Requirements](../../../install-palette-vertex.md#kubernetes-requirements) section to learn if the
     version of Palette you are installing requires a new OS and Kubernetes OVA.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates self-hosted and VerteX guides to replace references to the third-party binary with the release binary, as the release binary is the one responsible for installing packs and images that are specific to a release.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Self-hosted Env Setup](https://deploy-preview-5564--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/airgap-install/environment-setup/vmware-vsphere-airgap-instructions/)
💻 [Self-hosted Checklist](https://deploy-preview-5564--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/airgap-install/checklist/)

💻 [VerteX Env Setup](https://deploy-preview-5564--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/airgap-install/environment-setup/vmware-vsphere-airgap-instructions/)
💻 [VerteX Checklist](https://deploy-preview-5564--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/airgap-install/checklist/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1618](https://spectrocloud.atlassian.net/browse/DOC-1618)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1618]: https://spectrocloud.atlassian.net/browse/DOC-1618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ