### PR TITLE
Update generate-keys.md

### DIFF
--- a/docs/docs-content/clusters/edge/trusted-boot/keys/generate-keys.md
+++ b/docs/docs-content/clusters/edge/trusted-boot/keys/generate-keys.md
@@ -122,7 +122,7 @@ difficult because there is no higher authority.
    :::
 
    ```shell
-   ./earthly.sh +uki-genkey --MY_ORG="org-name" --EXPIRATION_IN_DAYS=5475 --UKI_SELF_SIGNED_KEYS=false
+   ./earthly.sh +uki-genkey --MY_ORG="org-name" --EXPIRATION_IN_DAYS=5475
    ```
 
    All keys are generated to the **secure-boot** folder. Private keys are kept in a subdirectory called


### PR DESCRIPTION


## Describe the Change
The default for +uki-genkey is setting --UKI_BRING_YOUR_OWN_KEYS=false.  The value set in the current command on line 125 is old and no longer used.  This addresses that making the doc more readable.
This PR ....

## Changed Pages

[<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->
](https://docs.spectrocloud.com/clusters/edge/trusted-boot/keys/generate-keys/#instructions)
Line 125
💻 [Add Preview URL for Page]()

## Backports

4.5

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
