### PR TITLE
Include us-docker domain in proxy requirements

### DIFF
--- a/docs/docs-content/clusters/clusters.md
+++ b/docs/docs-content/clusters/clusters.md
@@ -295,24 +295,25 @@ The following table lists the proxy requirements required by Palette. Depending 
 configuration, you may have to specify all subdomains of the top-level domains listed in the table. For example, an
 entry containing `gcr.io` and `*.gcr.io` may be required. Consult your network administrator for the exact requirements.
 
-| **Top-level Domain**        | **Port** | **Description**                               |
-| --------------------------- | -------- | --------------------------------------------- |
-| docker.io                   | 443      | Third party container images.                 |
-| docker.com                  | 443      | Third party container images.                 |
-| gcr.io                      | 443      | Spectro Cloud and 3rd party container images. |
-| ghcr.io                     | 443      | Third party container images.                 |
-| github.com                  | 443      | Third party content.                          |
-| googleapis.com              | 443      | Spectro Cloud images.                         |
-| grafana.com                 | 443      | Grafana container images and manifests.       |
-| k8s.gcr.io                  | 443      | Third party container images.                 |
-| projectcalico.org           | 443      | Calico container images.                      |
-| registry.k8s.io             | 443      | Third party container images.                 |
-| raw.githubusercontent.com   | 443      | Third party content.                          |
-| spectrocloud.com            | 443      | Spectro Cloud Palette SaaS.                   |
-| s3.amazonaws.com            | 443      | Spectro Cloud VMware OVA files.               |
-| quay.io                     | 443      | Third party container images.                 |
-| ecr.us-east-1.amazonaws.com | 443      | OCI Pack images.                              |
-| ecr.us-west-2.amazonaws.com | 443      | OCI Pack images.                              |
+| **Top-level Domain**        | **Port** | **Description**                                                 |
+| --------------------------- | -------- | --------------------------------------------------------------- |
+| docker.io                   | 443      | Third party container images.                                   |
+| docker.com                  | 443      | Third party container images.                                   |
+| gcr.io                      | 443      | Spectro Cloud and 3rd party container images                    |
+| ghcr.io                     | 443      | Third party container images.                                   |
+| github.com                  | 443      | Third party content.                                            |
+| googleapis.com              | 443      | Spectro Cloud images.                                           |
+| grafana.com                 | 443      | Grafana container images and manifests.                         |
+| k8s.gcr.io                  | 443      | Third party container images.                                   |
+| projectcalico.org           | 443      | Calico container images.                                        |
+| registry.k8s.io             | 443      | Third party container images.                                   |
+| raw.githubusercontent.com   | 443      | Third party content.                                            |
+| spectrocloud.com            | 443      | Spectro Cloud Palette SaaS.                                     |
+| s3.amazonaws.com            | 443      | Spectro Cloud VMware OVA files.                                 |
+| quay.io                     | 443      | Third party container images.                                   |
+| ecr.us-east-1.amazonaws.com | 443      | OCI Pack images.                                                |
+| ecr.us-west-2.amazonaws.com | 443      | OCI Pack images.                                                |
+| us-docker.pkg.dev           | 443      | Required content repository and common third party content      |
 
 ## Scope
 

--- a/docs/docs-content/clusters/clusters.md
+++ b/docs/docs-content/clusters/clusters.md
@@ -299,7 +299,7 @@ entry containing `gcr.io` and `*.gcr.io` may be required. Consult your network a
 | --------------------------- | -------- | ---------------------------------------------------------- |
 | docker.io                   | 443      | Third party container images.                              |
 | docker.com                  | 443      | Third party container images.                              |
-| gcr.io                      | 443      | Spectro Cloud and 3rd party container images               |
+| gcr.io                      | 443      | Spectro Cloud and third party container images               |
 | ghcr.io                     | 443      | Third party container images.                              |
 | github.com                  | 443      | Third party content.                                       |
 | googleapis.com              | 443      | Spectro Cloud images.                                      |
@@ -313,7 +313,7 @@ entry containing `gcr.io` and `*.gcr.io` may be required. Consult your network a
 | quay.io                     | 443      | Third party container images.                              |
 | ecr.us-east-1.amazonaws.com | 443      | OCI Pack images.                                           |
 | ecr.us-west-2.amazonaws.com | 443      | OCI Pack images.                                           |
-| us-docker.pkg.dev           | 443      | Required content repository and common third party content |
+| us-docker.pkg.dev           | 443      | Required content repository and common third party content. |
 
 ## Scope
 

--- a/docs/docs-content/clusters/clusters.md
+++ b/docs/docs-content/clusters/clusters.md
@@ -295,25 +295,25 @@ The following table lists the proxy requirements required by Palette. Depending 
 configuration, you may have to specify all subdomains of the top-level domains listed in the table. For example, an
 entry containing `gcr.io` and `*.gcr.io` may be required. Consult your network administrator for the exact requirements.
 
-| **Top-level Domain**        | **Port** | **Description**                                                 |
-| --------------------------- | -------- | --------------------------------------------------------------- |
-| docker.io                   | 443      | Third party container images.                                   |
-| docker.com                  | 443      | Third party container images.                                   |
-| gcr.io                      | 443      | Spectro Cloud and 3rd party container images                    |
-| ghcr.io                     | 443      | Third party container images.                                   |
-| github.com                  | 443      | Third party content.                                            |
-| googleapis.com              | 443      | Spectro Cloud images.                                           |
-| grafana.com                 | 443      | Grafana container images and manifests.                         |
-| k8s.gcr.io                  | 443      | Third party container images.                                   |
-| projectcalico.org           | 443      | Calico container images.                                        |
-| registry.k8s.io             | 443      | Third party container images.                                   |
-| raw.githubusercontent.com   | 443      | Third party content.                                            |
-| spectrocloud.com            | 443      | Spectro Cloud Palette SaaS.                                     |
-| s3.amazonaws.com            | 443      | Spectro Cloud VMware OVA files.                                 |
-| quay.io                     | 443      | Third party container images.                                   |
-| ecr.us-east-1.amazonaws.com | 443      | OCI Pack images.                                                |
-| ecr.us-west-2.amazonaws.com | 443      | OCI Pack images.                                                |
-| us-docker.pkg.dev           | 443      | Required content repository and common third party content      |
+| **Top-level Domain**        | **Port** | **Description**                                            |
+| --------------------------- | -------- | ---------------------------------------------------------- |
+| docker.io                   | 443      | Third party container images.                              |
+| docker.com                  | 443      | Third party container images.                              |
+| gcr.io                      | 443      | Spectro Cloud and 3rd party container images               |
+| ghcr.io                     | 443      | Third party container images.                              |
+| github.com                  | 443      | Third party content.                                       |
+| googleapis.com              | 443      | Spectro Cloud images.                                      |
+| grafana.com                 | 443      | Grafana container images and manifests.                    |
+| k8s.gcr.io                  | 443      | Third party container images.                              |
+| projectcalico.org           | 443      | Calico container images.                                   |
+| registry.k8s.io             | 443      | Third party container images.                              |
+| raw.githubusercontent.com   | 443      | Third party content.                                       |
+| spectrocloud.com            | 443      | Spectro Cloud Palette SaaS.                                |
+| s3.amazonaws.com            | 443      | Spectro Cloud VMware OVA files.                            |
+| quay.io                     | 443      | Third party container images.                              |
+| ecr.us-east-1.amazonaws.com | 443      | OCI Pack images.                                           |
+| ecr.us-west-2.amazonaws.com | 443      | OCI Pack images.                                           |
+| us-docker.pkg.dev           | 443      | Required content repository and common third party content |
 
 ## Scope
 

--- a/docs/docs-content/clusters/clusters.md
+++ b/docs/docs-content/clusters/clusters.md
@@ -295,24 +295,24 @@ The following table lists the proxy requirements required by Palette. Depending 
 configuration, you may have to specify all subdomains of the top-level domains listed in the table. For example, an
 entry containing `gcr.io` and `*.gcr.io` may be required. Consult your network administrator for the exact requirements.
 
-| **Top-level Domain**        | **Port** | **Description**                                            |
-| --------------------------- | -------- | ---------------------------------------------------------- |
-| docker.io                   | 443      | Third party container images.                              |
-| docker.com                  | 443      | Third party container images.                              |
-| gcr.io                      | 443      | Spectro Cloud and third party container images               |
-| ghcr.io                     | 443      | Third party container images.                              |
-| github.com                  | 443      | Third party content.                                       |
-| googleapis.com              | 443      | Spectro Cloud images.                                      |
-| grafana.com                 | 443      | Grafana container images and manifests.                    |
-| k8s.gcr.io                  | 443      | Third party container images.                              |
-| projectcalico.org           | 443      | Calico container images.                                   |
-| registry.k8s.io             | 443      | Third party container images.                              |
-| raw.githubusercontent.com   | 443      | Third party content.                                       |
-| spectrocloud.com            | 443      | Spectro Cloud Palette SaaS.                                |
-| s3.amazonaws.com            | 443      | Spectro Cloud VMware OVA files.                            |
-| quay.io                     | 443      | Third party container images.                              |
-| ecr.us-east-1.amazonaws.com | 443      | OCI Pack images.                                           |
-| ecr.us-west-2.amazonaws.com | 443      | OCI Pack images.                                           |
+| **Top-level Domain**        | **Port** | **Description**                                             |
+| --------------------------- | -------- | ----------------------------------------------------------- |
+| docker.io                   | 443      | Third party container images.                               |
+| docker.com                  | 443      | Third party container images.                               |
+| gcr.io                      | 443      | Spectro Cloud and third party container images              |
+| ghcr.io                     | 443      | Third party container images.                               |
+| github.com                  | 443      | Third party content.                                        |
+| googleapis.com              | 443      | Spectro Cloud images.                                       |
+| grafana.com                 | 443      | Grafana container images and manifests.                     |
+| k8s.gcr.io                  | 443      | Third party container images.                               |
+| projectcalico.org           | 443      | Calico container images.                                    |
+| registry.k8s.io             | 443      | Third party container images.                               |
+| raw.githubusercontent.com   | 443      | Third party content.                                        |
+| spectrocloud.com            | 443      | Spectro Cloud Palette SaaS.                                 |
+| s3.amazonaws.com            | 443      | Spectro Cloud VMware OVA files.                             |
+| quay.io                     | 443      | Third party container images.                               |
+| ecr.us-east-1.amazonaws.com | 443      | OCI Pack images.                                            |
+| ecr.us-west-2.amazonaws.com | 443      | OCI Pack images.                                            |
 | us-docker.pkg.dev           | 443      | Required content repository and common third party content. |
 
 ## Scope


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR includes `us-docker.pkg.dev` domain in the proxy requirements. This is currently missing in [proxy-whitelist](https://docs.spectrocloud.com/4.5.x/clusters/#proxy-whitelist) doc page

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
