### PR TITLE
docs: remove ansible references

### DIFF
--- a/docs/docs-content/clusters/clusters.md
+++ b/docs/docs-content/clusters/clusters.md
@@ -36,20 +36,6 @@ The out-of-the-box images are hosted in the public cloud (AWS - AMI, Azure - VHD
 (vSphere - OVA). During provisioning, the image is copied (if missing) to the desired cloud region or downloaded onto a
 private data center.
 
-### Customization
-
-Palette provides various forms of customization options for VM images. All these customization options require a private
-pack registry to be set up with customized OS packs.
-
-#### Customize Out-of-the Box Images
-
-The Palette out-of-the-box images are security-hardened and have Kubernetes components preinstalled. Additional
-components can be installed on the images at runtime by defining one or more Ansible roles in the customized OS pack.
-Palette's orchestration engine creates a new image by instantiating a VM instance from the out-of-the-box image and
-executing the specified Ansible roles on the instance. This custom image is used for cluster provisioning. The
-customized image is tagged with a unique signature generated from the pack definition so that it can be reused for
-future cluster provisioning requests.
-
 ## Security
 
 Palette secures the Kubernetes clusters provisioned by following security best practices at the Operating System,

--- a/docs/docs-content/registries-and-packs/add-custom-packs.md
+++ b/docs/docs-content/registries-and-packs/add-custom-packs.md
@@ -268,9 +268,9 @@ empty file still needs to be added to the OS pack.
 
 :::
 
-Parameters for all charts, manifests, and Ansible roles defined in the pack are defined in the `values.yaml` file.
-_Helm_ charts natively support values override. Any values defined are merged with those defined within a chart.
-_Manifests_ and _Ansible_ roles need to be explicitly templatized if parameter configuration is desired.
+Parameters for all charts and manifests defined in the pack are defined in the `values.yaml` file. _Helm_ charts
+natively support values override. Any values defined are merged with those defined within a chart. _Manifests_ need to
+be explicitly templatized if parameter configuration is desired.
 
 ```yaml
     pack:
@@ -285,11 +285,6 @@ _Manifests_ and _Ansible_ roles need to be explicitly templatized if parameter c
             <templatized manifest1 parameters>
         manifest2:
             <templatized manifest2 parameters>
-    ansibleRoles:
-        role1:
-        <templatized role1 parameters>
-        role2:
-            <templatized role2 parameters>
 ```
 
 4. A pack must have the logo file named `logo.png` and must be copied into the pack directory.
@@ -323,9 +318,8 @@ There are typically the following two scenarios for the OS image:
 
 2. **Vanilla OS Image** - Kubernetes components are not installed.
 
-Additionally, for both scenarios additional components or packages may need to be installed at runtime to prepare the
-final OS image. This can be done by specifying one or more Ansible roles in the pack. The following are a few examples
-of building custom OS pack to cover the some of these scenarios.
+Additionally, for both scenarios, additional components or packages may need to be installed at runtime to prepare the
+final OS image. The following are a few examples of building custom OS packs to cover some of these scenarios.
 
 A few sample pack manifests for building a custom OS pack are shown in the following examples. These are examples for
 images that do not have Kubernetes components pre-installed. Palette installs these components at the time of

--- a/docs/docs-content/registries-and-packs/registries-and-packs.md
+++ b/docs/docs-content/registries-and-packs/registries-and-packs.md
@@ -31,18 +31,17 @@ Palette provides a rich collection of out-of-the-box packs for various integrati
 through custom-built packs. To configure an existing infrastructure or add-on pack or to define a new add-on custom
 pack, it is essential to understand the pack structure.
 
-Each pack is a collection of files such as manifests, helm charts, Ansible roles, configuration files, and more. Ansible
-roles, if provided, are used to customize cluster VM images, whereas Kubernetes manifests and Helm charts are applied to
-the Kubernetes clusters after deployment. The following is a typical pack structure:
+Each pack is a collection of files such as manifests, Helm charts, configuration files, and more. Kubernetes manifests
+and Helm charts are applied to the Kubernetes clusters after deployment. The following is a typical pack structure:
 
-| **Pack Name** | **Requirement** | **Description**                                                                                                 |
-| ------------- | --------------- | --------------------------------------------------------------------------------------------------------------- |
-| `pack.json`   | mandatory       | Pack metadata.                                                                                                  |
-| `values.yaml` | mandatory       | Pack configuration, parameters exposed from the underlying charts, and templated parameters from Ansible roles. |
-| `charts/`     | mandatory       | Mandatory for Helm chart-based packs. Contains the Helm charts to be deployed for the pack.                     |
-| `manifests/`  | mandatory       | Mandatory for Manifest-based packs. Contains the manifest files to be deployed for the pack.                    |
-| `logo.png`    | optional        | Contains the pack logo.                                                                                         |
-| `README.md`   | optional        | The pack description.                                                                                           |
+| **Pack Name** | **Requirement** | **Description**                                                                              |
+| ------------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `pack.json`   | mandatory       | Pack metadata.                                                                               |
+| `values.yaml` | mandatory       | Pack configuration, parameters exposed from the underlying charts or manifests.              |
+| `charts/`     | mandatory       | Mandatory for Helm chart-based packs. Contains the Helm charts to be deployed for the pack.  |
+| `manifests/`  | mandatory       | Mandatory for Manifest-based packs. Contains the manifest files to be deployed for the pack. |
+| `logo.png`    | optional        | Contains the pack logo.                                                                      |
+| `README.md`   | optional        | The pack description.                                                                        |
 
 Let's look at the examples below to better understand pack structure.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes Ansible references from the Packs and Registries docs.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Registries and Packs](https://deploy-preview-6064--docs-spectrocloud.netlify.app/registries-and-packs/)
💻 [Add a Custom Pack](https://deploy-preview-6064--docs-spectrocloud.netlify.app/registries-and-packs/add-custom-packs/)
💻 [Clusters](https://deploy-preview-6064--docs-spectrocloud.netlify.app/clusters/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1742](https://spectrocloud.atlassian.net/browse/DOC-1742)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1742]: https://spectrocloud.atlassian.net/browse/DOC-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ