### PR TITLE
doc: adjust prettier-ignore to fix EKS header formatting

### DIFF
--- a/docs/docs-content/clusters/public-cloud/aws/eks.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks.md
@@ -143,16 +143,13 @@ an AWS account. This section guides you on how to create an EKS cluster in AWS t
 11. Provide the following node pool and cloud configuration information. If you will be using Fargate profiles, you can
     add them here.
 
-<!-- prettier-ignore-start -->
-
     :::info
 
-    To automatically scale the number of worker nodes for EKS clusters, you must add the
-    <VersionedLink text="AWS Cluster Autoscaler" url="/integrations/packs/?pack=aws-cluster-autoscaler"/> pack to your cluster profile.
+    <!-- prettier-ignore -->
+    To automatically scale the number of worker nodes for EKS clusters, you must add the <VersionedLink text="AWS Cluster Autoscaler" url="/integrations/packs/?pack=aws-cluster-autoscaler" />
+    pack to your cluster profile.
 
     :::
-
-<!-- prettier-ignore-end -->
 
     #### Node Configuration Settings
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adjusts a prettier-ignore flag to format the following headers correctly. I discovered this while looking into https://spectrocloud.atlassian.net/browse/DOC-1839.

I have also tried indenting the original `prettier-ignore-start/end` flags, but this didn't work.

### Before Change

![eks-before-6513](https://github.com/user-attachments/assets/8a1c0f38-3a91-4a67-9bda-fd2f3349f3f9)

### After Change

![eks-after-6513](https://github.com/user-attachments/assets/9b5c6be9-a598-4599-9a2a-31818d0c031b)

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Create and Manage AWS EKS Cluster](https://deploy-preview-6513--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/eks/)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
