### PR TITLE
docs: allow custom logos in Docs DOC-1886 DOC-1893

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,8 +230,7 @@ docker-image: ## Build the docker image
 	docker build -t $(IMAGE) .
 
 docker-start: docker-image ## Build the docker image and start a local development container
-	docker run --env-file=.env --rm -it -v $(CURDIR)/docs:/librarium/docs/ -v $(CURDIR)/_partials/:/librarium/_partials/ -p 9000:9000 $(IMAGE)
-
+	IMAGE=$(IMAGE) ./scripts/start-docker.sh
 
 ##@ Writing Checks
 
@@ -249,7 +248,7 @@ check-writing: ## Run Vale on changed Markdown/MDX files
 
 ##@ Formatting Checks
 
-format: ## Apply Prettier formating to all files.
+format: ## Apply Prettier formatting to all files.
 	npm run format
 
 format-check: ## Check if all files are formatted with Prettier.

--- a/docs/docs-content/downloads/offline-docs.md
+++ b/docs/docs-content/downloads/offline-docs.md
@@ -126,10 +126,10 @@ We recommend that you provide two logos, one for dark mode and one for light mod
 
    ```shell
    docker run \
-    -e LIGHT_LOGO_PATH=$LIGHT_LOGO_PATH \
-    -e DARK_LOGO_PATH=$DARK_LOGO_PATH \
-    -v "$(realpath "$LIGHT_LOGO_PATH")":/librarium/static/img/custom-light-logo.png \
-    -v "$(realpath "$DARK_LOGO_PATH")":/librarium/static/img/custom-dark-logo.png \
+    --env LIGHT_LOGO_PATH=$LIGHT_LOGO_PATH \
+    --env DARK_LOGO_PATH=$DARK_LOGO_PATH \
+    --volume "$(realpath "$LIGHT_LOGO_PATH")":/librarium/static/img/custom-light-logo.png \
+    --volume "$(realpath "$DARK_LOGO_PATH")":/librarium/static/img/custom-dark-logo.png \
     --publish 8080:80 \
     --publish 2019:2019  \
     --rm ghcr.io/spectrocloud/librarium:nightly

--- a/docs/docs-content/downloads/offline-docs.md
+++ b/docs/docs-content/downloads/offline-docs.md
@@ -117,10 +117,10 @@ We recommend that you provide two logos, one for dark mode and one for light mod
 2. Replace the placeholders in the following command with the path to your logo files. Then, execute the command in your
    terminal to save the location of the files to two environment variables.
 
-```shell
-export LIGHT_LOGO_PATH=path/to/light/custom/logo/file \
-export DARK_LOGO_PATH=path/to/dark/custom/logo/file
-```
+   ```shell
+   export LIGHT_LOGO_PATH=path/to/light/custom/logo/file \
+   export DARK_LOGO_PATH=path/to/dark/custom/logo/file
+   ```
 
 3. Use the following command to start the documentation in a Docker container.
 
@@ -134,17 +134,6 @@ export DARK_LOGO_PATH=path/to/dark/custom/logo/file
     --publish 2019:2019  \
     --rm ghcr.io/spectrocloud/librarium:nightly
    ```
-
-   :::info
-
-   If another process is using port `8080`, you can change the port mapping to use a different port. For example, to use
-   port `8081`, use the following command:
-
-   ```shell
-   docker run --publish 8081:80 --publish 2019:2019 --rm ghcr.io/spectrocloud/librarium:nightly
-   ```
-
-   :::
 
 4. Open a browser and navigate to `http://localhost:8080` to view the documentation. The navigation bar displays your
    custom configured logo.

--- a/docs/docs-content/downloads/offline-docs.md
+++ b/docs/docs-content/downloads/offline-docs.md
@@ -102,7 +102,7 @@ The following software must be installed on your system:
 docker run --publish 8080:80 --publish 2019:2019 --rm ghcr.io/spectrocloud/librarium:nightly
 ```
 
-## Deploy the Documentation with Custom Logos
+## Deploy the Offline Documentation with Custom Logos
 
 You can provide your own custom logos to the Spectro Cloud documentation.
 
@@ -112,17 +112,17 @@ We recommend that you provide two logos, one for dark mode and one for light mod
 
 :::
 
-1. Download the logos you want to configure to your local machine. Replace the placeholders in the following command
-   with the path to your logo files. Then, execute the command in your terminal to save the location of the files to two
-   environment variables.
+1. Download the logos you want to configure to your local machine.
+
+2. Replace the placeholders in the following command with the path to your logo files. Then, execute the command in your
+   terminal to save the location of the files to two environment variables.
 
 ```shell
-export LIGHT_LOGO_PATH= path/to/your/light/logo/file
-export DARK_LOGO_PATH= path/to/your/dark/logo/file
-
+export LIGHT_LOGO_PATH=path/to/light/custom/logo/file \
+export DARK_LOGO_PATH=path/to/dark/custom/logo/file
 ```
 
-2. Use the following command to start the documentation in a Docker container.
+3. Use the following command to start the documentation in a Docker container.
 
    ```shell
    docker run \
@@ -146,8 +146,8 @@ export DARK_LOGO_PATH= path/to/your/dark/logo/file
 
    :::
 
-3. Open a browser and navigate to `http://localhost:8080` to view the documentation. The navigation bar displays your
-   configured logo.
+4. Open a browser and navigate to `http://localhost:8080` to view the documentation. The navigation bar displays your
+   custom configured logo.
 
 ## Validation
 

--- a/docs/docs-content/downloads/offline-docs.md
+++ b/docs/docs-content/downloads/offline-docs.md
@@ -22,7 +22,7 @@ the Palette CLI `docs` command [page](../automation/palette-cli/commands/docs.md
 
 :::
 
-### Limitations
+## Limitations
 
 The following limitations apply when using the offline documentation:
 
@@ -32,7 +32,7 @@ The following limitations apply when using the offline documentation:
 
 - The documentation AI helper is not available.
 
-### Prerequisites
+## Prerequisites
 
 The following software must be installed on your system:
 

--- a/docs/docs-content/downloads/offline-docs.md
+++ b/docs/docs-content/downloads/offline-docs.md
@@ -102,6 +102,53 @@ The following software must be installed on your system:
 docker run --publish 8080:80 --publish 2019:2019 --rm ghcr.io/spectrocloud/librarium:nightly
 ```
 
+## Deploy the Documentation with Custom Logos
+
+You can provide your own custom logos to the Spectro Cloud documentation.
+
+:::info
+
+We recommend that you provide two logos, one for dark mode and one for light mode. The files must be in PNG format.
+
+:::
+
+1. Download the logos you want to configure to your local machine. Replace the placeholders in the following command
+   with the path to your logo files. Then, execute the command in your terminal to save the location of the files to two
+   environment variables.
+
+```shell
+export LIGHT_LOGO_PATH= path/to/your/light/logo/file
+export DARK_LOGO_PATH= path/to/your/dark/logo/file
+
+```
+
+2. Use the following command to start the documentation in a Docker container.
+
+   ```shell
+   docker run \
+    -e LIGHT_LOGO_PATH=$LIGHT_LOGO_PATH \
+    -e DARK_LOGO_PATH=$DARK_LOGO_PATH \
+    -v "$(realpath "$LIGHT_LOGO_PATH")":/librarium/static/img/custom-light-logo.png \
+    -v "$(realpath "$DARK_LOGO_PATH")":/librarium/static/img/custom-dark-logo.png \
+    --publish 8080:80 \
+    --publish 2019:2019  \
+    --rm ghcr.io/spectrocloud/librarium:nightly
+   ```
+
+   :::info
+
+   If another process is using port `8080`, you can change the port mapping to use a different port. For example, to use
+   port `8081`, use the following command:
+
+   ```shell
+   docker run --publish 8081:80 --publish 2019:2019 --rm ghcr.io/spectrocloud/librarium:nightly
+   ```
+
+   :::
+
+3. Open a browser and navigate to `http://localhost:8080` to view the documentation. The navigation bar displays your
+   configured logo.
+
 ## Validation
 
 To validate that the offline documentation is working, open a browser and navigate to `http://localhost:8080`. The

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,6 +10,22 @@ const { pluginPacksAndIntegrationsData } = require("./plugins/packs-integrations
 const { pluginImportFontAwesomeIcons } = require("./plugins/font-awesome");
 import path from "path";
 
+function getLightLogoPath() {
+  if(process.env.LIGHT_LOGO_PATH && process.env.LIGHT_LOGO_PATH.trim() !== "") {
+    return "img/custom-light-logo.png";
+  }
+  // Otherwise, use the default light logo.
+  return 'img/spectrocloud-logo-light.svg?new=true';
+}
+
+function getDarkLogoPath() {
+  if(process.env.DARK_LOGO_PATH && process.env.DARK_LOGO_PATH.trim() !== "") {
+    return "img/custom-dark-logo.png";
+  }
+  // Otherwise, use the default light logo.
+  return 'img/spectrocloud-logo-dark.svg?new=true';
+}
+
 // We will only show the update time if the environment variable is set to true.
 function showLastUpdateTime() {
   const envValue = process.env.SHOW_LAST_UPDATE_TIME || "";
@@ -354,8 +370,8 @@ const config = {
           width: 105,
           height: 48,
           alt: "Spectro cloud logo",
-          src: "img/spectrocloud-logo-light.svg?new=true",
-          srcDark: "img/spectrocloud-logo-dark.svg?new=true",
+          src: getLightLogoPath(),
+          srcDark: getDarkLogoPath(),
         },
         items: [
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,20 +10,22 @@ const { pluginPacksAndIntegrationsData } = require("./plugins/packs-integrations
 const { pluginImportFontAwesomeIcons } = require("./plugins/font-awesome");
 import path from "path";
 
+// Logo paths are hardcoded through Docker mounts or we use the default logos.
 function getLightLogoPath() {
-  if(process.env.LIGHT_LOGO_PATH && process.env.LIGHT_LOGO_PATH.trim() !== "") {
+  if (process.env.LIGHT_LOGO_PATH && process.env.LIGHT_LOGO_PATH.trim() !== "") {
     return "img/custom-light-logo.png";
   }
-  // Otherwise, use the default light logo.
-  return 'img/spectrocloud-logo-light.svg?new=true';
+
+  return "img/spectrocloud-logo-light.svg?new=true";
 }
 
+// Logo paths are hardcoded through Docker mounts or we use the default logos.
 function getDarkLogoPath() {
-  if(process.env.DARK_LOGO_PATH && process.env.DARK_LOGO_PATH.trim() !== "") {
+  if (process.env.DARK_LOGO_PATH && process.env.DARK_LOGO_PATH.trim() !== "") {
     return "img/custom-dark-logo.png";
   }
-  // Otherwise, use the default light logo.
-  return 'img/spectrocloud-logo-dark.svg?new=true';
+
+  return "img/spectrocloud-logo-dark.svg?new=true";
 }
 
 // We will only show the update time if the environment variable is set to true.

--- a/scripts/start-docker.sh
+++ b/scripts/start-docker.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+CURRENT_DIR=$(pwd)
+## Read logo paths from .env file.
+LIGHT_LOGO_PATH=$(grep '^LIGHT_LOGO_PATH=' .env | cut -d '=' -f2-)
+DARK_LOGO_PATH=$(grep '^DARK_LOGO_PATH=' .env | cut -d '=' -f2-)
+echo "ℹ️ LIGHT_LOGO_PATH: ${LIGHT_LOGO_PATH}"
+echo "ℹ️ DARK_LOGO_PATH: ${DARK_LOGO_PATH}"  
+
+start_default_docker() {
+    docker run \ 
+        --env-file=.env \ 
+        --rm \
+        -it \
+        -v "$(realpath "$CURRENT_DIR/docs")":/librarium/docs/ \
+        -v "$(realpath "$CURRENT_DIR/_partials")":/librarium/_partials/ \
+        -p 9000:9000 \
+        $IMAGE
+}
+
+start_custom_logos_docker() {
+    docker run \
+        --env-file=.env \
+        --rm \
+        -it \
+        -v "$(realpath "$CURRENT_DIR/docs")":/librarium/docs/ \
+        -v "$(realpath "$CURRENT_DIR/_partials")":/librarium/_partials/ \
+        -v "$(realpath "$LIGHT_LOGO_PATH")":/librarium/static/img/custom-light-logo.png \
+        -v "$(realpath "$DARK_LOGO_PATH")":/librarium/static/img/custom-dark-logo.png \
+        -p 9000:9000 \
+        $IMAGE
+}
+
+## If no custom directories are set don't export anything.
+if [ -z "${LIGHT_LOGO_PATH}" ] && [ -z "${LIGHT_LOGO_PATH}" ]; then
+    echo "✅ Starting Docker container with default Spectro Cloud logos."
+    start_default_docker
+
+elif [ -n "${LIGHT_LOGO_PATH}" ] && [ -n "${DARK_LOGO_PATH}" ]; then
+    echo "✅ Starting Docker container with custom logos."
+    start_custom_logos_docker
+else 
+    echo "❌ Error: Only one custom logo is set. Both LIGHT_LOGO_PATH and DARK_LOGO_PATH logo must be set. "
+    echo "✅ Starting Docker container with default Spectro Cloud logos."
+    start_default_docker
+fi


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR allows the customization of logos in librarium Docker container.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Offline Documentation](https://deploy-preview-6966--docs-spectrocloud.netlify.app/downloads/offline-docs/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1886](https://spectrocloud.atlassian.net/browse/DOC-1886)
🎫 [DOC-1893](https://spectrocloud.atlassian.net/browse/DOC-1893)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
We'll only take it back to 4.6 and 4.5, since the page is in the downloads section.

[DOC-1886]: https://spectrocloud.atlassian.net/browse/DOC-1886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOC-1893]: https://spectrocloud.atlassian.net/browse/DOC-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ