### PR TITLE
docs: DOC-1745: Zarf OCI Registry Cleanup

### DIFF
--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-zarf.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-zarf.md
@@ -11,7 +11,8 @@ You can add an OCI Zarf registry to Palette and use the Zarf packages in cluster
 
 ## Prerequisites
 
-- You must have an OCI registry that contains Zarf packages. Refer to the [Zarf documentation](https://docs.zarf.dev/tutorials/6-publish-and-deploy/) for guidance on creating a Zarf package.
+- You must have an OCI registry that contains Zarf packages. Refer to the
+  [Zarf documentation](https://docs.zarf.dev/tutorials/6-publish-and-deploy/) for guidance on creating a Zarf package.
 
 - Credentials to access the OCI registry. Public OCI registries are not supported.
 
@@ -34,10 +35,12 @@ Take the following steps to add an OCI Zarf registry to Palette.
 
 5. Enter the registry URL in the **Endpoint** field.
 
-6. Choose whether to **Enable Authentication** for your registry. If enabled, you must enter your registry credentials in the **Username** and **Password** fields.
+6. Choose whether to **Enable Authentication** for your registry. If enabled, you must enter your registry credentials
+   in the **Username** and **Password** fields.
 
-7. If your OCI registry server is using a self-signed certificate, or if the server certificate is not signed by a trusted CA, select **Insecure Skip TLS Verify** to skip verifying the x509 certificate, and select **Upload file** to upload the certificate.
-    
+7. If your OCI registry server is using a self-signed certificate, or if the server certificate is not signed by a
+   trusted CA, select **Insecure Skip TLS Verify** to skip verifying the x509 certificate, and select **Upload file** to
+   upload the certificate.
 8. **Confirm** your registry.
 
 ## Validate

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-zarf.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-zarf.md
@@ -11,7 +11,7 @@ You can add an OCI Zarf registry to Palette and use the Zarf packages in cluster
 
 ## Prerequisites
 
-- You must have an OCI registry that contains Zarf packages.
+- You must have an OCI registry that contains Zarf packages. Refer to the [Zarf documentation](https://docs.zarf.dev/tutorials/6-publish-and-deploy/) for guidance on creating a Zarf package.
 
 - Credentials to access the OCI registry. Public OCI registries are not supported.
 
@@ -22,44 +22,36 @@ You can add an OCI Zarf registry to Palette and use the Zarf packages in cluster
 
 ## Add OCI Zarf Registry
 
-Use the following steps to add an OCI Zarf registry to Palette.
+Take the following steps to add an OCI Zarf registry to Palette.
 
-1. Log in to the [Palette](https://console.spectrocloud.com) as a Tenant administrator.
+1. Log in to [Palette](https://console.spectrocloud.com) as a Tenant administrator.
 
-2. From the left **Main Menu** select **Tenant Settings**.
+2. From the left main menu, select **Tenant Settings**.
 
-3. From the **Tenant Settings Menu**, Select **Registries**.
+3. From the **Tenant Settings** menu, select **Registries > OCI Registries > Add New OCI Registry**.
 
-4. Click on the **OCI Registries** tab.
+4. Enter the **Name** of the registry. Select **Zarf** as the **Provider**.
 
-5. Click **Add New OCI Registry**.
+5. Enter the registry URL in the **Endpoint** field.
 
-6. Fill out the **Name** field and select **Helm** as the registry type.
+6. Choose whether to **Enable Authentication** for your registry. If enabled, you must enter your registry credentials in the **Username** and **Password** fields.
 
-7. Select the **OCI Authentication Type** as **Basic**.
-
-8. Provide the registry URL in the **Endpoint** field.
-
-9. Fill out the **Username** and **Password** fields with the credentials to access the registry.
-
-10. If your OCI registry server is using a self-signed certificate or if the server certificate is not signed by a
-    trusted CA, check the **Insecure Skip TLS Verify** box to skip verifying the x509 certificate, and click **Upload
-    file** to upload the certificate.
-
-11. Click **Confirm** to complete adding the registry.
+7. If your OCI registry server is using a self-signed certificate, or if the server certificate is not signed by a trusted CA, select **Insecure Skip TLS Verify** to skip verifying the x509 certificate, and select **Upload file** to upload the certificate.
+    
+8. **Confirm** your registry.
 
 ## Validate
 
-Use the following steps to validate that the OCI registry is added to Palette correctly.
+Take the following steps to confirm that the OCI registry was added to Palette.
 
-1. Log in to the [Palette](https://console.spectrocloud.com).
+1. Log in to [Palette](https://console.spectrocloud.com).
 
-2. From the left **Main Menu**, click on **Profiles**.
+2. From the left main menu, select **Profiles**.
 
-3. Click **Add Cluster Profile**.
+3. Choose **Add Cluster Profile**.
 
-4. Provide a name and select the type **Add-on**.
+4. Enter a **Name** for the profile. For the **Type**, choose **Add-on**, and select **Next**.
 
-5. In the following screen, click **Add Zarf**.
+5. On the **Profile Layers** screen, select **Add Zarf**.
 
-6. Verify the Zarf registry you added is displayed in the **Registry drop-down Menu**.
+6. Verify the Zarf registry you added is displayed in the **Registry** drop-down menu.

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-zarf.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-zarf.md
@@ -35,12 +35,13 @@ Take the following steps to add an OCI Zarf registry to Palette.
 
 5. Enter the registry URL in the **Endpoint** field.
 
-6. Choose whether to **Enable Authentication** for your registry. If enabled, you must enter your registry credentials
+6. Choose whether to **Enable Authentication** for your registry. If enabled, enter your registry credentials
    in the **Username** and **Password** fields.
 
 7. If your OCI registry server is using a self-signed certificate, or if the server certificate is not signed by a
    trusted CA, select **Insecure Skip TLS Verify** to skip verifying the x509 certificate, and select **Upload file** to
    upload the certificate.
+
 8. **Confirm** your registry.
 
 ## Validate

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-zarf.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-zarf.md
@@ -35,8 +35,8 @@ Take the following steps to add an OCI Zarf registry to Palette.
 
 5. Enter the registry URL in the **Endpoint** field.
 
-6. Choose whether to **Enable Authentication** for your registry. If enabled, enter your registry credentials
-   in the **Username** and **Password** fields.
+6. Choose whether to **Enable Authentication** for your registry. If enabled, enter your registry credentials in the
+   **Username** and **Password** fields.
 
 7. If your OCI registry server is using a self-signed certificate, or if the server certificate is not signed by a
    trusted CA, select **Insecure Skip TLS Verify** to skip verifying the x509 certificate, and select **Upload file** to


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the existing Add Zarf OCI Registry page to correctly reference Zarf instead of Helm and includes general cleanup. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Zarf OCI Registry](https://deploy-preview-6295--docs-spectrocloud.netlify.app/registries-and-packs/registries/oci-registry/add-oci-zarf/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1745](https://spectrocloud.atlassian.net/browse/DOC-1745)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1745]: https://spectrocloud.atlassian.net/browse/DOC-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ