### PR TITLE
docs: bump free-solid-svg-icons to 6.7.2

### DIFF
--- a/.github/workflows/eslint-test.yaml
+++ b/.github/workflows/eslint-test.yaml
@@ -10,6 +10,8 @@ on:
       - "src/**"
       - "plugins/**"
       - "utils/**"
+      - "package.json"
+      - "package-lock.json"
 
 concurrency:
   group: test-${{ github.ref }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/types": "^3.7.0",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
-        "@fortawesome/free-solid-svg-icons": "^6.6.0",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mdx-js/react": "^3.1.0",
         "antd": "^5.22.2",
@@ -46,9 +46,9 @@
         "@playwright/test": "^1.49.0",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/exec": "^6.0.3",
-        "@semantic-release/git": "*",
-        "@semantic-release/github": "*",
-        "@semantic-release/npm": "*",
+        "@semantic-release/git": "latest",
+        "@semantic-release/github": "latest",
+        "@semantic-release/npm": "latest",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
         "@tsconfig/docusaurus": "^2.0.3",
@@ -6357,9 +6357,9 @@
       "license": "MIT"
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
-      "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
       "engines": {
         "node": ">=6"
       }
@@ -6368,7 +6368,6 @@
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
-      "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -6376,21 +6375,12 @@
         "node": ">=6"
       }
     },
-    "node_modules/@fortawesome/fontawesome-svg-core/node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
-      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz",
-      "integrity": "sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.6.0"
+        "@fortawesome/fontawesome-common-types": "6.7.2"
       },
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/types": "^3.7.0",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
-    "@fortawesome/free-solid-svg-icons": "^6.6.0",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mdx-js/react": "^3.1.0",
     "antd": "^5.22.2",


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR bumps the `free-solid-svg-icons` dependency to match `fontawesome-svg-core` which was updated in https://github.com/spectrocloud/librarium/pull/5921

The version mismatch lead to compile errors and test failures.  

It also adds `package.json` and `package-lock.json` as paths that can trigger the test workflows so that we can detect such breakages in the future.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Docs](https://deploy-preview-5959--docs-spectrocloud.netlify.app/)

## Jira Tickets
None.

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Everywhere