### PR TITLE
PCP-4421 - GKE repave release note due to CAPG upgrade

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -33,6 +33,11 @@ tags: ["release-notes"]
   [Required IAM Permissions](../clusters/public-cloud/gcp/required-permissions.md#required-permissions) guide for all
   required GCP IAM permissions.
 
+- After upgrading Palette to this release, Palette will automatically trigger a repave on existing GKE clusters for node
+  pools. This is because the the CAPG version has been updated from v1.2.1 to v1.8.1, which automatically adds a new
+  ownership label `capg-<cluster-name>=owned`. As GKE treats a node pool label map as immutable, the label insertion
+  triggers a rolling repave of all worker nodes.
+
 #### Features
 
 - You can now assign an Amazon Machine Image (AMI) to a node pool when deploying Amazon EKS clusters. To do this, apply
@@ -49,6 +54,28 @@ tags: ["release-notes"]
   more information.
 
 #### Improvements
+
+- CAPG has been upgraded to [v1.8.1](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/tag/v1.8.1)
+  from [v1.2.1](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/tag/v1.2.1).
+
+  As part of this release, newly created GKE clusters will have an additional default label applied to their node pools.
+  This is due to a change starting from CAPG v1.3 where a cluster-ownership label is automatically injected into every
+  node pool.
+
+  The following table displays the default labels between the previous and current CAPG release.
+
+  | CAPG Version | Default Labels on Node Pools                                                     |
+  | ------------ | -------------------------------------------------------------------------------- |
+  | v1.2.1       | `goog-gke-node-pool-provisioning-model: on-demand`                               |
+  | v1.8.1       | `goog-gke-node-pool-provisioning-model: on-demand`, `capg-<cluster-name>: owned` |
+
+  :::warning
+
+  In GKE, a node pool’s label set is an immutable field, and any changes to it will trigger a repave. As such, any GKE
+  clusters built with an older release will be automatically repaved by Palette. This will occur after Palette has been
+  upgraded to this release or later.
+
+  :::
 
 #### Deprecations and Removals
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -34,7 +34,7 @@ tags: ["release-notes"]
   required GCP IAM permissions.
 
 - After upgrading Palette to this release, Palette will automatically trigger a repave on existing GKE clusters for node
-  pools. This is because the the CAPG version has been updated from v1.2.1 to v1.8.1, which automatically adds a new
+  pools. This is because the CAPG version has been updated from v1.2.1 to v1.8.1, which automatically adds a new
   ownership label `capg-<cluster-name>=owned`. As GKE treats a node pool label map as immutable, the label insertion
   triggers a rolling repave of all worker nodes.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a release note and breaking change to cover the CAPG upgrade in the 4.6.c Palette release.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PCP-4421](https://spectrocloud.atlassian.net/browse/PCP-4421)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[PCP-4421]: https://spectrocloud.atlassian.net/browse/PCP-4421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ