### PR TITLE
docs: DOC-1816: Increased Rate Limit for v1/events/components

### DIFF
--- a/docs/api-content/api-docs/1-introduction.md
+++ b/docs/api-content/api-docs/1-introduction.md
@@ -225,7 +225,7 @@ The API rate limits are as follows:
 | /v1/edgehosts/registers                                                                 | 10                     | 5              | 50                 |
 | /v1/errlogs                                                                             | 10                     | 5              | 50                 |
 | /v1/events                                                                              | 10                     | 5              | 50                 |
-| /v1/events/components                                                                   | 10                     | 5              | 50                 |
+| /v1/events/components                                                                   | 50                     | 5              | 250                |
 | /v1/files                                                                               | 10                     | 5              | 50                 |
 | /v1/git/webhook                                                                         | 10                     | 5              | 50                 |
 | /v1/health                                                                              | 10                     | 5              | 50                 |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR increases the rate limit and burst limit for `v1/events/components`.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [API - Introduction - Endpoint Prefix Rate]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1816](https://spectrocloud.atlassian.net/browse/DOC-1816)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work.

[DOC-1816]: https://spectrocloud.atlassian.net/browse/DOC-1816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ