### PR TITLE
Update add-gcp-accounts.md

### DIFF
--- a/docs/docs-content/clusters/public-cloud/gcp/add-gcp-accounts.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/add-gcp-accounts.md
@@ -60,7 +60,7 @@ You can validate the account is available in Palette by reviewing the list of cl
 
 ## Next Steps
 
-Now that you have added an AWS account to Palette, you deploy clusters to your GCP account. To learn how to get started
+Now that you have added an GCP account to Palette, you deploy clusters to your GCP account. To learn how to get started
 with deploying Kubernetes clusters to GCP, check out the
 [Create and Manage GCP IaaS Cluster](create-gcp-iaas-cluster.md) guide or the
 [Create and Manage AWS GKE Cluster](create-gcp-gke-cluster.md) guide.

--- a/docs/docs-content/clusters/public-cloud/gcp/add-gcp-accounts.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/add-gcp-accounts.md
@@ -60,7 +60,7 @@ You can validate the account is available in Palette by reviewing the list of cl
 
 ## Next Steps
 
-Now that you have added an GCP account to Palette, you deploy clusters to your GCP account. To learn how to get started
+Now that you have added a GCP account to Palette, you can deploy clusters to your GCP account. To learn how to get started
 with deploying Kubernetes clusters to GCP, check out the
 [Create and Manage GCP IaaS Cluster](create-gcp-iaas-cluster.md) guide or the
 [Create and Manage AWS GKE Cluster](create-gcp-gke-cluster.md) guide.

--- a/docs/docs-content/clusters/public-cloud/gcp/add-gcp-accounts.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/add-gcp-accounts.md
@@ -60,7 +60,7 @@ You can validate the account is available in Palette by reviewing the list of cl
 
 ## Next Steps
 
-Now that you have added a GCP account to Palette, you can deploy clusters to your GCP account. To learn how to get started
-with deploying Kubernetes clusters to GCP, check out the
+Now that you have added a GCP account to Palette, you can deploy clusters to your GCP account. To learn how to get
+started with deploying Kubernetes clusters to GCP, check out the
 [Create and Manage GCP IaaS Cluster](create-gcp-iaas-cluster.md) guide or the
 [Create and Manage AWS GKE Cluster](create-gcp-gke-cluster.md) guide.


### PR DESCRIPTION
Should read GCP and not AWS in the GCP section

## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes an incorrect reference to AWS on the GCP account page.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Register and Manage GCP Accounts](https://deploy-preview-6924--docs-spectrocloud.netlify.app/clusters/public-cloud/gcp/add-gcp-accounts/#next-steps)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
