### PR TITLE
docs: DOC-1789: Updating Stylus tagsFromFile and tagsFromScript Parameters

### DIFF
--- a/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
@@ -324,11 +324,11 @@ You can specify tags from a file by using the `tagsFromFile` parameter object or
 
 | Parameter                              | Description                                            | Default Value |
 | -------------------------------------- | ------------------------------------------------------ | ------------- |
-| `stylus.site.tagFromFile.fileName`     | The path to the file containing the tags.              | `''`          |
-| `stylus.site.tagFromFile.delimiter`    | The delimiter used to separate the key-value pairs.    | `\n`          |
-| `stylus.site.tagFromFile.separator`    | The separator used to separate the key from the value. | `:`           |
-| `stylus.site.tagFromScript.scriptName` | The path to the script that returns a JSON object.     | `''`          |
-| `stylus.site.tagFromScript.timeout`    | The timeout value in seconds.                          | `60`          |
+| `stylus.site.tagsFromFile.fileName`     | The path to the file containing the tags.              | `''`          |
+| `stylus.site.tagsFromFile.delimiter`    | The delimiter used to separate the key-value pairs.    | `\n`          |
+| `stylus.site.tagsFromFile.separator`    | The separator used to separate the key from the value. | `:`           |
+| `stylus.site.tagsFromScript.scriptName` | The path to the script that returns a JSON object.     | `''`          |
+| `stylus.site.tagsFromScript.timeout`    | The timeout value in seconds.                          | `60`          |
 
 With tags from a file, you can specify different delimiters and separators to parse the content of a file depending on
 how the content is formatted. For example, assume the file **/etc/palette/tags.txt** contains the following content.

--- a/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
@@ -322,8 +322,8 @@ automatically apply to application workloads. To configure applications to use t
 You can specify tags from a file by using the `tagsFromFile` parameter object or from a script by using the
 `tagsFromScript` parameter.
 
-| Parameter                              | Description                                            | Default Value |
-| -------------------------------------- | ------------------------------------------------------ | ------------- |
+| Parameter                               | Description                                            | Default Value |
+| --------------------------------------- | ------------------------------------------------------ | ------------- |
 | `stylus.site.tagsFromFile.fileName`     | The path to the file containing the tags.              | `''`          |
 | `stylus.site.tagsFromFile.delimiter`    | The delimiter used to separate the key-value pairs.    | `\n`          |
 | `stylus.site.tagsFromFile.separator`    | The separator used to separate the key from the value. | `:`           |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR corrects the`tagsFromFile` and `tagsFromScript` parameters on the Edge Configuration Reference page. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Edge Configuration Reference](https://deploy-preview-6296--docs-spectrocloud.netlify.app/clusters/edge/edge-configuration/installer-reference/#tags)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1789](https://spectrocloud.atlassian.net/browse/DOC-1789)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1789]: https://spectrocloud.atlassian.net/browse/DOC-1789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ