### PR TITLE
docs: DOC-1650: Edge Binary Download Link Fix

### DIFF
--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -34,7 +34,7 @@ the [Palette CLI](./automation/palette-cli/palette-cli.md) document for installa
 
 | Version | Operating System                                                                       | Checksum (SHA256)                                                  |
 | ------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 4.5.14  | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.13/cli/linux/palette-edge) | `5265133de8b204b6569b559a895aa03514b42b3285640755ed29e23d812e21cb` |
+| 4.5.14  | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.14/cli/linux/palette-edge) | `5265133de8b204b6569b559a895aa03514b42b3285640755ed29e23d812e21cb` |
 | 4.5.11  | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.11/cli/linux/palette-edge) | `390b4693a91c938ef230ce329ec28f42c058f98fb77160685e9a885dd2083587` |
 | 4.5.7   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.7/cli/linux/palette-edge)  | `abbceb9844991fc70af1e7967095873583c7f8aba549583cfc27d22f1e0819b1` |
 | 4.5.5   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.5/cli/linux/palette-edge)  | `f93382a7ab92e9621f47d857252c2673b33de79735cf729fcb4b2fb24719d537` |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the Edge binary download link to use the correct version (4.5.13 > 4.5.14).

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Downloads](https://deploy-preview-5607--docs-spectrocloud.netlify.app/spectro-downloads/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1650](https://spectrocloud.atlassian.net/browse/DOC-1650)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1650]: https://spectrocloud.atlassian.net/browse/DOC-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ