### PR TITLE
docs: add VM tools to deploy import guide DOC-1847

### DIFF
--- a/docs/docs-content/vm-management/create-manage-vm/advanced-topics/deploy-import-ova.md
+++ b/docs/docs-content/vm-management/create-manage-vm/advanced-topics/deploy-import-ova.md
@@ -103,7 +103,7 @@ name, for example `cdi-uploadproxy.mycompany.io`, to the Nginx load balancer’s
    The following command uses the `gcr.io/spectro-images-public/release/vmo-jh:v4.5.0` image to create a VM that
    contains all the prerequisites required for the import and deployment process.
 
-   Alternatively, you skip VM creation and use any VM that has the following tools installed.
+   Alternatively, you can skip the VM creation and use any VM that has the following tools installed.
 
    - [Docker](https://docs.docker.com/engine/install/)
    - [`virtctl`](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/)

--- a/docs/docs-content/vm-management/create-manage-vm/advanced-topics/deploy-import-ova.md
+++ b/docs/docs-content/vm-management/create-manage-vm/advanced-topics/deploy-import-ova.md
@@ -94,7 +94,24 @@ name, for example `cdi-uploadproxy.mycompany.io`, to the Nginx load balancer’s
    ```
 
 3. Execute the following command in your terminal. It creates a dedicated VM inside your VMO cluster which contains all
-   the tools required for OVA import and deployment. The VM is named `vmo-jh`.
+   the tools required for OVA import and deployment. The VM is named `vmo-jh`. Depending on the configuration of your
+   VMO cluster's CSI layer, you may need to change the configured `ReadWriteMany` access mode to `ReadWriteOnce`. Check
+   the documentation for your chosen CSI to ensure you have the correct setting.
+
+   :::info
+
+   The following command uses the `gcr.io/spectro-images-public/release/vmo-jh:v4.5.0` image to create a VM that
+   contains all the prerequisites required for the import and deployment process.
+
+   Alternatively, you skip VM creation and use any VM that has the following tools installed.
+
+   - [Docker](https://docs.docker.com/engine/install/)
+   - [`virtctl`](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/)
+   - [`kubectl`](https://kubernetes.io/docs/tasks/tools/)
+   - [`qemu-utils`](https://www.qemu.org/download/)
+   - [`libguestfs-tools`](https://libguestfs.org/)
+
+   :::
 
    ```shell
    cat <<EOF | kubectl apply --filename -
@@ -161,13 +178,6 @@ name, for example `cdi-uploadproxy.mycompany.io`, to the Nginx load balancer’s
                name: cloudinitdisk
    EOF
    ```
-
-   :::info
-
-   Depending on the configuration of your VMO cluster's CSI layer, you may need to change the configured `ReadWriteMany`
-   access mode to `ReadWriteOnce`. Check the documentation for your chosen CSI to ensure you have the correct setting.
-
-   :::
 
 4. The VM provisioning and start up process will take a few minutes to complete. Execute the following command to check
    the status of your VMs.

--- a/docs/docs-content/vm-management/create-manage-vm/advanced-topics/deploy-import-ova.md
+++ b/docs/docs-content/vm-management/create-manage-vm/advanced-topics/deploy-import-ova.md
@@ -103,7 +103,7 @@ name, for example `cdi-uploadproxy.mycompany.io`, to the Nginx load balancer’s
    The following command uses the `gcr.io/spectro-images-public/release/vmo-jh:v4.5.0` image to create a VM that
    contains all the prerequisites required for the import and deployment process.
 
-   Alternatively, you can skip the VM creation and use any VM that has the following tools installed.
+   Alternatively, you can skip the VM creation and use any VM that has the following tools installed:
 
    - [Docker](https://docs.docker.com/engine/install/)
    - [`virtctl`](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/)


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds an info box with the VM prerequisite tools. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Import and Deploy OVAs to Palette VMO](https://deploy-preview-6654--docs-spectrocloud.netlify.app/vm-management/create-manage-vm/advanced-topics/deploy-import-ova/#enablement)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1847](https://spectrocloud.atlassian.net/browse/DOC-1847)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
This guide is everywhere. 

[DOC-1847]: https://spectrocloud.atlassian.net/browse/DOC-1847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ