### PR TITLE
docs: add link to all CAPI provider versions section DOC-1960

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -163,6 +163,16 @@ impacted clusters until you've handled the below mentioned breaking changes and 
 
 #### Improvements
 
+:::info
+
+All Cluster API provider versions were updated in this release. Refer to the
+[Cluster API Provider Versions](../architecture/orchestration-spectrocloud.md#cluster-api-provider-versions) section
+further details.
+
+:::
+
+- Palette now uses Cluster API Provider AWS (CAPA) version 2.7.1 internally. Refer to the
+  [documentation](https://github.com/kubernetes-sigs/cluster-api-provider-aws/tree/v2.7.1) for further information.
 - CAPG has been upgraded to [v1.8.1](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/tag/v1.8.1)
   from [v1.2.1](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/tag/v1.2.1).
 
@@ -200,8 +210,6 @@ impacted clusters until you've handled the below mentioned breaking changes and 
   access to backup and restore functionality. Refer to the
   [Backup and Restore](../clusters/cluster-management/backup-restore/backup-restore.md) page to learn more about backup
   and restore tools in Palette.
-- Palette now uses Cluster API Provider AWS (CAPA) version 2.7.1 internally. Refer to the
-  [documentation](https://github.com/kubernetes-sigs/cluster-api-provider-aws/tree/v2.7.1) for further information.
 - [Self-hosted Palette](../enterprise-version/enterprise-version.md) now supports anonymous SMTP mode, allowing users to
   authenticate without a username and password. We recommend using authenticated SMTP wherever possible. Refer to the
   [Configure SMTP](../enterprise-version/system-management/smtp.md) guide for further information.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a link to the cluster api providers table to the release notes.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-7076--docs-spectrocloud.netlify.app/release-notes/#improvements)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1960](https://spectrocloud.atlassian.net/browse/DOC-1960)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Only to 4.6.

[DOC-1960]: https://spectrocloud.atlassian.net/browse/DOC-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ