### PR TITLE
docs: DOC-1621: semodule_package --outfile flag

### DIFF
--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -136,7 +136,7 @@ Palette. You will then create a cluster profile and use the registered host to d
 
      ```shell
      checkmodule -M -m --output rsync_dac_override.mod rsync_dac_override.te
-     semodule_package --output rsync_dac_override.pp -m rsync_dac_override.mod
+     semodule_package --outfile rsync_dac_override.pp -m rsync_dac_override.mod
      ```
 
   6. Install the compiled policy module.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR corrects an incorrect flag in the "Install Agent Mode" prereq section for SELinux policy permissions.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Install Agent Mode](https://deploy-preview-5566--docs-spectrocloud.netlify.app/deployment-modes/agent-mode/install-agent-host/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1621](https://spectrocloud.atlassian.net/browse/DOC-1621)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1621]: https://spectrocloud.atlassian.net/browse/DOC-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ