### PR TITLE
docs: update release branch flows to support triple number release branches DOC-1973

### DIFF
--- a/.github/workflows/release-branch-pr.yaml
+++ b/.github/workflows/release-branch-pr.yaml
@@ -1,4 +1,4 @@
-# This workflow is trigged when a PR is opened, synchronized, reopened, or ready for review, and the branch name matches the pattern release-[0-9]-[0-9] or release-[0-9]-[0-9]-[a-z].
+# This workflow is trigged when a PR is opened, synchronized, reopened, or ready for review, and the branch name matches the pattern release-[0-9]-[0-9], release-[0-9]-[0-9]-[0-9] or release-[0-9]-[0-9]-[a-z].
 # In simple terms, this workflow targers a release preview branch.
 # Workflow attempts to build the site and configure Netlify to allow for preview builds. By default, Netlify does not create preview builds for pull requests that are not targeting the main branch.
 # The workflow uses the Netlify API to add the branch to the branch deploy list of branches that Netlify will build previews for.
@@ -14,6 +14,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "release-[0-9]-[0-9]"
+      - "release-[0-9]-[0-9]-[0-9]"
       - "release-[0-9]-[0-9]-[a-z]"
 
 env:

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - "release-[0-9]-[0-9]"
+      - "release-[0-9]-[0-9]-[0-9]"
       - "release-[0-9]-[0-9]-[a-z]"
 
 env:


### PR DESCRIPTION

## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the release github actions to support a triple number format like `release-4-7-0` in the release branches. Currently, only double number formats like `release-4-7` and double number with a letter `release-4-7-a` are supported. 

## Changed Pages

_No user facing changes._

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1973](https://spectrocloud.atlassian.net/browse/DOC-1973)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Backport everywhere. 