### PR TITLE
docs: update flags in oras login commands

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/airgap-install/kubernetes-airgap-instructions.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/airgap-install/kubernetes-airgap-instructions.md
@@ -115,14 +115,14 @@ Complete the following steps before deploying the airgap Palette installation.
     additional CLI flags and examples.
 
     ```shell
-    oras login X.X.X.X --user 'yourUserNameHere' --password 'yourPasswordHere'
+    oras login X.X.X.X --username 'yourUserNameHere' --password 'yourPasswordHere'
     ```
 
     If you are using a Harbor registry with a self-signed certificate, you will need to add the `--insecure` flag to the
     `oras` command.
 
     ```shell
-    oras login X.X.X.X --insecure --user 'yourUserNameHere' --password 'yourPasswordHere'
+    oras login X.X.X.X --insecure --username 'yourUserNameHere' --password 'yourPasswordHere'
     ```
 
     </TabItem>

--- a/docs/docs-content/enterprise-version/upgrade/upgrade-k8s/airgap.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade-k8s/airgap.md
@@ -73,7 +73,7 @@ Palette upgrade.
     examples.
 
     ```shell
-    oras login X.X.X.X --user 'yourUserNameHere' --password 'yourPasswordHere'
+    oras login X.X.X.X --username 'yourUserNameHere' --password 'yourPasswordHere'
     ```
 
     :::tip
@@ -81,7 +81,7 @@ Palette upgrade.
     If your Harbor registry has a self-signed certificate, use the `--insecure` flag.
 
     ```shell
-    oras login X.X.X.X --insecure --user 'yourUserNameHere' --password 'yourPasswordHere'
+    oras login X.X.X.X --insecure --username 'yourUserNameHere' --password 'yourPasswordHere'
     ```
 
     :::

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/kubernetes-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/kubernetes-airgap-instructions.md
@@ -117,14 +117,14 @@ Complete the following steps before deploying the airgap VerteX installation.
     additional CLI flags and examples.
 
     ```shell
-    oras login X.X.X.X --user 'yourUserNameHere' --password 'yourPasswordHere'
+    oras login X.X.X.X --username 'yourUserNameHere' --password 'yourPasswordHere'
     ```
 
     If you are using a Harbor registry with a self-signed certificate, you will need to add the `--insecure` flag to the
     `oras` command.
 
     ```shell
-    oras login X.X.X.X --insecure --user 'yourUserNameHere' --password 'yourPasswordHere'
+    oras login X.X.X.X --insecure --username 'yourUserNameHere' --password 'yourPasswordHere'
     ```
 
     </TabItem>

--- a/docs/docs-content/vertex/upgrade/upgrade-k8s/airgap.md
+++ b/docs/docs-content/vertex/upgrade/upgrade-k8s/airgap.md
@@ -70,7 +70,7 @@ Palette VerteX upgrade.
     examples.
 
     ```shell
-    oras login X.X.X.X --user 'yourUserNameHere' --password 'yourPasswordHere'
+    oras login X.X.X.X --username 'yourUserNameHere' --password 'yourPasswordHere'
     ```
 
     :::tip
@@ -78,7 +78,7 @@ Palette VerteX upgrade.
     If your Harbor registry has a self-signed certificate, use the `--insecure` flag.
 
     ```shell
-    oras login X.X.X.X --insecure --user 'yourUserNameHere' --password 'yourPasswordHere'
+    oras login X.X.X.X --insecure --username 'yourUserNameHere' --password 'yourPasswordHere'
     ```
 
     :::


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the `oras login` flags.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Self-hosted Environment Setup](https://deploy-preview-6123--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-kubernetes/airgap-install/kubernetes-airgap-instructions/)
💻 [Self-hosted Upgrade](https://deploy-preview-6123--docs-spectrocloud.netlify.app/enterprise-version/upgrade/upgrade-k8s/airgap/)
💻 [VerteX Environment Setup](https://deploy-preview-6123--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/kubernetes-airgap-instructions/)
💻 [VerteX Upgrade](https://deploy-preview-6123--docs-spectrocloud.netlify.app/vertex/upgrade/upgrade-k8s/airgap/)


## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
