### PR TITLE
PCP-4572 Warning for use of dynamic IP allocation for private Azure IaaS cluster LBs

### DIFF
--- a/docs/docs-content/clusters/public-cloud/azure/create-azure-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/azure/create-azure-cluster.md
@@ -180,12 +180,21 @@ Use the following steps to deploy an Azure cluster.
 
     #### Private API Server LB Settings
 
-    | **Parameter**                   | **Description**                                                                                                                                                                                                                                                                                    |
-    | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-    | **Resource Group (Optional)**   | The Azure resource group that contains the **Private DNS zone** you want to use for the private API server load balancer. It can be different from the cluster’s own resource group. Leave blank to default to the selected cluster **Resource Group**.                                            |
-    | **Private DNS zone (Optional)** | The existing private DNS zone that will hold the A record of the private endpoint. After you choose a resource group, the dropdown lists the zones in that resource group. Select an existing zone, or leave it blank. If left blank, Palette will create a new zone in the chosen resource group. |
-    | **IP Allocation Method**        | How the load balancer virtual IP is assigned. <br /> - **Dynamic** (default) lets Azure pick the next free address in the subnet. <br /> - **Static** lets you choose a specific IP address for the load balancer that you supply in the **Static IP** field.                                      |
-    | **Static IP**                   | The private IP address to use only when **IP Allocation Method** is set to **Static**. The address must be unused and inside the subnet delegated for the private API server load balancer.                                                                                                        |
+    :::warning
+
+    Dynamic IP allocation is no longer supported for private API server load balancers. Select **Static** for **IP
+    Allocation Method** and enter an IP address in **Static IP**.
+
+    If you omit a static IP, cluster provisioning will fail.
+
+    :::
+
+    | **Parameter**                   | **Description**                                                                                                                                                                                                                                                                                                                  |
+    | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | **Resource Group (Optional)**   | The Azure resource group that contains the **Private DNS zone** you want to use for the private API server load balancer. It can be different from the cluster’s own resource group. Leave blank to default to the selected cluster **Resource Group**.                                                                          |
+    | **Private DNS zone (Optional)** | The existing private DNS zone that will hold the A record of the private endpoint. After you choose a resource group, the dropdown lists the zones in that resource group. Select an existing zone, or leave it blank. If left blank, Palette will create a new zone in the chosen resource group.                               |
+    | **IP Allocation Method**        | How the load balancer virtual IP is assigned. <br /> - **Dynamic** (default) lets Azure pick the next free address in the subnet. _This option is no longer supported, you must assign a static IP._ <br /> - **Static** lets you choose a specific IP address for the load balancer that you supply in the **Static IP** field. |
+    | **Static IP**                   | The private IP address to use only when **IP Allocation Method** is set to **Static**. The address must be unused and inside the subnet delegated for the private API server load balancer.                                                                                                                                      |
 
 13. Click **Next** to continue.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a warning and guidance to select static IP allocation when configuring a private API Server LB for a private Azure IaaS cluster.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Create and Manage Azure IaaS Cluster](https://deploy-preview-6940--docs-spectrocloud.netlify.app/clusters/public-cloud/azure/create-azure-cluster/#private-api-server-lb-settings)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PCP-4572](https://spectrocloud.atlassian.net/browse/PCP-4572)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[PCP-4572]: https://spectrocloud.atlassian.net/browse/PCP-4572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ