### PR TITLE
Fix warning and formatting

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
@@ -145,11 +145,11 @@ customization.
    export CUSTOM_TAG=palette-learn
    ```
 
-7. Issue the command below to create the `.arg` file containing the custom tag. The remaining arguments in the
-   `.arg` file will use the default values. For example, `ubuntu` is the default operating system, `demo` is the
-   default tag, and [ttl.sh](https://ttl.sh/) is the default image registry. Refer to the existing `.arg.template`
-   file in the current directory or the [README](https://github.com/spectrocloud/CanvOS#readme) to learn more about the
-   available customizable arguments.
+7. Issue the command below to create the `.arg` file containing the custom tag. The remaining arguments in the `.arg`
+   file will use the default values. For example, `ubuntu` is the default operating system, `demo` is the default tag,
+   and [ttl.sh](https://ttl.sh/) is the default image registry. Refer to the existing `.arg.template` file in the
+   current directory or the [README](https://github.com/spectrocloud/CanvOS#readme) to learn more about the available
+   customizable arguments.
 
    :::info
 
@@ -159,8 +159,8 @@ customization.
 
    :::
 
-   Using the arguments defined in the `.arg` file, the final provider images you generate will have the following
-   naming convention, `[IMAGE_REGISTRY]/[IMAGE_REPO]:[CUSTOM_TAG]`. For example, one of the provider images will be
+   Using the arguments defined in the `.arg` file, the final provider images you generate will have the following naming
+   convention, `[IMAGE_REGISTRY]/[IMAGE_REPO]:[CUSTOM_TAG]`. For example, one of the provider images will be
    `ttl.sh/ubuntu:k3s-1.27.2-v4.4.12-palette-learn`.
 
    ```bash
@@ -216,12 +216,13 @@ customization.
             passwd: kairos
    EOF
    ```
+
    :::warning
 
-   If you haven't set a default project for the registration token, ensure that you provide the `stylus.site.projectName` parameter with the value `Default` in `user-data`.
+   If you haven't set a default project for the registration token, ensure that you provide the
+   `stylus.site.projectName` parameter with the value `Default` in `user-data`.
 
    :::
-   
 
    View the newly created `user-data` file to ensure the token is set correctly.
 
@@ -595,9 +596,9 @@ git checkout v4.4.12
    export OS_DISTRIBUTION=opensuse-leap
    ```
 
-10. Issue the command below to create the `.arg` file containing the custom tag, Docker Hub image registry hostname,
-    and openSUSE Leap OS distribution. The `.arg` file uses the default values for the remaining arguments. You can
-    refer to the existing `.arg.template` file to learn more about the available customizable arguments.
+10. Issue the command below to create the `.arg` file containing the custom tag, Docker Hub image registry hostname, and
+    openSUSE Leap OS distribution. The `.arg` file uses the default values for the remaining arguments. You can refer to
+    the existing `.arg.template` file to learn more about the available customizable arguments.
 
     ```bash
     cat << EOF > .arg
@@ -733,9 +734,11 @@ git checkout v4.4.12
         passwd: kairos
     EOF
     ```
+
     :::warning
 
-    If you haven't set a default project for the registration token, ensure that you provide the `stylus.site.projectName` parameter with the value `Default` in `user-data`.
+    If you haven't set a default project for the registration token, ensure that you provide the
+    `stylus.site.projectName` parameter with the value `Default` in `user-data`.
 
     :::
 
@@ -747,9 +750,9 @@ git checkout v4.4.12
     :::info
 
     If you need to pull images from a private image registry, you can supply the credentials for the registry in the
-    `user-data` file in the `registryCredentials` field or in the cluster profile. Credentials specified in the `user-data` file
-    overwrites the credentials provided in the cluster profile. To learn how to provide credentials in cluster profiles,
-    refer to
+    `user-data` file in the `registryCredentials` field or in the cluster profile. Credentials specified in the
+    `user-data` file overwrites the credentials provided in the cluster profile. To learn how to provide credentials in
+    cluster profiles, refer to
     [Deploy Cluster with a Private Registry](../../site-deployment/deploy-custom-registries/deploy-private-registry.md).
 
     :::

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
@@ -111,7 +111,7 @@ customization.
    git clone https://github.com/spectrocloud/CanvOS.git
    ```
 
-2. Change to the **CanvOS/** directory.
+2. Change to the `CanvOS` directory.
 
    ```bash
    cd CanvOS
@@ -131,11 +131,11 @@ customization.
 
 5. Review the files relevant for this guide.
 
-   - **.arg.template** - A sample **.arg** file that defines arguments to use during the build process.
-   - **Dockerfile** - Embeds the arguments and other configurations in the image.
-   - **Earthfile** - Contains a series of commands to create target artifacts.
-   - **earthly.sh** - Script to invoke the Earthfile, and generate target artifacts.
-   - **user-data.template** - A sample user-data file.
+   - `.arg.template` - A sample `.arg` file that defines arguments to use during the build process.
+   - `Dockerfile` - Embeds the arguments and other configurations in the image.
+   - `Earthfile` - Contains a series of commands to create target artifacts.
+   - `earthly.sh` - Script to invoke the `Earthfile`, and generate target artifacts.
+   - `user-data.template` - A sample user-data file.
 
 6. Issue the command below to assign an image tag value that will be used when creating the provider images. This guide
    uses the value `palette-learn` as an example. However, you can assign any lowercase and alphanumeric string to the
@@ -145,9 +145,9 @@ customization.
    export CUSTOM_TAG=palette-learn
    ```
 
-7. Issue the command below to create the **.arg** file containing the custom tag. The remaining arguments in the
-   **.arg** file will use the default values. For example, `ubuntu` is the default operating system, `demo` is the
-   default tag, and [ttl.sh](https://ttl.sh/) is the default image registry. Refer to the existing **.arg.template**
+7. Issue the command below to create the `.arg` file containing the custom tag. The remaining arguments in the
+   `.arg` file will use the default values. For example, `ubuntu` is the default operating system, `demo` is the
+   default tag, and [ttl.sh](https://ttl.sh/) is the default image registry. Refer to the existing `.arg.template`
    file in the current directory or the [README](https://github.com/spectrocloud/CanvOS#readme) to learn more about the
    available customizable arguments.
 
@@ -159,7 +159,7 @@ customization.
 
    :::
 
-   Using the arguments defined in the **.arg** file, the final provider images you generate will have the following
+   Using the arguments defined in the `.arg` file, the final provider images you generate will have the following
    naming convention, `[IMAGE_REGISTRY]/[IMAGE_REPO]:[CUSTOM_TAG]`. For example, one of the provider images will be
    `ttl.sh/ubuntu:k3s-1.27.2-v4.4.12-palette-learn`.
 
@@ -193,7 +193,7 @@ customization.
    export token=[your_token_here]
    ```
 
-9. Use the following command to create the **user-data** file containing the tenant registration token.
+9. Use the following command to create the `user-data` file containing the tenant registration token.
 
    ```shell
    cat <<EOF > user-data
@@ -216,8 +216,14 @@ customization.
             passwd: kairos
    EOF
    ```
+   :::warning
 
-   View the newly created user data file to ensure the token is set correctly.
+   If you haven't set a default project for the registration token, ensure that you provide the `stylus.site.projectName` parameter with the value `Default` in `user-data`.
+
+   :::
+   
+
+   View the newly created `user-data` file to ensure the token is set correctly.
 
    ```bash
    cat user-data
@@ -231,11 +237,11 @@ customization.
 
    :::
 
-10. Open the **k8s_versions.json** file in the CanvOS directory. Remove the Kubernetes versions that you don't need from
+10. Open the `k8s_versions.json` file in the `CanvOS` directory. Remove the Kubernetes versions that you don't need from
     the JSON object corresponding to your Kubernetes distribution.
 
-    If you are using a tag that is earlier than v4.4.12, the **k8s_versions.json** file does not exist in those tags.
-    Instead, open the **Earthfile** in the CanvOS directory. In the file, find the block that starts with
+    If you are using a tag that is earlier than v4.4.12, the `k8s_versions.json` file does not exist in those tags.
+    Instead, open the `Earthfile` in the `CanvOS` directory. In the file, find the block that starts with
     `build-provider-images-fips:` and delete the Kubernetes versions that you do not want. This will speed up the build
     process and save storage space.
 
@@ -278,7 +284,7 @@ customization.
     This command may take up to 15-20 minutes to finish depending on the resources of the host machine. Upon completion,
     the command will display the manifest, as shown in the example below, that you will use in your cluster profile
     later in this tutorial. Note that the `system.xxxxx` attribute values in the manifest example are the same as what
-    you defined earlier in the **.arg** file.
+    you defined earlier in the `.arg` file.
 
     Copy and save the output attributes in a notepad or clipboard to use later in your cluster profile.
 
@@ -316,7 +322,7 @@ customization.
 
 12. List the Docker images to review the provider images created. By default, provider images for all the Palette's
     Edge-supported Kubernetes versions are created. You can identify the provider images by reviewing the image tag
-    value you used in the **.arg** file's `CUSTOM_TAG` argument.
+    value you used in the `.arg` file's `CUSTOM_TAG` argument.
 
     ```shell
     docker images --filter=reference='*/*:*palette-learn'
@@ -329,7 +335,7 @@ customization.
     ttl.sh/ubuntu          k3s-1.26.4-v4.4.12-palette-learn       4e373ddfb53f   10 minutes ago   4.11GB
     ```
 
-13. To use the provider images in your cluster profile, push them to the image registry mentioned in the **.arg** file.
+13. To use the provider images in your cluster profile, push them to the image registry mentioned in the `.arg` file.
     The current example uses the [ttl.sh](https://ttl.sh/) image registry. This image registry is free to use and does
     not require a sign-up. Images pushed to _ttl.sh_ are ephemeral and will expire after the 24 hrs time limit. Use the
     following commands to push the provider images to the _ttl.sh_ image registry.
@@ -366,8 +372,8 @@ customization.
 17. Replace the cluster profile's BYOOS pack manifest with the following custom manifest so that the cluster profile can
     pull the provider image from the ttl.sh image registry.
 
-    The `system.xxxxx` attribute values below refer to the arguments defined in the **.arg** file. If you modified the
-    arguments in the **.arg** file, you must modify the attribute values below accordingly.
+    The `system.xxxxx` attribute values below refer to the arguments defined in the `.arg` file. If you modified the
+    arguments in the `.arg` file, you must modify the attribute values below accordingly.
 
     ```yaml
     pack:
@@ -410,7 +416,7 @@ customization.
     The BYOOS pack's `system.uri` attribute references the Kubernetes version selected in the cluster profile by using
     the `{{ .spectro.system.kubernetes.version }}` [macro](../../../cluster-management/macros.md). This is how the
     provider images you created and pushed to a registry are tied to the OS and Kubernetes version you selected in the
-    **.arg** file.
+    `.arg` file.
 
     :::
 
@@ -437,7 +443,7 @@ customization.
 
 ### Validate
 
-List the Edge installer ISO image and checksum by issuing the following command from the **CanvOS/** directory.
+List the Edge installer ISO image and checksum by issuing the following command from the `CanvOS` directory.
 
 ```shell
 ls build/
@@ -510,7 +516,7 @@ This guide uses Docker Hub as an example. You can use any other image registry t
 
 ### Instructions
 
-Use the following instructions on your Linux machine to customize the arguments and Dockerfile and then create all the
+Use the following instructions on your Linux machine to customize the arguments and `Dockerfile` and then create all the
 required Edge artifacts.
 
 1. Check out the [CanvOS](https://github.com/spectrocloud/CanvOS.git) GitHub repository containing the starter code.
@@ -519,7 +525,7 @@ required Edge artifacts.
 git clone https://github.com/spectrocloud/CanvOS.git
 ```
 
-2. Change to the **CanvOS/** directory.
+2. Change to the `CanvOS` directory.
 
 ```bash
 cd CanvOS
@@ -539,13 +545,13 @@ git checkout v4.4.12
 
 5. Review the files relevant for this guide.
 
-   - **.arg.template** - A sample **.arg** file that defines arguments to use during the build process.
-   - **Dockerfile** - Embeds the arguments and other configurations in the image.
-   - **Earthfile** - Contains a series of commands to create target artifacts.
-   - **earthly.sh** - Script to invoke the Earthfile, and generate target artifacts.
-   - **user-data.template** - A sample user-data file.
+   - `.arg.template` - A sample `.arg` file that defines arguments to use during the build process.
+   - `Dockerfile` - Embeds the arguments and other configurations in the image.
+   - `Earthfile` - Contains a series of commands to create target artifacts.
+   - `earthly.sh` - Script to invoke the `Earthfile`, and generate target artifacts.
+   - `user-data.template` - A sample user-data file.
 
-6. Review the **.arg** file containing the customizable arguments, such as image tag, image registry, image repository,
+6. Review the `.arg` file containing the customizable arguments, such as image tag, image registry, image repository,
    and OS distribution. The table below shows all arguments, their default value, and allowed values.
 
    | **Argument**       | **Description**                                                                              | **Default Value**      | **Allowed Values**                                                                             |
@@ -589,9 +595,9 @@ git checkout v4.4.12
    export OS_DISTRIBUTION=opensuse-leap
    ```
 
-10. Issue the command below to create the **.arg** file containing the custom tag, Docker Hub image registry hostname,
-    and openSUSE Leap OS distribution. The **.arg** file uses the default values for the remaining arguments. You can
-    refer to the existing **.arg.template** file to learn more about the available customizable arguments.
+10. Issue the command below to create the `.arg` file containing the custom tag, Docker Hub image registry hostname,
+    and openSUSE Leap OS distribution. The `.arg` file uses the default values for the remaining arguments. You can
+    refer to the existing `.arg.template` file to learn more about the available customizable arguments.
 
     ```bash
     cat << EOF > .arg
@@ -617,7 +623,7 @@ git checkout v4.4.12
 
     :::warning
 
-    Using the arguments defined in the **.arg** file, the final provider image name will have the following naming
+    Using the arguments defined in the `.arg` file, the final provider image name will have the following naming
     pattern, `[IMAGE_REGISTRY]/[IMAGE_REPO]:[CUSTOM_TAG]`. Ensure the final artifact name conforms to the Docker Hub
     image name syntax - `[HOST]/[DOCKER-ID]/[REPOSITORY]:[TAG]`.
 
@@ -626,8 +632,8 @@ git checkout v4.4.12
 11. (Optional) This step is only required if your builds occur in a proxied network environment, and your proxy servers
     require client certificates, or if your base image is in a registry that requires client certificates.
 
-    You can provide the base-64 encoded certificates in PEM format in the **certs** folder at the root directory of the
-    **CanvOS** repository. You can provide as many certificates as you need in the folder.
+    You can provide the base-64 encoded certificates in PEM format in the `certs` folder at the root directory of the
+    `CanvOS` repository. You can provide as many certificates as you need in the folder.
 
     If you are using a CanvOS tag that is earlier than `4.5.15`, you need to use the `PROXY_CERT_PATH` build argument to
     provide a path to the certificate. This approach only allows you to specify one certificate. For more information,
@@ -644,8 +650,8 @@ git checkout v4.4.12
     :::
 
 12. Use the following command to append the [WireGuard](https://www.wireguard.com/install/) installation instructions to
-    the Dockerfile. You can install more tools and dependencies and configure the image to meet your needs. Add your
-    customizations below the line tagged with the `Add any other image customizations here` comment in the Dockerfile.
+    the `Dockerfile`. You can install more tools and dependencies and configure the image to meet your needs. Add your
+    customizations below the line tagged with the `Add any other image customizations here` comment in the `Dockerfile`.
     Do not edit or add any lines before this tagged comment.
 
     ```bash
@@ -663,7 +669,7 @@ git checkout v4.4.12
     Using the `-y` option with the `sudo zypper install` command is critical to successfully build the images. The
     default behavior for package installations is to prompt the user for permission to install the package. A user
     prompt will cause the image creation process to fail. This guidance applies to all dependencies you add through the
-    **Dockerfile**.
+    `Dockerfile`.
 
     :::
 
@@ -674,7 +680,7 @@ git checkout v4.4.12
     export token=[your_token_here]
     ```
 
-14. Use the following command to create the **user-data** file containing the tenant registration token.
+14. Use the following command to create the `user-data` file containing the tenant registration token.
 
     ```shell
     cat << EOF > user-data
@@ -683,7 +689,6 @@ git checkout v4.4.12
       site:
         paletteEndpoint: api.spectrocloud.com
         edgeHostToken: $token
-        projectName: stores
         tags:
           key1: value1
           key2: value2
@@ -728,6 +733,11 @@ git checkout v4.4.12
         passwd: kairos
     EOF
     ```
+    :::warning
+
+    If you haven't set a default project for the registration token, ensure that you provide the `stylus.site.projectName` parameter with the value `Default` in `user-data`.
+
+    :::
 
     You can take advantage of the Tech Preview feature to edit user data in Local UI after installation. Refer to
     [Edit User Data](../../local-ui/host-management/edit-user-data.md) for more information. However, we still recommend
@@ -737,20 +747,20 @@ git checkout v4.4.12
     :::info
 
     If you need to pull images from a private image registry, you can supply the credentials for the registry in the
-    user data file in the `registryCredentials` field or in the cluster profile. Credentials specified in **user-data**
+    `user-data` file in the `registryCredentials` field or in the cluster profile. Credentials specified in the `user-data` file
     overwrites the credentials provided in the cluster profile. To learn how to provide credentials in cluster profiles,
     refer to
     [Deploy Cluster with a Private Registry](../../site-deployment/deploy-custom-registries/deploy-private-registry.md).
 
     :::
 
-    View the newly created user data file to ensure the token is set correctly.
+    View the newly created `user-data` file to ensure the token is set correctly.
 
     ```bash
     cat user-data
     ```
 
-    If you want further customization, check the existing **user-data.template** file, and refer to the
+    If you want further customization, check the existing `user-data.template` file, and refer to the
     [Edge Configuration Stages](../../edge-configuration/cloud-init.md) and
     [User Data Parameters](../../edge-configuration/installer-reference.md) documents to learn more.
 
@@ -795,7 +805,7 @@ git checkout v4.4.12
     This command may take up to 15-20 minutes to finish depending on the resources of the host machine. Upon completion,
     the command will display the manifest, as shown in the example below, that you will use in your cluster profile
     later in this tutorial. Note that the `system.xxxxx` attribute values in the manifest example are the same as what
-    you defined earlier in the **.arg** file.
+    you defined earlier in the `.arg` file.
 
     Copy and save the output attributes in a notepad or clipboard to use later in your cluster profile.
 
@@ -828,7 +838,7 @@ git checkout v4.4.12
 
 16. List the Docker images to review the provider images created. By default, provider images for all the Palette's
     Edge-supported Kubernetes versions are created. You can identify the provider images by reviewing the image tag
-    value you used in the **.arg** file's `CUSTOM_TAG` argument.
+    value you used in the `.arg` file's `CUSTOM_TAG` argument.
 
     ```shell
     docker images --filter=reference='*/*:*palette-learn'
@@ -841,7 +851,7 @@ git checkout v4.4.12
     spectrocloud/opensuse-leap   k3s-1.25.2-v4.4.12-palette-learn   2427e3667b2f   24 minutes ago   2.22GB
     ```
 
-17. To use the provider images in your cluster profile, push them to your image registry mentioned in the **.arg** file.
+17. To use the provider images in your cluster profile, push them to your image registry mentioned in the `.arg` file.
     Issue the following command to log in to Docker Hub. Provide your Docker ID and password when prompted.
 
     ```bash
@@ -879,8 +889,8 @@ git checkout v4.4.12
 22. Replace the cluster profile's BYOOS pack manifest with the output that was provided to you earlier and that you
     copied.
 
-    The `system.xxxxx` attribute values below refer to the arguments defined in the **.arg** file. If you modified the
-    arguments in the **.arg** file, you must modify the attribute values below accordingly.
+    The `system.xxxxx` attribute values below refer to the arguments defined in the `.arg` file. If you modified the
+    arguments in the `.arg` file, you must modify the attribute values below accordingly.
 
     ```yaml hideClipboard
     pack:
@@ -923,7 +933,7 @@ git checkout v4.4.12
     The BYOOS pack's `system.uri` attribute references the Kubernetes version selected in the cluster profile by using
     the `{{ .spectro.system.kubernetes.version }}` [macro](../../../cluster-management/macros.md). This is how the
     provider images you created and pushed to a registry are tied to the OS and Kubernetes version you selected in the
-    **.arg** file.
+    `.arg` file.
 
     :::
 
@@ -950,7 +960,7 @@ git checkout v4.4.12
 
 ### Validate
 
-List the Edge installer ISO image and checksum by issuing the following command from the **CanvOS/** directory.
+List the Edge installer ISO image and checksum by issuing the following command from the `CanvOS` directory.
 
 ```shell
 ls build/

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
@@ -751,7 +751,7 @@ git checkout v4.4.12
 
     If you need to pull images from a private image registry, you can supply the credentials for the registry in the
     `user-data` file in the `registryCredentials` field or in the cluster profile. Credentials specified in the
-    `user-data` file overwrites the credentials provided in the cluster profile. To learn how to provide credentials in
+    `user-data` file overwrite the credentials provided in the cluster profile. To learn how to provide credentials in
     cluster profiles, refer to
     [Deploy Cluster with a Private Registry](../../site-deployment/deploy-custom-registries/deploy-private-registry.md).
 

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/create-registration-token.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/create-registration-token.md
@@ -43,14 +43,14 @@ To create a registration token, use the following steps.
 
    :::warning
 
-   To ensure your hosts register with Palette, you must either set a default project for the token or provide
-   the `stylus.site.projectName` parameter in the `user-data` file before building edge artifacts.
+   To ensure your hosts register with Palette, you must either set a default project for the token or provide the
+   `stylus.site.projectName` parameter in the `user-data` file before building edge artifacts.
 
    :::
 
    - **Expiration Date** - Set an expiration date for the token.
 
-8. Save the **Token** value.
+7. Save the **Token** value.
 
 ## Validate
 

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/create-registration-token.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/create-registration-token.md
@@ -41,14 +41,16 @@ To create a registration token, use the following steps.
 
    - **Default Project** - Set a default project for Edge host registration.
 
-   :::warning To ensure your hosts register with Palette, you must either set a default project for the token or provide
+   :::warning
+
+   To ensure your hosts register with Palette, you must either set a default project for the token or provide
    the `stylus.site.projectName` parameter in the `user-data` file before building edge artifacts.
 
    :::
 
    - **Expiration Date** - Set an expiration date for the token.
 
-7. Save the **Token** value.
+8. Save the **Token** value.
 
 ## Validate
 

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/create-registration-token.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/create-registration-token.md
@@ -42,8 +42,7 @@ To create a registration token, use the following steps.
    - **Default Project** - Set a default project for Edge host registration.
 
    :::warning
-
-   Ensure that you set a default project for the token. Otherwise, your Edge hosts will not register with Palette.
+   To ensure your hosts register with Palette, you must either set a default project for the token or provide the `stylus.site.projectName` parameter in the `user-data` file before building edge artifacts.
 
    :::
 

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/create-registration-token.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/create-registration-token.md
@@ -41,8 +41,8 @@ To create a registration token, use the following steps.
 
    - **Default Project** - Set a default project for Edge host registration.
 
-   :::warning
-   To ensure your hosts register with Palette, you must either set a default project for the token or provide the `stylus.site.projectName` parameter in the `user-data` file before building edge artifacts.
+   :::warning To ensure your hosts register with Palette, you must either set a default project for the token or provide
+   the `stylus.site.projectName` parameter in the `user-data` file before building edge artifacts.
 
    :::
 

--- a/docs/docs-content/tutorials/edge/deploy-cluster.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster.md
@@ -32,7 +32,7 @@ The following points summarize the primary stages of Edge cluster deployment to 
   software dependencies for each Kubernetes cluster.
 
 Following the primary stages outlined above, this tutorial will guide you to build the Edge artifacts (Edge installer
-ISO image and provider images) and use the Edge installer ISO image to prepare Edge hosts. Next, you will use the
+`ISO` image and provider images) and use the Edge installer `ISO` image to prepare Edge hosts. Next, you will use the
 provider image to create a cluster profile and then deploy a cluster on those Edge hosts. You will use VMware to deploy
 the Edge hosts to simulate a bare metal environment.
 
@@ -104,7 +104,7 @@ To complete this tutorial, you will need the following:
 ## Build Edge Artifacts
 
 In this section, you will use the [CanvOS](https://github.com/spectrocloud/CanvOS/blob/main/README.md) utility to build
-an Edge installer ISO image and provider images for all the Palette-supported Kubernetes versions. The utility builds
+an Edge installer `ISO` image and provider images for all the Palette-supported Kubernetes versions. The utility builds
 multiple provider images, so you can use any image that matches the desired Kubernetes version you want to use with your
 cluster profile. You must perform this part of the tutorial on a Linux machine with an AMD64(x86_64) processor
 architecture that has network connectivity to your VMware vCenter environment.
@@ -197,7 +197,7 @@ learn more about customizing arguments.
 
 Next, you will create a [`user-data`](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) file that embeds your
 [tenant registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) and Edge
-host's login credentials in the Edge Installer ISO image.
+host's login credentials in the Edge Installer `ISO` image.
 
 Issue the command below to save your tenant registration token to a local variable. Replace
 `<your-palette-registration-token>` with your actual registration token.
@@ -334,7 +334,7 @@ options:
 
 ## View Artifacts
 
-After completing the build process, list the edge installer ISO image and checksum by issuing the following command from
+After completing the build process, list the edge installer `ISO` image and checksum by issuing the following command from
 the `CanvOS` directory.
 
 ```bash
@@ -346,7 +346,7 @@ palette-edge-installer.iso
 palette-edge-installer.iso.sha256
 ```
 
-Export the path to the ISO file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial, you
+Export the path to the `ISO` file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial, you
 will use this local variable to mount the `build` directory to a Docker container.
 
 ```bash
@@ -410,7 +410,7 @@ use another registry.
 
 ## Provision Virtual Machines
 
-In this section, you will create a VM template in VMware vCenter from the Edge installer ISO image and clone that VM
+In this section, you will create a VM template in VMware vCenter from the Edge installer `ISO` image and clone that VM
 template to provision three VMs. Think of a VM template as a snapshot that can be used to provision new VMs. You cannot
 modify templates after you create them, so cloning the VM template will ensure all VMs have _consistent_ guest OS,
 dependencies, and user data configurations installed.
@@ -498,7 +498,7 @@ View the file to ensure variable values are set correctly.
 cat .goenv
 ```
 
-Next, verify the `ISOFILEPATH` local variable has the path to the ISO file. The `docker run` command uses this variable
+Next, verify the `ISOFILEPATH` local variable has the path to the `ISO` file. The `docker run` command uses this variable
 to bind mount the host's `build` directory to the container.
 
 ```bash
@@ -531,7 +531,7 @@ is an explanation of the options and sub-commands used below:
 
   - The `-force` flag destroys any existing template.
   - The `--var-file` option reads the `vsphere.hcl` file from the container. This file contains the VM template name, VM
-    configuration, and ISO file name to use. The VM configuration conforms to the
+    configuration, and `ISO` file name to use. The VM configuration conforms to the
     [minimum device requirements](../../clusters/edge/hardware-requirements.md).
 
   The `vsphere.hcl` file content is shown below for your reference. This tutorial does not require you to modify these
@@ -1018,7 +1018,7 @@ docker run --interactive --tty --rm --env-file .goenv \
 
 ### Delete Edge Artifacts
 
-If you want to delete Edge artifacts from your Linux development environment, delete the Edge installer ISO image and
+If you want to delete Edge artifacts from your Linux development environment, delete the Edge installer `ISO` image and
 its checksum by issuing the following commands from the `CanvOS` directory.
 
 ```bash

--- a/docs/docs-content/tutorials/edge/deploy-cluster.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster.md
@@ -96,12 +96,6 @@ To complete this tutorial, you will need the following:
   [Create Registration Token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) guide.
   Copy the newly created token to a clipboard or notepad file to use later in this tutorial.
 
-  :::warning
-
-  Ensure that you set a default project for the token. Otherwise, your Edge hosts will not register with Palette.
-
-  :::
-
   The screenshot below shows a sample registration token in the **Tenant Settings** > **Registration Tokens** section in
   Palette.
 
@@ -129,7 +123,7 @@ artifacts.
 git clone https://github.com/spectrocloud/CanvOS.git
 ```
 
-Change to the **CanvOS** directory.
+Change to the `CanvOS` directory.
 
 ```bash
 cd CanvOS
@@ -150,7 +144,7 @@ git checkout v4.6.12
 ## Define Arguments
 
 CanvOS requires arguments such as image tag, registry, repository, and OS distribution. The arguments are defined in the
-**.arg** file. In this step, you will create the **.arg** file and define all the required arguments.
+`.arg` file. In this step, you will create the `.arg` file and define all the required arguments.
 
 Issue the command below to assign an image tag value for the provider images. This guide uses the default value `demo`
 as an example. However, you can assign any lowercase and alphanumeric string to the `CUSTOM_TAG` variable.
@@ -159,14 +153,14 @@ as an example. However, you can assign any lowercase and alphanumeric string to 
 export CUSTOM_TAG=demo
 ```
 
-Issue the command below to create the **.arg** file with the custom tag. The remaining arguments will use the default
+Issue the command below to create the `.arg` file with the custom tag. The remaining arguments will use the default
 values. For example, `ubuntu` is the default operating system, `demo` is the default tag, and [ttl.sh](https://ttl.sh/)
 is the default image registry. The default ttl.sh image registry is free and does not require a sign-up. Images pushed
 to ttl.sh are ephemeral and will expire after the 24 hrs time limit.
 
-Using the arguments defined in the **.arg** file, the final provider images you generate will have the following naming
+Using the arguments defined in the `.arg` file, the final provider images you generate will have the following naming
 convention, `[IMAGE_REGISTRY]/[IMAGE_REPO]:[CUSTOM_TAG]`. In this example, the provider images will be
-`ttl.sh/ubuntu:k3s-1.32.1-v4.6.12-demo`. Refer to the **.arg.template** sample file in the current directory or the
+`ttl.sh/ubuntu:k3s-1.32.1-v4.6.12-demo`. Refer to the `.arg.template` sample file in the current directory or the
 [README](https://github.com/spectrocloud/CanvOS#readme) to learn more about the default values.
 
 ```bash
@@ -201,7 +195,7 @@ learn more about customizing arguments.
 
 ## Create User Data
 
-Next, you will create a [**user-data**](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) file that embeds
+Next, you will create a [`user-data`](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) file that embeds
 your [tenant registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) and
 Edge host's login credentials in the Edge Installer ISO image.
 
@@ -212,7 +206,7 @@ Issue the command below to save your tenant registration token to a local variab
 export TOKEN=<your-palette-registration-token>
 ```
 
-Use the following command to create the **user-data** file containing the tenant registration token.
+Use the following command to create the `user-data` file containing the tenant registration token.
 
 ```shell
 cat << EOF > user-data
@@ -233,13 +227,15 @@ EOF
 
 :::warning
 
+If you haven't set a default project for the registration token, ensure that you provide the `stylus.site.projectName` parameter with the value `Default` in `user-data`.
+
 Ensure that you include the `install.poweroff.true` parameter. This ensures that the Edge host will power off after
 installation. If you do not include this parameter, this could lead to a VM you will use in a subsequent step to refuse
 to power off automatically and cause a timeout error unless you manually shut down the VM.
 
 :::
 
-Review the newly created user data file.
+Review the newly created `user-data` file.
 
 ```bash
 cat user-data
@@ -269,15 +265,15 @@ start the build process.
 :::warning
 
 Make sure your machine has sufficient disk space for the provider images. Each image is about 4 - 5 GB in size, and
-images are created for all the Palette-supported Kubernetes versions by default. In the **4.6.12** branch of **CanvOS**
+images are created for all the Palette-supported Kubernetes versions by default. In the **4.6.12** branch of `CanvOS`
 used in this tutorial, the script builds 60 images. If your machine does not have enough disk space, the build process
 will fail silently.
 
 If you are using a Git tag earlier than v4.4.12, you can exclude image versions you do not need from the build process
-by commenting out the lines in the `build-provider-images` parameter in the file **Earthfile** in the **CanvOS**
+by commenting out the lines in the `build-provider-images` parameter in the file `Earthfile` in the **CanvOS**
 repository.
 
-If you are using a Git tag later than v4.4.12, open the **k8s_version.json** file in the CanvOS directory. Remove the
+If you are using a Git tag later than v4.4.12, open the `k8s_version.json` file in the `CanvOS` directory. Remove the
 Kubernetes versions that you don't need from the JSON object corresponding to your Kubernetes distribution.
 
 This speeds up build process and reduces the amount of space required for the build process. For an example of excluding
@@ -315,7 +311,7 @@ Share your logs with an Earthly account (experimental)! Register for one at http
 This command may take 15-20 minutes to finish depending on the hardware resources of the host machine. Upon completion,
 the command will display the manifest, as shown in the example below, that you will use in your cluster profile later in
 this tutorial. Note that the `system.xxxxx` attribute values in the manifest example are the same as what you defined
-earlier in the **.arg** file.
+earlier in the `.arg` file.
 
 Copy and save the output attributes in a notepad or clipboard to use later in your cluster profile.
 
@@ -338,7 +334,7 @@ options:
 ## View Artifacts
 
 After completing the build process, list the edge installer ISO image and checksum by issuing the following command from
-the **CanvOS** directory.
+the `CanvOS` directory.
 
 ```bash
 ls build/
@@ -349,8 +345,8 @@ palette-edge-installer.iso
 palette-edge-installer.iso.sha256
 ```
 
-Export the path to the ISO file, the **build** directory, in the `ISOFILEPATH` local variable. Later in the tutorial,
-you will use this local variable to mount the **build** directory to a Docker container.
+Export the path to the ISO file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial,
+you will use this local variable to mount the `build` directory to a Docker container.
 
 ```bash
 export ISOFILEPATH=$PWD/build
@@ -359,7 +355,7 @@ echo $ISOFILEPATH
 
 List the Docker images to review the created provider images. By default, provider images are created for all the
 Palette-supported Kubernetes versions. You can identify the provider images by the image tag value you used in the
-**.arg** file's `CUSTOM_TAG` variable.
+`.arg` file's `CUSTOM_TAG` variable.
 
 ```shell
 docker images --filter=reference='*/*:*demo*'
@@ -388,7 +384,7 @@ ttl.sh/ubuntu   k3s-1.30.5-v4.6.12-demo_linux_amd64    80f451092b91   2 hours ag
 
 ## Push Provider Images
 
-Push the provider images to the image registry indicated in the **.arg** file so that you can reference the provider
+Push the provider images to the image registry indicated in the `.arg` file so that you can reference the provider
 image later in your cluster profile.
 
 Since we used the provider image compatible with K3s v1.32 in the cluster profile, you would use the following command
@@ -426,7 +422,7 @@ official tutorials container that already contains the required tools. <br />
 ### Create a VM Template
 
 You will use the `heredoc` script to create a VM template. The script prompts you to enter your VMware vCenter
-environment details and saves them as environment variables in a file named **.packerenv**. Packer reads the environment
+environment details and saves them as environment variables in a file named `.packerenv`. Packer reads the environment
 variables during the build process.
 
 Before you invoke the `heredoc` script, have values handy in a notepad for the VMWare vCenter environment variables
@@ -467,9 +463,9 @@ View the file to ensure you have filled in the details correctly.
 cat .packerenv
 ```
 
-You will use the **.packerenv** file later in the tutorial when you start Packer.
+You will use the `.packerenv` file later in the tutorial when you start Packer.
 
-After you create the **.packerenv** file, source this file to set the variables in your environment. Echo one of the
+After you create the `.packerenv` file, source this file to set the variables in your environment. Echo one of the
 variables to ensure the variables are accessible on your host machine.
 
 ```shell
@@ -477,7 +473,7 @@ source .packerenv
 echo $PKR_VAR_vcenter_server
 ```
 
-After you create the **.packerenv** file, create another environment variable file named **.goenv**.
+After you create the `.packerenv` file, create another environment variable file named `.goenv`.
 [GOVC](https://github.com/vmware/govmomi/blob/main/govc/USAGE.md) is the tool you will be using to interact with
 vSphere, and it requires the same variables that you provided to Packer.
 
@@ -502,7 +498,7 @@ cat .goenv
 ```
 
 Next, verify the `ISOFILEPATH` local variable has the path to the ISO file. The `docker run` command uses this variable
-to bind mount the host's **build** directory to the container.
+to bind mount the host's `build` directory to the container.
 
 ```bash
 echo $ISOFILEPATH
@@ -519,25 +515,25 @@ reset it.
 The next step is to use the following `docker run` command to trigger Packer build process to create a VM template. Here
 is an explanation of the options and sub-commands used below:
 
-- The `--env-file` option reads the **.packerenv** file.
+- The `--env-file` option reads the `.packerenv` file.
 
 - The `--volume ` option mounts a local directory to our official tutorials container,
   `ghcr.io/spectrocloud/tutorials:1.1.13`.
 
 - The `sh -c "source /edge/vmware/clone_vm_template/setenv.sh "` shell sub-command defines the GOVC environment
   variables, the number of VMs, a prefix string for the VM name, and the VM template name. Most of the GOVC environment
-  variables refer to the variables you have defined in the **.goenv** file.
+  variables refer to the variables you have defined in the `.goenv` file.
 
 - The `cd /edge/vmware/packer/ && packer build -force --var-file=vsphere.hcl build.pkr.hcl` shell sub-command changes to
-  the container's **/edge/vmware/packer/** directory and invokes `packer build` to create the VM template. The
+  the container's `/edge/vmware/packer/` directory and invokes `packer build` to create the VM template. The
   `packer build` command has the following options:
 
   - The `-force` flag destroys any existing template.
-  - The `--var-file` option reads the **vsphere.hcl** file from the container. This file contains the VM template name,
+  - The `--var-file` option reads the `vsphere.hcl` file from the container. This file contains the VM template name,
     VM configuration, and ISO file name to use. The VM configuration conforms to the
     [minimum device requirements](../../clusters/edge/hardware-requirements.md).
 
-  The **vsphere.hcl** file content is shown below for your reference. This tutorial does not require you to modify these
+  The `vsphere.hcl` file content is shown below for your reference. This tutorial does not require you to modify these
   configurations.
 
   ```bash hideClipboard
@@ -564,10 +560,10 @@ is an explanation of the options and sub-commands used below:
 
   :::info
 
-  Should you need to change the VM template name or VM settings defined in the **vsphere.hcl** file, or review the
+  Should you need to change the VM template name or VM settings defined in the `vsphere.hcl` file, or review the
   Packer script, you must open a bash session into the container using the
   `docker run --interactive --tty --env-file .packerenv --volume "${ISOFILEPATH}:/edge/vmware/packer/build" ghcr.io/spectrocloud/tutorials:1.1.13 bash`
-  command, and change to the **edge/vmware/packer/** directory to make the modifications. After you finish the
+  command, and change to the `edge/vmware/packer/` directory to make the modifications. After you finish the
   modifications, issue the `packer build -force --var-file=vsphere.hcl build.pkr.hcl` command inside the container to
   trigger the Packer build process. This command creates a VM template, so that you can skip the next step.
 
@@ -608,26 +604,26 @@ Once Packer creates the VM template, you can use the template when provisioning 
 [GOVC](https://github.com/vmware/govmomi/tree/main/govc#govc) tool to deploy a VM and reference the VM template that
 Packer created. Remember that the VM instances you are deploying simulate bare metal devices.
 
-GOVC requires the same VMware vCenter details as the environment variables you defined earlier in the **.goenv** file.
+GOVC requires the same VMware vCenter details as the environment variables you defined earlier in the `.goenv` file.
 
 The next step is to use the following `docker run` command to clone the VM template and provision three VMs. Here is an
 explanation of the options and sub-commands used below:
 
-- The `--env-file` option reads the **.goenv** file in our official `ghcr.io/spectrocloud/tutorials:1.1.13` tutorials
+- The `--env-file` option reads the `.goenv` file in our official `ghcr.io/spectrocloud/tutorials:1.1.13` tutorials
   container.
 
 - The `sh -c "cd edge/vmware/clone_vm_template/ && ./deploy-edge-host.sh"` shell sub-command changes to the container's
-  **edge/vmware/clone_vm_template/** directory and invokes the **deploy-edge-host.sh** shell script.
+  `edge/vmware/clone_vm_template/` directory and invokes the `deploy-edge-host.sh` shell script.
 
-The **edge/vmware/clone_vm_template/** directory in the container has the following files:
+The `edge/vmware/clone_vm_template/` directory in the container has the following files:
 
-- **deploy-edge-host.sh** - Provisions the VMs.
-- **delete-edge-host.sh** - Deletes the VMs.
+- `deploy-edge-host.sh` - Provisions the VMs.
+- `delete-edge-host.sh` - Deletes the VMs.
 
-- **setenv.sh** - Defines the GOVC environment variables, the number of VMs, a prefix string for the VM name, and the VM
-  template name. Most of the GOVC environment variables refer to the variables you have defined in the **.goenv** file.
+- `setenv.sh`- Defines the GOVC environment variables, the number of VMs, a prefix string for the VM name, and the VM
+  template name. Most of the GOVC environment variables refer to the variables you have defined in the `.goenv` file.
 
-Below is the **setenv.sh** file content for your reference. This tutorial does not require you to modify these
+Below is the `setenv.sh` file content for your reference. This tutorial does not require you to modify these
 configurations.
 
 ```bash hideClipboard
@@ -653,11 +649,11 @@ export GOVC_FOLDER="${vcenter_folder}"
 :::info
 
 Suppose you have changed the VM template name in the previous step or need to change the number of VMs to provision. In
-that case, you must modify the **setenv.sh** script. To do so, you can reuse the container bash session from the
+that case, you must modify the `setenv.sh` script. To do so, you can reuse the container bash session from the
 previous step if it is still active, or you can open another bash session into the container using the
 `docker run --interactive --tty --env-file .goenv ghcr.io/spectrocloud/tutorials:1.1.13 bash` command. If you use an
-existing container bash session, create the **.goenv** file described above and source it in your container environment.
-Next, change to the **edge/vmware/clone_vm_template/** directory to modify the **setenv.sh** script, and issue the
+existing container bash session, create the `.goenv` file described above and source it in your container environment.
+Next, change to the `edge/vmware/clone_vm_template/` directory to modify the `setenv.sh` script, and issue the
 `./deploy-edge-host.sh` command to deploy the VMs.
 
 :::
@@ -761,7 +757,7 @@ Replace the OS layer manifest with the custom manifest so that the cluster profi
 _ttl.sh_ image registry. You may recall that the CanvOS script returned an output containing a custom manifest after
 building the Edge artifacts. Copy the CanvOS output into the cluster profile's BYOOS pack YAML file.
 
-The `system.xxxxx` attribute values in the manifest are as same as those you defined in the **.arg** file while building
+The `system.xxxxx` attribute values in the manifest are as same as those you defined in the `.arg` file while building
 the Edge artifacts. The code snippet below serves as an example.
 
 ```yaml
@@ -1010,7 +1006,7 @@ Wait for Palette to successfully delete the resources.
 
 ### Delete Edge Hosts
 
-Switch back to the **CanvOS** directory in the Linux development environment containing the **.goenv** file, and use the
+Switch back to the `CanvOS` directory in the Linux development environment containing the `.goenv` file, and use the
 following command to delete the Edge hosts.
 
 ```bash
@@ -1022,7 +1018,7 @@ docker run --interactive --tty --rm --env-file .goenv \
 ### Delete Edge Artifacts
 
 If you want to delete Edge artifacts from your Linux development environment, delete the Edge installer ISO image and
-its checksum by issuing the following commands from the **CanvOS/** directory.
+its checksum by issuing the following commands from the `CanvOS` directory.
 
 ```bash
 rm build/palette-edge-installer.iso
@@ -1062,8 +1058,8 @@ docker rmi ttl.sh/ubuntu:k3s-1.30.5-v4.6.12-demo_linux_amd64
 Navigate to **Inventory** > **VMs and Templates** in your vSphere client. To delete the **palette-edge-template** VM
 template, right-click on it and choose **Delete** option from the **drop-down Menu**.
 
-Switch to the **Storage** view in your vSphere client. To delete the **palette-edge-installer.iso** file from the
-**packer_cache/** directory in the VMware vCenter datastore, right-click on it and choose **Delete** option from the
+Switch to the **Storage** view in your vSphere client. To delete the `palette-edge-installer.iso` file from the
+`packer_cache/` directory in the VMware vCenter datastore, right-click on it and choose **Delete** option from the
 **drop-down Menu**. <br />
 
 ## Wrap-Up

--- a/docs/docs-content/tutorials/edge/deploy-cluster.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster.md
@@ -195,9 +195,9 @@ learn more about customizing arguments.
 
 ## Create User Data
 
-Next, you will create a [`user-data`](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) file that embeds
-your [tenant registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) and
-Edge host's login credentials in the Edge Installer ISO image.
+Next, you will create a [`user-data`](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) file that embeds your
+[tenant registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) and Edge
+host's login credentials in the Edge Installer ISO image.
 
 Issue the command below to save your tenant registration token to a local variable. Replace
 `<your-palette-registration-token>` with your actual registration token.
@@ -227,7 +227,8 @@ EOF
 
 :::warning
 
-If you haven't set a default project for the registration token, ensure that you provide the `stylus.site.projectName` parameter with the value `Default` in `user-data`.
+If you haven't set a default project for the registration token, ensure that you provide the `stylus.site.projectName`
+parameter with the value `Default` in `user-data`.
 
 Ensure that you include the `install.poweroff.true` parameter. This ensures that the Edge host will power off after
 installation. If you do not include this parameter, this could lead to a VM you will use in a subsequent step to refuse
@@ -345,8 +346,8 @@ palette-edge-installer.iso
 palette-edge-installer.iso.sha256
 ```
 
-Export the path to the ISO file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial,
-you will use this local variable to mount the `build` directory to a Docker container.
+Export the path to the ISO file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial, you
+will use this local variable to mount the `build` directory to a Docker container.
 
 ```bash
 export ISOFILEPATH=$PWD/build
@@ -384,8 +385,8 @@ ttl.sh/ubuntu   k3s-1.30.5-v4.6.12-demo_linux_amd64    80f451092b91   2 hours ag
 
 ## Push Provider Images
 
-Push the provider images to the image registry indicated in the `.arg` file so that you can reference the provider
-image later in your cluster profile.
+Push the provider images to the image registry indicated in the `.arg` file so that you can reference the provider image
+later in your cluster profile.
 
 Since we used the provider image compatible with K3s v1.32 in the cluster profile, you would use the following command
 to push the provider image compatible with K3s v1.32 to the image registry. If you want to use the other provider image,
@@ -529,8 +530,8 @@ is an explanation of the options and sub-commands used below:
   `packer build` command has the following options:
 
   - The `-force` flag destroys any existing template.
-  - The `--var-file` option reads the `vsphere.hcl` file from the container. This file contains the VM template name,
-    VM configuration, and ISO file name to use. The VM configuration conforms to the
+  - The `--var-file` option reads the `vsphere.hcl` file from the container. This file contains the VM template name, VM
+    configuration, and ISO file name to use. The VM configuration conforms to the
     [minimum device requirements](../../clusters/edge/hardware-requirements.md).
 
   The `vsphere.hcl` file content is shown below for your reference. This tutorial does not require you to modify these
@@ -560,8 +561,8 @@ is an explanation of the options and sub-commands used below:
 
   :::info
 
-  Should you need to change the VM template name or VM settings defined in the `vsphere.hcl` file, or review the
-  Packer script, you must open a bash session into the container using the
+  Should you need to change the VM template name or VM settings defined in the `vsphere.hcl` file, or review the Packer
+  script, you must open a bash session into the container using the
   `docker run --interactive --tty --env-file .packerenv --volume "${ISOFILEPATH}:/edge/vmware/packer/build" ghcr.io/spectrocloud/tutorials:1.1.13 bash`
   command, and change to the `edge/vmware/packer/` directory to make the modifications. After you finish the
   modifications, issue the `packer build -force --var-file=vsphere.hcl build.pkr.hcl` command inside the container to
@@ -649,8 +650,8 @@ export GOVC_FOLDER="${vcenter_folder}"
 :::info
 
 Suppose you have changed the VM template name in the previous step or need to change the number of VMs to provision. In
-that case, you must modify the `setenv.sh` script. To do so, you can reuse the container bash session from the
-previous step if it is still active, or you can open another bash session into the container using the
+that case, you must modify the `setenv.sh` script. To do so, you can reuse the container bash session from the previous
+step if it is still active, or you can open another bash session into the container using the
 `docker run --interactive --tty --env-file .goenv ghcr.io/spectrocloud/tutorials:1.1.13 bash` command. If you use an
 existing container bash session, create the `.goenv` file described above and source it in your container environment.
 Next, change to the `edge/vmware/clone_vm_template/` directory to modify the `setenv.sh` script, and issue the

--- a/docs/docs-content/tutorials/edge/deploy-cluster.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster.md
@@ -526,7 +526,7 @@ is an explanation of the options and sub-commands used below:
   variables refer to the variables you have defined in the `.goenv` file.
 
 - The `cd /edge/vmware/packer/ && packer build -force --var-file=vsphere.hcl build.pkr.hcl` shell sub-command changes to
-  the container's `/edge/vmware/packer/` directory and invokes `packer build` to create the VM template. The
+  the container's `/edge/vmware/packer` directory and invokes `packer build` to create the VM template. The
   `packer build` command has the following options:
 
   - The `-force` flag destroys any existing template.
@@ -564,7 +564,7 @@ is an explanation of the options and sub-commands used below:
   Should you need to change the VM template name or VM settings defined in the `vsphere.hcl` file, or review the Packer
   script, you must open a bash session into the container using the
   `docker run --interactive --tty --env-file .packerenv --volume "${ISOFILEPATH}:/edge/vmware/packer/build" ghcr.io/spectrocloud/tutorials:1.1.13 bash`
-  command, and change to the `edge/vmware/packer/` directory to make the modifications. After you finish the
+  command, and change to the `edge/vmware/packer` directory to make the modifications. After you finish the
   modifications, issue the `packer build -force --var-file=vsphere.hcl build.pkr.hcl` command inside the container to
   trigger the Packer build process. This command creates a VM template, so that you can skip the next step.
 
@@ -572,7 +572,7 @@ is an explanation of the options and sub-commands used below:
 
 Issue the following command to trigger the Packer build process to create a VM template in the VMware vCenter. It will
 also delete any existing `packer_cache` before uploading and keeping a copy of the `palette-edge-installer.iso` to the
-`packer_cache/` directory in the specified datastore.
+`packer_cache` directory in the specified datastore.
 
 ```bash
 docker run --interactive --tty --rm \
@@ -614,9 +614,9 @@ explanation of the options and sub-commands used below:
   container.
 
 - The `sh -c "cd edge/vmware/clone_vm_template/ && ./deploy-edge-host.sh"` shell sub-command changes to the container's
-  `edge/vmware/clone_vm_template/` directory and invokes the `deploy-edge-host.sh` shell script.
+  `edge/vmware/clone_vm_template` directory and invokes the `deploy-edge-host.sh` shell script.
 
-The `edge/vmware/clone_vm_template/` directory in the container has the following files:
+The `edge/vmware/clone_vm_template` directory in the container has the following files:
 
 - `deploy-edge-host.sh` - Provisions the VMs.
 - `delete-edge-host.sh` - Deletes the VMs.
@@ -654,7 +654,7 @@ that case, you must modify the `setenv.sh` script. To do so, you can reuse the c
 step if it is still active, or you can open another bash session into the container using the
 `docker run --interactive --tty --env-file .goenv ghcr.io/spectrocloud/tutorials:1.1.13 bash` command. If you use an
 existing container bash session, create the `.goenv` file described above and source it in your container environment.
-Next, change to the `edge/vmware/clone_vm_template/` directory to modify the `setenv.sh` script, and issue the
+Next, change to the `edge/vmware/clone_vm_template` directory to modify the `setenv.sh` script, and issue the
 `./deploy-edge-host.sh` command to deploy the VMs.
 
 :::
@@ -1060,7 +1060,7 @@ Navigate to **Inventory** > **VMs and Templates** in your vSphere client. To del
 template, right-click on it and choose **Delete** option from the **drop-down Menu**.
 
 Switch to the **Storage** view in your vSphere client. To delete the `palette-edge-installer.iso` file from the
-`packer_cache/` directory in the VMware vCenter datastore, right-click on it and choose **Delete** option from the
+`packer_cache` directory in the VMware vCenter datastore, right-click on it and choose **Delete** option from the
 **drop-down Menu**. <br />
 
 ## Wrap-Up

--- a/docs/docs-content/tutorials/edge/deploy-cluster.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster.md
@@ -756,7 +756,7 @@ In the **Profile Layers** section, add the following
 
 Replace the OS layer manifest with the custom manifest so that the cluster profile can pull the provider image from the
 _ttl.sh_ image registry. You may recall that the CanvOS script returned an output containing a custom manifest after
-building the Edge artifacts. Copy the CanvOS output into the cluster profile's BYOOS pack YAML file.
+building the Edge artifacts. Copy the CanvOS output into the cluster profile's BYOOS pack `YAML` file.
 
 The `system.xxxxx` attribute values in the manifest are as same as those you defined in the `.arg` file while building
 the Edge artifacts. The code snippet below serves as an example.

--- a/docs/docs-content/tutorials/edge/deploy-cluster.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster.md
@@ -32,7 +32,7 @@ The following points summarize the primary stages of Edge cluster deployment to 
   software dependencies for each Kubernetes cluster.
 
 Following the primary stages outlined above, this tutorial will guide you to build the Edge artifacts (Edge installer
-`ISO` image and provider images) and use the Edge installer `ISO` image to prepare Edge hosts. Next, you will use the
+ISO image and provider images) and use the Edge installer ISO image to prepare Edge hosts. Next, you will use the
 provider image to create a cluster profile and then deploy a cluster on those Edge hosts. You will use VMware to deploy
 the Edge hosts to simulate a bare metal environment.
 
@@ -104,7 +104,7 @@ To complete this tutorial, you will need the following:
 ## Build Edge Artifacts
 
 In this section, you will use the [CanvOS](https://github.com/spectrocloud/CanvOS/blob/main/README.md) utility to build
-an Edge installer `ISO` image and provider images for all the Palette-supported Kubernetes versions. The utility builds
+an Edge installer ISO image and provider images for all the Palette-supported Kubernetes versions. The utility builds
 multiple provider images, so you can use any image that matches the desired Kubernetes version you want to use with your
 cluster profile. You must perform this part of the tutorial on a Linux machine with an AMD64(x86_64) processor
 architecture that has network connectivity to your VMware vCenter environment.
@@ -197,7 +197,7 @@ learn more about customizing arguments.
 
 Next, you will create a [`user-data`](../../clusters/edge/edgeforge-workflow/prepare-user-data.md) file that embeds your
 [tenant registration token](../../clusters/edge/site-deployment/site-installation/create-registration-token.md) and Edge
-host's login credentials in the Edge Installer `ISO` image.
+host's login credentials in the Edge Installer ISO image.
 
 Issue the command below to save your tenant registration token to a local variable. Replace
 `<your-palette-registration-token>` with your actual registration token.
@@ -334,7 +334,7 @@ options:
 
 ## View Artifacts
 
-After completing the build process, list the edge installer `ISO` image and checksum by issuing the following command
+After completing the build process, list the edge installer ISO image and checksum by issuing the following command
 from the `CanvOS` directory.
 
 ```bash
@@ -346,7 +346,7 @@ palette-edge-installer.iso
 palette-edge-installer.iso.sha256
 ```
 
-Export the path to the `ISO` file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial,
+Export the path to the ISO file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial,
 you will use this local variable to mount the `build` directory to a Docker container.
 
 ```bash
@@ -410,7 +410,7 @@ use another registry.
 
 ## Provision Virtual Machines
 
-In this section, you will create a VM template in VMware vCenter from the Edge installer `ISO` image and clone that VM
+In this section, you will create a VM template in VMware vCenter from the Edge installer ISO image and clone that VM
 template to provision three VMs. Think of a VM template as a snapshot that can be used to provision new VMs. You cannot
 modify templates after you create them, so cloning the VM template will ensure all VMs have _consistent_ guest OS,
 dependencies, and user data configurations installed.
@@ -498,7 +498,7 @@ View the file to ensure variable values are set correctly.
 cat .goenv
 ```
 
-Next, verify the `ISOFILEPATH` local variable has the path to the `ISO` file. The `docker run` command uses this
+Next, verify the `ISOFILEPATH` local variable has the path to the ISO file. The `docker run` command uses this
 variable to bind mount the host's `build` directory to the container.
 
 ```bash
@@ -531,7 +531,7 @@ is an explanation of the options and sub-commands used below:
 
   - The `-force` flag destroys any existing template.
   - The `--var-file` option reads the `vsphere.hcl` file from the container. This file contains the VM template name, VM
-    configuration, and `ISO` file name to use. The VM configuration conforms to the
+    configuration, and ISO file name to use. The VM configuration conforms to the
     [minimum device requirements](../../clusters/edge/hardware-requirements.md).
 
   The `vsphere.hcl` file content is shown below for your reference. This tutorial does not require you to modify these
@@ -1018,7 +1018,7 @@ docker run --interactive --tty --rm --env-file .goenv \
 
 ### Delete Edge Artifacts
 
-If you want to delete Edge artifacts from your Linux development environment, delete the Edge installer `ISO` image and
+If you want to delete Edge artifacts from your Linux development environment, delete the Edge installer ISO image and
 its checksum by issuing the following commands from the `CanvOS` directory.
 
 ```bash

--- a/docs/docs-content/tutorials/edge/deploy-cluster.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster.md
@@ -334,8 +334,8 @@ options:
 
 ## View Artifacts
 
-After completing the build process, list the edge installer ISO image and checksum by issuing the following command
-from the `CanvOS` directory.
+After completing the build process, list the edge installer ISO image and checksum by issuing the following command from
+the `CanvOS` directory.
 
 ```bash
 ls build/
@@ -346,8 +346,8 @@ palette-edge-installer.iso
 palette-edge-installer.iso.sha256
 ```
 
-Export the path to the ISO file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial,
-you will use this local variable to mount the `build` directory to a Docker container.
+Export the path to the ISO file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial, you
+will use this local variable to mount the `build` directory to a Docker container.
 
 ```bash
 export ISOFILEPATH=$PWD/build
@@ -498,8 +498,8 @@ View the file to ensure variable values are set correctly.
 cat .goenv
 ```
 
-Next, verify the `ISOFILEPATH` local variable has the path to the ISO file. The `docker run` command uses this
-variable to bind mount the host's `build` directory to the container.
+Next, verify the `ISOFILEPATH` local variable has the path to the ISO file. The `docker run` command uses this variable
+to bind mount the host's `build` directory to the container.
 
 ```bash
 echo $ISOFILEPATH

--- a/docs/docs-content/tutorials/edge/deploy-cluster.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster.md
@@ -756,7 +756,7 @@ In the **Profile Layers** section, add the following
 
 Replace the OS layer manifest with the custom manifest so that the cluster profile can pull the provider image from the
 _ttl.sh_ image registry. You may recall that the CanvOS script returned an output containing a custom manifest after
-building the Edge artifacts. Copy the CanvOS output into the cluster profile's BYOOS pack `YAML` file.
+building the Edge artifacts. Copy the CanvOS output into the cluster profile's BYOOS pack YAML file.
 
 The `system.xxxxx` attribute values in the manifest are as same as those you defined in the `.arg` file while building
 the Edge artifacts. The code snippet below serves as an example.

--- a/docs/docs-content/tutorials/edge/deploy-cluster.md
+++ b/docs/docs-content/tutorials/edge/deploy-cluster.md
@@ -334,8 +334,8 @@ options:
 
 ## View Artifacts
 
-After completing the build process, list the edge installer `ISO` image and checksum by issuing the following command from
-the `CanvOS` directory.
+After completing the build process, list the edge installer `ISO` image and checksum by issuing the following command
+from the `CanvOS` directory.
 
 ```bash
 ls build/
@@ -346,8 +346,8 @@ palette-edge-installer.iso
 palette-edge-installer.iso.sha256
 ```
 
-Export the path to the `ISO` file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial, you
-will use this local variable to mount the `build` directory to a Docker container.
+Export the path to the `ISO` file, the `build` directory, in the `ISOFILEPATH` local variable. Later in the tutorial,
+you will use this local variable to mount the `build` directory to a Docker container.
 
 ```bash
 export ISOFILEPATH=$PWD/build
@@ -498,8 +498,8 @@ View the file to ensure variable values are set correctly.
 cat .goenv
 ```
 
-Next, verify the `ISOFILEPATH` local variable has the path to the `ISO` file. The `docker run` command uses this variable
-to bind mount the host's `build` directory to the container.
+Next, verify the `ISOFILEPATH` local variable has the path to the `ISO` file. The `docker run` command uses this
+variable to bind mount the host's `build` directory to the container.
 
 ```bash
 echo $ISOFILEPATH


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR:

1. Updates file name and directory formatting to follow the style guide.
2. Improves project name warnings by handling both ways it can be set before edge host deployment—either through the registration token or in the user data field.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Build Edge Artifacts](https://deploy-preview-6595--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/)
💻 [Deploy an Edge Cluster on VMware](https://deploy-preview-6595--docs-spectrocloud.netlify.app/tutorials/edge/deploy-cluster/)
💻 [Create a Registration Token](https://deploy-preview-6595--docs-spectrocloud.netlify.app/clusters/edge/site-deployment/site-installation/create-registration-token/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1817](https://spectrocloud.atlassian.net/browse/DOC-1817)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes.
- [ ] No.


[DOC-1817]: https://spectrocloud.atlassian.net/browse/DOC-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ