### PR TITLE
doc: Additional IAM Permissions for GCP due to CAPG upgrade

### DIFF
--- a/docs/docs-content/clusters/public-cloud/gcp/required-permissions.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/required-permissions.md
@@ -38,6 +38,7 @@ having issues when deploying a host cluster.
 | `compute.backendServices.update`                       | Update backend services                                                                         |
 | `compute.backendServices.use`                          | Use backend services                                                                            |
 | `compute.disks.create`                                 | Create persistent disks                                                                         |
+| `compute.disks.setLabels`                              | Add or update labels on persistent disks                                                        |
 | `compute.firewalls.create`                             | Create firewall rules                                                                           |
 | `compute.firewalls.delete`                             | Delete firewall rules                                                                           |
 | `compute.firewalls.get`                                | Get firewall rule information                                                                   |
@@ -51,6 +52,7 @@ having issues when deploying a host cluster.
 | `compute.globalForwardingRules.delete`                 | Delete global forwarding rules                                                                  |
 | `compute.globalForwardingRules.get`                    | Get global forwarding rule information                                                          |
 | `compute.globalForwardingRules.list`                   | List global forwarding rules                                                                    |
+| `compute.globalForwardingRules.setLabels`              | Add or update labels on global forwarding rules                                                 |
 | `compute.healthChecks.create`                          | Create health checks                                                                            |
 | `compute.healthChecks.delete`                          | Delete health checks                                                                            |
 | `compute.healthChecks.get`                             | Get health check information                                                                    |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -21,6 +21,18 @@ tags: ["release-notes"]
 
 #### Breaking Changes {#breaking-changes-4.6.c}
 
+- Due to an upgrade of Cluster API Provider GCP (CAPG) to
+  [v1.8.1](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/tag/v1.8.1), the following additional
+  IAM permissions are now required for GCP cluster deployments:
+
+  - `compute.disks.setLabels`
+  - `compute.globalForwardingRules.setLabels`
+
+  This is due to a fix in [v1.8.0](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/tag/v1.8.0) that
+  means labels may be populated for persistent disks and global forwarding rules. Refer to the
+  [Required IAM Permissions](../clusters/public-cloud/gcp/required-permissions.md#required-permissions) guide for all
+  required GCP IAM permissions.
+
 #### Features
 
 #### Improvements


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds new permissions to the GCP required IAM permissions list due to a CAPG upgrade and includes a release note.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1819](https://spectrocloud.atlassian.net/browse/DOC-1819)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1819]: https://spectrocloud.atlassian.net/browse/DOC-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ