### PR TITLE
docs: add TF provider release DOC-1804

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,19 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## April 3, 2025 - Automation Updates
+
+Terraform version 0.23.4 of the
+[Spectro Cloud Terraform provider](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs) is
+available. For more details, refer to the Terraform provider
+[release page](https://github.com/spectrocloud/terraform-provider-spectrocloud/releases).
+
+### Bug Fixes
+
+- Fixed an issue that resulted in Admin Kubeconfig files to be fetched instead of the Kubeconfig file when using the
+  `kubeconfig` field on cluster resources. Refer to the
+  [Kubeconfig Files](../clusters/cluster-management/kubeconfig.md#kubeconfig-files) for more details.
+
 ## March 28, 2025 - Release 4.6.18
 
 ### Bug Fixes


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR add the new TF provider to the release notes. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-6314--docs-spectrocloud.netlify.app/release-notes/#april-3-2025---automation-updates)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1804](https://spectrocloud.atlassian.net/browse/DOC-1804)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
To 4.6

[DOC-1804]: https://spectrocloud.atlassian.net/browse/DOC-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ