### PR TITLE
docs: do not use Palette Edge CLI for upgrade to 4.6.16 or later

### DIFF
--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -111,6 +111,13 @@ If you already know the agent version you want to use for your cluster, you can 
    [Export Cluster Definition](../local-ui/cluster-management/export-cluster-definition.md) to build a content bundle
    using your new cluster profile and export the cluster definition.
 
+   :::warning
+
+   If you are upgrading to an agent version that is 4.6.16 or later, use the Palette CLI. Do not use the Palette Edge
+   CLI.
+
+   :::
+
 8. Upload the content bundle to your cluster through Local UI. For more information, refer to
    [Upload Content Bundle](../local-ui/cluster-management/upload-content-bundle.md).
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a warning that upgrades to 4.6.16 or later cannot use the Edge CLI.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page](https://spectrocloud.atlassian.net/issues/PE-6560?filter=11884)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PE-6560](https://spectrocloud.atlassian.net/issues/PE-6560)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[PE-6560]: https://spectrocloud.atlassian.net/browse/PE-6560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ