### PR TITLE
docs: update upgrade path

### DIFF
--- a/_partials/self-hosted/_kubernetes_palette_versions.mdx
+++ b/_partials/self-hosted/_kubernetes_palette_versions.mdx
@@ -8,7 +8,7 @@ partial_name: kubernetes-palette-versions
 
 | **Palette Version** | **Kubernetes Version** | **OVA Download URL**                                                        | **FIPS OVA Download URL**                                                      |
 | ------------------- | ---------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| 4.6.3               | 1.30.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1309-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1309-fips.ova`          |
+| 4.6.6               | 1.30.9                 | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-1309-0.ova`          | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-1309-fips.ova`          |
 | 4.5.21              | 1.29.12                | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12912-0.ova`         | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-12912-fips.ova`         |
 | 4.5.20              | 1.29.12                | `https://vmwaregoldenimage.s3.amazonaws.com/u-2204-0-k-12912-0.ova`         | `https://vmwaregoldenimage.s3.amazonaws.com/u-2004-0-k-12912-fips.ova`         |
 | 4.5.15              | 1.29.9                 | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1299-0.ova`  | `https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1299-fips.ova`  |
@@ -36,7 +36,7 @@ For installations using a Kubernetes cluster, we support any non-EOL (End of Lif
 
 | **Palette Version** | **Highest Supported Kubernetes Version** |
 | ------------------- | ---------------------- |
-| 4.6.3               | 1.31.x                 |
+| 4.6.6               | 1.31.x                 |
 | 4.5.21              | 1.30.x                 |
 | 4.5.20              | 1.30.x                 |
 | 4.5.15              | 1.30.x                 |

--- a/docs/docs-content/component.md
+++ b/docs/docs-content/component.md
@@ -16,7 +16,7 @@ This page lists the version details of various Palette components and their resp
 
 | Palette Release | Recommended CLI Version |
 | --------------- | ----------------------- |
-| 4.6.3           | v4.6.0                  |
+| 4.6.6           | v4.6.0                  |
 | 4.5.21          | v4.5.7                  |
 | 4.5.20          | v4.5.7                  |
 | 4.5.15          | v4.5.4                  |
@@ -31,7 +31,7 @@ This page lists the version details of various Palette components and their resp
 
 | Palette Release | CLI Version |
 | --------------- | ----------- |
-| 4.6.3           | v4.6.1      |
+| 4.6.6           | v4.6.3      |
 | 4.5.21          | v4.5.15     |
 | 4.5.20          | v4.5.14     |
 | 4.5.15          | v4.5.11     |

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -41,6 +41,13 @@ minor version available.
 <Tabs>
 <TabItem label="VMware" value="VMware">
 
+**4.6.x**
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.6        | :white_check_mark: |
+
 **4.5.x**
 
 | **Source Version** | **Target Version** |    **Support**     |
@@ -101,6 +108,13 @@ minor version available.
 </TabItem>
 
 <TabItem label="Kubernetes" value="Kubernetes">
+
+**4.6.x**
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.6        | :white_check_mark: |
 
 **4.5.x**
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,13 +11,13 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
-## February 16, 2025 - Release 4.6.0 - 4.6.3
+## February 16, 2025 - Release 4.6.0 - 4.6.6
 
 ### Security Notices
 
 - Review the [Security Bulletins](../security-bulletins/reports/reports.mdx) page for the latest security advisories.
 
-### Palette Enterprise {#palette-enterprise-4-6-3}
+### Palette Enterprise {#palette-enterprise-4-6-6}
 
 #### Features
 
@@ -57,7 +57,7 @@ tags: ["release-notes"]
 #### Features
 
 - Includes all Palette features, improvements, breaking changes, and deprecations in this release. Refer to the
-  [Palette section](#palette-enterprise-4-6-3) for more details.
+  [Palette section](#palette-enterprise-4-6-6) for more details.
 
 - [Palette VerteX](../vertex/vertex.md) now offers complete brand customization. System operators can apply custom logos
   and color schemes to the instances they manage by using the **Customize interface** tab in the **Administration**

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -193,6 +193,7 @@ tags: ["release-notes"]
 | ExternalDNS                | 0.15.1      |
 | External Secrets Operator  | 0.12.1      |
 | Kong                       | 2.47.0      |
+| Nvidia GPU Operator        | 24.9.2      |
 
 #### Community
 

--- a/docs/docs-content/spectro-downloads.md
+++ b/docs/docs-content/spectro-downloads.md
@@ -25,7 +25,7 @@ the [Palette CLI](./automation/palette-cli/palette-cli.md) document for installa
 
 | Version | Operating System                                                                      | Checksum (SHA256)                                                  |
 | ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 4.6.0   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.6.0/linux/cli/palette) | `de3630033d28b80e9411d39b831a2fdc4a02f8e71caea2cef82ac0ac00f95de8` |
+| 4.6.0   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.6.0/linux/cli/palette) | `07d63693a8c90483f6f000d4580cfd86f81178e4b96cfbd32e0f50955d57eec7` |
 | 4.5.7   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.5.7/linux/cli/palette) | `e37032f6aac7c15a54e6d2085021ae795669a292cf7a5993a945592b8b8c0d9e` |
 | 4.5.4   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.5.4/linux/cli/palette) | `74723cae5e87353e9c6b0191036229c0a9b645f10101e309586ecb18b6691bbd` |
 | 4.5.1   | [Linux-amd64](https://software.spectrocloud.com/palette-cli/v4.5.1/linux/cli/palette) | `050e853483065b63ef3096813611b13b9dcfe4556a6fd370ec6ebdf5c6be8738` |
@@ -35,7 +35,7 @@ the [Palette CLI](./automation/palette-cli/palette-cli.md) document for installa
 
 | Version | Operating System                                                                       | Checksum (SHA256)                                                  |
 | ------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 4.6.1   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.6.1/cli/linux/palette-edge)  | `87f418015a618627f105ca2ca3bf587c796716dca7ce757c14546e0c7e810e35` |
+| 4.6.3   | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.6.3/cli/linux/palette-edge)  | `639d325659b369b8e71e00d36763b6088ac1932dbdbd105bdf3c63051cfd500b` |
 | 4.5.15  | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.15/cli/linux/palette-edge) | `5265133de8b204b6569b559a895aa03514b42b3285640755ed29e23d812e21cb` |
 | 4.5.14  | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.14/cli/linux/palette-edge) | `5265133de8b204b6569b559a895aa03514b42b3285640755ed29e23d812e21cb` |
 | 4.5.11  | [Linux-amd64](https://software.spectrocloud.com/stylus/v4.5.11/cli/linux/palette-edge) | `390b4693a91c938ef230ce329ec28f42c058f98fb77160685e9a885dd2083587` |

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -41,6 +41,13 @@ latest minor version available.
 <Tabs>
 <TabItem label="VMware" value="VMware">
 
+**4.6.x**
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.6        | :white_check_mark: |
+
 **4.5.x**
 
 | **Source Version** | **Target Version** |    **Support**     |
@@ -101,6 +108,13 @@ latest minor version available.
 </TabItem>
 
 <TabItem label="Kubernetes" value="Kubernetes">
+
+**4.6.x**
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.6        | :white_check_mark: |
 
 **4.5.x**
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates VerteX and Palette self-hosted upgrade paths for 4.6.6.
It also updates binaries/names to 4.6.6.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Self-hosted Kubernetes Requirements](https://deploy-preview-5758--docs-spectrocloud.netlify.app/enterprise-version/install-palette/#kubernetes-requirements) -> VerteX and PCG use the same partial
💻 [Downloads](https://deploy-preview-5758--docs-spectrocloud.netlify.app/spectro-downloads/)
💻 [Compatibility Matrix](https://deploy-preview-5758--docs-spectrocloud.netlify.app/component/)
💻 [Release Notes](https://deploy-preview-5758--docs-spectrocloud.netlify.app/release-notes/)
💻 [VerteX upgrade](https://deploy-preview-5758--docs-spectrocloud.netlify.app/vertex/upgrade/)
💻 [Self-hosted upgrade](https://deploy-preview-5758--docs-spectrocloud.netlify.app/enterprise-version/upgrade/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1678](https://spectrocloud.atlassian.net/browse/DOC-1678)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [X] No. _Please leave a short comment below about why this PR cannot be backported._RELEASE PR


[DOC-1678]: https://spectrocloud.atlassian.net/browse/DOC-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ