### PR TITLE
docs: add removal of dynamic IP allocation for private Azure IaaS cluster LBs to release notes PCP-4572

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -115,7 +115,7 @@ impacted clusters until you've handled the below mentioned breaking changes and 
      ```
 
 - Dynamic IP allocation is no longer supported for private API server load balancers on Azure IaaS clusters. You must
-  now use static IP allocation and provide a static IP address during cluster configuration. Otherwise,cluster
+  now use static IP allocation and provide a static IP address during cluster configuration. Otherwise, cluster
   provisioning will fail if you omit providing these settings. Refer to the
   [Private API Server LB Settings](../clusters/public-cloud/azure/create-azure-cluster.md#private-api-server-lb-settings)
   section for further details.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds breaking change about dynamic IP allocation removal in release notes.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-7035--docs-spectrocloud.netlify.app/release-notes/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PCP-4572](https://spectrocloud.atlassian.net/browse/PCP-4572)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Just 4.6

[PCP-4572]: https://spectrocloud.atlassian.net/browse/PCP-4572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ