### PR TITLE
docs: DOC-1762: Double Quote Cluster Profile Variable Exception

### DIFF
--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/create-cluster-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/create-cluster-profile-variables.md
@@ -95,7 +95,9 @@ guide to learn how to create a cluster profile.
 
     :::warning
 
-    If you plan to populate your variables with values that contain single quotes (`'`), wrap `{{.spectro.var.variable_name}}` in double quotes (`"`); otherwise, the YAML file will be invalid when the variable is resolved. 
+    If you plan to populate your variables with values that contain single quotes (`'`), wrap
+    `{{.spectro.var.variable_name}}` in double quotes (`"`); otherwise, the YAML file will be invalid when the variable
+    is resolved.
 
     :::
 

--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/create-cluster-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/create-cluster-profile-variables.md
@@ -95,7 +95,7 @@ guide to learn how to create a cluster profile.
 
     :::warning
 
-    If you plan to populate your variables with values that contain single quotes (`'`), wrap `{{.spectro.var.variable_name}}` in double quotes (`"`); otherwise, the YAML file will be invalid when the variable is substituted. 
+    If you plan to populate your variables with values that contain single quotes (`'`), wrap `{{.spectro.var.variable_name}}` in double quotes (`"`); otherwise, the YAML file will be invalid when the variable is resolved. 
 
     :::
 

--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/create-cluster-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/create-cluster-profile-variables.md
@@ -93,6 +93,12 @@ guide to learn how to create a cluster profile.
     keys to select the appropriate profile variable. Press **TAB** to accept the suggestion and add the variable. You
     must still wrap the profile variable in single quotes (`'`).
 
+    :::warning
+
+    If you plan to populate your variables with values that contain single quotes (`'`), wrap `{{.spectro.var.variable_name}}` in double quotes (`"`); otherwise, the YAML file will be invalid when the variable is substituted. 
+
+    :::
+
     ![Palette YAML editor with the added profile variables.](/profiles_create-cluster-profiles_define-profile-variables_add-vars-to-yaml.webp)
 
     :::tip


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds an admonition re: cluster profile variables stating that if the cluster profile variable contains a single quote, the definition should be wrapped in double quotes instead of single quotes to avoid an invalid YAML when resolving the variable.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Create Cluster Profile Variables](https://deploy-preview-6459--docs-spectrocloud.netlify.app/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/create-cluster-profile-variables/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1762](https://spectrocloud.atlassian.net/browse/DOC-1762)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1762]: https://spectrocloud.atlassian.net/browse/DOC-1762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ