### PR TITLE
docs: DOC-1856: Correcting Earthly Script Command (FIPS)

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/fips.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/fips.md
@@ -331,7 +331,7 @@ FIPS-complaint provider images are built on top of the base OS image you have bu
     provider images.
 
     ```shell
-      ./earthly +build-provider-images-fips
+      ./earthly.sh +build-provider-images-fips
     ```
 
     :::warning


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR corrects the command `./earthly +build-provider-images-fips` > `./earthly.sh +build-provider-images-fips`. Relates to https://github.com/spectrocloud/librarium/pull/6563, which must be separate due to different backport versions.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Build FIPS-Compliant Edge Artifacts](https://deploy-preview-6562--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/fips/#validate)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1856](https://spectrocloud.atlassian.net/browse/DOC-1856)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1856]: https://spectrocloud.atlassian.net/browse/DOC-1856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ