### PR TITLE
docs: Remove Shared Storage requirement from EC install

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/airgap-install/install.md
@@ -60,8 +60,6 @@ and assets.
 
 - Assigned IP addresses for application workload services, such as Load Balancer services.
 
-- Shared Storage between VMware vSphere hosts.
-
 - A [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) to manage persistent storage, with the
   annotation `storageclass.kubernetes.io/is-default-class` set to `true`. To override the default StorageClass for a
   workload, modify the `storageClass` parameter. Check out the

--- a/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-vmware/install.md
@@ -75,8 +75,6 @@ for more information.
 - Ensure Palette has access to the required domains and ports. Refer to the
   [Required Domains](../install-palette.md#proxy-requirements) section for more information.
 
-- Shared Storage between VMware vSphere hosts.
-
 - A [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) to manage persistent storage, with the
   annotation `storageclass.kubernetes.io/is-default-class` set to `true`. To override the default StorageClass for a
   workload, modify the `storageClass` parameter. Check out the

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/airgap-install/install.md
@@ -75,8 +75,6 @@ assets.
 
 - Assigned IP addresses for application workload services, such as Load Balancer services.
 
-- Shared Storage between VMware vSphere hosts.
-
 - A [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) to manage persistent storage, with the
   annotation `storageclass.kubernetes.io/is-default-class` set to `true`. To override the default StorageClass for a
   workload, modify the `storageClass` parameter. Check out the

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-vmware/install.md
@@ -99,8 +99,6 @@ for more information.
 - Ensure Palette has access to the required domains and ports. Refer to the
   [Required Domains](../install-palette-vertex.md#proxy-requirements) section for more information.
 
-- Shared Storage between VMware vSphere hosts.
-
 - A [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) to manage persistent storage, with the
   annotation `storageclass.kubernetes.io/is-default-class` set to `true`. To override the default StorageClass for a
   workload, modify the `storageClass` parameter. Check out the


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes the requirement "Shared Storage between VMware vSphere hosts" from VerteX and Self-hosted EC installation processes.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Palette VerteX > VMware > Airgap Installation > Install VerteX](https://deploy-preview-7116--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/airgap-install/install/)
💻 [Palette VerteX > VMware > Non-Airgap Install](https://deploy-preview-7116--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/install/)
💻 [Self-Hosted Palette > Installation > VMware > Airgap Installation > Install Palette](https://deploy-preview-7116--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/airgap-install/install/)
💻 [Self-Hosted Palette > Installation > VMware > Non-Airgap Installation](https://deploy-preview-7116--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/install/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1954](https://spectrocloud.atlassian.net/browse/DOC-1954)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. 
- [ ] No.


[DOC-1954]: https://spectrocloud.atlassian.net/browse/DOC-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ