### PR TITLE
Update Husky scripts for v9.1.7 compatibility

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,4 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx lint-staged
+lint-staged
 
 npm run clean-api-docs
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 ./scripts/check-branch.sh

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ initialize: ## Initialize the repository dependencies
 	@echo "initializing npm dependencies"
 	npm ci
 	touch .env
-	npx husky
+	npm run prepare
 	vale sync
 
 clean: clean-security ## Clean common artifacts

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ initialize: ## Initialize the repository dependencies
 	@echo "initializing npm dependencies"
 	npm ci
 	touch .env
-	npx husky-init
+	npx husky
 	vale sync
 
 clean: clean-security ## Clean common artifacts
@@ -94,7 +94,7 @@ init: ## Initialize npm dependencies
 	grep -q "^DSO_AUTH_TOKEN=" .env || echo "\nDISABLE_SECURITY_INTEGRATIONS=true\nDSO_AUTH_TOKEN=" >> .env
 	grep -q "^PALETTE_API_KEY=" .env || echo "\nDISABLE_PACKS_INTEGRATIONS=true" >> .env
 	grep -q "^SHOW_LAST_UPDATE_TIME=" .env || echo "\nSHOW_LAST_UPDATE_TIME=false" >> .env
-	npx husky install
+	npm run prepare
 
 start: ## Start a local development server
 	npm run start

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write \"**/*.{js,jsx,json,ts,tsx,md,mdx,css}\"",
     "format-check": "prettier . --check",
-    "copy-cve-data": "mkdir -p static/security-data && cp .docusaurus/security-bulletins/default/data.json static/security-data/data.json"
+    "copy-cve-data": "mkdir -p static/security-data && cp .docusaurus/security-bulletins/default/data.json static/security-data/data.json",
+    "prepare": "husky"
   },
   "lint-staged": {
     "**/*.{js,jsx,json,ts,tsx,md,mdx,css}": "npm run format"


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adjusts the Husky commit hook scripts based on various deprecations and updates to how Husky operates post-upgrade.

- Removal of shebang and directory code setting as deprecated post v10.x.y. See [9.1.2](https://github.com/typicode/husky/releases/tag/v9.1.2) release notes.
- Removal of `npx` from package commands as no longer needed from [9.1.1](https://github.com/typicode/husky/releases/tag/v9.1.1) onwards.
- Changed `npx husky-init` to `npx husky` in `Makefile` as running `husky-init` replaces the `pre-commit` hook with a templated version regardless of whether it already exists.
- `"prepare": "husky"` has been added to the `package.json`. I've adjusted the `Makefile` command as `npx husky install` is now deprecated in favour of `npm run prepare` with the command being called from the `package.json`. See [9.0.1](https://newreleases.io/project/yarn/husky/release/9.0.1) release notes.

I tested the `pre-commit` and `pre-push` hooks locally, and they fired correctly.

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._
