### PR TITLE
[version-4-3] docs: remove docker username & password DOC-1941 (#7017)

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
@@ -150,22 +150,22 @@ Creating a content bundle provides several benefits that may address common use 
    For example, the following JSON code provides access to two registries `ttl.sh` and `docker.io` with two
    username-password pairs.
 
-   ```json
-   {
-     "image": [
-       {
-         "endpoint": "ttl.sh",
-         "username": "admin",
-         "password": "Welc0me!123"
-       },
-       {
-         "endpoint": "docker.io",
-         "username": "akhileshpvt",
-         "password": "Lucent122333!"
-       }
-     ]
-   }
-   ```
+    ```json
+    {
+      "image": [
+        {
+          "endpoint": "ttl.sh",
+          "username": "admin",
+          "password": "*********"
+        },
+        {
+          "endpoint": "docker.io",
+          "username": "username",
+          "password": "*********"
+        }
+      ]
+    }
+    ```
 
    For Google Container Registry (GCR) access, you need to set the username field to `"_json_key"` and set the password
    to an JSON object containing the following fields.

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/upload-images-to-registry.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/upload-images-to-registry.md
@@ -123,8 +123,8 @@ download the images and upload them to the external registry.
        },
        {
          "endpoint": "docker.io",
-         "username": "akhileshpvt",
-         "password": "Lucent122333!"
+         "username": "username",
+         "password": "*********"
        }
      ]
    }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-3`:
 - [docs: remove docker username &amp; password DOC-1941 (#7017)](https://github.com/spectrocloud/librarium/pull/7017)