### PR TITLE
docs: update pcg k8s requirements table

### DIFF
--- a/docs/docs-content/clusters/pcg/deploy-pcg-k8s.md
+++ b/docs/docs-content/clusters/pcg/deploy-pcg-k8s.md
@@ -71,9 +71,8 @@ development and testing environments.
     to the [PCG Sizing](#pcg-sizing) section for more information.
   - A Container Network Interface plugin installed.
   - A Container Storage Interface plugin installed.
-  - The Kubernetes cluster must be set up on a version of Kubernetes that is compatible to your PCG version. Refer to
-    the [Kubernetes Requirements](./pcg.md#kubernetes-requirements) section to find the version required for your
-    Palette installation
+  - The Kubernetes cluster must be set up on a version of Kubernetes that is compatible to your Palette version. Refer
+    to the [Kubernetes Requirements](./pcg.md#kubernetes-requirements) section to find the required Kubernetes version.
 
 - PCG IP address requirements:
 

--- a/docs/docs-content/clusters/pcg/pcg.md
+++ b/docs/docs-content/clusters/pcg/pcg.md
@@ -33,18 +33,31 @@ existing Kubernetes cluster. Refer to the table below to learn more about the su
 
 ## Kubernetes Requirements
 
-The following table presents the Kubernetes version corresponding to each Palette version. It provides the download URLs
-for the Operating System and Kubernetes distribution OVA required for the PCG install. Ensure that you use FIPS OVA URL
-if you require a <VersionedLink text="FIPS" url="/vertex/fips/" /> compliant installation.
+The following table presents the Kubernetes version corresponding to each Palette version. This applies when you deploy
+a PCG to an existing Kubernetes cluster. Refer to the
+[Deploy a PCG to an Existing Kubernetes Cluster](./deploy-pcg-k8s.md) guide for more information.
 
-:::warning
-
-The versions included in the following table apply for PCG installs on VMware vSphere and MAAS. The Kubernetes version
-for OpenStack is 1.24.10 on all the Palette versions included below.
-
-:::
-
-<PartialsComponent category="self-hosted" name="kubernetes-palette-versions" />
+| **Palette Version** | **Kubernetes Version** |
+| ------------------- | ---------------------- |
+| 4.6.6               | 1.30.9                 |
+| 4.5.21              | 1.29.12                |
+| 4.5.20              | 1.29.12                |
+| 4.5.15              | 1.29.9                 |
+| 4.5.11              | 1.29.9                 |
+| 4.5.10              | 1.29.9                 |
+| 4.5.8               | 1.29.9                 |
+| 4.5.5               | 1.29.9                 |
+| 4.5.4               | 1.29.9                 |
+| 4.5.3               | 1.29.9                 |
+| 4.4.20              | 1.28.13                |
+| 4.4.18              | 1.28.13                |
+| 4.4.14              | 1.28.12                |
+| 4.4.11              | 1.28.11                |
+| 4.4.6               | 1.28.9                 |
+| 4.3.6               | 1.27.11                |
+| 4.2.13              | 1.26.10                |
+| 4.2.7               | 1.26.10                |
+| 4.1.12              | 1.26.8                 |
 
 ## Resources
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the PCG Kubernetes requirement table to remove the OVA columns, as they only apply to self-hosted/vertex.

Note: I will manually remove the 4.6 version from the K8s table in the 4.5 backport PR.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [PCG](https://deploy-preview-5791--docs-spectrocloud.netlify.app/clusters/pcg/)
💻 [Deploy a PCG to an Existing Kubernetes Cluster](https://deploy-preview-5791--docs-spectrocloud.netlify.app/clusters/pcg/deploy-pcg-k8s/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
