### PR TITLE
docs: Airgap support for VM Migration Assistant (pack URL pending)

### DIFF
--- a/_partials/_additional-deployment-options.mdx
+++ b/_partials/_additional-deployment-options.mdx
@@ -3,11 +3,14 @@ partial_category: self-hosted-and-vertex
 partial_name: additional-deployment-options
 ---
 
-Palette [Virtual Machine Orchestrator](/vm-management/) (VMO) and
-[Virtual Clusters](/clusters/palette-virtual-clusters/) can also be installed for
-airgapped self-hosted instances of Palette and Palette VerteX.
+The following deployment options are also available for airgapped self-hosted Palette and Palette VerteX instances.
 
-| File Name                                            | URL                                                                                                       |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `airgap-pack-virtual-machine-orchestrator-4.6.2.bin` | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-virtual-machine-orchestrator-4.6.2.bin |
-| `airgap-pack-vcluster-4.6.1.bin`                     | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vcluster-4.6.1.bin                     |
+- Palette [Virtual Machine Orchestrator](/vm-management/) (VMO)
+- [Virtual Machine Migration Assistant](/vm-management/vm-migration-assistant/) (VM Migration Assistant)
+- [Virtual Clusters](/clusters/palette-virtual-clusters/)
+
+| File Name                                                     | URL                                                                                                       |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `airgap-pack-virtual-machine-orchestrator-4.6.2.bin`          | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-virtual-machine-orchestrator-4.6.2.bin |
+| `<placeholder-for-vm-migration-assistant-pack-filename>`      | `<placeholder-for-vm-migration-assistant-pack-url>`                                                       |
+| `airgap-pack-vcluster-4.6.1.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vcluster-4.6.1.bin                     |

--- a/_partials/_additional-deployment-options.mdx
+++ b/_partials/_additional-deployment-options.mdx
@@ -3,7 +3,7 @@ partial_category: self-hosted-and-vertex
 partial_name: additional-deployment-options
 ---
 
-The following deployment options are also available for airgapped self-hosted Palette and Palette VerteX instances.
+The following deployment options are also available for airgapped self-hosted Palette and Palette VerteX instances:
 
 - Palette [Virtual Machine Orchestrator](/vm-management/) (VMO)
 - [Virtual Machine Migration Assistant](/vm-management/vm-migration-assistant/) (VM Migration Assistant)

--- a/_partials/_additional-deployment-options.mdx
+++ b/_partials/_additional-deployment-options.mdx
@@ -12,5 +12,5 @@ The following deployment options are also available for airgapped self-hosted Pa
 | File Name                                                     | URL                                                                                                       |
 | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `airgap-pack-virtual-machine-orchestrator-4.6.2.bin`          | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-virtual-machine-orchestrator-4.6.2.bin |
-| `<placeholder-for-vm-migration-assistant-pack-filename>`      | `<placeholder-for-vm-migration-assistant-pack-url>`                                                       |
+| `airgap-pack-vm-migration-assistant-4.6.0.bin`                | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vm-migration-assistant-4.6.0.bin       |
 | `airgap-pack-vcluster-4.6.1.bin`                              | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-vcluster-4.6.1.bin                     |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -78,6 +78,16 @@ Check out the [CLI Tools](../downloads/cli-tools.md) page to find the compatible
 
 #### Improvements
 
+### Virtual Machine Orchestrator (VMO)
+
+#### Improvements
+
+- The [Virtual Machine Migration Assistant](../vm-management/vm-migration-assistant/vm-migration-assistant.md) is now
+  supported for airgapped environments. Refer to the Additional Packs pages for
+  [self-hosted Palette](../downloads/self-hosted-palette/additional-packs.md#additional-deployment-options) and
+  [Palette VerteX](../downloads/palette-vertex/additional-packs.md#additional-deployment-options) for the relevant link
+  to download this pack and upload instructions.
+
 ### Docs and Education
 
 - We have added a new [Downloads](../downloads/downloads.md) tab to the top navigation bar of the Spectro Cloud


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a release note covering airgap support for the VM Migration Assistant. It also adds the pack download URL and filename, and adjusts the Additional Deployment Options section for scalability.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-6742--docs-spectrocloud.netlify.app/release-notes/#improvements-3)
💻 [Additional Deployment Options (Self-Hosted)](https://deploy-preview-6742--docs-spectrocloud.netlify.app/downloads/self-hosted-palette/additional-packs/#additional-deployment-options)
💻 [Additional Deployment Options (VerteX)](https://deploy-preview-6742--docs-spectrocloud.netlify.app/downloads/palette-vertex/additional-packs/#additional-deployment-options)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-7413](https://spectrocloud.atlassian.net/browse/PEM-7413)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[PEM-7413]: https://spectrocloud.atlassian.net/browse/PEM-7413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ