### PR TITLE
Revert "docs: DOC-1778: 4.4 Release Notes - Security Advisory"

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,21 +11,6 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
-## March 29, 2025 - Release 4.4.22
-
-- On March 24, 2025, a security vulnerability regarding certain versions of
-  [ingress-nginx](https://github.com/kubernetes/ingress-nginx) was reported. The vulnerable versions were used in
-  Palette's and VerteX's management planes and were also available as packs for workload clusters. On March 26, 2025,
-  all managed Palette and VerteX deployments were patched and the affected component was upgraded to a secure version, `1.11.5`. On March 28,
-  2025, connected Palette [Enterprise](../enterprise-version/enterprise-version.md) and [VerteX](../vertex/vertex.md)
-  versions 4.5 - 4.6 were patched, and on March 29, 2025, version 4.4 was patched. Currently, airgapped Palette Enterprise and VerteX installations must manually upgrade
-  their `ingress-nginx` controllers to version `1.11.5`.
-
-  All workload clusters across all Palette and VerteX installations must be updated manually. All users should review
-  their [cluster profiles](../profiles/cluster-profiles/cluster-profiles.md) and workload clusters and upgrade the Nginx
-  pack to version `1.11.5`. For more information, refer to our
-  [Security Advisory](../security-bulletins/security-advisories/security-advisories.md).
-
 ## February 21, 2025 - Documentation & Education Updates
 
 - The Documentation & Education team is enabling a new Q&A bot functionality on the Spectro Cloud official documentation

--- a/docs/docs-content/security-bulletins/security-advisories/security-advisories.md
+++ b/docs/docs-content/security-bulletins/security-advisories/security-advisories.md
@@ -17,7 +17,7 @@ This advisory outlines security vulnerabilities related to [ingress-nginx](https
 and the recommended remediation actions.
 
 - **Release Date**: March 27, 2025
-- **Last Updated**: March 31, 2025
+- **Last Updated**: March 27, 2025
 - **Severity**: 9.8
 - **Affected Versions**: All versions prior to v1.11.0, v1.11.0 - v1.11.4, and v1.12.0
 - **Fixed Versions**: v1.11.5 and v1.12.1
@@ -40,14 +40,15 @@ Refer to the [Security Bulletins](../reports/reports.mdx) page for detailed info
 - **March 24, 2025**: CVE bulletin published.
 - **March 26, 2025**: New Nginx pack published.
 - **March 26, 2025, 11:30 PM PST - March 27, 2025, 12:43 AM PST**: All managed Palette instances patched.
-- **March 27, 2025**: Manual patch procedure provided for connected and airgapped Palette Enterprise and VerteX installations.
-- **March 28, 2025**: Affected Nginx packs deprecated.
-- **March 28, 2025**: Connected Palette Enterprise and VerteX patched for versions 4.5 - 4.6.
-- **March 29, 2025**: Connected Palette Enterprise and VerteX patched for version 4.4.
+- **March 27, 2025**: Manual patch procedure provided for connected and airgapped Palette enterprise installations.
 
 #### Future Updates
 
-- **April 2, 2025, 10:00 PM PST**: Airgapped Palette Enterprise and VerteX patch for versions 4.4 - 4.6.
+Estimated release dates for patches with the fix for Palette and VerteX versions 4.4 - 4.6, including the deprecation of
+affected Nginx packs:
+
+- **March 28, 2025, 10:00 PM PST**: Connected Palette and VerteX patch.
+- **April 2, 2025, 10:00 PM PST**: Airgapped Palette and VerteX patch.
 
 ### Summary
 
@@ -57,12 +58,10 @@ download confidential information such as secrets available in the cluster. Thes
 Palette and VerteX management planes. Additionally, Spectro Cloud also provides the Nginx pack to customers for their
 workload clusters, which contains several vulnerable image versions.
 
-As of March 29, 2025, all managed Palette instances have been patched, as well as connected Palette Enterprise and VerteX installations, and vulnerable Nginx packs have been deprecated. Currently, airgapped Palette Enterprise and VerteX
-installations must manually upgrade their `ingress-nginx` controllers to version `1.11.5`.
-
-All workload clusters across all Palette and VerteX installations must be updated manually. All users should review their cluster profiles and workload clusters and upgrade the Nginx pack to version `1.11.5`.
-
-Follow the below procedures to manually upgrade the affected components and upgrade affected workload clusters. 
+As of March 26, 2025, all managed Palette instances have been patched. Customers should follow the below procedures to
+manually upgrade the affected component in Palette enterprise and VerteX deployments and use the newly published Nginx
+pack (`1.11.5`) to upgrade affected workload clusters. All prior versions of Nginx will be marked deprecated within
+Palette.
 
 ### Recommended Actions
 


### PR DESCRIPTION
Reverts spectrocloud/librarium#6252

The 4.4.22 patch is still not out, even though it is listed in Retool as GA. 