### PR TITLE
docs: update the edge CLI version DOC-1801

### DIFF
--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
@@ -41,10 +41,10 @@ same time in a single command.
 
 1. Download Palette Edge CLI and assign the executable bit to the CLI. Refer to
    [Palette Components Compatibility Matrix](../../../../component.md#palette-edge-cli-versions) to use the right
-   Palette Edge CLI version. This guide uses 4.6.9 as an example.
+   Palette Edge CLI version. This guide uses 4.5.5 as an example.
 
    ```shell
-   VERSION=4.6.9
+   VERSION=4.5.5
    wget https://software.spectrocloud.com/stylus/v$VERSION/cli/linux/palette-edge
    chmod +x palette-edge
    ```
@@ -75,7 +75,6 @@ same time in a single command.
    help             Help about any command
    show             Display all the preset default values and supported OS and K8S flavors
    upload
-   validate         Validate a user-data YAML file
 
    Flags:
          --config string    config file (default is $HOME/.palette-edge-cli.yaml)

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
@@ -41,10 +41,10 @@ same time in a single command.
 
 1. Download Palette Edge CLI and assign the executable bit to the CLI. Refer to
    [Palette Components Compatibility Matrix](../../../../component.md#palette-edge-cli-versions) to use the right
-   Palette Edge CLI version. This guide uses 4.4.12 as an example.
+   Palette Edge CLI version. This guide uses 4.6.9 as an example.
 
    ```shell
-   VERSION=4.4.12
+   VERSION=4.6.9
    wget https://software.spectrocloud.com/stylus/v$VERSION/cli/linux/palette-edge
    chmod +x palette-edge
    ```
@@ -75,6 +75,7 @@ same time in a single command.
    help             Help about any command
    show             Display all the preset default values and supported OS and K8S flavors
    upload
+   validate         Validate a user-data YAML file
 
    Flags:
          --config string    config file (default is $HOME/.palette-edge-cli.yaml)


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the edge CLI version to the newest one. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Export Cluster Definition](https://deploy-preview-6323--docs-spectrocloud.netlify.app/clusters/edge/local-ui/cluster-management/export-cluster-definition/#instructions)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1801](https://spectrocloud.atlassian.net/browse/DOC-1801)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Only to 4.6.

[DOC-1801]: https://spectrocloud.atlassian.net/browse/DOC-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ