### PR TITLE
[version-4-2] chore: bump hashicorp/vault-action from 3.0.0 to 3.1.0 (#5530)

### DIFF
--- a/.github/workflows/api_format.yaml
+++ b/.github/workflows/api_format.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Retrieve Credentials
         id: import-secrets
-        uses: hashicorp/vault-action@v3.0.0
+        uses: hashicorp/vault-action@v3.1.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Retrieve Credentials
         id: import-secrets
-        uses: hashicorp/vault-action@v2.7.3
+        uses: hashicorp/vault-action@v3.1.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle

--- a/.github/workflows/clean-up-unused-images.yaml
+++ b/.github/workflows/clean-up-unused-images.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Retrieve Credentials
         id: import-secrets
-        uses: hashicorp/vault-action@v3.0.0
+        uses: hashicorp/vault-action@v3.1.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle

--- a/.github/workflows/image_optimizer.yaml
+++ b/.github/workflows/image_optimizer.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Retrieve Credentials
         id: import-secrets
-        uses: hashicorp/vault-action@v2.7.3
+        uses: hashicorp/vault-action@v3.1.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle

--- a/.github/workflows/packs-data.yaml
+++ b/.github/workflows/packs-data.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Retrieve Credentials
         id: import-secrets
-        uses: hashicorp/vault-action@v2.7.3
+        uses: hashicorp/vault-action@v3.1.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Retrieve Credentials
         id: import-secrets
-        uses: hashicorp/vault-action@v3.0.0
+        uses: hashicorp/vault-action@v3.1.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Retrieve Credentials
         id: import-secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v3.1.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle


### PR DESCRIPTION

## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the backport issues for PR #5530 
