### PR TITLE
docs: DOC-1757: Self-Hosted Anonymous SMTP Configuration

### DIFF
--- a/_partials/self-hosted/_smtp.mdx
+++ b/_partials/self-hosted/_smtp.mdx
@@ -17,7 +17,12 @@ Anonymous SMTP configuration introduces additional security risks. We recommend 
 
 ## Prerequisites
 
-- Access to the system console.
+- Access to the
+  <PaletteVertexUrlMapper
+     edition={props.edition}
+     text="system console"
+     url="/system-management/#access-the-system-console"
+   />.
 
 - SMTP server details such as the host name and port number. If you are using authenticated SMTP instead of anonymous SMTP, your SMTP server username and password are also required.
 
@@ -25,12 +30,7 @@ Anonymous SMTP configuration introduces additional security risks. We recommend 
 
 ## Configure SMTP
 
-1. Log in to the 
-  <PaletteVertexUrlMapper
-     edition={props.edition}
-     text="system console"
-     url="/system-management/#access-the-system-console"
-   />.
+1. Log in to the system console.
 
 2. From the left main menu, select **Administration**.
 

--- a/_partials/self-hosted/_smtp.mdx
+++ b/_partials/self-hosted/_smtp.mdx
@@ -43,11 +43,11 @@ Anonymous SMTP configuration introduces additional security risks. We recommend 
     | **Insecure Skip TLS Verify** | This option disables Transport Layer Security (TLS) certificate verification. Enable this option if your SMTP server is using a self-signed certificate or has a certificate that is not trusted by the system.  | No |
     | **Outgoing Server**          | The host name of the SMTP server. For example, `smtp.gmail.com`.                                                                                                                           | Yes |
     | **Outgoing Port**            | The port number of the SMTP server.                                                                                                                                                       | Yes |
-    | **From Email**               | The email address from which emails will be sent. Emails sent from {props.version} will be sent from this email address.                                                                      | Yes |
+    | **From Email**               | Emails sent by {props.version} will use this email address as the sender.                                                                      | Yes |
     | **Username**                 | The username of the SMTP server. This is required for authenticated SMTP. If you are using anonymous SMTP, do not include a username or password.                                                                                                                                                         | No |
     | **Password**                 | The password of the SMTP server. This is required for authenticated SMTP. Certain SMTP servers, such as `smtp.gmail.com`, require app passwords instead of user passwords. If you are using anonymous SMTP configuration, do not include a username or password.                                                                                                                                                         | No |
 
-5. Select **Validate configuration**. A success message is displayed if the configuration is valid; otherwise, an error message is displayed. Additional error details can be found in the {props.version} `system-<ID>-<ID>` container logs, located in the `hubble-system` namespace.
+5. Select **Validate configuration**. A success message is displayed if the configuration is valid; otherwise, an error message is displayed. For additional error details, refer to the {props.version} `system-<ID>-<ID>` container logs, located in the `hubble-system` namespace.
 
 6. **Save** your changes.
 
@@ -55,4 +55,4 @@ Anonymous SMTP configuration introduces additional security risks. We recommend 
 
 ## Validate
 
-The SMTP configuration is validated when you select **Validate configuration**. A success message is displayed if the configuration is valid; otherwise, an error message is displayed. Additional error details can be found in the {props.version} `system-<ID>-<ID>` container logs, located in the `hubble-system` namespace.
+The SMTP configuration is validated when you select **Validate configuration**. A success message is displayed if the configuration is valid; otherwise, an error message is displayed. For additional error details, refer to the {props.version} `system-<ID>-<ID>` container logs, located in the `hubble-system` namespace.

--- a/_partials/self-hosted/_smtp.mdx
+++ b/_partials/self-hosted/_smtp.mdx
@@ -7,15 +7,19 @@ You can configure a Simple Mail Transport Protocol (SMTP) server to send emails 
 instance. An SMTP server is required to change the email address of the admin user and to send the initial tenant
 invitation email.
 
-## Limitations
+SMTP servers can be authenticated with a username and password or anonymously. 
 
-- Anonymous SMTP configuration (configuration without a username and password) is not supported at this time. 
+:::warning
+
+Anonymous SMTP configuration introduces additional security risks. We recommend using authenticated SMTP whenever possible.
+
+:::
 
 ## Prerequisites
 
 - Access to the system console.
 
-- SMTP server details such as the host name, port number, and login credentials.
+- SMTP server details such as the host name and port number. If you are using authenticated SMTP instead of anonymous SMTP, your SMTP server username and password are also required.
 
 - The outgoing SMTP port must be open on the cluster to allow {props.version} to send emails.
 
@@ -28,25 +32,27 @@ invitation email.
      url="/system-management/#access-the-system-console"
    />.
 
-2. From the **left Main Menu**, select **Administration**.
+2. From the left main menu, select **Administration**.
 
-3. Click on the **SMTP** tab.
+3. Select the **SMTP** tab.
 
 4. Fill out the following fields.
 
-  | **Field**                    | **Description**                                                                                                                                                                           | **Required** |
-  | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-  | **Outgoing Server**          | The host name of the SMTP server. For example, `smtp.gmail.com`.                                                                                                                           | Yes |
-  | **Outgoing Port**            | The port number of the SMTP server.                                                                                                                                                       | Yes |
-  | **From Email**               | The email address from which emails will be sent. Emails sent from {props.version} will be sent from this email address.                                                                      | Yes |
-  | **Username**                 | The username of the SMTP server.                                                                                                                                                          | Yes |
-  | **Password**                 | The password of the SMTP server. Certain SMTP servers, such as `smtp.gmail.com`, require app passwords instead of user passwords.                                                                                                                                                         | Yes |
-  | **Insecure Skip TLS Verify** | This option disables Transport Layer Security (TLS) certificate verification. Enable this option if your SMTP server is using a self-signed certificate or has a certificate that is not trusted by the system.  | No |
+    | **Field**                    | **Description**                                                                                                                                                                           | **Required** |
+    | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+    | **Insecure Skip TLS Verify** | This option disables Transport Layer Security (TLS) certificate verification. Enable this option if your SMTP server is using a self-signed certificate or has a certificate that is not trusted by the system.  | No |
+    | **Outgoing Server**          | The host name of the SMTP server. For example, `smtp.gmail.com`.                                                                                                                           | Yes |
+    | **Outgoing Port**            | The port number of the SMTP server.                                                                                                                                                       | Yes |
+    | **From Email**               | The email address from which emails will be sent. Emails sent from {props.version} will be sent from this email address.                                                                      | Yes |
+    | **Username**                 | The username of the SMTP server. This is required for authenticated SMTP. If you are using anonymous SMTP, do not include a username or password.                                                                                                                                                         | No |
+    | **Password**                 | The password of the SMTP server. This is required for authenticated SMTP. Certain SMTP servers, such as `smtp.gmail.com`, require app passwords instead of user passwords. If you are using anonymous SMTP configuration, do not include a username or password.                                                                                                                                                         | No |
 
-5. Click **Validate configuration**. A success message is displayed if the configuration is valid; otherwise, an error message is displayed. Additional error details can be found in the {props.version} `system-<ID>-<ID>` container logs, located in the `hubble-system` namespace.
+5. Select **Validate configuration**. A success message is displayed if the configuration is valid; otherwise, an error message is displayed. Additional error details can be found in the {props.version} `system-<ID>-<ID>` container logs, located in the `hubble-system` namespace.
 
 6. **Save** your changes.
 
+    If you are using anonymous SMTP, a security message is displayed. If possible, update your configuration to use authenticated SMTP. The system console reminds you that you are using an anonymous SMTP configuration by displaying a warning icon beside **Connection**.
+
 ## Validate
 
-The SMTP configuration is validated when you click **Validate configuration**. A success message is displayed if the configuration is valid; otherwise, an error message is displayed. Additional error details can be found in the {props.version} `system-<ID>-<ID>` container logs, located in the `hubble-system` namespace.
+The SMTP configuration is validated when you select **Validate configuration**. A success message is displayed if the configuration is valid; otherwise, an error message is displayed. Additional error details can be found in the {props.version} `system-<ID>-<ID>` container logs, located in the `hubble-system` namespace.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the anonymous SMTP limitation and provides guidance for configuring it. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Configure SMTP - Palette](https://deploy-preview-6604--docs-spectrocloud.netlify.app/enterprise-version/system-management/smtp/)
- [Configure SMTP - VerteX](https://deploy-preview-6604--docs-spectrocloud.netlify.app/vertex/system-management/smtp/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1757](https://spectrocloud.atlassian.net/browse/DOC-1757)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work.

[DOC-1757]: https://spectrocloud.atlassian.net/browse/DOC-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ