### PR TITLE
docs: add warning for non editable labels on existing nodes

### DIFF
--- a/docs/docs-content/clusters/cluster-management/node-labels.md
+++ b/docs/docs-content/clusters/cluster-management/node-labels.md
@@ -10,7 +10,7 @@ tags: ["clusters", "cluster management"]
 Node labels provide pods the ability to specify which nodes they should be scheduled on. This ability can be useful in
 scenarios where pods should be co-located or executed on dedicated nodes. A common use case of node labels is to ensure
 that certain workloads only execute on certain hardware configurations. Labels are optional configurations, as the
-scheduler will automatically place pods across nodes.
+scheduler automatically places pods across nodes.
 
 :::tip
 
@@ -20,8 +20,13 @@ on certain nodes.
 
 :::
 
-Palette allows you to apply node labels during cluster provisioning. Once the cluster is in a healthy state, labels can
-be modified on the **Nodes** tab of the cluster details page.
+Palette allows you to apply node labels during cluster provisioning.
+
+:::warning
+
+Updating labels on existing nodes of deployed clusters is not currently supported.
+
+:::
 
 This guide covers the Palette UI flow.
 
@@ -43,7 +48,7 @@ Node labels can also be applied to node pools using our
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
-2. Navigate to the left **Main Menu** and select **Profiles**.
+2. Navigate to the left main menu and select **Profiles**.
 
 3. Create a cluster profile to deploy to your environment. Refer to the
    [Create a Full Profile](../../profiles/cluster-profiles/create-cluster-profiles/create-full-profile.md) guide for
@@ -74,7 +79,7 @@ Node labels can also be applied to node pools using our
 
 6. Save the changes made to your cluster profile.
 
-7. Navigate to the left **Main Menu** and select **Clusters**.
+7. Navigate to the left main menu and select **Clusters**.
 
 8. Click on **Add New Cluster**.
 
@@ -92,13 +97,6 @@ Node labels can also be applied to node pools using our
     selector. Click on **Next**.
 
     ![Screenshot of adding node labels during cluster creation](/clusters_cluster-management_node-labels_cluster-creation-labels.webp)
-
-    :::info
-
-    Node labels can also be updated on a deployed cluster by editing a worker node pool from the **Nodes** tab of the
-    cluster details page.
-
-    :::
 
 14. Accept the default settings on the **Cluster Settings** tab and click on **Validate**.
 
@@ -118,7 +116,7 @@ You can follow these steps to validate that your node labels are applied success
 
 1. Log in to [Palette](https://console.spectrocloud.com).
 
-2. Navigate to the left **Main Menu** and select **Clusters**.
+2. Navigate to the left main menu and select **Clusters**.
 
 3. Select the cluster you deployed, and download the [kubeconfig](./kubeconfig.md) file.
 
@@ -130,7 +128,7 @@ You can follow these steps to validate that your node labels are applied success
    export KUBECONFIG=~/Downloads/admin.azure-cluster.kubeconfig
    ```
 
-5. Confirm the cluster deployment process has scheduled your pods as expected. Remember that only pods will be scheduled
+5. Confirm the cluster deployment process has scheduled your pods as expected. Remember that only pods are scheduled
    on nodes with labels matching their node selectors.
 
    ```

--- a/docs/docs-content/clusters/cluster-management/node-labels.md
+++ b/docs/docs-content/clusters/cluster-management/node-labels.md
@@ -22,12 +22,6 @@ on certain nodes.
 
 Palette allows you to apply node labels during cluster provisioning.
 
-:::warning
-
-Updating labels on existing nodes of deployed clusters is not currently supported.
-
-:::
-
 This guide covers the Palette UI flow.
 
 :::info
@@ -36,6 +30,10 @@ Node labels can also be applied to node pools using our
 [Terraform provider](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs).
 
 :::
+
+## Limitations
+
+- Updates to labels on existing nodes of deployed clusters is not supported.
 
 ## Prerequisites
 

--- a/docs/docs-content/clusters/cluster-management/node-labels.md
+++ b/docs/docs-content/clusters/cluster-management/node-labels.md
@@ -126,7 +126,7 @@ You can follow these steps to validate that your node labels are applied success
    export KUBECONFIG=~/Downloads/admin.azure-cluster.kubeconfig
    ```
 
-5. Confirm the cluster deployment process has scheduled your pods as expected. Remember that only pods are scheduled on
+5. Confirm the cluster deployment process has scheduled your pods as expected. Remember that pods are only scheduled on
    nodes with labels matching their node selectors.
 
    ```

--- a/docs/docs-content/clusters/cluster-management/node-labels.md
+++ b/docs/docs-content/clusters/cluster-management/node-labels.md
@@ -128,8 +128,8 @@ You can follow these steps to validate that your node labels are applied success
    export KUBECONFIG=~/Downloads/admin.azure-cluster.kubeconfig
    ```
 
-5. Confirm the cluster deployment process has scheduled your pods as expected. Remember that only pods are scheduled
-   on nodes with labels matching their node selectors.
+5. Confirm the cluster deployment process has scheduled your pods as expected. Remember that only pods are scheduled on
+   nodes with labels matching their node selectors.
 
    ```
    kubectl get pods --all-namespaces --output wide --watch


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR:
1. Adds a warning stating that editing labels on existing pods is currently not supported.
2. Removes the sentences stating that editing labels on existing pods is available.
3. Changes the "main menu" writing format in accordance with the Style Guide.
4. Rephrases sentences that contain "will".

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page](https://deploy-preview-6313--docs-spectrocloud.netlify.app/clusters/cluster-management/node-labels/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/PE-3218)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
