### PR TITLE
DOC-1879 - Refactor 'connected/airgap' to 'central/local' on Prepare Edge Hosts page (EKS Hybrid)

### DIFF
--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
@@ -147,7 +147,12 @@ mode to manage configurations, updates, and workloads.
   - [iptables](https://linux.die.net/man/8/iptables)
   - [rsyslog](https://github.com/rsyslog/rsyslog). This is required for audit logs.
 
-  <br />
+  If you are using Ubuntu or any OS that uses apt or apt-get for package management, you can issue the following command
+  to install all dependencies for installation with the following command:
+
+  ```shell
+  sudo apt-get update && sudo apt-get install -y bash jq zstd rsync systemd-timesyncd conntrack iptables rsyslog --no-install-recommends
+  ```
 
   :::warning
 
@@ -276,66 +281,15 @@ mode to manage configurations, updates, and workloads.
 
 6. Download the latest version of the Palette agent installation script. There is a FIPS-compliant script, if needed.
 
-   <Tabs groupId="FIPS">
-
-   <TabItem value="Non-FIPS">
-
-   ```shell
-   curl --location --output ./palette-agent-install.sh https://github.com/spectrocloud/agent-mode/releases/latest/download/palette-agent-install.sh
-   ```
-
-   </TabItem>
-
-   <TabItem value="FIPS">
-
-   ```shell
-   curl --location --output ./palette-agent-install-fips.sh https://github.com/spectrocloud/agent-mode/releases/latest/download/palette-agent-install-fips.sh
-   ```
-
-   </TabItem>
-
-   </Tabs>
+   <PartialsComponent category="agent-mode" name="agent-mode-latest-version" />
 
    <details>
 
-   <summary>Dedicated or On-Prem Palette Instance</summary>
+   {" "}
 
-   If you have a dedicated or on-prem instance of Palette, you need to identify the correct agent version and then
-   download the corresponding version of the agent installation script. Use the command below and replace
-   `<palette-endpoint>` with your Palette endpoint and `<api-key>` with your Palette API key to identify the version.
+   <summary>Dedicated or On-Premises Palette Instance</summary>
 
-   ```shell
-   curl --location --request GET 'https://<palette-endpoint>/v1/services/stylus/version' --header 'Content-Type: application/json' --header 'Apikey: <api-key>'  | jq --raw-output '.spec.latestVersion.content | match("version: ([^\n]+)").captures[0].string'
-   ```
-
-   Example output.
-
-   ```text hideClipboard
-   4.6.0
-   ```
-
-   Issue the following command to download the version of the Palette agent for your dedicated or on-prem instance.
-   Replace `<stylus-version>` with your output from the previous step.
-
-   <Tabs groupId="FIPS">
-
-   <TabItem value="Non-FIPS">
-
-   ```shell
-   curl --location --output ./palette-agent-install.sh https://github.com/spectrocloud/agent-mode/releases/download/v<stylus-version>/palette-agent-install.sh
-   ```
-
-   </TabItem>
-
-   <TabItem value="FIPS">
-
-   ```shell
-   curl --location --output ./palette-agent-install-fips.sh https://github.com/spectrocloud/agent-mode/releases/download/v<stylus-version>/palette-agent-install-fips.sh
-   ```
-
-   </TabItem>
-
-   </Tabs>
+   <PartialsComponent category="agent-mode" name="agent-mode-versioned" />
 
    </details>
 

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
@@ -26,8 +26,8 @@ of both modes.
 
 ## Agent Mode
 
-In Agent Mode, you install the Palette agent on your existing host OS. This agent communicates with Palette in connected
-mode to manage configurations, updates, and workloads.
+In Agent Mode, you install the Palette agent on your existing host OS. This agent communicates with Palette in central
+management mode to manage configurations, updates, and workloads.
 
 ### Prerequisites
 

--- a/docs/docs-content/deployment-modes/agent-mode/agent-mode.md
+++ b/docs/docs-content/deployment-modes/agent-mode/agent-mode.md
@@ -24,16 +24,16 @@ The order of operations can be summarized as follows:
 3. You create a cluster profile in Palette. The profile contains the Kubernetes distribution, the Container Network
    Interface (CNI), the Container Storage Interface (CSI) as well as any other applications.
 
-4. If the agent is installed on your host in connected mode, it will register the host with Palette.
+4. If the agent is installed on your host in central management mode, it will register the host with Palette.
 
-   If the agent is installed on your host in airgap mode, you will need to export the cluster profile. Depending on
-   whether your host has access to image registries, you may also need to build a content bundle.
+   If the agent is installed on your host in local management mode, you will need to export the cluster profile.
+   Depending on whether your host has access to image registries, you may also need to build a content bundle.
 
-5. If the agent is installed on your host in connected mode, you can use the registered host to provision a cluster with
-   your cluster profile.
+5. If the agent is installed on your host in central management mode, you can use the registered host to provision a
+   cluster with your cluster profile.
 
-   If the agent is installed on your host in airgap mode, you can use the exported cluster profile to provision a
-   cluster from Local UI.
+   If the agent is installed on your host in local management mode, you can use the exported cluster profile to
+   provision a cluster from Local UI.
 
 ## Use Cases
 

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -30,7 +30,7 @@ Palette. You will then create a cluster profile and use the registered host to d
   | AMD64             | Ubuntu                            | K3s                                        | Flannel                           | :white_check_mark: |
   | AMD64             | Rocky Linux 8.10 (Green Obsidian) | Palette eXtended Kubernetes - Edge (PXK-E) | Cilium                            | :white_check_mark: |
 
-- Clusters with Flannel CNI is not verified for airgap deployments.
+- Clusters with Flannel CNI is not verified for local management mode deployments.
 
 - Agent mode is only supported on Linux distributions that have
   [`systemd`](https://www.freedesktop.org/software/systemd/man/latest/systemd.html) installed and available.
@@ -38,14 +38,14 @@ Palette. You will then create a cluster profile and use the registered host to d
 - The FIPS-compliant version of Agent Mode is only available for Red Hat Enterprise Linux (RHEL) and Rocky Linux 8
   systems.
 
-- ARM64 support for airgap clusters is not available. This is because Harbor, which is required for airgap clusters,
-  does not have an ARM64 image.
+- ARM64 support for local management mode clusters is not available. This is because Harbor, which is required for local
+  management mode clusters, does not have an ARM64 image.
 
 ## Prerequisites
 
-- A physical or virtual host with SSH access, access to the internet, and connection to Palette. For airgap deployments,
-  the host does not need to have a connection to Palette and may have limited access to the internet. This guide uses an
-  **Ubuntu 22.04** virtual machine deployed in VMware vSphere as an example.
+- A physical or virtual host with SSH access, access to the internet, and connection to Palette. For local management
+  mode deployments, the host does not need to have a connection to Palette and may have limited access to the internet.
+  This guide uses an **Ubuntu 22.04** virtual machine deployed in VMware vSphere as an example.
 
 - The host must meet the following minimum hardware requirements:
 
@@ -81,7 +81,7 @@ Palette. You will then create a cluster profile and use the registered host to d
     use PXKE as the Kubernetes layer
   - [iptables](https://linux.die.net/man/8/iptables)
   - [rsyslog](https://github.com/rsyslog/rsyslog). This is required for audit logs.
-  - (Airgap only) [Palette Edge CLI](../../downloads/cli-tools.md#palette-edge-cli)
+  - (Local management mode only) [Palette Edge CLI](../../downloads/cli-tools.md#palette-edge-cli)
 
   If you are using Ubuntu or any OS that uses apt or apt-get for package management, you can issue the following command
   to install all dependencies for installation (not including the Palette Edge CLI) with the following command:
@@ -303,7 +303,7 @@ Palette. You will then create a cluster profile and use the registered host to d
 
 <Tabs groupId="env">
 
-<TabItem value="Connected">
+<TabItem value="Central Management Mode">
 
 1. In your terminal, use the following command to SSH into the host. Replace `</path/to/private/key>` with the path to
    your private SSH key and `<host-ip-or-domain>` with the host's IP address or hostname.
@@ -556,9 +556,9 @@ guidance.
 
 </TabItem>
 
-<TabItem value="Airgap">
+<TabItem value="Local Management Mode">
 
-In an airgapped environment, your host does not have a connection to Palette and may also have limited access to the
+In local management mode, your host does not have a connection to Palette and may also have limited access to the
 internet.
 
 1. In your terminal, use the following command to SSH into the host. Replace `</path/to/private/key>` with the path to
@@ -598,7 +598,7 @@ internet.
 
 5. Issue the command below to create the `userdata` file and configure your host declaratively.
 
-   The following configuration indicates the installation mode to be airgap and sets up the `kairos` user. The host will
+   The following configuration indicates the management mode to be local and sets up the `kairos` user. The host will
    not shut down and will reboot after the agent installation, with
    [kube-vip](../../clusters/edge/networking/kubevip.md) enabled, as this is required for bare metal and VMware vSphere
    deployments. If your environment does not require kube-vip, set `stylus.vip.skip` to `true`. Refer to
@@ -691,7 +691,7 @@ internet.
     ```
 
 17. Complete the cluster profile creation process by filling out the remaining layers. In the application layer, make
-    sure you include the **Harbor Edge-Native Config** pack. This pack is required for airgapped clusters.
+    sure you include the **Harbor Edge-Native Config** pack. This pack is required for local management mode clusters.
 
 18. Follow the steps in
     [Export Cluster Definition](../../clusters/edge/local-ui/cluster-management/export-cluster-definition.md) to export
@@ -732,7 +732,7 @@ guidance.
 
 <Tabs groupId="env">
 
-<TabItem value="Connected">
+<TabItem value="Central Management Mode">
 
 1. Log in to [Palette](https://console.spectrocloud.com/).
 
@@ -749,7 +749,7 @@ details on how to use these operations
 
 </TabItem>
 
-<TabItem value="Airgap">
+<TabItem value="Local Management Mode">
 
 1. Log in to [Local UI](../../clusters/edge/local-ui/host-management/access-console.md).
 

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -30,7 +30,7 @@ Palette. You will then create a cluster profile and use the registered host to d
   | AMD64             | Ubuntu                            | K3s                                        | Flannel                           | :white_check_mark: |
   | AMD64             | Rocky Linux 8.10 (Green Obsidian) | Palette eXtended Kubernetes - Edge (PXK-E) | Cilium                            | :white_check_mark: |
 
-- Clusters with Flannel CNI is not verified for local management mode deployments.
+- Clusters with Flannel CNI are not verified for local management mode deployments.
 
 - Agent mode is only supported on Linux distributions that have
   [`systemd`](https://www.freedesktop.org/software/systemd/man/latest/systemd.html) installed and available.
@@ -38,8 +38,8 @@ Palette. You will then create a cluster profile and use the registered host to d
 - The FIPS-compliant version of Agent Mode is only available for Red Hat Enterprise Linux (RHEL) and Rocky Linux 8
   systems.
 
-- ARM64 support for local management mode clusters is not available. This is because Harbor, which is required for local
-  management mode clusters, does not have an ARM64 image.
+- ARM64 support for clusters in local management mode is not available. This is because Harbor, which is required for
+  local management mode, does not have an ARM64 image.
 
 ## Prerequisites
 
@@ -691,7 +691,8 @@ internet.
     ```
 
 17. Complete the cluster profile creation process by filling out the remaining layers. In the application layer, make
-    sure you include the **Harbor Edge-Native Config** pack. This pack is required for local management mode clusters.
+    sure you include the **Harbor Edge-Native Config** pack. This pack is required for clusters in local management
+    mode.
 
 18. Follow the steps in
     [Export Cluster Definition](../../clusters/edge/local-ui/cluster-management/export-cluster-definition.md) to export

--- a/docs/docs-content/downloads/agent-mode.md
+++ b/docs/docs-content/downloads/agent-mode.md
@@ -16,7 +16,7 @@ deployment modes, agent mode gives you more flexibility in managing your infrast
 [agent mode documentation](../deployment-modes/agent-mode/agent-mode.md) for guidance on how to set up agent mode on
 your hosts.
 
-## Connected
+## Central Management Mode
 
 This version of agent mode requires internet access on the host to connect to a Palette instance.
 
@@ -30,11 +30,12 @@ Use the following command to download the latest version of the Palette agent in
 
 <PartialsComponent category="agent-mode" name="agent-mode-versioned" />
 
-## Airgap
+## Local Management Mode
 
-This version of agent mode is designed for environments without direct internet access.
+This version of agent mode is designed for environments without a connection to Palette and may also have limited access
+to the internet.
 
-Download the airgap agent installation package and save it as a TAR file.
+Download the agent installation package and save it as a TAR file.
 
 - Replace `<architecture>` with the architecture of your CPU. If you have ARM64, use `arm64`. If you have AMD64 or
   x86_64, use `amd64`.

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -63,8 +63,7 @@ tags: ["release-notes"]
 
 :::info
 
-Check out the [Downloads](../downloads/downloads.md) and [Compatibility Matrix](../downloads/cli-tools.md) pages to find
-the compatible version of the Palette CLI.
+Check out the [CLI Tools](../downloads/cli-tools.md) page to find the compatible version of the Palette CLI.
 
 :::
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the Prepare Edge Hosts page in the EKS Hybrid docs to be more inline with the Appliance Mode documentation.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1879](https://spectrocloud.atlassian.net/browse/DOC-1879)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1879]: https://spectrocloud.atlassian.net/browse/DOC-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ