### PR TITLE
[version-4-1] PEM-7063 Imported cluster limitations (#6376)

### DIFF
--- a/docs/docs-content/clusters/imported-clusters/cluster-import.md
+++ b/docs/docs-content/clusters/imported-clusters/cluster-import.md
@@ -40,8 +40,10 @@ Select the mode you want to use when importing a cluster into Palette.
 4. Fill out the required information and make your selections:
 
    - Cluster Name - The name of the cluster you want to import.
-   - Cloud Type - Select the infrastructure environment your cluster resides in. Select **Generic** if the environment
-     list doesn't contain your specific environment, but be aware of the limitations with generic clusters.
+   - Cloud Type - Select the infrastructure environment your cluster resides in.
+     - Choose **Amazon** for Amazon EKS, **Google Cloud** for GKE, and **Azure** for AKS.
+     - Select **Generic** if the environment list doesn't contain your specific environment, but be aware of the
+       [limitations for generic clusters](./imported-clusters.md#generic-clusters).
    - Proxy - Optional and only available for generic clusters. Specify a network proxy address or DNS value.
    - No Proxy - Optional and only available for generic clusters. Specify a no proxy address or DNS value.
 

--- a/docs/docs-content/clusters/imported-clusters/imported-clusters.md
+++ b/docs/docs-content/clusters/imported-clusters/imported-clusters.md
@@ -13,8 +13,8 @@ management, and additional capabilities such as application lifecycle management
 from various infrastructure providers, such as public and private clouds and bare-metal environments.
 
 Palette supports importing _generic_ or _cloud-specific_ clusters. Cloud-specific clusters enable more functionality
-because Palette understands how to interact with the infrastructure provider's API. Cloud-specific clusters provide the
-same experience as Palette deployed clusters.
+because Palette understands how to interact with the infrastructure provider's API. Refer to [Limitations](#limitations)
+for details on what functionality may be missing from generic or cloud-specific clusters when imported.
 
 The generic type is for a cluster that is deployed in an environment where Palette lacks integration with the underlying
 infrastructure provider's API. Palette can support basic operations for generic clusters, such as reporting metrics,
@@ -64,6 +64,8 @@ target import cluster and the Palette instance.
 
 ## Limitations
 
+### All Imported Clusters
+
 A few restrictions apply to all cluster imports that you need to be aware of before importing a cluster.
 
 <br />
@@ -83,6 +85,50 @@ operations that require Palette to have knowledge of the underlying infrastructu
 :::
 
 <br />
+
+### Generic Clusters
+
+- Palette displays limited metadata for imported generic clusters when compared with cloud-specific clusters. The
+  metadata displayed for generic clusters are `region` and `instance type`.
+
+### Cloud-Specific Clusters
+
+Imported Cloud-specific clusters provide a similar experience as Palette deployed clusters but with the following
+limitations:
+
+- Palette cannot manage [node groups/pools](../cluster-management/node-pool.md) for imported cloud-specific clusters
+  because it does not provision the nodes directly.
+
+- When interacting with imported EKS, GKE, or AKS clusters through the Palette API, use the IaaS endpoint. Refer to the
+  following tabs for examples.
+
+  <Tabs>
+
+  <TabItem value="Amazon EKS Example">
+
+  To update the imported Amazon EKS cluster configuration information, use
+  [`/v1/cloudconfigs/aws/<configUid>/clusterConfig`](/api/v1/v-1-cloud-configs-aws-uid-cluster-config/) instead of
+  `/v1/cloudconfigs/eks/<configUid>/clusterConfig`.
+
+  </TabItem>
+
+  <TabItem value="GKE Example">
+
+  To update the imported GKE cluster configuration information, use
+  [`/v1/cloudconfigs/gcp/<configUid>/clusterConfig`](/api/v1/v-1-cloud-configs-gcp-uid-cluster-config/) instead of
+  `/v1/cloudconfigs/gke/<configUid>/clusterConfig`.
+
+  </TabItem>
+
+  <TabItem value="AKS Example">
+
+  To update the imported AKS cluster configuration information, use
+  [`/v1/cloudconfigs/azure/<configUid>/clusterConfig`](/api/v1/v-1-cloud-configs-azure-uid-cluster-config/) instead of
+  `/v1/cloudconfigs/aks/<configUid>/clusterConfig`.
+
+  </TabItem>
+
+  </Tabs>
 
 ## Delete Imported Cluster
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-1`:
 - [PEM-7063 Imported cluster limitations (#6376)](https://github.com/spectrocloud/librarium/pull/6376)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)