### PR TITLE
docs: DOC-1968: Update Image Mapping Registry

### DIFF
--- a/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
@@ -89,7 +89,7 @@ Below is an example of how to configure an external registry.
 stylus:
   externalRegistries:
     registries:
-      - domain: "example.registry.com/internal-images"
+      - domain: "example.registry.com/palette-images"
         username: "admin"
         password: "***************"
         repositoryName: example-repository-private
@@ -121,10 +121,10 @@ stylus:
             DlN636dYFSJBG3LjGuzyO66kEvbGJAIT
             -----END CERTIFICATE-----
     registryMappingRules:
-      "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
-      "us-docker.pkg.dev/palette-images": "example.registry.com/internal-images"
-      "grc.io/spectro-dev-public": "example.registry.com/internal-images"
-      "grc.io/spectro-images-public": "example.registry.com/internal-images"
+      "us-docker.pkg.dev/palette-images": "example.registry.com/palette-images"
+      "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/palette-images"
+      "grc.io/spectro-dev-public": "example.registry.com/palette-images"
+      "grc.io/spectro-images-public": "example.registry.com/palette-images"
 ```
 
 #### Registry Mapping Rules
@@ -132,22 +132,22 @@ stylus:
 Use registry mapping rules to map a domain name to an external registry. The `registryMappingRules` parameter accepts a
 list of key-value pairs where the key is the domain name and the value is a URL mapping to the external registry.
 
-Below is an example of registry mapping rules. The registry in the code snippet, `example.registry.com/internal-images`
+Below is an example of registry mapping rules. The registry in the code snippet, `example.registry.com/palette-images`
 is assumed to contain the images that are mapped from the external registries.
 
 ```yaml
 stylus:
   externalRegistries:
     registries:
-      - domain: "example.registry.com/internal-images"
+      - domain: "example.registry.com/palette-images"
         repositoryName: "primary-registry"
         username: "admin"
         password: "***************"
     registryMappingRules:
-      "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
-      "us-docker.pkg.dev/palette-images": "example.registry.com/internal-images"
-      "grc.io/spectro-dev-public": "example.registry.com/internal-images"
-      "grc.io/spectro-images-public": "example.registry.com/internal-images"
+      "us-docker.pkg.dev/palette-images": "example.registry.com/palette-images"
+      "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/palette-images"
+      "grc.io/spectro-dev-public": "example.registry.com/palette-images"
+      "grc.io/spectro-images-public": "example.registry.com/palette-images"
 ```
 
 All matched portion on the source URL will be replaced with the mapped value and any unmatched path is preserved. Using
@@ -168,11 +168,11 @@ were downloaded when creating the [content bundle](../edgeforge-workflow/palette
 Palette will automatically update the image path when <VersionedLink text="Harbor Edge-Native Config" url="/integrations/packs/?pack=harbor-edge-native-config" />  pack is enabled. For example, if you have a registry mapping rule such as the following.
 
 ```yaml
-"us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
+"us-docker.pkg.dev/palette-images": "example.registry.com/palette-images"
 ```
 
 Then the image tag will be updated with the prefix URL to the primary registry, such as
-`https://10.10.100.45:30003/example.registry.com/internal-images`. Palette will do this for all registry mapping rules
+`https://10.10.100.45:30003/example.registry.com/palette-images`. Palette will do this for all registry mapping rules
 specified in the user data. This allows the Edge host to find and pull images that came from an external registry
 through the primary registry.
 
@@ -183,10 +183,10 @@ stylus:
   managementMode: local
   externalRegistries:
     registryMappingRules:
-      "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
-      "us-docker.pkg.dev/palette-images": "example.registry.com/internal-images"
-      "grc.io/spectro-dev-public": "example.registry.com/internal-images"
-      "grc.io/spectro-images-public": "example.registry.com/internal-images"
+      "us-docker.pkg.dev/palette-images": "example.registry.com/palette-images"
+      "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/palette-images"
+      "grc.io/spectro-dev-public": "example.registry.com/palette-images"
+      "grc.io/spectro-images-public": "example.registry.com/palette-images"
 ```
 
 ### Single External Registry

--- a/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/deploy-external-registry.md
+++ b/docs/docs-content/clusters/edge/site-deployment/deploy-custom-registries/deploy-external-registry.md
@@ -149,10 +149,10 @@ bandwidth use and protect against outages. For more information, refer to
             ...
             -----END CERTIFICATE-----
         registryMappingRules:
-          "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
-          "us-docker.pkg.dev/palette-images": "example.registry.com/internal-images"
-          "grc.io/spectro-dev-public": "example.registry.com/internal-images"
-          "grc.io/spectro-images-public": "example.registry.com/internal-images"
+          "us-docker.pkg.dev/palette-images": "example.registry.com/palette-images"
+          "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/palette-images"
+          "grc.io/spectro-dev-public": "example.registry.com/palette-images"
+          "grc.io/spectro-images-public": "example.registry.com/palette-images"
     ```
     Refer to [Installer Configuration](../../edge-configuration/installer-reference.md#multiple-external-registries) for a
     description of each field.

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -371,7 +371,7 @@ Palette. You will then create a cluster profile and use the registered host to d
          projectName: Default
        externalRegistries:
          registries:
-           - domain: "example.registry.com/internal-images"
+           - domain: "example.registry.com/palette-images"
              username: "admin"
              password: "***************"
              repositoryName: example-repository-private
@@ -381,7 +381,7 @@ Palette. You will then create a cluster profile and use the registered host to d
                   **********************
                   -----END CERTIFICATE-----
          registryMappingRules:
-           "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
+           "us-docker.pkg.dev/palette-images": "example.registry.com/palette-images"
 
      stages:
        initramfs:
@@ -417,7 +417,7 @@ Palette. You will then create a cluster profile and use the registered host to d
        projectName: Default
      externalRegistries:
        registries:
-         - domain: "example.registry.com/internal-images"
+         - domain: "example.registry.com/palette-images"
            username: "admin"
            password: "***************"
            repositoryName: example-repository-private
@@ -427,7 +427,7 @@ Palette. You will then create a cluster profile and use the registered host to d
                 **********************
                 -----END CERTIFICATE-----
        registryMappingRules:
-         "us-east1-docker.pkg.dev/spectro-images/daily": "example.registry.com/internal-images"
+         "us-docker.pkg.dev/palette-images": "example.registry.com/palette-images"
    stages:
      initramfs:
        - users:


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR changes the recommended external image registry for registry mapping purposes from `"us-east1-docker.pkg.dev/spectro-images/daily"` --> `"us-docker.pkg.dev/palette-images"`, as most images reside in the `us-docker.pkg.dev` domain.

Registry mapping examples with multiple registries has retained `"us-east1-docker.pkg.dev/spectro-images/daily"`, but I moved it lower in the list to prioritize the recommended domain.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Deploy Cluster with a Private External Registry]()
- [Edge Installer Configuration Reference]()
- [Install Palette Agent]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1968](https://spectrocloud.atlassian.net/browse/DOC-1968)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
