### PR TITLE
doc: check cloud credentials before force-deleting a cluster

### DIFF
--- a/docs/docs-content/clusters/cluster-management/remove-clusters.md
+++ b/docs/docs-content/clusters/cluster-management/remove-clusters.md
@@ -52,11 +52,19 @@ To force delete a cluster, follow the steps to delete the cluster. After 15 minu
 is available in the **Settings Menu**. The **drop-down Menu** will provide you with an estimated remaining time left
 before the force deletion becomes available.
 
+:::tip
+
+To ensure a complete cleanup of all associated resources, verify that your cloud credentials are valid and correctly
+configured. Force-deleting a cluster may leave some cloud resources behind if your cloud account credentials are
+invalid.
+
+:::
+
+### Remove Lingering Resources
+
 A force delete can result in Palette-provisioned resources being missed in the removal process. Verify there are no
 remaining resources by visiting the deployed resources in the target cluster's infrastructure provider environment. Use
 one of the following lists for your environment to help you identify resources to remove.
-
-<br />
 
 :::warning
 
@@ -64,9 +72,7 @@ Failure to remove provisioned resources can result in unexpected costs.
 
 :::
 
-<br />
-
-**Azure**
+#### Azure
 
 - Virtual Network (VNet)
 - Static Public IP addresses
@@ -76,7 +82,7 @@ Failure to remove provisioned resources can result in unexpected costs.
 - Managed Disks
 - Virtual Network Gateway
 
-**AWS**
+#### AWS
 
 - VPC
 - Elastic IP addresses
@@ -86,7 +92,7 @@ Failure to remove provisioned resources can result in unexpected costs.
 - EBS Volumes
 - Network Address Translation (NAT) Gateway
 
-**GCP**
+#### GCP
 
 - Virtual Private Cloud (VPC) Network
 - Static External IP addresses


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds an admonition informing users to check their cloud credentials before force-deleting a cluster.

It also improves the structure of the page with some additional headers.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1862](https://spectrocloud.atlassian.net/browse/DOC-1862)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1862]: https://spectrocloud.atlassian.net/browse/DOC-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ