### PR TITLE
docs: DOC-1664: Removing Erroneous "EOF" from .arg File

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
@@ -128,7 +128,6 @@ Use the following instructions to build the Edge Installer ISO. The optional ste
    HTTP_PROXY=
    PROXY_CERT_PATH=
    UPDATE_KERNEL=false
-   EOF
    ```
 
 7. (Optional) You can embed a public key in your Edge installer ISO. If you choose to add a public key to your ISO or


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the text "EOF" from the example Edgeforge .arg file. This was left over from a `cat << EOF > .arg` command in 4.2 documentation.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Build Installer ISO](https://deploy-preview-5682--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso/#instructions)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1664](https://spectrocloud.atlassian.net/browse/DOC-1664)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1664]: https://spectrocloud.atlassian.net/browse/DOC-1664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ