### PR TITLE
doc: update VMO and vCluster airgap binary versions

### DIFF
--- a/_partials/_additional-deployment-options.mdx
+++ b/_partials/_additional-deployment-options.mdx
@@ -1,0 +1,13 @@
+---
+partial_category: self-hosted-and-vertex
+partial_name: additional-deployment-options
+---
+
+Palette [Virtual Machine Orchestrator](/vm-management/) (VMO) and
+[Virtual Clusters](/clusters/palette-virtual-clusters/) can also be installed for
+airgapped self-hosted instances of Palette and Palette VerteX.
+
+| File Name                                            | URL                                                                                                       |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `airgap-pack-virtual-machine-orchestrator-4.6.2.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-virtual-machine-orchestrator-4.6.2.bin |
+| `airgap-pack-vcluster-4.6.1.bin`                     | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vcluster-4.6.1.bin                     |

--- a/docs/docs-content/downloads/palette-vertex/additional-packs.md
+++ b/docs/docs-content/downloads/palette-vertex/additional-packs.md
@@ -16,16 +16,9 @@ Review the following table to determine which pack binaries you need to download
 
 ## Additional Deployment Options
 
-Palette [Virtual Machine Orchestrator](../../vm-management/vm-management.md) (VMO) and
-[Virtual Clusters](../../clusters/palette-virtual-clusters/palette-virtual-clusters.md) can also be installed for
-airgapped self-hosted instances of Palette and Palette VerteX.
+<PartialsComponent category="self-hosted-and-vertex" name="additional-deployment-options" />
 
-| File Name                                            | URL                                                                                                       |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `airgap-pack-virtual-machine-orchestrator-4.5.7.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-virtual-machine-orchestrator-4.5.7.bin |
-| `airgap-pack-vcluster-4.5.10.bin`                    | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vcluster-4.5.10.bin                    |
-
-### Usage Instructions
+## Usage Instructions
 
 You must SSH into your Palette VerteX airgap support VM to download and install the binary. You must also provide the
 username and password for the support team's private repository. Reach out to our support team to

--- a/docs/docs-content/downloads/self-hosted-palette/additional-packs.md
+++ b/docs/docs-content/downloads/self-hosted-palette/additional-packs.md
@@ -16,16 +16,9 @@ Review the following table to determine which pack binaries you need to download
 
 ## Additional Deployment Options
 
-Palette [Virtual Machine Orchestrator](../../vm-management/vm-management.md) (VMO) and
-[Virtual Clusters](../../clusters/palette-virtual-clusters/palette-virtual-clusters.md) can also be installed for
-airgapped self-hosted instances of Palette and Palette VerteX.
+<PartialsComponent category="self-hosted-and-vertex" name="additional-deployment-options" />
 
-| File Name                                            | URL                                                                                                       |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `airgap-pack-virtual-machine-orchestrator-4.5.7.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-virtual-machine-orchestrator-4.5.7.bin |
-| `airgap-pack-vcluster-4.5.10.bin`                    | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vcluster-4.5.10.bin                    |
-
-### Usage Instructions
+## Usage Instructions
 
 You must SSH into your Palette airgap support VM to download and install the binary. You must also provide the username
 and password for the support team's private repository. Reach out to our support team to


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the VMO and vCluster airgap binary versions. It also moves these sections for VerteX and Self-Hosted into a partial for easier updates in the future.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Additional Deployment Options (self-hosted)](https://deploy-preview-6671--docs-spectrocloud.netlify.app/downloads/self-hosted-palette/additional-packs/#additional-deployment-options)
💻 [Additional Deployment Options (vertex)](https://deploy-preview-6671--docs-spectrocloud.netlify.app/downloads/palette-vertex/additional-packs/#additional-deployment-options)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1880](https://spectrocloud.atlassian.net/browse/DOC-1880)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1880]: https://spectrocloud.atlassian.net/browse/DOC-1880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ