### PR TITLE
docs: invalidate cached logo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -315,8 +315,8 @@ const config = {
           width: 105,
           height: 48,
           alt: "Spectro cloud logo",
-          src: "img/spectrocloud-logo-light.svg",
-          srcDark: "img/spectrocloud-logo-dark.svg",
+          src: "img/spectrocloud-logo-light.svg?new=true",
+          srcDark: "img/spectrocloud-logo-dark.svg?new=true",
         },
         items: [
           {


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR invalidates the logo and stops caching of old logo.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

No ticket. 

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
