### PR TITLE
docs: add extra information about Ubuntu Pro DOC-1843

### DIFF
--- a/docs/docs-content/vertex/fips/fips-compliant-components.md
+++ b/docs/docs-content/vertex/fips/fips-compliant-components.md
@@ -38,7 +38,8 @@ are:
 
 :::info
 
-Ubuntu Pro subscription keys must be obtained independently or purchased through Spectro Cloud. Contact your support representative to learn more.
+Ubuntu Pro subscription keys must be obtained independently or purchased through Spectro Cloud. Contact your support
+representative to learn more.
 
 :::
 

--- a/docs/docs-content/vertex/fips/fips-compliant-components.md
+++ b/docs/docs-content/vertex/fips/fips-compliant-components.md
@@ -38,6 +38,13 @@ are:
 - Container Storage Interface (CSI)
   - vSphere CSI
 
+:::info
+
+Please note that Ubuntu Pro subscription keys must be obtained independently or purchased through Spectro Cloud. Get in
+touch with your support representative to find out more.
+
+:::
+
 ## Management Plane
 
 All services in the management plane are FIPS compiled with Go using

--- a/docs/docs-content/vertex/fips/fips-compliant-components.md
+++ b/docs/docs-content/vertex/fips/fips-compliant-components.md
@@ -22,6 +22,13 @@ are:
 
 - Operating System (OS)
 
+  :::info
+
+  Ubuntu Pro subscription keys must be obtained independently or purchased through Spectro Cloud. Contact your support
+  representative to learn more.
+
+  :::
+
   - Ubuntu Pro
 
 - Kubernetes
@@ -35,13 +42,6 @@ are:
 
 - Container Storage Interface (CSI)
   - vSphere CSI
-
-:::info
-
-Ubuntu Pro subscription keys must be obtained independently or purchased through Spectro Cloud. Contact your support
-representative to learn more.
-
-:::
 
 ## Management Plane
 

--- a/docs/docs-content/vertex/fips/fips-compliant-components.md
+++ b/docs/docs-content/vertex/fips/fips-compliant-components.md
@@ -20,8 +20,6 @@ modules must meet to ensure their security and integrity.
 Palette VerteX provides FIPS-compliant infrastructure components in Kubernetes clusters it deploys. These components
 are:
 
-<br />
-
 - Operating System (OS)
 
   - Ubuntu Pro

--- a/docs/docs-content/vertex/fips/fips-compliant-components.md
+++ b/docs/docs-content/vertex/fips/fips-compliant-components.md
@@ -38,8 +38,7 @@ are:
 
 :::info
 
-Please note that Ubuntu Pro subscription keys must be obtained independently or purchased through Spectro Cloud. Get in
-touch with your support representative to find out more.
+Ubuntu Pro subscription keys must be obtained independently or purchased through Spectro Cloud. Contact your support representative to learn more.
 
 :::
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds additional info on Ubuntu Pro keys. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [FIPS Compliant Components](https://deploy-preview-6547--docs-spectrocloud.netlify.app/vertex/fips/fips-compliant-components/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1843](https://spectrocloud.atlassian.net/browse/DOC-1843)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Everywhere

[DOC-1843]: https://spectrocloud.atlassian.net/browse/DOC-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ