### PR TITLE
docs: netmask specification

### DIFF
--- a/docs/docs-content/byoos/capi-image-builder/build-image-vmware/airgap-build/rhel-capi-airgap.md
+++ b/docs/docs-content/byoos/capi-image-builder/build-image-vmware/airgap-build/rhel-capi-airgap.md
@@ -383,9 +383,7 @@ Enterprise Linux (RHEL) image with <VersionedLink text="Palette eXtended Kuberne
             network --bootproto=static --ip=<vcenter-static-ip-address> --netmask=<vcenter-netmask> --gateway=<vcenter-gateway> --nameserver=<vcenter-nameserver>
             ```
 
-            Then, replace `<vcenter-static-ip-address>` with a valid IP address from your VMware vSphere environment, and
-            `<vcenter-netmask>`, `<vcenter-gateway>`, and `<vcenter-nameserver>` with the correct values from your VMware vSphere
-            environment.
+            Then, replace `<vcenter-static-ip-address>` with a valid IP address from your VMware vSphere environment. Similarly, replace `<vcenter-netmask>`, `<vcenter-gateway>`, and `<vcenter-nameserver>` with the correct values from your environment. The `<vcenter-netmask>` parameter must be specified in dotted decimal notation, for example, `--netmask=255.255.255.0`.
 
             Once you are finished doing the alterations, save and exit the file.
 

--- a/docs/docs-content/byoos/capi-image-builder/build-image-vmware/airgap-build/rocky-capi-airgap.md
+++ b/docs/docs-content/byoos/capi-image-builder/build-image-vmware/airgap-build/rocky-capi-airgap.md
@@ -376,9 +376,7 @@ This guide teaches you how to use the [CAPI Image Builder](../../capi-image-buil
             network --bootproto=static --ip=<vcenter-static-ip-address> --netmask=<vcenter-netmask> --gateway=<vcenter-gateway> --nameserver=<vcenter-nameserver>
             ```
 
-            Then, replace `<vcenter-static-ip-address>` with a valid IP address from your VMware vSphere environment, and
-            `<vcenter-netmask>`, `<vcenter-gateway>`, and `<vcenter-nameserver>` with the correct values from your VMware vSphere
-            environment.
+            Then, replace `<vcenter-static-ip-address>` with a valid IP address from your VMware vSphere environment. Similarly, replace `<vcenter-netmask>`, `<vcenter-gateway>`, and `<vcenter-nameserver>` with the correct values from your environment. The `<vcenter-netmask>` parameter must be specified in dotted decimal notation, for example, `--netmask=255.255.255.0`.
 
             Once you are finished doing the alterations, save and exit the file.
 

--- a/docs/docs-content/byoos/capi-image-builder/build-image-vmware/non-airgap-build/rhel-capi.md
+++ b/docs/docs-content/byoos/capi-image-builder/build-image-vmware/non-airgap-build/rhel-capi.md
@@ -264,9 +264,7 @@ Enterprise Linux (RHEL) image with <VersionedLink text="Palette eXtended Kuberne
             network --bootproto=static --ip=<vcenter-static-ip-address> --netmask=<vcenter-netmask> --gateway=<vcenter-gateway> --nameserver=<vcenter-nameserver>
             ```
 
-            Then, replace `<vcenter-static-ip-address>` with a valid IP address from your VMware vSphere environment, and
-            `<vcenter-netmask>`, `<vcenter-gateway>`, and `<vcenter-nameserver>` with the correct values from your VMware vSphere
-            environment.
+            Then, replace `<vcenter-static-ip-address>` with a valid IP address from your VMware vSphere environment. Similarly, replace `<vcenter-netmask>`, `<vcenter-gateway>`, and `<vcenter-nameserver>` with the correct values from your environment. The `<vcenter-netmask>` parameter must be specified in dotted decimal notation, for example, `--netmask=255.255.255.0`.
 
             Once you are finished doing the alterations, save and exit the file.
 

--- a/docs/docs-content/byoos/capi-image-builder/build-image-vmware/non-airgap-build/rocky-capi.md
+++ b/docs/docs-content/byoos/capi-image-builder/build-image-vmware/non-airgap-build/rocky-capi.md
@@ -256,9 +256,7 @@ This guide teaches you how to use the [CAPI Image Builder](../../capi-image-buil
             network --bootproto=static --ip=<vcenter-static-ip-address> --netmask=<vcenter-netmask> --gateway=<vcenter-gateway> --nameserver=<vcenter-nameserver>
             ```
 
-            Then, replace `<vcenter-static-ip-address>` with a valid IP address from your VMware vSphere environment, and
-            `<vcenter-netmask>`, `<vcenter-gateway>`, and `<vcenter-nameserver>` with the correct values from your VMware vSphere
-            environment.
+            Then, replace `<vcenter-static-ip-address>` with a valid IP address from your VMware vSphere environment. Similarly, replace `<vcenter-netmask>`, `<vcenter-gateway>`, and `<vcenter-nameserver>` with the correct values from your environment. The `<vcenter-netmask>` parameter must be specified in dotted decimal notation, for example, `--netmask=255.255.255.0`.
 
             Once you are finished doing the alterations, save and exit the file.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR clarifies the netmask parameter in the CAPI Builder documentation.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [RHEL - Non airgap](https://deploy-preview-6529--docs-spectrocloud.netlify.app/byoos/capi-image-builder/build-image-vmware/non-airgap-build/rhel-capi/)
💻 [Rocky - Non airgap](https://deploy-preview-6529--docs-spectrocloud.netlify.app/byoos/capi-image-builder/build-image-vmware/non-airgap-build/rocky-capi/)
💻 [RHEL - Airgap](https://deploy-preview-6529--docs-spectrocloud.netlify.app/byoos/capi-image-builder/build-image-vmware/airgap-build/rhel-capi-airgap/)
💻 [Rocky - Airgap](https://deploy-preview-6529--docs-spectrocloud.netlify.app/byoos/capi-image-builder/build-image-vmware/airgap-build/rocky-capi-airgap/)


## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1775](https://spectrocloud.atlassian.net/browse/DOC-1775)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1775]: https://spectrocloud.atlassian.net/browse/DOC-1775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ