### PR TITLE
docs: Release note for updated GCP permissions

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -68,9 +68,11 @@ tags: ["release-notes"]
     - `recommender.networkAnalyzerGkeConnectivityInsights.list`
     - `recommender.networkAnalyzerGkeConnectivityInsights.update`
 
-  - `recommender.networkAnalyzerGkeIpAddressInsights.*` changes to: -
-    `recommender.networkAnalyzerGkeIpAddressInsights.get` - `recommender.networkAnalyzerGkeIpAddressInsights.list` -
-    `recommender.networkAnalyzerGkeIpAddressInsights.update`
+  - `recommender.networkAnalyzerGkeIpAddressInsights.*` changes to:
+
+    - `recommender.networkAnalyzerGkeIpAddressInsights.get`
+    - `recommender.networkAnalyzerGkeIpAddressInsights.list`
+    - `recommender.networkAnalyzerGkeIpAddressInsights.update`
 
   </details>
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -20,6 +20,65 @@ tags: ["release-notes"]
 - Fixed an issue that prevented add-on profiles from being deployed on [Edge](../clusters/edge/edge.md) clusters
   containing the `harbor-edge-native-config` pack.
 
+- The required IAM permissions for GCP have been updated.
+
+  <details>
+  <summary> Added permissions </summary>
+
+  - `compute.instanceGroupManagers.get`
+  - `compute.subnetworks.get`
+  - `compute.zones.get`
+  - `container.operations.get`
+  - `container.operations.list`
+  - `orgpolicy.policy.get`
+  - `storage.objects.create`
+  - `storage.objects.delete`
+  - `compute.targetTcpProxies.create`
+  - `compute.targetTcpProxies.get`
+  - `compute.targetTcpProxies.delete`
+  - `compute.targetTcpProxies.use`
+
+  </details>
+
+  <details>
+  <summary> Changed permissions </summary>
+
+  - `recommender.containerDiagnosisInsights.*` changes to:
+    - `recommender.containerDiagnosisInsights.get`
+    - `recommender.containerDiagnosisInsights.list`
+    - `recommender.containerDiagnosisInsights.update`
+
+  - `recommender.containerDiagnosisRecommendations.*` changes to:
+    - `recommender.containerDiagnosisRecommendations.get`
+    - `recommender.containerDiagnosisRecommendations.list`
+    - `recommender.containerDiagnosisRecommendations.update`
+
+  - `recommender.locations.*` changes to:
+    - `recommender.locations.get`
+    - `recommender.locations.list`
+
+  - `recommender.networkAnalyzerGkeConnectivityInsights.*` changes to:
+    - `recommender.networkAnalyzerGkeConnectivityInsights.get`
+    - `recommender.networkAnalyzerGkeConnectivityInsights.list`
+    - `recommender.networkAnalyzerGkeConnectivityInsights.update`
+
+  - `recommender.networkAnalyzerGkeIpAddressInsights.*` changes to:
+    - `recommender.networkAnalyzerGkeIpAddressInsights.get`
+    - `recommender.networkAnalyzerGkeIpAddressInsights.list`
+    - `recommender.networkAnalyzerGkeIpAddressInsights.update`
+
+  </details>
+
+  <details>
+  <summary> Removed permissions </summary>
+
+  - `resourcemanager.projects.list`
+  - `serviceusage.quotas.get` 
+
+  </details>
+
+  Refer to the [Required IAM Permissions](../clusters/public-cloud/gcp/required-permissions.md#required-permissions) guide for all required GCP IAM permissions.
+
 ## May 20, 2025 - Release 4.6.26
 
 ### Bug Fixes

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -22,8 +22,8 @@ tags: ["release-notes"]
 
 - The required IAM permissions for GCP have been updated.
 
-      <details>
-
+  <!--prettier-ignore-->
+  <details>
   <summary> Added permissions </summary>
 
   - `compute.instanceGroupManagers.get`
@@ -39,11 +39,11 @@ tags: ["release-notes"]
   - `compute.targetTcpProxies.delete`
   - `compute.targetTcpProxies.use`
 
-        </details>
+  </details>
 
-        <details>
-
-    <summary> Changed permissions </summary>
+  <!--prettier-ignore-->
+  <details>
+  <summary> Changed permissions </summary>
 
   - `recommender.containerDiagnosisInsights.*` changes to:
 
@@ -72,16 +72,16 @@ tags: ["release-notes"]
     `recommender.networkAnalyzerGkeIpAddressInsights.get` - `recommender.networkAnalyzerGkeIpAddressInsights.list` -
     `recommender.networkAnalyzerGkeIpAddressInsights.update`
 
-        </details>
+  </details>
 
-        <details>
-
-    <summary> Removed permissions </summary>
+  <!--prettier-ignore-->
+  <details>
+  <summary> Removed permissions </summary>
 
   - `resourcemanager.projects.list`
   - `serviceusage.quotas.get`
 
-    </details>
+  </details>
 
   Refer to the [Required IAM Permissions](../clusters/public-cloud/gcp/required-permissions.md#required-permissions)
   guide for all required GCP IAM permissions.

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -22,7 +22,7 @@ tags: ["release-notes"]
 
 - The required IAM permissions for GCP have been updated.
 
-  <details>
+    <details>
 <summary> Added permissions </summary>
 
   - `compute.instanceGroupManagers.get`
@@ -38,9 +38,9 @@ tags: ["release-notes"]
   - `compute.targetTcpProxies.delete`
   - `compute.targetTcpProxies.use`
 
-  </details>
+    </details>
 
-  <details>
+    <details>
 <summary> Changed permissions </summary>
 
   - `recommender.containerDiagnosisInsights.*` changes to:
@@ -71,15 +71,15 @@ tags: ["release-notes"]
     - `recommender.networkAnalyzerGkeIpAddressInsights.list`
     - `recommender.networkAnalyzerGkeIpAddressInsights.update`
 
-  </details>
+    </details>
 
-  <details>
+    <details>
 <summary> Removed permissions </summary>
 
   - `resourcemanager.projects.list`
   - `serviceusage.quotas.get`
 
-  </details>
+    </details>
 
   Refer to the [Required IAM Permissions](../clusters/public-cloud/gcp/required-permissions.md#required-permissions)
   guide for all required GCP IAM permissions.

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -22,8 +22,9 @@ tags: ["release-notes"]
 
 - The required IAM permissions for GCP have been updated.
 
-    <details>
-<summary> Added permissions </summary>
+      <details>
+
+  <summary> Added permissions </summary>
 
   - `compute.instanceGroupManagers.get`
   - `compute.subnetworks.get`
@@ -38,10 +39,11 @@ tags: ["release-notes"]
   - `compute.targetTcpProxies.delete`
   - `compute.targetTcpProxies.use`
 
-    </details>
+        </details>
 
-    <details>
-<summary> Changed permissions </summary>
+        <details>
+
+    <summary> Changed permissions </summary>
 
   - `recommender.containerDiagnosisInsights.*` changes to:
 
@@ -66,15 +68,15 @@ tags: ["release-notes"]
     - `recommender.networkAnalyzerGkeConnectivityInsights.list`
     - `recommender.networkAnalyzerGkeConnectivityInsights.update`
 
-  - `recommender.networkAnalyzerGkeIpAddressInsights.*` changes to:
-    - `recommender.networkAnalyzerGkeIpAddressInsights.get`
-    - `recommender.networkAnalyzerGkeIpAddressInsights.list`
-    - `recommender.networkAnalyzerGkeIpAddressInsights.update`
+  - `recommender.networkAnalyzerGkeIpAddressInsights.*` changes to: -
+    `recommender.networkAnalyzerGkeIpAddressInsights.get` - `recommender.networkAnalyzerGkeIpAddressInsights.list` -
+    `recommender.networkAnalyzerGkeIpAddressInsights.update`
 
-    </details>
+        </details>
 
-    <details>
-<summary> Removed permissions </summary>
+        <details>
+
+    <summary> Removed permissions </summary>
 
   - `resourcemanager.projects.list`
   - `serviceusage.quotas.get`

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -23,7 +23,7 @@ tags: ["release-notes"]
 - The required IAM permissions for GCP have been updated.
 
   <details>
-  <summary> Added permissions </summary>
+<summary> Added permissions </summary>
 
   - `compute.instanceGroupManagers.get`
   - `compute.subnetworks.get`
@@ -41,23 +41,27 @@ tags: ["release-notes"]
   </details>
 
   <details>
-  <summary> Changed permissions </summary>
+<summary> Changed permissions </summary>
 
   - `recommender.containerDiagnosisInsights.*` changes to:
+
     - `recommender.containerDiagnosisInsights.get`
     - `recommender.containerDiagnosisInsights.list`
     - `recommender.containerDiagnosisInsights.update`
 
   - `recommender.containerDiagnosisRecommendations.*` changes to:
+
     - `recommender.containerDiagnosisRecommendations.get`
     - `recommender.containerDiagnosisRecommendations.list`
     - `recommender.containerDiagnosisRecommendations.update`
 
   - `recommender.locations.*` changes to:
+
     - `recommender.locations.get`
     - `recommender.locations.list`
 
   - `recommender.networkAnalyzerGkeConnectivityInsights.*` changes to:
+
     - `recommender.networkAnalyzerGkeConnectivityInsights.get`
     - `recommender.networkAnalyzerGkeConnectivityInsights.list`
     - `recommender.networkAnalyzerGkeConnectivityInsights.update`
@@ -70,14 +74,15 @@ tags: ["release-notes"]
   </details>
 
   <details>
-  <summary> Removed permissions </summary>
+<summary> Removed permissions </summary>
 
   - `resourcemanager.projects.list`
-  - `serviceusage.quotas.get` 
+  - `serviceusage.quotas.get`
 
   </details>
 
-  Refer to the [Required IAM Permissions](../clusters/public-cloud/gcp/required-permissions.md#required-permissions) guide for all required GCP IAM permissions.
+  Refer to the [Required IAM Permissions](../clusters/public-cloud/gcp/required-permissions.md#required-permissions)
+  guide for all required GCP IAM permissions.
 
 ## May 20, 2025 - Release 4.6.26
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a release note for https://github.com/spectrocloud/librarium/pull/6980. It has been created separately as this portion cannot be backported except to 4.6.x.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-6985--docs-spectrocloud.netlify.app/release-notes/#bug-fixes)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1933](https://spectrocloud.atlassian.net/browse/DOC-1933)
🎫 [DOC-1890](https://spectrocloud.atlassian.net/browse/DOC-1890)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1933]: https://spectrocloud.atlassian.net/browse/DOC-1933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-1890]: https://spectrocloud.atlassian.net/browse/DOC-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ