### PR TITLE
docs: update cilium parameter descriptions and agent mode steps for EKS Hybrid Nodes

### DIFF
--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
@@ -39,8 +39,8 @@ You must then configure your networking to allow traffic to reach the pods on yo
 
 6. Select **BYOS - Edge OS** as your base OS pack.
 
-7. If using [Agent Mode](../../../../deployment-modes/agent-mode/agent-mode.md), on the **Configure Pack** page, click **Values** under **Pack Details**. Then,
-   click on **Presets** on the right-hand side, and select **Agent Mode**.
+7. If using [Agent Mode](../../../../deployment-modes/agent-mode/agent-mode.md), on the **Configure Pack** page, click
+   **Values** under **Pack Details**. Then, click on **Presets** on the right-hand side, and select **Agent Mode**.
 
 8. Click **Next layer** to continue.
 

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools.md
@@ -37,12 +37,9 @@ You must then configure your networking to allow traffic to reach the pods on yo
 
 5. Select **Edge Native** from the **Infrastructure provider** list, and click **Next**.
 
-6. Select your base OS pack depending on how you will register your edge hosts.
+6. Select **BYOS - Edge OS** as your base OS pack.
 
-   - For Agent Mode, select **BYOS - Agent Mode**.
-   - For Appliance Mode, select **BYOS - Edge OS**.
-
-7. If selecting **BYOS - Agent Mode**, on the **Configure Pack** page, click **Values** under **Pack Details**. Then,
+7. If using [Agent Mode](../../../../deployment-modes/agent-mode/agent-mode.md), on the **Configure Pack** page, click **Values** under **Pack Details**. Then,
    click on **Presets** on the right-hand side, and select **Agent Mode**.
 
 8. Click **Next layer** to continue.

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/import-eks-cluster-enable-hybrid-mode.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/import-eks-cluster-enable-hybrid-mode.md
@@ -369,13 +369,18 @@ Cilium handles IP Address Management (IPAM) and Border Gateway Protocol (BGP) fo
 
 8. For **IPAM mode**, select **Cluster Pool**.
 
-9. In the YAML editor, search for **clusterPoolIPv4PodCIDRList**. This parameter specifies the CIDR ranges from which pod IPs will be allocated across all your hybrid nodes.
+9. In the YAML editor, search for **clusterPoolIPv4PodCIDRList**. This parameter specifies the CIDR ranges from which
+   pod IPs will be allocated across all your hybrid nodes.
 
-   Adjust the pod CIDR list for hybrid pods in other networks that need to connect to this cluster. This should match the **Remote Pod CIDRs** value defined in step 11 during the [Import Cluster](#import-cluster) steps. For example, `192.168.0.0/16`.
+   Adjust the pod CIDR list for hybrid pods in other networks that need to connect to this cluster. This should match
+   the **Remote Pod CIDRs** value defined in step 11 during the [Import Cluster](#import-cluster) steps. For example,
+   `192.168.0.0/16`.
 
-10. In the YAML editor, search for **clusterPoolIPv4MaskSize**. This parameter defines the size of each per-node CIDR block.
+10. In the YAML editor, search for **clusterPoolIPv4MaskSize**. This parameter defines the size of each per-node CIDR
+    block.
 
-    Adjust the mask size based on your required pods per hybrid node. For example, `/25` would provides 126 usable pod IPs for each node.
+    Adjust the mask size based on your required pods per hybrid node. For example, `/25` would provides 126 usable pod
+    IPs for each node.
 
 11. In the Presets, find the **cilium-agent - Hybrid Nodes Affinity** option, and select **Amazon EKS**.
 

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/import-eks-cluster-enable-hybrid-mode.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/import-eks-cluster-enable-hybrid-mode.md
@@ -369,16 +369,13 @@ Cilium handles IP Address Management (IPAM) and Border Gateway Protocol (BGP) fo
 
 8. For **IPAM mode**, select **Cluster Pool**.
 
-9. In the YAML editor, search for **clusterPoolIPv4PodCIDRList**. This parameter specifies the overall IP ranges
-   available for pod networking across all your hybrid nodes.
+9. In the YAML editor, search for **clusterPoolIPv4PodCIDRList**. This parameter specifies the CIDR ranges from which pod IPs will be allocated across all your hybrid nodes.
 
-   Adjust the pod CIDR list for hybrid pods in other networks that need to connect to this cluster. For example,
-   `192.168.0.0`.
+   Adjust the pod CIDR list for hybrid pods in other networks that need to connect to this cluster. This should match the **Remote Pod CIDRs** value defined in step 11 during the [Import Cluster](#import-cluster) steps. For example, `192.168.0.0/16`.
 
-10. In the YAML editor, search for **clusterPoolIPv4MaskSize**. This parameter determines the subnet mask size used for
-    pod IP allocation within each hybrid node.
+10. In the YAML editor, search for **clusterPoolIPv4MaskSize**. This parameter defines the size of each per-node CIDR block.
 
-    Adjust the mask size based on your required pods per hybrid node. For example, `/25`.
+    Adjust the mask size based on your required pods per hybrid node. For example, `/25` would provides 126 usable pod IPs for each node.
 
 11. In the Presets, find the **cilium-agent - Hybrid Nodes Affinity** option, and select **Amazon EKS**.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes some descriptions for the Cilium configuration during EKS Hybrid Nodes - Cluster Import steps. It also fixes the steps to enable agent mode when configuring the hybrid node pool cluster profile.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Import EKS Cluster and Enable Hybrid Mode](https://deploy-preview-5605--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/eks-hybrid-nodes/import-eks-cluster-enable-hybrid-mode/#add-cni-cluster-profile)
💻 [Create Hybrid Node Pools](https://deploy-preview-5605--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/eks-hybrid-nodes/create-hybrid-node-pools/#create-profile)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
