### PR TITLE
docs: fix cd path

### DIFF
--- a/docs/docs-content/getting-started/aws/deploy-manage-k8s-cluster-tf.md
+++ b/docs/docs-content/getting-started/aws/deploy-manage-k8s-cluster-tf.md
@@ -60,7 +60,7 @@ docker run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tut
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 :::warning
@@ -96,7 +96,7 @@ podman run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tut
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 :::warning
@@ -130,7 +130,7 @@ git checkout v1.1.10
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 </TabItem>

--- a/docs/docs-content/getting-started/azure/deploy-manage-k8s-cluster-tf.md
+++ b/docs/docs-content/getting-started/azure/deploy-manage-k8s-cluster-tf.md
@@ -60,7 +60,7 @@ docker run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tut
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 :::warning
@@ -96,7 +96,7 @@ podman run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tut
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 :::warning
@@ -130,7 +130,7 @@ git checkout v1.1.10
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 </TabItem>

--- a/docs/docs-content/getting-started/gcp/deploy-manage-k8s-cluster-tf.md
+++ b/docs/docs-content/getting-started/gcp/deploy-manage-k8s-cluster-tf.md
@@ -60,7 +60,7 @@ docker run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tut
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 :::warning
@@ -96,7 +96,7 @@ podman run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tut
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 :::warning
@@ -130,7 +130,7 @@ git checkout v1.1.10
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 </TabItem>

--- a/docs/docs-content/getting-started/vmware/deploy-manage-k8s-cluster-tf.md
+++ b/docs/docs-content/getting-started/vmware/deploy-manage-k8s-cluster-tf.md
@@ -62,7 +62,7 @@ docker run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tut
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 :::warning
@@ -98,7 +98,7 @@ podman run --name tutorialContainer --interactive --tty ghcr.io/spectrocloud/tut
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 :::warning
@@ -132,7 +132,7 @@ git checkout v1.1.10
 Navigate to the folder that contains the tutorial code.
 
 ```shell
-cd /terraform/getting-started-deployment-tf
+cd terraform/getting-started-deployment-tf
 ```
 
 </TabItem>


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes a `cd` command in the Terraform tutorial.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Cluster Management with Terraform - AWS](https://deploy-preview-6420--docs-spectrocloud.netlify.app/getting-started/aws/deploy-manage-k8s-cluster-tf/)
💻 [Cluster Management with Terraform - GCP](https://deploy-preview-6420--docs-spectrocloud.netlify.app/getting-started/gcp/deploy-manage-k8s-cluster-tf/)
💻 [Cluster Management with Terraform - Azure](https://deploy-preview-6420--docs-spectrocloud.netlify.app/getting-started/azure/deploy-manage-k8s-cluster-tf/)
💻 [Cluster Management with Terraform - VMware](https://deploy-preview-6420--docs-spectrocloud.netlify.app/getting-started/vmware/deploy-manage-k8s-cluster-tf/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
