### PR TITLE
docs: DOC-1856: Correcting Earthly Script Command (EFI Size)

### DIFF
--- a/docs/docs-content/clusters/edge/trusted-boot/edgeforge/check-efi-limit.md
+++ b/docs/docs-content/clusters/edge/trusted-boot/edgeforge/check-efi-limit.md
@@ -74,7 +74,7 @@ Follow the instructions below to determine if your Edge host is capable of booti
 5. Issue the following command to build the ISO image that is used to check your hardware EFI boot limit.
 
    ```
-   ./earthly +iso-efi-size-check
+   ./earthly.sh +iso-efi-size-check
    ```
 
    This will generate an ISO image located at **./build/efi-size-check.iso**.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR corrects the command `./earthly +iso-efi-size-check` > `./earthly.sh +iso-efi-size-check`. Found during https://github.com/spectrocloud/librarium/pull/6562 but must be separate due to different backport conditions. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1856](https://spectrocloud.atlassian.net/browse/DOC-1856)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
