### PR TITLE
docs: DOC-1782: Fixing Portworx Spelling

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/prepare-user-data.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/prepare-user-data.md
@@ -429,7 +429,7 @@ Kubernetes cluster. This setup is useful for scenarios where your applications a
 access to files or directories on the Edge host.
 
 <!-- prettier-ignore -->
-Several packs require you set up bind mounts in order to function. For example, the <VersionedLink text="Portwox pack" url="/integrations/packs/?pack=csi-portworx-generic" /> requires several folders to be mounted on Edge deployments. You can use the `install.bind_mounts` parameter to specify folders to be mounted. For
+Several packs require you set up bind mounts in order to function. For example, the <VersionedLink text="Portworx pack" url="/integrations/packs/?pack=csi-portworx-generic" /> requires several folders to be mounted on Edge deployments. You can use the `install.bind_mounts` parameter to specify folders to be mounted. For
 example, the following user data mounts three folders required by Portworx from the Edge host to the cluster.
 
 ```yaml


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR corrects a "Portwox" spelling error.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1782](https://spectrocloud.atlassian.net/browse/DOC-1782)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1782]: https://spectrocloud.atlassian.net/browse/DOC-1782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ