### PR TITLE
docs: DOC-1646: Update API Rate Limit for v1/cloudconfig Resources

### DIFF
--- a/docs/api-content/api-docs/1-introduction.md
+++ b/docs/api-content/api-docs/1-introduction.md
@@ -176,7 +176,7 @@ curl --location 'https://api.spectrocloud.com/v1/packs?continue=eyJvZmZzZXQiOjUw
 
 The API rate limits are as follows:
 
-- There is a limit of ten API requests per second for each source IP address. The API supports additional bursts through
+- Most Palette APIs have a limit of ten API requests per second for each source IP address. The API supports additional bursts through
   the usage of a burst queue. The default burst queue size is set to five. You could make 50 (10 \* 5) requests in
   seconds before the API returns a `429 - TooManyRequests` error. Refer to the
   [Endpoint Prefix Rate](#endpoint-prefix-rate) for additional information.
@@ -225,8 +225,8 @@ The API rate limits are as follows:
 | /v1/services                                                                            | 10                     | 5              | 50                 |
 | /v1/overlords                                                                           | 10                     | 5              | 50                 |
 | /v1/cluster                                                                             | 10                     | 5              | 50                 |
-| /v1/cloudconfigs                                                                        | 10                     | 5              | 50                 |
-| /v1/cloudconfigs/\{cloudType}/\{uid}/machinePools                                       | 10                     | 5              | 50                 |
+| /v1/cloudconfigs                                                                        | 50                     | 5              | 250                 |
+| /v1/cloudconfigs/\{cloudType}/\{uid}/machinePools                                       | 50                     | 5              | 250                 |
 | /v1/edgehosts                                                                           | 10                     | 5              | 50                 |
 | /v1/metrics                                                                             | 10                     | 5              | 50                 |
 | /v1/system                                                                              | 10                     | 5              | 50                 |
@@ -235,8 +235,8 @@ The API rate limits are as follows:
 | /v1/clouds                                                                              | 10                     | 5              | 50                 |
 | /v1/events/components                                                                   | 10                     | 5              | 50                 |
 | /v1/dashboard                                                                           | 10                     | 5              | 50                 |
-| /v1/cloudconfigs/\{cloudType}/:uid/machinePools/\{machinePoolName}/machines             | 10                     | 5              | 50                 |
-| /v1/cloudconfigs/\{cloudType}/:uid/machinePools/\{machinePoolName}/machines/:machineUid | 10                     | 5              | 50                 |
+| /v1/cloudconfigs/\{cloudType}/:uid/machinePools/\{machinePoolName}/machines             | 50                     | 5              | 250                 |
+| /v1/cloudconfigs/\{cloudType}/:uid/machinePools/\{machinePoolName}/machines/:machineUid | 50                     | 5              | 250                 |
 | /v1/auth/authenticate                                                                   | 10                     | 5              | 50                 |
 | /v1/auth/services/login                                                                 | 10                     | 5              | 50                 |
 | /v1/auth/services/edge/login                                                            | 10                     | 5              | 50                 |

--- a/docs/api-content/api-docs/1-introduction.md
+++ b/docs/api-content/api-docs/1-introduction.md
@@ -176,9 +176,9 @@ curl --location 'https://api.spectrocloud.com/v1/packs?continue=eyJvZmZzZXQiOjUw
 
 The API rate limits are as follows:
 
-- Most Palette APIs have a limit of ten API requests per second for each source IP address. The API supports additional bursts through
-  the usage of a burst queue. The default burst queue size is set to five. You could make 50 (10 \* 5) requests in
-  seconds before the API returns a `429 - TooManyRequests` error. Refer to the
+- Most Palette APIs have a limit of ten API requests per second for each source IP address. The API supports additional
+  bursts through the usage of a burst queue. The default burst queue size is set to five. You could make 50 (10 \* 5)
+  requests in seconds before the API returns a `429 - TooManyRequests` error. Refer to the
   [Endpoint Prefix Rate](#endpoint-prefix-rate) for additional information.
 
 - API request limits are categorized by the parent resources, such as `/v1/cloudconfig/:uid` and `/v1/roles`. You can
@@ -225,8 +225,8 @@ The API rate limits are as follows:
 | /v1/services                                                                            | 10                     | 5              | 50                 |
 | /v1/overlords                                                                           | 10                     | 5              | 50                 |
 | /v1/cluster                                                                             | 10                     | 5              | 50                 |
-| /v1/cloudconfigs                                                                        | 50                     | 5              | 250                 |
-| /v1/cloudconfigs/\{cloudType}/\{uid}/machinePools                                       | 50                     | 5              | 250                 |
+| /v1/cloudconfigs                                                                        | 50                     | 5              | 250                |
+| /v1/cloudconfigs/\{cloudType}/\{uid}/machinePools                                       | 50                     | 5              | 250                |
 | /v1/edgehosts                                                                           | 10                     | 5              | 50                 |
 | /v1/metrics                                                                             | 10                     | 5              | 50                 |
 | /v1/system                                                                              | 10                     | 5              | 50                 |
@@ -235,8 +235,8 @@ The API rate limits are as follows:
 | /v1/clouds                                                                              | 10                     | 5              | 50                 |
 | /v1/events/components                                                                   | 10                     | 5              | 50                 |
 | /v1/dashboard                                                                           | 10                     | 5              | 50                 |
-| /v1/cloudconfigs/\{cloudType}/:uid/machinePools/\{machinePoolName}/machines             | 50                     | 5              | 250                 |
-| /v1/cloudconfigs/\{cloudType}/:uid/machinePools/\{machinePoolName}/machines/:machineUid | 50                     | 5              | 250                 |
+| /v1/cloudconfigs/\{cloudType}/:uid/machinePools/\{machinePoolName}/machines             | 50                     | 5              | 250                |
+| /v1/cloudconfigs/\{cloudType}/:uid/machinePools/\{machinePoolName}/machines/:machineUid | 50                     | 5              | 250                |
 | /v1/auth/authenticate                                                                   | 10                     | 5              | 50                 |
 | /v1/auth/services/login                                                                 | 10                     | 5              | 50                 |
 | /v1/auth/services/edge/login                                                            | 10                     | 5              | 50                 |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -30,6 +30,8 @@ soluta voluptatibus quibusdam aut autem. Repellendus magni nostrum ex et autem d
 
 #### Improvements
 
+- The [rate limit](../../api-content/api-docs/1-introduction.md#rate-limits) for Palette API endpoints with a prefix of `/v1/cloudconfigs` has been increased to 50 requests per second per IP address, and the maximum burst has been increased to 250 requests per second per IP address.
+
 #### Deprecations and Removals
 
 ### Edge

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -30,7 +30,9 @@ soluta voluptatibus quibusdam aut autem. Repellendus magni nostrum ex et autem d
 
 #### Improvements
 
-- The [rate limit](https://docs.spectrocloud.com/api/introduction/#rate-limits) for Palette API endpoints with a prefix of `/v1/cloudconfigs` has been increased to 50 requests per second per IP address, and the maximum burst has been increased to 250 requests per second per IP address.
+- The [rate limit](https://docs.spectrocloud.com/api/introduction/#rate-limits) for Palette API endpoints with a prefix
+  of `/v1/cloudconfigs` has been increased to 50 requests per second per IP address, and the maximum burst has been
+  increased to 250 requests per second per IP address.
 
 #### Deprecations and Removals
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -30,7 +30,7 @@ soluta voluptatibus quibusdam aut autem. Repellendus magni nostrum ex et autem d
 
 #### Improvements
 
-- The [rate limit](../../api-content/api-docs/1-introduction.md#rate-limits) for Palette API endpoints with a prefix of `/v1/cloudconfigs` has been increased to 50 requests per second per IP address, and the maximum burst has been increased to 250 requests per second per IP address.
+- The [rate limit](https://docs.spectrocloud.com/api/introduction/#rate-limits) for Palette API endpoints with a prefix of `/v1/cloudconfigs` has been increased to 50 requests per second per IP address, and the maximum burst has been increased to 250 requests per second per IP address.
 
 #### Deprecations and Removals
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the API rate limit for `v1/cloudconfigs` resources and adds the updated limit to the release notes.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 
[Release Notes](https://deploy-preview-5609--docs-spectrocloud.netlify.app/release-notes/) - Added to release notes
[Palette API - Introduction](https://deploy-preview-5609--docs-spectrocloud.netlify.app/api/introduction/#rate-limits) - Increased rate/burst limit

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1646](https://spectrocloud.atlassian.net/browse/DOC-1646)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

4.6 release work.


[DOC-1646]: https://spectrocloud.atlassian.net/browse/DOC-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ