### PR TITLE
docs: add additional packs

### DIFF
--- a/_partials/self-hosted/_airgap-cluster-profile-packs.mdx
+++ b/_partials/self-hosted/_airgap-cluster-profile-packs.mdx
@@ -71,6 +71,8 @@ partial_name: airgap-cluster-profile-packs
 | `airgap-pack-aws-cluster-autoscaler-1.31.0.bin`                | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-aws-cluster-autoscaler-1.31.0.bin                |
 | `airgap-pack-aws-efs-2.1.6.bin`                                | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-aws-efs-2.1.6.bin                                |
 | `airgap-pack-aws-efs-2.1.4.bin`                                | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-aws-efs-2.1.4.bin                                |
+| `airgap-pack-cni-calico-3.29.3.bin`                            | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-calico-3.29.3.bin                            |
+| `airgap-pack-cni-calico-azure-3.29.3.bin`                      | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-cni-calico-azure-3.29.3.bin                      |
 | `airgap-pack-csi-azure-1.31.2.bin`                             | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-azure-1.31.2.bin                             |
 | `airgap-pack-csi-aws-ebs-1.41.0.bin`                           | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-aws-ebs-1.41.0.bin                           |
 | `airgap-pack-istio-1.24.0.bin`                                 | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-istio-1.24.0.bin                                 |
@@ -79,6 +81,7 @@ partial_name: airgap-cluster-profile-packs
 | `airgap-pack-open-policy-agent-3.18.1.bin`                     | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-open-policy-agent-3.18.1.bin                     |
 | `airgap-pack-portworx-add-on-3.2.2.bin`                        | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-portworx-add-on-3.2.2.bin                        |
 | `airgap-pack-prometheus-operator-68.4.4.bin`                   | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-prometheus-operator-68.4.4.bin                   |
+| `airgap-pack-prometheus-operator-70.2.1.bin`                   | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-prometheus-operator-70.2.1.bin                   |
 | `airgap-pack-registry-connect-0.1.0.bin`                       | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-registry-connect-0.1.0.bin                       |
 | `airgap-pack-spectro-k8s-dashboard-7.11.1.bin`                 | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-spectro-k8s-dashboard-7.11.1.bin                 |
 | `airgap-pack-tetragon-1.3.0.bin`                               | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-tetragon-1.3.0.bin                               |

--- a/_partials/vertex/_airgap-cluster-profile-packs.mdx
+++ b/_partials/vertex/_airgap-cluster-profile-packs.mdx
@@ -6,7 +6,11 @@ partial_name: airgap-cluster-profile-packs
 | **File Name**                                                         | **Download URL**                                                                                                                  |
 | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `airgap-vertex-pack-cni-calico-3.29.2.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-3.29.2.bin                            |
+| `airgap-vertex-pack-cni-calico-3.29.3.bin`                            | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-3.29.3.bin                            |
+| `airgap-vertex-pack-cni-calico-azure-fips-3.29.3.bin`                 | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-azure-fips-3.29.3.bin                 |
 | `airgap-vertex-pack-cni-cilium-fips-1.16.6.bin`                       | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-cilium-fips-1.16.6.bin                       |
+| `airgap-vertex-pack-cni-cilium-fips-1.17.1.bin`                       | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-cilium-fips-1.17.1.bin                       |
+| `airgap-vertex-pack-cni-flannel-fips-0.26.4.bin`                      | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-flannel-fips-0.26.4.bin                      |
 | `airgap-vertex-pack-csi-aws-ebs-1.41.0.bin`                           | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-csi-aws-ebs-1.41.0.bin                           |
 | `airgap-vertex-pack-csi-local-path-provisioner-addon-fips-0.0.31.bin` | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-csi-local-path-provisioner-addon-fips-0.0.31.bin |
 | `airgap-vertex-pack-csi-local-path-provisioner-fips-0.0.31.bin`       | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-csi-local-path-provisioner-fips-0.0.31.bin       |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -270,6 +270,8 @@ Check out the [CLI Tools](../downloads/cli-tools.md) page to find the compatible
 
 | Pack Name                                | New Version |
 | ---------------------------------------- | ----------- |
+| Kubernetes GKE                           | 1.31        |
+| Kubernetes AKS                           | 1.32        |
 | Palette eXtended Kubernetes              | 1.32.3      |
 | Palette eXtended Kubernetes              | 1.31.7      |
 | Palette eXtended Kubernetes              | 1.30.11     |
@@ -289,28 +291,41 @@ Check out the [CLI Tools](../downloads/cli-tools.md) page to find the compatible
 
 #### CNI
 
-| Pack Name | New Version |
-| --------- | ----------- |
-| Flannel   | 0.26.4      |
+| Pack Name      | New Version |
+| -------------- | ----------- |
+| Calico (Azure) | 3.29.3      |
+| Flannel        | 0.26.4      |
 
 #### CSI
 
 | Pack Name              | New Version |
 | ---------------------- | ----------- |
 | Local Path Provisioner | 0.0.31      |
+| Piraeus                | 2.8.0       |
+| Portworx /w Operator   | 3.2.3       |
 
 #### Add-on Packs
 
 | Pack Name                    | New Version |
 | ---------------------------- | ----------- |
+| AWS Application Loadbalancer | 2.12.0      |
+| Cilium Tetragon              | 1.4.0       |
+| External Secrets Operator    | 0.15.0      |
+| Flux2                        | 2.15.0      |
 | Local Path Provisioner       | 0.0.31      |
+| Nvidia GPU Operator          | 25.3.0      |
+| Prometheus - Grafana         | 70.2.1      |
 | Spectro Kubernetes Dashboard | 7.11.1      |
-| Zot Registry                 | 0.1.66      |
+| Zot Registry                 | 0.1.67      |
 
 #### FIPS Packs
 
 | Pack Name                                | New Version |
 | ---------------------------------------- | ----------- |
+| Calico                                   | 3.29.3      |
+| Calico (Azure)                           | 3.29.3      |
+| Cilium                                   | 1.17.1      |
+| Flannel                                  | 0.26.4      |
 | Local Path Provisioner                   | 0.0.31      |
 | Palette eXtended Kubernetes              | 1.32.3      |
 | Palette eXtended Kubernetes              | 1.31.7      |
@@ -321,10 +336,11 @@ Check out the [CLI Tools](../downloads/cli-tools.md) page to find the compatible
 | Palette Optimized RKE2                   | 1.32.3      |
 | Palette Optimized RKE2                   | 1.31.7      |
 | Palette Optimized RKE2                   | 1.30.11     |
+| Registry Connect                         | 0.1.0       |
 | RKE2                                     | 1.32.3      |
 | RKE2                                     | 1.31.7      |
 | RKE2                                     | 1.30.11     |
-| Zot Registry                             | 0.1.66      |
+| Zot Registry                             | 0.1.67      |
 
 #### Deprecations and Removals
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -285,9 +285,9 @@ Check out the [CLI Tools](../downloads/cli-tools.md) page to find the compatible
 | Palette eXtended Kubernetes Edge (PXK-E) | 1.31.7      |
 | Palette eXtended Kubernetes Edge (PXK-E) | 1.30.11     |
 | Palette Optimized Canonical              | 1.32.3      |
-| Palette Optimized K3S                    | 1.32.3      |
-| Palette Optimized K3S                    | 1.31.7      |
-| Palette Optimized K3S                    | 1.30.11     |
+| Palette Optimized K3s                    | 1.32.3      |
+| Palette Optimized K3s                    | 1.31.7      |
+| Palette Optimized K3s                    | 1.30.11     |
 | Palette Optimized RKE2                   | 1.32.3      |
 | Palette Optimized RKE2                   | 1.31.7      |
 | Palette Optimized RKE2                   | 1.30.11     |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -152,6 +152,12 @@ impacted clusters until you've handled the below mentioned breaking changes and 
 
 ### Edge
 
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.6.c Palette release is 4.6.21.
+
+:::
+
 #### Features
 
 - <TpBadge /> The new [Appliance Studio](../deployment-modes/appliance-mode/appliance-studio.md) is a lightweight


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the 4.6.c packs in the release notes. It also updates the airgap packs and adds the CanvOS version to the release notes.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-6962--docs-spectrocloud.netlify.app/release-notes/)
💻 [Self-hosted additional packs](https://deploy-preview-6962--docs-spectrocloud.netlify.app/downloads/self-hosted-palette/additional-packs/)
💻 [VerteX additional packs](https://deploy-preview-6962--docs-spectrocloud.netlify.app/downloads/palette-vertex/additional-packs/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1921](https://spectrocloud.atlassian.net/browse/DOC-1921)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1921]: https://spectrocloud.atlassian.net/browse/DOC-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ