### PR TITLE
[version-4-4] doc: fix third-party binary addition and conformance instructions

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/airgap/supplemental-packs.md
+++ b/docs/docs-content/enterprise-version/install-palette/airgap/supplemental-packs.md
@@ -72,6 +72,7 @@ Review the following table to determine which pack binaries you need to download
 | `airgap-pack-prometheus-operator-58.6.0.bin`                   | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-prometheus-operator-58.6.0.bin                   |
 | `airgap-pack-reloader-1.0.74.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-reloader-1.0.74.bin                              |
 | `airgap-pack-reloader-1.0.107.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-reloader-1.0.107.bin                             |
+| `airgap-thirdparty-4.4.bin`                                    | https://software-private.spectrocloud.com/airgap/thirdparty/airgap-thirdparty-4.4.bin                               |
 | `airgap-pack-volume-snapshot-controller-8.0.1.bin`             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-volume-snapshot-controller-8.0.1.bin             |
 
 ## Download Instructions
@@ -134,8 +135,8 @@ All binaries require the OCI environment variables to be set and for the registr
 In an airgap installation, you need to upload the conformance packs to the self-hosted OCI registry. The conformance
 binary contains the packs required to use the [Compliance Scan](../../../clusters/cluster-management/compliance-scan.md)
 capabilities. The conformance binary can be found in the pack table above. The binary has the prefix
-`airgap-thirdparty-`. Follow the [Usage Instructions](#usage-instructions) to upload the conformance packs to the OCI
-registry.
+`airgap-thirdparty-`. Follow the [Download Instructions](#download-instructions) to upload the conformance packs to the
+OCI registry.
 
 ## Additional OVAs
 

--- a/docs/docs-content/vertex/install-palette-vertex/airgap/supplemental-packs.md
+++ b/docs/docs-content/vertex/install-palette-vertex/airgap/supplemental-packs.md
@@ -62,6 +62,7 @@ Review the following table to determine which pack binaries you need to download
 | `airgap-vertex-pack-kubernetes-rke2-1.28.12-rke2r1-build20240717.bin` | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.28.12-rke2r1-build20240717.bin |
 | `airgap-vertex-pack-kubernetes-rke2-1.29.7-rke2r1-build20240717.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.29.7-rke2r1-build20240717.bin  |
 | `airgap-vertex-pack-kubernetes-rke2-1.30.3-rke2r1-build20240717.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.30.3-rke2r1-build20240717.bin  |
+| `airgap-thirdparty-4.4.bin`                                           | https://software-private.spectrocloud.com/airgap/thirdparty/airgap-thirdparty-4.4.bin                                             |
 
 ### Usage Instructions
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds the missing third-party binary pack for version 4.4 and corrects the conformance capabilities section as the usage instructions should be pointing to download instructions.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1874](https://spectrocloud.atlassian.net/browse/DOC-1874)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._
Only for version-4-4.

[DOC-1874]: https://spectrocloud.atlassian.net/browse/DOC-1874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ