### PR TITLE
docs: Add Pack Add-on Types to Pack Constraints Page

### DIFF
--- a/docs/docs-content/registries-and-packs/pack-constraints.md
+++ b/docs/docs-content/registries-and-packs/pack-constraints.md
@@ -344,7 +344,7 @@ table lists the different layer types.
 | `k8s`   | The dependent pack can only be found in the Kubernetes layer of the Cluster Profile. The `k8s` layer contains packs such as <VersionedLink text="Palette eXtended Kubernetes (PXK)" url="/integrations/packs/?pack=kubernetes" />, RKE2, k3s or MicroK8s. |
 | `cni`   | The dependent pack can only be found in the network layer of the Cluster Profile. The `cni` layer contains packs such as Calico, Cilium, Flannel and Antrea.                                                     |
 | `csi`   | The dependent pack can only be found in the storage layer of the Cluster Profile. The `csi` layer contains packs such as vSphere CSI, Amazon EBS CSI, Amazon EFS, Azure Disk and Portworx.                       |
-| `addon` | The dependent pack can only be found in the add-on layers of the Cluster Profile. The `addon` layer contains packs such as ArgoCD, Vault, Nginx, and many more.                                                  |
+| `addon` | The dependent pack can only be found in the add-on layers of the Cluster Profile. The types of packs include `logging`, `monitoring`, `load balancer`, `authentication`, `ingress`, `security`, `app services`, `network`, `storage`, `registry`, `servicemesh`, and `system app`. The `addon` layer contains packs such as ArgoCD, Vault, Nginx, and many more.                                                  |
 
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR copies the add-on pack types found on the Add a Custom Pack [page](https://docs.spectrocloud.com/registries-and-packs/add-custom-packs/#:~:text=logging,%20monitoring) to the Pack Constraints page.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Pack Constraints]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1906](https://spectrocloud.atlassian.net/browse/DOC-1906)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
