### PR TITLE
docs: Clarify high availability and node roles in Canonical Kubernetes

### DIFF
--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -55,9 +55,9 @@ The following are architectural highlights of Palette-provisioned Edge native cl
 The Palette Optimized Canonical Kubernetes distribution uses distributed SQLite (Dqlite) as its datastore. Each node
 assumes one of the following roles at any given time:
 
-- Voter: replication and leader election voting are enabled.
-- Stand-by: only replication is enabled.
-- Spare: neither replication nor election is enabled.
+- Voter - replication and leader election voting are enabled.
+- Stand-by - only replication is enabled.
+- Spare - neither replication nor election is enabled.
 
 Run the `k8s status` command on a control plane node to view the current roles of all nodes in the cluster.
 

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -61,10 +61,6 @@ assumes one of the following roles at any given time:
 
 Run the `k8s status` command on a control plane node to view the current roles of all nodes in the cluster.
 
-```bash
-k8s status
-```
-
 ```bash hideClipboard title="Example output"
 cluster status:           ready
 control plane nodes:      10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 10.10.220.115:6400 (voter)

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -64,12 +64,14 @@ Run the `k8s status` command on a control plane node to view the current roles o
 ```bash
 k8s status
 ```
+
 ```bash hideClipboard title="Example output"
 cluster status:           ready
 control plane nodes:      10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 10.10.220.115:6400 (voter)
 high availability:        yes
 datastore:                k8s-dqlite
 ```
+
 :::
 
 ## Minimum Device Requirements
@@ -155,4 +157,4 @@ cluster:
     disable-network-policy: true
     Disable:
       - metrics-server
-````
+```

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -37,6 +37,7 @@ The following are architectural highlights of Palette-provisioned Edge native cl
 
 - The Palette Optimized Canonical distribution that supports Canonical Kubernetes is a Tech Preview feature and does not
   support the following:
+
   - ARM64 architecture
   - Versions other than 1.32.3
   - Cluster updates
@@ -45,11 +46,15 @@ The following are architectural highlights of Palette-provisioned Edge native cl
   - [Network overlay](../networking/vxlan-overlay/)
   - High availability mode with one or two nodes.
 
-- When scaling down a Palette Optimized Canonical Kubernetes cluster with two nodes, ensure you do not delete the leader node. In this configuration, one node is the leader (and voter), while the other is a spare. Deleting the leader will render the cluster inaccessible, as database updates are not replicated to the spare node.
+- When scaling down a Palette Optimized Canonical Kubernetes cluster with two nodes, ensure you do not delete the leader
+  node. In this configuration, one node is the leader (and voter), while the other is a spare. Deleting the leader will
+  render the cluster inaccessible, as database updates are not replicated to the spare node.
 
 :::info
 
-The Palette Optimized Canonical Kubernetes distibution uses Dqlite as its datastore. Each node assumes one of the following roles at any given time:
+The Palette Optimized Canonical Kubernetes distibution uses Dqlite as its datastore. Each node assumes one of the
+following roles at any given time:
+
 - Voter: replication and leader election voting are enabled.
 - Stand-by: only replication is enabled.
 - Spare: neither replication nor election is enabled.
@@ -63,6 +68,7 @@ control plane nodes:      10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 1
 high availability:        yes
 datastore:                k8s-dqlite
 ```
+
 :::
 
 ## Minimum Device Requirements

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -61,12 +61,11 @@ assumes one of the following roles at any given time:
 
 Run the `k8s status` command on a control plane node to view the current roles of all nodes in the cluster.
 
-```bash hideClipboard title="Example output of `k8s status`"
-cluster status:           ready
-control plane nodes:      10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 10.10.220.115:6400 (voter)
-high availability:        yes
-datastore:                k8s-dqlite
-```
+```bash hideClipboard title="Example output of `k8s status`" cluster status: ready control plane nodes:
+10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 10.10.220.115:6400 (voter) high availability: yes datastore:
+k8s-dqlite
+
+````
 
 :::
 
@@ -153,4 +152,4 @@ cluster:
     disable-network-policy: true
     Disable:
       - metrics-server
-```
+````

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -61,12 +61,15 @@ assumes one of the following roles at any given time:
 
 Run the `k8s status` command on a control plane node to view the current roles of all nodes in the cluster.
 
-```bash hideClipboard title="Example output of `k8s status`" cluster status: ready control plane nodes:
-10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 10.10.220.115:6400 (voter) high availability: yes datastore:
-k8s-dqlite
-
-````
-
+```bash
+k8s status
+```
+```bash hideClipboard title="Example output"
+cluster status:           ready
+control plane nodes:      10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 10.10.220.115:6400 (voter)
+high availability:        yes
+datastore:                k8s-dqlite
+```
 :::
 
 ## Minimum Device Requirements

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -52,7 +52,7 @@ The following are architectural highlights of Palette-provisioned Edge native cl
 
 :::info
 
-The Palette Optimized Canonical Kubernetes distribution uses Dqlite (distributed SQLite) as its datastore. Each node
+The Palette Optimized Canonical Kubernetes distribution uses distributed SQLite (Dqlite) as its datastore. Each node
 assumes one of the following roles at any given time:
 
 - Voter: replication and leader election voting are enabled.

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -61,8 +61,7 @@ assumes one of the following roles at any given time:
 
 Run the `k8s status` command on a control plane node to view the current roles of all nodes in the cluster.
 
-```bash
-root@edge-d86b3842940aaf4296dcdb0d5f374f89:~# k8s status
+```bash hideClipboard title="Example output of 'k8s status'"
 cluster status:           ready
 control plane nodes:      10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 10.10.220.115:6400 (voter)
 high availability:        yes

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -52,7 +52,7 @@ The following are architectural highlights of Palette-provisioned Edge native cl
 
 :::info
 
-The Palette Optimized Canonical Kubernetes distribution uses Dqlite as its datastore. Each node assumes one of the
+The Palette Optimized Canonical Kubernetes distribution uses Dqlite (distributed SQLite) as its datastore. Each node assumes one of the
 following roles at any given time:
 
 - Voter: replication and leader election voting are enabled.

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -43,6 +43,27 @@ The following are architectural highlights of Palette-provisioned Edge native cl
   - Palette VerteX
   - Custom installation paths for Kubernetes and its dependencies in [agent mode](../../../deployment-modes/agent-mode/)
   - [Network overlay](../networking/vxlan-overlay/)
+  - High availability mode with one or two nodes.
+
+- When scaling down a Palette Optimized Canonical Kubernetes cluster with two nodes, ensure you do not delete the leader node. In this configuration, one node is the leader (and voter), while the other is a spare. Deleting the leader will render the cluster inaccessible, as database updates are not replicated to the spare node.
+
+:::info
+
+The Palette Optimized Canonical Kubernetes distibution uses DQLite as its datastore. Each node assumes one of the following roles at any given time:
+- Voter: replication and leader election voting are enabled.
+- Stand-by: only replication is enabled.
+- Spare: neither replication nor election is enabled.
+
+Run the `k8s status` command on a control plane node to view the current roles of all nodes in the cluster.
+
+```bash
+root@edge-d86b3842940aaf4296dcdb0d5f374f89:~# k8s status
+cluster status:           ready
+control plane nodes:      10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 10.10.220.115:6400 (voter)
+high availability:        yes
+datastore:                k8s-dqlite
+```
+:::
 
 ## Minimum Device Requirements
 

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -49,7 +49,7 @@ The following are architectural highlights of Palette-provisioned Edge native cl
 
 :::info
 
-The Palette Optimized Canonical Kubernetes distibution uses DQLite as its datastore. Each node assumes one of the following roles at any given time:
+The Palette Optimized Canonical Kubernetes distibution uses Dqlite as its datastore. Each node assumes one of the following roles at any given time:
 - Voter: replication and leader election voting are enabled.
 - Stand-by: only replication is enabled.
 - Spare: neither replication nor election is enabled.

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -52,8 +52,8 @@ The following are architectural highlights of Palette-provisioned Edge native cl
 
 :::info
 
-The Palette Optimized Canonical Kubernetes distribution uses Dqlite (distributed SQLite) as its datastore. Each node assumes one of the
-following roles at any given time:
+The Palette Optimized Canonical Kubernetes distribution uses Dqlite (distributed SQLite) as its datastore. Each node
+assumes one of the following roles at any given time:
 
 - Voter: replication and leader election voting are enabled.
 - Stand-by: only replication is enabled.

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -61,7 +61,7 @@ assumes one of the following roles at any given time:
 
 Run the `k8s status` command on a control plane node to view the current roles of all nodes in the cluster.
 
-```bash hideClipboard title="Example output of 'k8s status'"
+```bash hideClipboard title="Example output of `k8s status`"
 cluster status:           ready
 control plane nodes:      10.10.216.81:6400 (voter), 10.10.217.4:6400 (voter), 10.10.220.115:6400 (voter)
 high availability:        yes

--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -52,7 +52,7 @@ The following are architectural highlights of Palette-provisioned Edge native cl
 
 :::info
 
-The Palette Optimized Canonical Kubernetes distibution uses Dqlite as its datastore. Each node assumes one of the
+The Palette Optimized Canonical Kubernetes distribution uses Dqlite as its datastore. Each node assumes one of the
 following roles at any given time:
 
 - Voter: replication and leader election voting are enabled.

--- a/docs/docs-content/clusters/edge/architecture/two-node.md
+++ b/docs/docs-content/clusters/edge/architecture/two-node.md
@@ -47,9 +47,7 @@ change the number of nodes.
   [Deployment Modes](../../../deployment-modes/deployment-modes.md).
 - Two-node clusters can only have exactly two nodes in the control plane pool. You cannot adjust the number of the nodes
   in the control plane pool after cluster creation.
-- Two-node clusters only support K3s and Palette Optimized Canonical Kubernetes distributions. Other Kubernetes
-  distributions are not supported. However, Palette Optimized Canonical Kubernetes clusters require at least three nodes
-  to operate in high availability mode.
+- Two-node clusters only support K3s. Other Kubernetes distributions are not supported.
 
 ## Use Cases
 

--- a/docs/docs-content/clusters/edge/architecture/two-node.md
+++ b/docs/docs-content/clusters/edge/architecture/two-node.md
@@ -47,7 +47,9 @@ change the number of nodes.
   [Deployment Modes](../../../deployment-modes/deployment-modes.md).
 - Two-node clusters can only have exactly two nodes in the control plane pool. You cannot adjust the number of the nodes
   in the control plane pool after cluster creation.
-- Two-node clusters only support K3s and Palette Optimized Canonical Kubernetes distributions. Other Kubernetes distributions are not supported. However, Palette Optimized Canonical Kubernetes clusters require at least three nodes to operate in high availability mode.
+- Two-node clusters only support K3s and Palette Optimized Canonical Kubernetes distributions. Other Kubernetes
+  distributions are not supported. However, Palette Optimized Canonical Kubernetes clusters require at least three nodes
+  to operate in high availability mode.
 
 ## Use Cases
 

--- a/docs/docs-content/clusters/edge/architecture/two-node.md
+++ b/docs/docs-content/clusters/edge/architecture/two-node.md
@@ -47,7 +47,7 @@ change the number of nodes.
   [Deployment Modes](../../../deployment-modes/deployment-modes.md).
 - Two-node clusters can only have exactly two nodes in the control plane pool. You cannot adjust the number of the nodes
   in the control plane pool after cluster creation.
-- Two-node clusters only support K3s. Other Kubernetes distributions are not supported.
+- Two-node clusters only support K3s and Palette Optimized Canonical Kubernetes distributions. Other Kubernetes distributions are not supported. However, Palette Optimized Canonical Kubernetes clusters require at least three nodes to operate in high availability mode.
 
 ## Use Cases
 

--- a/docs/docs-content/clusters/edge/site-deployment/cluster-deployment.md
+++ b/docs/docs-content/clusters/edge/site-deployment/cluster-deployment.md
@@ -39,7 +39,8 @@ Use the following steps to create a new host cluster so that you can add Edge ho
   is because whenever a node is drained during an upgrade or for any other reason, the volumes will not dynamically move
   with the local path provisioner.
 
-- Two-node clusters only support K3s and Palette Optimized Canonical Kubernetes distributions. However, Palette Optimized Canonical Kubernetes clusters require at least three nodes to operate in high availability mode.
+- Two-node clusters operating in high availability mode only support K3s and no other Kubernetes distributions.
+- Palette Optimized Canonical Kubernetes clusters require at least three nodes to operate in high availability mode.
 
 ### Prerequisites
 

--- a/docs/docs-content/clusters/edge/site-deployment/cluster-deployment.md
+++ b/docs/docs-content/clusters/edge/site-deployment/cluster-deployment.md
@@ -39,7 +39,7 @@ Use the following steps to create a new host cluster so that you can add Edge ho
   is because whenever a node is drained during an upgrade or for any other reason, the volumes will not dynamically move
   with the local path provisioner.
 
-- Two-node clusters only support K3s and no other Kubernetes distributions.
+- Two-node clusters only support K3s and Palette Optimized Canonical Kubernetes distributions. However, Palette Optimized Canonical Kubernetes clusters require at least three nodes to operate in high availability mode.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds the following information on the new Canonical K8s pack:
1) High availability limitation.
2) Description of node roles.
3) Scaling down a cluster with two nodes limitation.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Clusters > Edge > Architecture](https://deploy-preview-6963--docs-spectrocloud.netlify.app/clusters/edge/architecture/#limitations)
💻 [Clusters > Edge > Deployment > Create Cluster Definition](https://deploy-preview-6963--docs-spectrocloud.netlify.app/clusters/edge/site-deployment/cluster-deployment#limitations)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PE-6846](https://spectrocloud.atlassian.net/browse/PE-6846)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes.
- [x] No. A release PR.


[PE-6846]: https://spectrocloud.atlassian.net/browse/PE-6846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ