### PR TITLE
docs: add special handling for broken GitHub link detection DOC-1877

### DIFF
--- a/.github/workflows/url-checks.yaml
+++ b/.github/workflows/url-checks.yaml
@@ -3,9 +3,6 @@
 # The workflow is scheduled to run every Monday at 6 am.
 
 on:
-  push:
-    branches:
-      - doc-1877-github-broken-links
   schedule:
     # Every Monday at 6 am
     - cron: '0 6 * * 1'

--- a/.github/workflows/url-checks.yaml
+++ b/.github/workflows/url-checks.yaml
@@ -3,9 +3,6 @@
 # The workflow is scheduled to run every Monday at 6 am.
 
 on:
-  push:
-    branches:
-      - doc-1877-github-broken-links
   schedule:
     # Every Monday at 6 am
     - cron: '0 6 * * 1'
@@ -40,7 +37,7 @@ jobs:
         run: make verify-rate-limited-links-ci
 
       - name: Check for Broken Github Links
-        run: make verify-github-links-ci
+        run: make verify-github-links
         env:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
   

--- a/.github/workflows/url-checks.yaml
+++ b/.github/workflows/url-checks.yaml
@@ -3,6 +3,9 @@
 # The workflow is scheduled to run every Monday at 6 am.
 
 on:
+  push:
+    branches:
+      - doc-1877-github-broken-links
   schedule:
     # Every Monday at 6 am
     - cron: '0 6 * * 1'

--- a/.github/workflows/url-checks.yaml
+++ b/.github/workflows/url-checks.yaml
@@ -53,3 +53,13 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           SLACK_WEBHOOK_URL:  ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
+      
+      - name: Failure Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2.3.2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACKIFY_MARKDOWN: true
+          ENABLE_ESCAPES: true
+          SLACK_MESSAGE: 'The url-checks job in `${{ github.repository }}` failed. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).'

--- a/.github/workflows/url-checks.yaml
+++ b/.github/workflows/url-checks.yaml
@@ -1,8 +1,11 @@
 # This workflow scans the markdown files in the repository for broken URLs.
 # Additional logic is added to the Make command verify-rate-limited-links-ci to check for rate-limited URLs, including guidance on what domains to ignore.
-# The workflow is scheduled to run every Monday at 6 am. All results are posted to the #docs channel in Slack.
+# The workflow is scheduled to run every Monday at 6 am.
 
 on:
+  push:
+    branches:
+      - doc-1877-github-broken-links
   schedule:
     # Every Monday at 6 am
     - cron: '0 6 * * 1'
@@ -35,6 +38,11 @@ jobs:
 
       - name: URL Rate Limit Checker
         run: make verify-rate-limited-links-ci
+
+      - name: Check for Broken Github Links
+        run: make verify-github-links-ci
+        env:
+          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
   
       - name: Post Comment
         run: |
@@ -44,4 +52,4 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL:  ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ ALOGLIA_CONFIG=$(shell cat docsearch.dev.config.json | jq -r tostring)
 # Remove all security-bulletins and cve-reports.md because they are rate limited by nvd.nist.gov
 # Remove oss-licenses.md because they are rate limited by npmjs.com
 # Remove all /deprecated paths because we don't want to maintain their links
-VERIFY_URL_PATHS=$(shell find ./docs -name "*.md" | cut -c 3- | \
+VERIFY_URL_PATHS=$(shell find ./docs ./_partials \( -name "*.md" -o -name "*.mdx" \) | \
+ 	sed 's|^\./||' \
 	sed '/security-bulletins/d' | \
 	sed '/cve-reports/d' | \
 	sed '/oss-licenses/d' | \

--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,12 @@ verify-rate-limited-links-ci: ## Check for broken URLs in production in a GitHub
 	@rm temp_rate_limit_report.json
 	@mv filtered_rate_limit_report.json scripts/link_rate_limit_report.json
 
+verify-github-links-ci: ## Check for broken GitHub links in production in a GitHub Actions CI environment
+	@echo "Checking for broken GitHub links in CI environment..."
+	@rm link_report_github.txt || echo "No report exists. Proceeding to scan step"
+	./scripts/url-checker-github.sh
+	@mv link_report_github.txt scripts/link_report_github.txt
+
 ###@ Image Formatting
 
 format-images: ## Format images

--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ verify-rate-limited-links-ci: ## Check for broken URLs in production in a GitHub
 	@rm temp_rate_limit_report.json
 	@mv filtered_rate_limit_report.json scripts/link_rate_limit_report.json
 
-verify-github-links-ci: ## Check for broken GitHub links in production in a GitHub Actions CI environment
+verify-github-links: ## Check for broken GitHub links
 	@echo "Checking for broken GitHub links in CI environment..."
 	@rm link_report_github.txt || echo "No report exists. Proceeding to scan step"
 	./scripts/url-checker-github.sh

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ALOGLIA_CONFIG=$(shell cat docsearch.dev.config.json | jq -r tostring)
 # Remove oss-licenses.md because they are rate limited by npmjs.com
 # Remove all /deprecated paths because we don't want to maintain their links
 VERIFY_URL_PATHS=$(shell find ./docs ./_partials \( -name "*.md" -o -name "*.mdx" \) | \
- 	sed 's|^\./||' \
+ 	sed 's|^\./||' | \
 	sed '/security-bulletins/d' | \
 	sed '/cve-reports/d' | \
 	sed '/oss-licenses/d' | \

--- a/docs/docs-content/getting-started/getting-started.md
+++ b/docs/docs-content/getting-started/getting-started.md
@@ -8,6 +8,8 @@ sidebar_custom_props:
 tags: ["getting-started"]
 ---
 
+[Broken link for testing](https://github.com/spectrocloud/invalid)
+
 This page gives you an overview of how to get started with Spectro Cloud Palette and begin leveraging its Kubernetes
 full-stack management at scale. Palette's unique capabilities provide end-to-end declarative cluster management, cluster
 monitoring and reconciliation, as well as enterprise-grade security.

--- a/docs/docs-content/getting-started/getting-started.md
+++ b/docs/docs-content/getting-started/getting-started.md
@@ -8,8 +8,6 @@ sidebar_custom_props:
 tags: ["getting-started"]
 ---
 
-[Broken link for testing](https://github.com/spectrocloud/invalid)
-
 This page gives you an overview of how to get started with Spectro Cloud Palette and begin leveraging its Kubernetes
 full-stack management at scale. Palette's unique capabilities provide end-to-end declarative cluster management, cluster
 monitoring and reconciliation, as well as enterprise-grade security.

--- a/linkinator/linkinator-ci.config.json
+++ b/linkinator/linkinator-ci.config.json
@@ -18,7 +18,8 @@
     ".(jpg|jpeg|png|gif|webp)$$",
     "https://linux.die.net/man/.*$$",
     "https://mysql.com/.*.*$$",
-    "https://dev.mysql.com/doc/.*$$"
+    "https://dev.mysql.com/doc/.*$$",
+    "^https://github.com.*$$"
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/linkinator/linkinator-rate-limit-ci.config.json
+++ b/linkinator/linkinator-rate-limit-ci.config.json
@@ -20,7 +20,6 @@
     "https://mysql.com/.*.*$$",
     "https://dev.mysql.com/doc/.*$$",
     "^https://github.com.*$$"
-
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/linkinator/linkinator-rate-limit-ci.config.json
+++ b/linkinator/linkinator-rate-limit-ci.config.json
@@ -18,7 +18,9 @@
     ".(jpg|jpeg|png|gif|webp)$$",
     "https://linux.die.net/man/.*$$",
     "https://mysql.com/.*.*$$",
-    "https://dev.mysql.com/doc/.*$$"
+    "https://dev.mysql.com/doc/.*$$",
+    "^https://github.com.*$$"
+
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/linkinator/linkinator-rate-limit.config.json
+++ b/linkinator/linkinator-rate-limit.config.json
@@ -19,7 +19,9 @@
     ".(jpg|jpeg|png|gif|webp)$$",
     "https://linux.die.net/man/.*$$",
     "https://mysql.com/.*.*$$",
-    "https://dev.mysql.com/doc/.*$$"
+    "https://dev.mysql.com/doc/.*$$",
+    "^https://github.com.*$$"
+
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/linkinator/linkinator-rate-limit.config.json
+++ b/linkinator/linkinator-rate-limit.config.json
@@ -21,7 +21,6 @@
     "https://mysql.com/.*.*$$",
     "https://dev.mysql.com/doc/.*$$",
     "^https://github.com.*$$"
-
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/linkinator/linkinator.config.json
+++ b/linkinator/linkinator.config.json
@@ -18,7 +18,8 @@
     ".(jpg|jpeg|png|gif|webp)$$",
     "https://linux.die.net/man/.*$$",
     "https://mysql.com/.*.*$$",
-    "https://dev.mysql.com/doc/.*$$"
+    "https://dev.mysql.com/doc/.*$$",
+    "^https://github.com.*$$"
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/scripts/url-checker-github.sh
+++ b/scripts/url-checker-github.sh
@@ -15,9 +15,9 @@ touch "$CACHE_FILE"
 
 echo "⏭️ Starting checks for Github URLs in Docs."
 
-# Find all GitHub links in the documentation
+# Find all GitHub links in the documentation.
+# Strip all parentheses and anchors from the links, as they will be heavily throttled by GitHub.
 grep -rHoE '\(https?://github\.com/[^") ]+' --include="*.md" ./docs | sed 's/[()]//g' | sed 's/#.*$//' > "$LINKS_FILE"
-
 
 if [[ -n "$ACCESS_TOKEN" ]]; then
     echo "🔏 Access token found. We will use it for authentication where possible."

--- a/scripts/url-checker-github.sh
+++ b/scripts/url-checker-github.sh
@@ -12,6 +12,7 @@ RETRY_DELAY=10  # increment seconds to wait before retrying
 
 # Create cache file if it doesn't exist
 touch "$CACHE_FILE"
+touch "$BROKEN_LINKS_FILE"
 
 echo "⏭️ Starting checks for Github URLs in Docs."
 

--- a/scripts/url-checker-github.sh
+++ b/scripts/url-checker-github.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Set variables for GitHub API
+ACCESS_TOKEN=$ACCESS_TOKEN
+DELAY=1  # seconds between requests
+LINKS_FILE="all_github_links.txt"
+BROKEN_LINKS_FILE="link_report_github.txt"
+CACHE_FILE="github_cache.txt"
+TOO_MANY_REQUESTS=429
+MAX_RETRIES=5 # maximum number of retries for a single URL
+RETRY_DELAY=10  # increment seconds to wait before retrying
+
+# Create cache file if it doesn't exist
+touch "$CACHE_FILE"
+
+echo "⏭️ Starting checks for Github URLs in Docs."
+
+# Find all GitHub links in the documentation
+grep -rHoE '\(https?://github\.com/[^") ]+' --include="*.md" ./docs | sed 's/[()]//g' | sed 's/#.*$//' > "$LINKS_FILE"
+
+
+if [[ -n "$ACCESS_TOKEN" ]]; then
+    echo "🔏 Access token found. We will use it for authentication where possible."
+else
+    echo "🟡 Access token not found. You may be rate-limited by GitHub."
+fi
+
+# Function to make a request to the URL and get the status code.
+# Params:
+# $1 - url
+make_request () {
+    url=$1
+    status_code=""
+    if [[ -n "$ACCESS_TOKEN" ]]; then
+        status_code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: token $ACCESS_TOKEN" -A "Spectro-URL-Checker" "$url")
+    else
+        status_code=$(curl -s -o /dev/null -w "%{http_code}" -A "URL-Checker" "$url")
+    fi
+    
+    echo "$status_code"
+}
+
+# Function to retry the URL request if it fails with a 429 status code.
+# Params: 
+# $1 - url
+retry_url_get() {
+    url=$1
+    retries=0
+    status_code=""
+
+    while [[ $retries -lt $MAX_RETRIES ]]; do
+        # Make the request and get the status code
+        status_code=$(make_request "$url")
+
+        code=$(echo "$status_code" | cut -d' ' -f1)
+        # Check if the status code is 429 (Too Many Requests)
+        if [[ "$code" =~ ^[0-9]{3}$ && "$code" -eq $TOO_MANY_REQUESTS ]]; then
+            # Calculate the delay based on the number of retries
+            # This is a simple exponential backoff strategy.
+            delay=$(( RETRY_DELAY * (retries + 1) ))
+            echo "🔄 Rate limit hit for $url. Retrying in $delay seconds..." >&2
+            sleep $delay
+            ((retries++))
+        else
+            break
+        fi
+    done
+
+    # If we exhausted all retries, return the last status code
+    echo "$status_code"
+}
+
+# Function to get the status code of a URL, either from the cache or by making a request.
+# Params: 
+# $1 - url
+get_url_status_code() {
+    url=$1
+
+    # Check if the URL is already in the cache
+    cached_status=$(grep -F "$url" "$CACHE_FILE" | cut -d' ' -f1)
+    if [[ -n "$cached_status" ]]; then
+        echo "$cached_status"
+        return 0
+    fi
+
+    # Not cached – call retry logic
+    status_code=$(retry_url_get "$url")
+
+    echo "$status_code $url" >> "$CACHE_FILE"
+    echo "$status_code"
+}
+
+while IFS= read -r line; do
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+
+    filename="${line%%:*}"  # everything before the first colon
+    url="${line#*:}"        # everything after the first colon
+    
+    # Skip if the URL is empty
+    [[ -z "$url" ]] && continue
+
+    # Get the status code, either from GH or from the cache
+    status_code=$(get_url_status_code "$url")
+
+    code=$(echo "$status_code" | cut -d' ' -f1)
+    # Consider all statuses larger than 400 as errors
+    if [[ "$code" =~ ^[0-9]{3}$ && "$code" -gt 400 ]]; then
+        echo "$filename:$url" >> "$BROKEN_LINKS_FILE"
+    fi 
+
+    # Delay to avoid hitting rate limits on non-API endpoints. 
+    sleep $DELAY
+done < "$LINKS_FILE"
+
+echo "✅ Completed checks for Github URLs in Docs."
+
+# Cleanup
+rm -f $LINKS_FILE
+rm -f $CACHE_FILE
+

--- a/scripts/url-checker-github.sh
+++ b/scripts/url-checker-github.sh
@@ -15,9 +15,14 @@ touch "$CACHE_FILE"
 
 echo "⏭️ Starting checks for Github URLs in Docs."
 
-# Find all GitHub links in the documentation.
+# Find all GitHub links in the documentation /docs and /partials directories.
 # Strip all parentheses and anchors from the links, as they will be heavily throttled by GitHub.
-grep -rHoE '\(https?://github\.com/[^") ]+' --include="*.md" ./docs | sed 's/[()]//g' | sed 's/#.*$//' > "$LINKS_FILE"
+grep -rHoE '\(https?://github\.com/[^") ]+' \
+    --include="*.md" \
+    --include="*.mdx" \
+    ./docs ./_partials | \
+    sed 's/[()]//g' | \
+    sed 's/#.*$//' > "$LINKS_FILE"
 
 if [[ -n "$ACCESS_TOKEN" ]]; then
     echo "🔏 Access token found. We will use it for authentication where possible."

--- a/scripts/url-checker.sh
+++ b/scripts/url-checker.sh
@@ -74,8 +74,8 @@ done
 
 for link in $(echo "${GITHUB_BROKEN_LINKS_CONTENT}"); do
     ((BROKEN_LINK_COUNT++)) # All the links in this file are broken
-    filename="${line%%:*}"  # everything before the first colon
-    url="${line#*:}"        # everything after the first colon
+    filename="${link%%:*}"  # everything before the first colon
+    url="${link#*:}"        # everything after the first colon
 
     COMMENT="${COMMENT}\n\n:link: Broken URL: ${url}  \n:red_circle: State: BROKEN  \n:arrow_up: Parent Page: ${filename}\n\n"
 done

--- a/scripts/url-checker.sh
+++ b/scripts/url-checker.sh
@@ -29,10 +29,10 @@ echo "Pull request number: $PR_NUMBER"
 # Read JSON file contents into a variable
 JSON_CONTENT=$(cat link_report.json)
 JSON_RATE_LIMIT_CONTENT=$(cat link_rate_limit_report.json)
+GITHUB_BROKEN_LINKS_CONTENT=$(cat link_report_github.txt)
 
-
-# Check if JSON file is empty
-if [[ -z "$JSON_CONTENT" ]] && [[ -z "$JSON_RATE_LIMIT_CONTENT" ]]; then
+# Check if files are empty
+if [[ -z "$JSON_CONTENT" ]] && [[ -z "$JSON_RATE_LIMIT_CONTENT" ]] && [[ -z "$GITHUB_BROKEN_LINKS_CONTENT" ]]; then
   echo "No broken links found"
   exit 0
 fi
@@ -70,6 +70,14 @@ for link in $(echo "${JSON_RATE_LIMIT_CONTENT}" | jq -c '.[]'); do
     fi
 
     COMMENT="${COMMENT}\n\n:link: Broken URL: ${url}  \n:red_circle: State: ${state}  \n:arrow_up: Parent Page: ${parent}\n\n"
+done
+
+for link in $(echo "${GITHUB_BROKEN_LINKS_CONTENT}"); do
+    ((BROKEN_LINK_COUNT++)) # All the links in this file are broken
+    filename="${line%%:*}"  # everything before the first colon
+    url="${line#*:}"        # everything after the first colon
+
+    COMMENT="${COMMENT}\n\n:link: Broken URL: ${url}  \n:red_circle: State: BROKEN  \n:arrow_up: Parent Page: ${filename}\n\n"
 done
 
 # Check if no broken links are found


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a special job for handling URL checks on Github links. It also moves posting to the private team channel. Linkinator is now configured to skip validation of Github links.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

_No UI changes._

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1877](https://spectrocloud.atlassian.net/browse/DOC-1877)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?
- [x] No. _Please leave a short comment below about why this PR cannot be backported._
Job only executes in master, but can target other branches. Won't backport.


[DOC-1877]: https://spectrocloud.atlassian.net/browse/DOC-1877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ