### PR TITLE
docs: remove access pack section for VMMA

### DIFF
--- a/docs/docs-content/vm-management/vm-migration-assistant/vm-migration-assistant.md
+++ b/docs/docs-content/vm-management/vm-migration-assistant/vm-migration-assistant.md
@@ -24,19 +24,6 @@ add-on pack that can be added to your cluster profile and works alongside the
 
 <!-- prettier-ignore-end -->
 
-## Access Pack
-
-To get access to the Virtual Machine Migration Assistant Pack, contact our support team by sending an email to
-support@spectrocloud.com. Include the following information in your email:
-
-- Your full name
-- Organization name (if applicable)
-- Email address
-- Phone number (optional)
-
-Our dedicated Support team will promptly get in touch with you to provide the necessary credentials and assistance
-required to get access.
-
 ## Resources
 
 - [Create a VM Migration Assistant Cluster Profile](./create-vm-migration-assistant-profile.md)


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the Access Pack section from the VM Migration Assistant entry page as the pack is now available in the Public Repo.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
