### PR TITLE
[version-4-0] docs: fix broken MAAS doc links (#5761)

### DIFF
--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-clusters.md
@@ -26,7 +26,7 @@ create a Kubernetes cluster in MAAS that is managed by Palette.
   [Cluster Profiles](../../../profiles/cluster-profiles/cluster-profiles.md) for more information.
 
 - Verify that the required Operating System (OS) images you use in your cluster profiles are downloaded and available in
-  your MAAS environment. Review the [How to use standard images](https://maas.io/docs/how-to-use-standard-images) for
+  your MAAS environment. Review the [How to use standard images](https://maas.io/docs/about-standard-images) for
   guidance on downloading OS images for MAAS.
 
 :::info
@@ -89,6 +89,10 @@ To deploy a new MAAS cluster:
 
       - Resource Pool: The MAAS resource pool from which to select available servers for deployment. Filter available
         servers to only those that have at least the amount of CPU and Memory selected.
+
+      - Tags: Specify the MAAS machine tags so that Palette can deploy nodes onto the MAAS machines that match the
+        provided tags. To learn more about MAAS tags, refer to the [MAAS Tags](https://maas.io/docs/about-device-labels)
+        documentation.
 
 11. You can configure the following cluster management features now if needed, or you can do it later:
 

--- a/docs/docs-content/clusters/data-center/maas/register-manage-maas-cloud-accounts.md
+++ b/docs/docs-content/clusters/data-center/maas/register-manage-maas-cloud-accounts.md
@@ -20,11 +20,11 @@ additional cloud accounts that reference specific PCGs.
   Gateway**. To learn more about when you would use Palette's PCG or the System Private Gateway, refer to the
   [PCG Architecture](../../pcg/architecture.md#pcg-deployment-options) page.
 
-- An active [MAAS API key](https://maas.io/docs/api-authentication-reference) which can be generated in the MAAS web
-  console under **My Preferences**, and selecting **API keys**.
+- An active [MAAS API key](https://maas.io/docs/api) which can be generated in the MAAS web console under **My
+  Preferences**, and selecting **API keys**.
 
 For details, refer to the MAAS document on
-[how to add an API key](https://maas.io/docs/how-to-manage-user-accounts#heading--api-key).
+[how to add an API key](https://maas.io/docs/how-to-manage-user-access#p-9090-edit-sshapi-keys-ui).
 
 ## Register a MAAS Cloud Account
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-0`:
 - [docs: fix broken MAAS doc links (#5761)](https://github.com/spectrocloud/librarium/pull/5761)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)