### PR TITLE
docs: adjust cloud type in the case that packs have cloudProvider=all DOC-1888

### DIFF
--- a/plugins/packs-integrations.js
+++ b/plugins/packs-integrations.js
@@ -500,7 +500,7 @@ async function pluginPacksAndIntegrationsData(context, options) {
         let apiPacksData = [];
         const promisesPackDetails = packDataArr.map((packData) => {
           packMDMap[packData.spec.name] = packData;
-          const cloudType = packData.spec.cloudTypes.includes("all") ? "aws" : packData.spec.cloudTypes[0];
+          const cloudType = packData.spec.cloudTypes.includes("all") ? "all" : packData.spec.cloudTypes[0];
           const registryPackData = [];
           try {
             for (const registry of packData.spec.registries) {

--- a/utils/helpers/affected-table.js
+++ b/utils/helpers/affected-table.js
@@ -47,7 +47,7 @@ function generateMarkdownTable(cveImpactMap) {
   // Step 3: Filter versions per minor key
   const finalVersions = new Set();
 
-  for (const [minor, versions] of Object.entries(groupedByMinor)) {
+  for (const versions of Object.values(groupedByMinor)) {
     const versionList = Array.from(versions);
     const latestPatch = versionList.sort(semver.rcompare)[0]; // highest version in this minor line
     finalVersions.add(latestPatch);

--- a/utils/helpers/revision-history.js
+++ b/utils/helpers/revision-history.js
@@ -79,8 +79,4 @@ function getSeverityDescription(revisedFrom, revisedTo) {
   return "";
 }
 
-function formatArray(value) {
-  return value.replace(/\s+/g, ", ").replace(/^\[|\]$/g, "");
-}
-
 module.exports = { generateRevisionHistory };


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR changes the cloud type from `aws` to `all` in the case that packs have `cloudType: all`.
The logic of  why it was previously set to `aws` eludes me at this time. 

The old configuration resulted in the pack README for the `harbor` pack to fail fetch with the following error. The setting `cloudType=aws` was the cause of this error.

```
[ERROR] Failed to fetch the details for the following pack v1/packs/harbor/registries/64eaff453040297344bcad5d?cloudType=aws&layer=addon
```

This PR also fixed lint errors detected  in other files. 

![CleanShot 2025-05-19 at 19 29 31](https://github.com/user-attachments/assets/3fecb749-2826-4010-9cde-6b7e095e992e)


## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Harbor pack](https://deploy-preview-6884--docs-spectrocloud.netlify.app/integrations/packs/?pack=harbor&version=1.16.2&parent=1.16.x&tab=main)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1888](https://spectrocloud.atlassian.net/browse/DOC-1888)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Everywhere.

[DOC-1888]: https://spectrocloud.atlassian.net/browse/DOC-1888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ