### PR TITLE
docs: PEM-7190: Troubleshooting to Remove nats-system Namespace

### DIFF
--- a/docs/docs-content/troubleshooting/nodes.md
+++ b/docs/docs-content/troubleshooting/nodes.md
@@ -300,7 +300,9 @@ Once the CRD is removed, it will not be recreated by Palette.
 
 ### Scenario - Remove Deprecated NATS Namespace
 
-Palette's internal message communication between components transitioned from using Neural Autonomous Transport System (NATS) to gRPC with version 4.0. As a result, clusters with Palette agents older than version 4.0 may have leftover NATS resources. Manually delete the `nats-system` namespace to remove any remaining NATS-related resources.
+Palette's internal message communication between components transitioned from using Neural Autonomous Transport System
+(NATS) to gRPC with version 4.0. As a result, clusters with Palette agents older than version 4.0 may have leftover NATS
+resources. Manually delete the `nats-system` namespace to remove any remaining NATS-related resources.
 
 #### Debug Steps
 

--- a/docs/docs-content/troubleshooting/nodes.md
+++ b/docs/docs-content/troubleshooting/nodes.md
@@ -300,7 +300,8 @@ Once the CRD is removed, it will not be recreated by Palette.
 
 ### Scenario - Remove Unused Namespaces
 
-To remove a namespace from a cluster whose resources are not being referenced or used elsewhere in the cluster, follow the steps below.
+To remove a namespace from a cluster whose resources are not being referenced or used elsewhere in the cluster, follow
+the steps below.
 
 #### Debug Steps
 
@@ -317,7 +318,8 @@ To remove a namespace from a cluster whose resources are not being referenced or
    kubectl get namespaces
    ```
 
-4. Identify the namespaces you want to delete. For example, to remove the `nats-system` namespace, used for Neural Autonomous Transport System (NATS) resources prior to Palette's transition to gRPC, issue the following command.
+4. Identify the namespaces you want to delete. For example, to remove the `nats-system` namespace, used for Neural
+   Autonomous Transport System (NATS) resources prior to Palette's transition to gRPC, issue the following command.
 
    ```shell
    kubectl delete namespaces nats-system

--- a/docs/docs-content/troubleshooting/nodes.md
+++ b/docs/docs-content/troubleshooting/nodes.md
@@ -298,10 +298,9 @@ workload cluster, you can follow the steps below.
 
 Once the CRD is removed, it will not be recreated by Palette.
 
-### Scenario - Remove Unused Namespaces
+### Scenario - Remove Deprecated NATS Namespace
 
-To remove a namespace from a cluster whose resources are not being referenced or used elsewhere in the cluster, follow
-the steps below.
+Palette's internal message communication between components transitioned from using Neural Autonomous Transport System (NATS) to gRPC with version 4.0. As a result, clusters with Palette agents older than version 4.0 may have leftover NATS resources. Manually delete the `nats-system` namespace to remove any remaining NATS-related resources.
 
 #### Debug Steps
 
@@ -312,14 +311,13 @@ the steps below.
    [Access Cluster with CLI](../clusters/cluster-management/palette-webctl.md#access-cluster-with-cli) guide for
    guidance on how to set up your terminal session to use the kubeconfig file.
 
-3. Issue the following command to list the namespaces in your target cluster.
+3. Issue the following command to list the namespaces in your cluster.
 
    ```shell
    kubectl get namespaces
    ```
 
-4. Identify the namespaces you want to delete. For example, to remove the `nats-system` namespace, used for Neural
-   Autonomous Transport System (NATS) resources prior to Palette's transition to gRPC, issue the following command.
+4. Remove the `nats-system` namespace.
 
    ```shell
    kubectl delete namespaces nats-system

--- a/docs/docs-content/troubleshooting/nodes.md
+++ b/docs/docs-content/troubleshooting/nodes.md
@@ -297,3 +297,28 @@ workload cluster, you can follow the steps below.
    ```
 
 Once the CRD is removed, it will not be recreated by Palette.
+
+### Scenario - Remove Unused Namespaces
+
+To remove a namespace from a cluster whose resources are not being referenced or used elsewhere in the cluster, follow the steps below.
+
+#### Debug Steps
+
+1. Open a terminal session that has [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed.
+
+2. Set up your terminal session to use the kubeconfig file for your Kubernetes workload cluster. You can find the
+   kubeconfig for your cluster in the Palette UI by visiting the cluster's details page. Check out the
+   [Access Cluster with CLI](../clusters/cluster-management/palette-webctl.md#access-cluster-with-cli) guide for
+   guidance on how to set up your terminal session to use the kubeconfig file.
+
+3. Issue the following command to list the namespaces in your target cluster.
+
+   ```shell
+   kubectl get namespaces
+   ```
+
+4. Identify the namespaces you want to delete. For example, to remove the `nats-system` namespace, used for Neural Autonomous Transport System (NATS) resources prior to Palette's transition to gRPC, issue the following command.
+
+   ```shell
+   kubectl delete namespaces nats-system
+   ```


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds troubleshooting for removing unused namespaces from a cluster, using the NATS namespace `nats-system` as an example.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Troubleshooting - Nodes and Clusters](https://deploy-preview-6122--docs-spectrocloud.netlify.app/troubleshooting/nodes/#scenario---remove-unused-namespaces)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-7190](https://spectrocloud.atlassian.net/browse/PEM-7190)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work.


[PEM-7190]: https://spectrocloud.atlassian.net/browse/PEM-7190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ