### PR TITLE
[version-4-5] doc: fix indentation on Install Agent Host (#6447)

### DIFF
--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -101,211 +101,207 @@ Palette. You will then create a cluster profile and use the registered host to d
 
   :::
 
-  - If installing the FIPS version of Agent Mode on a Rocky Linux edge host, you must configure your SELinux policies to
-    grant rsync the required host permissions and ensure you enable cgroup V2.
+- If installing the FIPS version of Agent Mode on a Rocky Linux edge host, you must configure your SELinux policies to
+  grant rsync the required host permissions and ensure you enable cgroup V2.
 
-    If you are using Cilium and have firewalld enabled, you must also configure the appropriate firewalld rules. Follow
-    the process below to apply the necessary configurations before installing Agent Mode.
+  If you are using Cilium and have firewalld enabled, you must also configure the appropriate firewalld rules. Follow
+  the process below to apply the necessary configurations before installing Agent Mode.
 
-    <details>
+  <details>
 
-    <summary>Rocky Linux 8 Configurations</summary>
+  <summary>Rocky Linux 8 Configurations</summary>
 
-    ### Configure rsync
+  ### Configure rsync
 
-    1. Enable SELinux to allow full rsync access.
+  1. Enable SELinux to allow full rsync access.
 
-    ```shell
-    setsebool -P rsync_full_access 1
-    ```
+     ```shell
+     setsebool -P rsync_full_access 1
+     ```
 
-    2. Install the necessary tools to create and apply SELinux policy modules.
+  2. Install the necessary tools to create and apply SELinux policy modules.
 
-    ```shell
-    dnf install selinux-policy-devel audit
-    ```
+     ```shell
+     dnf install selinux-policy-devel audit
+     ```
 
-    3. Create a file named **rsync_dac_override.te**.
+  3. Create a file named **rsync_dac_override.te**.
 
-    ```shell
-    nano rsync_dac_override.te
-    ```
+     ```shell
+     nano rsync_dac_override.te
+     ```
 
-    4. Add the following content to the **rsync_dac_override.te** file.
+  4. Add the following content to the **rsync_dac_override.te** file.
 
-    ```shell
-    module rsync_dac_override 1.0;
+     ```shell
+     module rsync_dac_override 1.0;
 
-    require {
-      type rsync_t;
-      type default_t;
-      class dir read;
-      class capability dac_override;
-    }
+     require {
+       type rsync_t;
+       type default_t;
+       class dir read;
+       class capability dac_override;
+     }
 
-    # Allow rsync_t to read directories labeled default_t
-    allow rsync_t default_t:dir read;
+     # Allow rsync_t to read directories labeled default_t
+     allow rsync_t default_t:dir read;
 
-    # Allow rsync_t to override discretionary access control (DAC)
-    allow rsync_t self:capability dac_override;
-    ```
+     # Allow rsync_t to override discretionary access control (DAC)
+     allow rsync_t self:capability dac_override;
+     ```
 
-    5. Compile and package the SELinux policy module.
+  5. Compile and package the SELinux policy module.
 
-    ```shell
-    checkmodule -M -m --output rsync_dac_override.mod rsync_dac_override.te
-    semodule_package --outfile rsync_dac_override.pp -m rsync_dac_override.mod
-    ```
+     ```shell
+     checkmodule -M -m --output rsync_dac_override.mod rsync_dac_override.te
+     semodule_package --outfile rsync_dac_override.pp -m rsync_dac_override.mod
+     ```
 
-    6. Install the compiled policy module.
+  6. Install the compiled policy module.
 
-    ```shell
-    semodule --install rsync_dac_override.pp
-    ```
+     ```shell
+     semodule --install rsync_dac_override.pp
+     ```
 
-    ### Enable cgroup V2
+  ### Enable cgroup V2
 
-    7.  Issue the following command to check if your kernel supports cgroup v2.
+  7.  Issue the following command to check if your kernel supports cgroup v2.
 
-        ```shell
-        grep cgroup2 /proc/filesystems
-        ```
+      ```shell
+      grep cgroup2 /proc/filesystems
+      ```
 
-        If the response is `nodev	cgroup2`, your kernel supports cgroup v2 and you may proceed to the next step. If the
-        response does not match `nodev	cgroup2`, then your kernel does not support cgroup v2. You need to upgrade to a
-        kernel that supports cgroup v2 to proceed.
+      If the response is `nodev	cgroup2`, your kernel supports cgroup v2 and you may proceed to the next step. If the
+      response does not match `nodev	cgroup2`, then your kernel does not support cgroup v2. You need to upgrade to a
+      kernel that supports cgroup v2 to proceed.
 
-    8.  Issue the following command to check if cgroup v2 is already enabled.
+  8.  Issue the following command to check if cgroup v2 is already enabled.
 
-        ```shell
-        stat -fc %T /sys/fs/cgroup
-        ```
+      ```shell
+      stat -fc %T /sys/fs/cgroup
+      ```
 
-        If the output is `tmpfs` then cgroup v2 is not enabled. When cgroup v2 is enabled, the output is `cgroup2fs`. If
-        cgroup v2 is enabled, skip to step 12.
+      If the output is `tmpfs` then cgroup v2 is not enabled. When cgroup v2 is enabled, the output is `cgroup2fs`. If
+      cgroup v2 is enabled, skip to step 12.
 
-    9.  Issue the following command to edit the GRUB file to enable cgroup v2.
+  9.  Issue the following command to edit the GRUB file to enable cgroup v2.
 
-        ```shell
-        sudo vi /etc/default/grub
-        ```
+      ```shell
+      sudo vi /etc/default/grub
+      ```
 
-        Find the line starting with `GRUB_CMDLINE_LINUX` and add the `systemd.unified_cgroup_hierarchy=1` parameter.
+      Find the line starting with `GRUB_CMDLINE_LINUX` and add the `systemd.unified_cgroup_hierarchy=1` parameter.
 
-        ```
-        GRUB_TIMEOUT=5
-        GRUB_DISTRIBUTOR="$(sed 's, release *$,,g' / etc/system-release)"
-        GRUB_DEFAULT=saved
-        GRUB_DISABLE_SUBMENU=true
-        GRUB_TERMINAL_OUTPUT="console"
-        GRUB_CMDLINE_LINUX="crashkernel=auto resume=/dev/mapper/rl-swap rd.lvm.lv=rl/root rd.lvm.lv=rl/swap systemd.unified_cgroup_hierarchy=1
-        systemd.unified_cgroup_hierarchv=1" GRUB_DISABLE_RECOVERY=" true"
-        GRUB_ENABLE_BLSCFG=true
-        ```
+      ```
+      GRUB_TIMEOUT=5
+      GRUB_DISTRIBUTOR="$(sed 's, release *$,,g' / etc/system-release)"
+      GRUB_DEFAULT=saved
+      GRUB_DISABLE_SUBMENU=true
+      GRUB_TERMINAL_OUTPUT="console"
+      GRUB_CMDLINE_LINUX="crashkernel=auto resume=/dev/mapper/rl-swap rd.lvm.lv=rl/root rd.lvm.lv=rl/swap systemd.unified_cgroup_hierarchy=1
+      systemd.unified_cgroup_hierarchv=1" GRUB_DISABLE_RECOVERY=" true"
+      GRUB_ENABLE_BLSCFG=true
+      ```
 
-    10. Save the file and regenerate the GRUB configuration.
+  10. Save the file and regenerate the GRUB configuration.
 
-        ```shell
-        sudo grub2-mkconfig -o /boot/grub2/grub.cfg
-        ```
+      ```shell
+      sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+      ```
 
-    11. Reboot the system.
+  11. Reboot the system.
 
-        ```shell
-        sudo reboot
-        ```
+      ```shell
+      sudo reboot
+      ```
 
-    ### Configure firewalld (Cilium Only)
+  ### Configure firewalld (Cilium Only)
 
-    12. (Optional) If you are using Cilium and have firewalld enabled, put the the following commands into a shell
-        script.
+  12. (Optional) If you are using Cilium and have firewalld enabled, put the following commands into a shell script.
 
-        ```shell
-        cat << 'EOF' > firewalld-cilium.sh
-        #!/bin/bash
+      ```shell
+      cat << 'EOF' > firewalld-cilium.sh
+      #!/bin/bash
 
-        if [ -z "$1" ]; then
-          echo "Usage: $0 <zone>"
-          exit 1
-        fi
+      if [ -z "$1" ]; then
+        echo "Usage: $0 <zone>"
+        exit 1
+      fi
 
-        ZONE="$1"
+      ZONE="$1"
 
-        # Kubernetes API Server
-        firewall-cmd --permanent --zone="$ZONE" --add-port=6443/tcp
+      # Kubernetes API Server
+      firewall-cmd --permanent --zone="$ZONE" --add-port=6443/tcp
 
-        # Etcd
-        firewall-cmd --permanent --zone="$ZONE" --add-port=2379-2380/tcp
+      # Etcd
+      firewall-cmd --permanent --zone="$ZONE" --add-port=2379-2380/tcp
 
-        # Kubelet API
-        firewall-cmd --permanent --zone="$ZONE" --add-port=10250/tcp
+      # Kubelet API
+      firewall-cmd --permanent --zone="$ZONE" --add-port=10250/tcp
 
-        # Scheduler and Controller Manager
-        firewall-cmd --permanent --zone="$ZONE" --add-port=10257-10259/tcp
+      # Scheduler and Controller Manager
+      firewall-cmd --permanent --zone="$ZONE" --add-port=10257-10259/tcp
 
-        # kube proxy health check
-        firewall-cmd --permanent --zone="$ZONE" --add-port=10255/tcp
+      # kube proxy health check
+      firewall-cmd --permanent --zone="$ZONE" --add-port=10255/tcp
 
-        # Nodeport range
-        firewall-cmd --permanent --zone="$ZONE" --add-port=30000-32767/tcp
+      # Nodeport range
+      firewall-cmd --permanent --zone="$ZONE" --add-port=30000-32767/tcp
 
-        ############### Start Cilium Rules ##########################
+      ############### Start Cilium Rules ##########################
 
-        # Cilium: VXLAN Overlay
-        firewall-cmd --permanent --zone="$ZONE" --add-port=8472/udp
+      # Cilium: VXLAN Overlay
+      firewall-cmd --permanent --zone="$ZONE" --add-port=8472/udp
 
-        # Cilium: Health Checks
-        firewall-cmd --permanent --zone="$ZONE" --add-port=4240/tcp
+      # Cilium: Health Checks
+      firewall-cmd --permanent --zone="$ZONE" --add-port=4240/tcp
 
-        # Cilium: Geneve Overlay networking (if enabled)
-        firewall-cmd --permanent --zone="$ZONE" --add-port=6081/udp
+      # Cilium: Geneve Overlay networking (if enabled)
+      firewall-cmd --permanent --zone="$ZONE" --add-port=6081/udp
 
-        # Cilium: WireGuard Encryption (if enabled)
-        firewall-cmd --permanent --zone="$ZONE" --add-port=51871/udp
+      # Cilium: WireGuard Encryption (if enabled)
+      firewall-cmd --permanent --zone="$ZONE" --add-port=51871/udp
 
-        # Cilium: IPsec Encryption (if enabled)
-        firewall-cmd --permanent --zone="$ZONE" --add-protocol=esp
+      # Cilium: IPsec Encryption (if enabled)
+      firewall-cmd --permanent --zone="$ZONE" --add-protocol=esp
 
-        # Cilium: Prometheus Observability
-        firewall-cmd --permanent --zone="$ZONE" --add-port=9962/tcp
-        firewall-cmd --permanent --zone="$ZONE" --add-port=9963/tcp
+      # Cilium: Prometheus Observability
+      firewall-cmd --permanent --zone="$ZONE" --add-port=9962/tcp
+      firewall-cmd --permanent --zone="$ZONE" --add-port=9963/tcp
 
-        # Cilium: Enable ICMP Type 8 (Echo request) and Type 0 (Echo Reply)
-        firewall-cmd --permanent --zone="$ZONE" --add-icmp-block-inversion
+      # Cilium: Enable ICMP Type 8 (Echo request) and Type 0 (Echo Reply)
+      firewall-cmd --permanent --zone="$ZONE" --add-icmp-block-inversion
 
-        ############### End Cilium Rules ##########################
+      ############### End Cilium Rules ##########################
 
-        # DNS and service communications
+      # DNS and service communications
 
-        # DNS (CoreDNS)
-        firewall-cmd --permanent --zone="$ZONE" --add-port=53/tcp
-        firewall-cmd --permanent --zone="$ZONE" --add-port=53/udp
+      # DNS (CoreDNS)
+      firewall-cmd --permanent --zone="$ZONE" --add-port=53/tcp
+      firewall-cmd --permanent --zone="$ZONE" --add-port=53/udp
 
-        # Allow inbound/outbound traffic to port 443 (HTTPS)
-        firewall-cmd --permanent --zone="$ZONE" --add-port=443/tcp
+      # Allow inbound/outbound traffic to port 443 (HTTPS)
+      firewall-cmd --permanent --zone="$ZONE" --add-port=443/tcp
 
-        # Allow inbound/outbound traffic to port 4222 (NATS)
-        firewall-cmd --permanent --zone="$ZONE" --add-port=4222/tcp
+      # Allow NAT traffic
+      firewall-cmd --permanent --add-masquerade
 
-        # Allow NAT traffic
-        firewall-cmd --permanent --add-masquerade
+      # Reload firewalld cache
+      firewall-cmd --reload
+      EOF
 
-        # Reload firewalld cache
-        firewall-cmd --reload
-        EOF
+      # Make the script executable
+      chmod +x firewalld-cilium.sh
+      ```
 
-        # Make the script executable
-        chmod +x firewalld-cilium.sh
-        ```
+  13. Execute the script with the name of the firewalld zone. For example, the following script sets the rules in the
+      firewall zone `public`.
 
-    13. Execute the script with the name of the firewalld zone. For example, the following script sets the rules in the
-        firewall zone `public`.
+      ```shell
+      ./firewalld-cilium.sh public
+      ```
 
-        ```shell
-        ./firewalld-cilium.sh public
-        ```
-
-     </details>
+  </details>
 
 ## Install Palette Agent
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-5`:
 - [doc: fix indentation on Install Agent Host (#6447)](https://github.com/spectrocloud/librarium/pull/6447)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)