### PR TITLE
[version-3-4] chore: prevent tutorial categories from being highlighted DOC-1587 (#5902)

### DIFF
--- a/src/css/dark-mode.scss
+++ b/src/css/dark-mode.scss
@@ -64,6 +64,15 @@ html[data-theme="dark"] {
     border-width: 0px;
   }
 
+  .menu__list-item-collapsible:has(.sidebar-category-title):hover {
+    background: var(--ifm-background-color) !important;
+    cursor: default;
+  }
+
+  .sidebar-category-title[class*="active_"] {
+    color: var(--ifm-color-primary);
+  }
+
   .menu__list-item-collapsible:hover {
     background: var(--ifm-dropdown-background-color);
   }

--- a/src/css/light-mode.scss
+++ b/src/css/light-mode.scss
@@ -71,6 +71,15 @@ html[data-theme="light"] {
     background: var(--ifm-menu-color-background-active);
   }
 
+  .menu__list-item-collapsible:has(.sidebar-category-title):hover {
+    background: var(--ifm-background-color) !important;
+    cursor: default;
+  }
+
+  .sidebar-category-title[class*="active_"] {
+    color: var(--ifm-color-primary);
+  }
+
   .menu__list-item-collapsible:hover {
     background: var(--ifm-menu-color-background-active);
   }

--- a/src/theme/DocSidebarItem/Category/index.js
+++ b/src/theme/DocSidebarItem/Category/index.js
@@ -112,39 +112,51 @@ export default function DocSidebarItemCategory({ item, onItemClick, activePath, 
           "menu__list-item-collapsible--active": isCurrentPage,
         })}
       >
-        <Link
-          className={clsx("menu__link", {
-            "menu__link--sublist": collapsible,
-            "menu__link--sublist-caret": !href && collapsible,
-            "menu__link--active": isActive,
-          })}
-          onClick={
-            collapsible
-              ? (e) => {
-                  onItemClick?.(item);
-                  if (href) {
-                    updateCollapsed(false);
-                  } else {
-                    e.preventDefault();
-                    updateCollapsed();
+        {href || collapsible ? (
+          <Link
+            className={clsx("menu__link", {
+              "menu__link--sublist": collapsible,
+              "menu__link--sublist-caret": !href && collapsible,
+              "menu__link--active": isActive,
+            })}
+            onClick={
+              collapsible
+                ? (e) => {
+                    onItemClick?.(item);
+                    if (href) {
+                      updateCollapsed(false);
+                    } else {
+                      e.preventDefault();
+                      updateCollapsed();
+                    }
                   }
-                }
-              : () => {
-                  onItemClick?.(item);
-                }
-          }
-          aria-current={isCurrentPage ? "page" : undefined}
-          aria-expanded={collapsible ? !collapsed : undefined}
-          href={collapsible ? hrefWithSSRFallback ?? "#" : hrefWithSSRFallback}
-          {...props}
-        >
-          {item?.customProps?.icon && (
-            <div className={`${styles.categoryItem} ${isActive ? styles.active : ""}`}>
-              <IconMapper type={item?.customProps?.icon}></IconMapper>
-            </div>
-          )}
-          {label}
-        </Link>
+                : () => {
+                    onItemClick?.(item);
+                  }
+            }
+            aria-current={isCurrentPage ? "page" : undefined}
+            aria-expanded={collapsible ? !collapsed : undefined}
+            href={href ? hrefWithSSRFallback : "#"}
+            {...props}
+          >
+            {item?.customProps?.icon && (
+              <div className={`${styles.categoryItem} ${isActive ? styles.active : ""}`}>
+                <IconMapper type={item?.customProps?.icon}></IconMapper>
+              </div>
+            )}
+            {label}
+          </Link>
+        ) : (
+          <span className={`menu__link sidebar-category-title ${isActive ? styles.active : ""}`}>
+            {item?.customProps?.icon && (
+              <div className={`${styles.categoryItem} ${isActive ? styles.active : ""}`}>
+                <IconMapper type={item?.customProps?.icon}></IconMapper>
+              </div>
+            )}
+            {label}
+          </span>
+        )}
+
         {href && collapsible && (
           <CollapseButton
             categoryLabel={label}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-3-4`:
 - [chore: prevent tutorial categories from being highlighted DOC-1587 (#5902)](https://github.com/spectrocloud/librarium/pull/5902)
