### PR TITLE
docs: DOC-1653: Changing VMware vSphere Local Operations Permission to Subcategory

### DIFF
--- a/_partials/permissions/_vsphere-permissions.mdx
+++ b/_partials/permissions/_vsphere-permissions.mdx
@@ -112,7 +112,7 @@ all required privileges on all required objects.
 
 :::info
 
-Propegation refers to the inheritance of permissions from a parent vSphere object to a child object. If a permission is
+Propagation refers to the inheritance of permissions from a parent vSphere object to a child object. If a permission is
 propagated to a child object, the child object inherits the permission from the parent object.
 
 :::
@@ -139,7 +139,7 @@ Select the tab for the vSphere version you are using to view the required privil
 | **CNS**                   | Searchable                                                                                                                                                            |
 | **Datastore**             | Allocate space<br />Browse datastore<br />Low level file operations<br />Remove file<br />Update virtual machine files<br />Update virtual machine metadata           |
 | **Folder**                | Create folder<br />Delete folder<br />Move folder<br />Rename folder                                                                                                  |
-| **Host Local Operations** | Reconfigure virtual machine                                                                                                                                           |
+| **Host**                  | Local Operations: Reconfigure virtual machine                                                                                                                         |
 | **Network**               | Assign network                                                                                                                                                        |
 | **Resource**              | Apply recommendation<br />Assign virtual machine to resource pool<br />Migrate powered off virtual machine<br />Migrate powered on virtual machine<br />Query vMotion |
 | **Sessions**              | Validate session                                                                                                                                                      |
@@ -174,7 +174,7 @@ Virtual Machines.
 | **CNS**                    | Searchable                                                                                                                                                            |
 | **Datastore**              | Allocate space<br />Browse datastore<br />Low level file operations<br />Remove file<br />Update virtual machine files<br />Update virtual machine metadata           |
 | **Folder**                 | Create Folder<br />Delete folder<br />Move folder<br />Rename folder                                                                                                  |
-| **Host Local Operations**  | Reconfigure virtual machine                                                                                                                                           |
+| **Host**                   | Local Operations: Reconfigure virtual machine                                                                                                                         |
 | **Network**                | Assign network                                                                                                                                                        |
 | **Resource**               | Apply recommendation<br />Assign virtual machine to resource pool<br />Migrate powered off virtual machine<br />Migrate powered on virtual machine<br />Query vMotion |
 | **Profile-driven Storage** | View                                                                                                                                                                  |
@@ -209,7 +209,7 @@ Virtual Machines.
 | **CNS**                    | Searchable                                                                                                                                                            |
 | **Datastore**              | Allocate space<br />Browse datastore<br />Low level file operations<br />Remove file<br />Update virtual machine files<br />Update virtual machine metadata           |
 | **Folder**                 | Create Folder<br />Delete folder<br />Move folder<br />Rename folder                                                                                                  |
-| **Host Local Operations**  | Reconfigure virtual machine                                                                                                                                           |
+| **Host**                   | Local Operations: Reconfigure virtual machine                                                                                                                         |
 | **Network**                | Assign network                                                                                                                                                        |
 | **Resource**               | Apply recommendation<br />Assign virtual machine to resource pool<br />Migrate powered off virtual machine<br />Migrate powered on virtual machine<br />Query vMotion |
 | **Profile-driven Storage** | View                                                                                                                                                                  |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR corrects a small typo, where "Local Operations" was listed as a category when it should be a subcategory of "Host." Small "propagation" spelling fix included.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [VMware - Required Permissions](https://deploy-preview-5610--docs-spectrocloud.netlify.app/clusters/data-center/vmware/permissions/#spectro-role-privileges)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1653](https://spectrocloud.atlassian.net/browse/DOC-1653)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1653]: https://spectrocloud.atlassian.net/browse/DOC-1653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ