### PR TITLE
docs: Removing Additional Earthly Link from VirtualBox Edge Tutorial

### DIFF
--- a/docs/docs-content/tutorials/edge/deploy-cluster-virtualbox.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster-virtualbox.md
@@ -112,7 +112,7 @@ git checkout v4.4.12
 
 ### Define Arguments
 
-EdgeForge leverages [Earthly](https://earthly.dev/)(https://earthly.dev) to build the Installer ISO and provider images
+EdgeForge leverages [Earthly](https://earthly.dev/) to build the Installer ISO and provider images
 artifacts. The **.arg** file is used to pass the values of a few arguments, such as the image tag and registry name, to
 Earthly for the build process.
 

--- a/docs/docs-content/tutorials/edge/deploy-cluster-virtualbox.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster-virtualbox.md
@@ -112,9 +112,9 @@ git checkout v4.4.12
 
 ### Define Arguments
 
-EdgeForge leverages [Earthly](https://earthly.dev/) to build the Installer ISO and provider images
-artifacts. The **.arg** file is used to pass the values of a few arguments, such as the image tag and registry name, to
-Earthly for the build process.
+EdgeForge leverages [Earthly](https://earthly.dev/) to build the Installer ISO and provider images artifacts. The
+**.arg** file is used to pass the values of a few arguments, such as the image tag and registry name, to Earthly for the
+build process.
 
 Execute the command below to create a custom tag for the provider images. The tag must be an alphanumeric lowercase
 string. This tutorial uses `vbox-tutorial` as an example.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes an additional Earthly link from the Edge Virtual Box tutorial that was left out of [PR 6027](https://github.com/spectrocloud/librarium/pull/6207). This fix is included in the backports for versions 4.4 - 4.0.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Edge - VirtualBox Tutorial](https://deploy-preview-6222--docs-spectrocloud.netlify.app/tutorials/edge/deploy-cluster-virtualbox/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
