### PR TITLE
docs: DOC-1741: Agent Mode Exiting Tech Preview

### DIFF
--- a/docs/docs-content/deployment-modes/agent-mode/agent-mode.md
+++ b/docs/docs-content/deployment-modes/agent-mode/agent-mode.md
@@ -11,10 +11,6 @@ In agent mode, you bring your own host, which can be any host that meets the min
 of the environment. This includes options like an AWS EC2 instance or a Raspberry Pi in your own home. All you need to
 do to have Palette manage your host is to [download and install the Palette agent](./install-agent-host.md).
 
-:::preview
-
-:::
-
 The diagram below illustrates the agent mode cluster provisioning workflow.
 
 ![Architecture Diagram for Agent Mode](/deployment-modes_agent-mode.webp)

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -20,10 +20,6 @@ This page guides you through the process of installing the Palette agent on your
 user data file to configure your host, install the agent, and verify that your host was successfully registered with
 Palette. You will then create a cluster profile and use the registered host to deploy a cluster.
 
-:::preview
-
-:::
-
 ## Limitations
 
 - The following table presents the verified combinations of host architecture and cluster profile layers.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the tech preview admonitions for Agent Mode, which is entering GA in 4.6.a.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Agent Mode]()
- [Install Palette Agent]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1741](https://spectrocloud.atlassian.net/browse/DOC-1741)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

4.6.a release work.

[DOC-1741]: https://spectrocloud.atlassian.net/browse/DOC-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ