### PR TITLE
docs: upgrade paths DOC-1719

### DIFF
--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -131,16 +131,22 @@ minor version available.
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.6.9        |       4.6.12       | :white_check_mark: |
+|       4.6.8        |       4.6.12       | :white_check_mark: |
 |       4.6.8        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.12       | :white_check_mark: |
 |       4.6.7        |       4.6.9        | :white_check_mark: |
 |       4.6.7        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.12       | :white_check_mark: |
 |       4.6.6        |       4.6.9        | :white_check_mark: |
 |       4.6.6        |       4.6.8        | :white_check_mark: |
 |       4.6.6        |       4.6.7        | :white_check_mark: |
+|       4.5.21       |       4.6.12       | :white_check_mark: |
 |       4.5.21       |       4.6.9        | :white_check_mark: |
 |       4.5.21       |       4.6.8        | :white_check_mark: |
 |       4.5.21       |       4.6.7        | :white_check_mark: |
 |       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.12       | :white_check_mark: |
 |       4.5.20       |       4.6.9        | :white_check_mark: |
 |       4.5.20       |       4.6.8        | :white_check_mark: |
 |       4.5.20       |       4.6.7        | :white_check_mark: |

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -45,7 +45,25 @@ minor version available.
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.6.9        |       4.6.12       | :white_check_mark: |
+|       4.6.8        |       4.6.12       | :white_check_mark: |
+|       4.6.8        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.12       | :white_check_mark: |
+|       4.6.7        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.12       | :white_check_mark: |
+|       4.6.6        |       4.6.9        | :white_check_mark: |
+|       4.6.6        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.7        | :white_check_mark: |
+|       4.5.21       |       4.6.12       | :white_check_mark: |
+|       4.5.21       |       4.6.9        | :white_check_mark: |
+|       4.5.21       |       4.6.8        | :white_check_mark: |
+|       4.5.21       |       4.6.7        | :white_check_mark: |
 |       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.12       | :white_check_mark: |
+|       4.5.20       |       4.6.9        | :white_check_mark: |
+|       4.5.20       |       4.6.8        | :white_check_mark: |
+|       4.5.20       |       4.6.7        | :white_check_mark: |
 |       4.5.20       |       4.6.6        | :white_check_mark: |
 
 **4.5.x**
@@ -113,7 +131,19 @@ minor version available.
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.6.8        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.9        | :white_check_mark: |
+|       4.6.6        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.7        | :white_check_mark: |
+|       4.5.21       |       4.6.9        | :white_check_mark: |
+|       4.5.21       |       4.6.8        | :white_check_mark: |
+|       4.5.21       |       4.6.7        | :white_check_mark: |
 |       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.9        | :white_check_mark: |
+|       4.5.20       |       4.6.8        | :white_check_mark: |
+|       4.5.20       |       4.6.7        | :white_check_mark: |
 |       4.5.20       |       4.6.6        | :white_check_mark: |
 
 **4.5.x**

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -45,7 +45,25 @@ latest minor version available.
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.6.9        |       4.6.12       | :white_check_mark: |
+|       4.6.8        |       4.6.12       | :white_check_mark: |
+|       4.6.8        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.12       | :white_check_mark: |
+|       4.6.7        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.12       | :white_check_mark: |
+|       4.6.6        |       4.6.9        | :white_check_mark: |
+|       4.6.6        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.7        | :white_check_mark: |
+|       4.5.21       |       4.6.12       | :white_check_mark: |
+|       4.5.21       |       4.6.9        | :white_check_mark: |
+|       4.5.21       |       4.6.8        | :white_check_mark: |
+|       4.5.21       |       4.6.7        | :white_check_mark: |
 |       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.12       | :white_check_mark: |
+|       4.5.20       |       4.6.9        | :white_check_mark: |
+|       4.5.20       |       4.6.8        | :white_check_mark: |
+|       4.5.20       |       4.6.7        | :white_check_mark: |
 |       4.5.20       |       4.6.6        | :white_check_mark: |
 
 **4.5.x**
@@ -113,7 +131,19 @@ latest minor version available.
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.6.8        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.9        | :white_check_mark: |
+|       4.6.6        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.7        | :white_check_mark: |
+|       4.5.21       |       4.6.9        | :white_check_mark: |
+|       4.5.21       |       4.6.8        | :white_check_mark: |
+|       4.5.21       |       4.6.7        | :white_check_mark: |
 |       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.9        | :white_check_mark: |
+|       4.5.20       |       4.6.8        | :white_check_mark: |
+|       4.5.20       |       4.6.7        | :white_check_mark: |
 |       4.5.20       |       4.6.6        | :white_check_mark: |
 
 **4.5.x**

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -131,16 +131,22 @@ latest minor version available.
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.6.9        |       4.6.12       | :white_check_mark: |
+|       4.6.8        |       4.6.12       | :white_check_mark: |
 |       4.6.8        |       4.6.9        | :white_check_mark: |
+|       4.6.7        |       4.6.12       | :white_check_mark: |
 |       4.6.7        |       4.6.9        | :white_check_mark: |
 |       4.6.7        |       4.6.8        | :white_check_mark: |
+|       4.6.6        |       4.6.12       | :white_check_mark: |
 |       4.6.6        |       4.6.9        | :white_check_mark: |
 |       4.6.6        |       4.6.8        | :white_check_mark: |
 |       4.6.6        |       4.6.7        | :white_check_mark: |
+|       4.5.21       |       4.6.12       | :white_check_mark: |
 |       4.5.21       |       4.6.9        | :white_check_mark: |
 |       4.5.21       |       4.6.8        | :white_check_mark: |
 |       4.5.21       |       4.6.7        | :white_check_mark: |
 |       4.5.21       |       4.6.6        | :white_check_mark: |
+|       4.5.20       |       4.6.12       | :white_check_mark: |
 |       4.5.20       |       4.6.9        | :white_check_mark: |
 |       4.5.20       |       4.6.8        | :white_check_mark: |
 |       4.5.20       |       4.6.7        | :white_check_mark: |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds the upgrade paths for 4.6.12.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1719](https://spectrocloud.atlassian.net/browse/DOC-1719)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1719]: https://spectrocloud.atlassian.net/browse/DOC-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ