### PR TITLE
docs: release notes patch 4.5.21

### DIFF
--- a/docs/docs-content/component.md
+++ b/docs/docs-content/component.md
@@ -16,6 +16,7 @@ This page lists the version details of various Palette components and their resp
 
 | Palette Release | Recommended CLI Version |
 | --------------- | ----------------------- |
+| 4.5.21          | v4.5.7                  |
 | 4.5.20          | v4.5.7                  |
 | 4.5.15          | v4.5.4                  |
 | 4.5.11          | v4.5.1                  |
@@ -29,6 +30,7 @@ This page lists the version details of various Palette components and their resp
 
 | Palette Release | CLI Version |
 | --------------- | ----------- |
+| 4.5.21          | v4.5.15     |
 | 4.5.20          | v4.5.14     |
 | 4.5.15          | v4.5.11     |
 | 4.5.11          | v4.5.7      |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -15,8 +15,8 @@ tags: ["release-notes"]
 
 ### Bug Fixes
 
-- Fixed an issue that prevented system upgrade logs from being included in the node logs of edge clusters. You
-  can download by selecting **Download Logs** from the **Settings** dropdown of the cluster.
+- Fixed an issue that prevented system upgrade logs from being included in the node logs of edge clusters. You can
+  download by selecting **Download Logs** from the **Settings** dropdown of the cluster.
 
 - Fixed an issue that prevented [App Profiles](../profiles/app-profiles/app-profiles.md) from being created using Helm.
   You can now safely create and deploy Helm Apps.

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,33 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## February 3, 2025 - Release 4.5.21
+
+### Bug Fixes
+
+- Fixed an issue that prevented system upgrade logs from being included in the node logs of edge native clusters. You
+  can download by selecting **Download Logs** from the **Settings** dropdown.
+
+- Fixed an issue that prevented App Profiles from being created with Helm configuration. You can now safely create and
+  deploy Helm Apps.
+
+<!-- prettier-ignore-start -->
+
+- Fixed an issue that caused the <VersionedLink text="Spectro Proxy" url="/integrations/packs/?pack=spectro-proxy" /> from being installed correctly as part of the <VersionedLink text="Spectro Kubernetes Dashboard" url="/integrations/packs/?pack=spectro-k8s-dashboard" /> pack. The installation of the <VersionedLink text="Spectro Kubernetes Dashboard" url="/integrations/packs/?pack=spectro-k8s-dashboard" /> now completes successfully.
+
+<!-- prettier-ignore-end -->
+
+- Fixed an issue that prevented the **Network Settings** page of system private gateways from loading. Refer to the
+  [System Private Gateway](../clusters/pcg/architecture.md#system-private-gateway) architecture section for further
+  information.
+
+- Fixed an issue that prevented cluster deployment with cluster profiles that included profile variables with `.` in
+  their name. Refer to the
+  [Define and Manage Profile Variables](../profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md)
+  guide for further information.
+
+- Fixed an issue that prevented custom content security policies from being applied in the Local UI user data.
+
 ## January 18, 2024 - Release 4.5.20
 
 ### Palette {#palette-enterprise-4-5-20}

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -15,8 +15,8 @@ tags: ["release-notes"]
 
 ### Bug Fixes
 
-- Fixed an issue that prevented system upgrade logs from being included in the node logs of edge clusters. You can
-  download by selecting **Download Logs** from the **Settings** dropdown of the cluster.
+- Fixed an issue that prevented system upgrade logs from being included in the node logs of edge clusters. You
+  can download by selecting **Download Logs** from the **Settings** dropdown of the cluster.
 
 - Fixed an issue that prevented [App Profiles](../profiles/app-profiles/app-profiles.md) from being created using Helm.
   You can now safely create and deploy Helm Apps.
@@ -33,9 +33,6 @@ tags: ["release-notes"]
 - Fixed an issue that prevented cluster deployment with cluster profiles that included
   [profile variables](../profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md) with a `.`
   character in their name.
-
-- Users are now allowed to provide custom [Content Security Policies (CSP)](https://content-security-policy.com/) in the
-  Local UI user data.
 
 ## January 18, 2024 - Release 4.5.20
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -15,28 +15,27 @@ tags: ["release-notes"]
 
 ### Bug Fixes
 
-- Fixed an issue that prevented system upgrade logs from being included in the node logs of edge native clusters. You
-  can download by selecting **Download Logs** from the **Settings** dropdown.
+- Fixed an issue that prevented system upgrade logs from being included in the node logs of edge clusters. You
+  can download by selecting **Download Logs** from the **Settings** dropdown of the cluster.
 
-- Fixed an issue that prevented App Profiles from being created with Helm configuration. You can now safely create and
-  deploy Helm Apps.
+- Fixed an issue that prevented [App Profiles](../profiles/app-profiles/app-profiles.md) from being created using Helm.
+  You can now safely create and deploy Helm Apps.
 
 <!-- prettier-ignore-start -->
 
-- Fixed an issue that caused the <VersionedLink text="Spectro Proxy" url="/integrations/packs/?pack=spectro-proxy" /> from being installed correctly as part of the <VersionedLink text="Spectro Kubernetes Dashboard" url="/integrations/packs/?pack=spectro-k8s-dashboard" /> pack. The installation of the <VersionedLink text="Spectro Kubernetes Dashboard" url="/integrations/packs/?pack=spectro-k8s-dashboard" /> now completes successfully.
+- Fixed an issue that caused the <VersionedLink text="Spectro Proxy" url="/integrations/packs/?pack=spectro-proxy" /> pack from being installed correctly as part of the <VersionedLink text="Spectro Kubernetes Dashboard" url="/integrations/packs/?pack=spectro-k8s-dashboard" /> pack. The deployment of the <VersionedLink text="Spectro Kubernetes Dashboard" url="/integrations/packs/?pack=spectro-k8s-dashboard" /> pack now completes successfully.
 
 <!-- prettier-ignore-end -->
 
-- Fixed an issue that prevented the **Network Settings** page of system private gateways from loading. Refer to the
-  [System Private Gateway](../clusters/pcg/architecture.md#system-private-gateway) architecture section for further
-  information.
+- Fixed an issue that prevented the **Network Settings** page of
+  [system private gateways](../clusters/pcg/architecture.md#system-private-gateway) from loading.
 
-- Fixed an issue that prevented cluster deployment with cluster profiles that included profile variables with `.` in
-  their name. Refer to the
-  [Define and Manage Profile Variables](../profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md)
-  guide for further information.
+- Fixed an issue that prevented cluster deployment with cluster profiles that included
+  [profile variables](../profiles/cluster-profiles/create-cluster-profiles/define-profile-variables.md) with a `.`
+  character in their name.
 
-- Fixed an issue that prevented custom content security policies from being applied in the Local UI user data.
+- Users are now allowed to provide custom [Content Security Policies (CSP)](https://content-security-policy.com/) in the
+  Local UI user data.
 
 ## January 18, 2024 - Release 4.5.20
 

--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -34,6 +34,7 @@ the [Palette CLI](./automation/palette-cli/palette-cli.md) document for installa
 
 | Version | Operating System                                                                       | Checksum (SHA256)                                                  |
 | ------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 4.5.15  | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.15/cli/linux/palette-edge) | `5265133de8b204b6569b559a895aa03514b42b3285640755ed29e23d812e21cb` |
 | 4.5.14  | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.14/cli/linux/palette-edge) | `5265133de8b204b6569b559a895aa03514b42b3285640755ed29e23d812e21cb` |
 | 4.5.11  | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.11/cli/linux/palette-edge) | `390b4693a91c938ef230ce329ec28f42c058f98fb77160685e9a885dd2083587` |
 | 4.5.7   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.7/cli/linux/palette-edge)  | `abbceb9844991fc70af1e7967095873583c7f8aba549583cfc27d22f1e0819b1` |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds release notes for patch 4.5.21. It also adds 4.5.15 edge CLI version. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-5622--docs-spectrocloud.netlify.app/release-notes/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1655](https://spectrocloud.atlassian.net/browse/DOC-1655)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Only 4.5

[DOC-1655]: https://spectrocloud.atlassian.net/browse/DOC-1655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ