### PR TITLE
docs: DOC-1833: externalRegistries and registryMappingRules user-data Indentation

### DIFF
--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/deploy-external-registry.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/deploy-external-registry.md
@@ -127,31 +127,31 @@ information, refer to [Enable Local Harbor Registry](./local-registry.md).
     ```yaml
     #cloud-config
     stylus:
-    externalRegistries:
-      registries:
-      - domain: "10.10.254.254:8000/spectro-images"
-        username: "admin"
-        password: ***************
-        repositoryName: "example-repository-private"
-        certificates: |
-          -----BEGIN CERTIFICATE-----
-          MIIDBzCCAe+gAwIBAgIJAJzQ
-          ...
-          -----END CERTIFICATE-----
-      - domain: "10.10.11.60:3899/security-images"
-        username: "projectAdmin2"
-        password: "***************"
-        repositoryName: security-images
-        certificates: |
-          -----BEGIN CERTIFICATE-----
-          MIIDBzCCAe+gAwIBAgIJAJzQ
-          ...
-          -----END CERTIFICATE-----
-    registryMappingRules:
-      "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
-      "us-docker.pkg.dev/palette-images": "example.registry.com/internal-images"
-      "grc.io/spectro-dev-public": "example.registry.com/internal-images"
-      "grc.io/spectro-images-public": "example.registry.com/internal-images"
+      externalRegistries:
+        registries:
+        - domain: "10.10.254.254:8000/spectro-images"
+          username: "admin"
+          password: ***************
+          repositoryName: "example-repository-private"
+          certificates: |
+            -----BEGIN CERTIFICATE-----
+            MIIDBzCCAe+gAwIBAgIJAJzQ
+            ...
+            -----END CERTIFICATE-----
+        - domain: "10.10.11.60:3899/security-images"
+          username: "projectAdmin2"
+          password: "***************"
+          repositoryName: security-images
+          certificates: |
+            -----BEGIN CERTIFICATE-----
+            MIIDBzCCAe+gAwIBAgIJAJzQ
+            ...
+            -----END CERTIFICATE-----
+        registryMappingRules:
+          "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
+          "us-docker.pkg.dev/palette-images": "example.registry.com/internal-images"
+          "grc.io/spectro-dev-public": "example.registry.com/internal-images"
+          "grc.io/spectro-images-public": "example.registry.com/internal-images"
     ```
     Refer to [Installer Configuration](../../edge-configuration/installer-reference.md#multiple-external-registries) for a
     description of each field.

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -372,19 +372,19 @@ Palette. You will then create a cluster profile and use the registered host to d
          edgeHostToken: $TOKEN
          paletteEndpoint: api.spectrocloud.com
          projectName: Default
-     externalRegistries:
-       registries:
-         - domain: "example.registry.com/internal-images"
-           username: "admin"
-           password: "***************"
-           repositoryName: example-repository-private
-           certificates:
-             - |
-                -----BEGIN CERTIFICATE-----
-                **********************
-                -----END CERTIFICATE-----
-     registryMappingRules:
-      "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
+       externalRegistries:
+         registries:
+           - domain: "example.registry.com/internal-images"
+             username: "admin"
+             password: "***************"
+             repositoryName: example-repository-private
+             certificates:
+               - |
+                  -----BEGIN CERTIFICATE-----
+                  **********************
+                  -----END CERTIFICATE-----
+         registryMappingRules:
+           "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
 
      stages:
        initramfs:
@@ -429,8 +429,8 @@ Palette. You will then create a cluster profile and use the registered host to d
                 -----BEGIN CERTIFICATE-----
                 **********************
                 -----END CERTIFICATE-----
-     registryMappingRules:
-      "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
+       registryMappingRules:
+         "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
    stages:
      initramfs:
        - users:


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR corrects the nesting of `externalRegistries` and `registryMappingRules` for several `user-data` examples.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Install Palette Agent](https://deploy-preview-6486--docs-spectrocloud.netlify.app/deployment-modes/agent-mode/install-agent-host/)
- [Deploy Cluster with a Private External Registry](https://deploy-preview-6486--docs-spectrocloud.netlify.app/clusters/edge/site-deployment/deploy-custom-registries/deploy-external-registry/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1833](https://spectrocloud.atlassian.net/browse/DOC-1833)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1833]: https://spectrocloud.atlassian.net/browse/DOC-1833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ