### PR TITLE
[version-4-6] docs: fix spelling errors (#7146)

### DIFF
--- a/docs/docs-content/clusters/edge/site-deployment/virtual-deployment/ipxe-boot.md
+++ b/docs/docs-content/clusters/edge/site-deployment/virtual-deployment/ipxe-boot.md
@@ -15,9 +15,9 @@ To use iPXE provisioning, you must use an HTTP/HTTPS server to serve the necessa
 configuration files, and configure the VMs to boot from a iPXE ISO file, which then chains a script that downloads the
 boot artifacts and boot using those artifacts.
 
-You do not need to customize the Palette Edge Installer ISO. It is only used to extract the generic kernel, initrd, and
-root filesystem. Configuration is handled externally via a `config.yaml` file served over HTTP. This lets you reuse the
-same boot artifacts across any number of nodes.
+You do not need to customize the Palette Edge Installer ISO. It is only used to extract the generic kernel, `initrd`,
+and root filesystem. Configuration is handled externally via a `config.yaml` file served over HTTP. This lets you reuse
+the same boot artifacts across any number of nodes.
 
 ## Prerequisites
 
@@ -129,13 +129,13 @@ same boot artifacts across any number of nodes.
 10. Finish configuring your VM and power it on.
 
 11. Open the VM’s console via the vCenter web client to access your VM. As soon as the "iPXE boot image" screen shows,
-    press **Ctrl+B** to interrupt and enter the `iPXE>` prompt. The interval you have to press **Ctrl+B** is very short.
-    Therefore, make sure to launch the web console as soon as your VM boots and get ready to press the keys.
+    press **CTRL + B** to interrupt and enter the `iPXE>` prompt. The interval you have to press **CTRL + B** is very
+    short. Therefore, make sure to launch the web console as soon as your VM boots and get ready to press the keys.
 
     :::tip
 
-    If the VM does not register **Ctrl + B**, try pressing **ESC + B** instead. Many BIOS-level environments and virtual
-    terminals interpret **Esc + B** as a fallback for **Ctrl + B**, especially when Ctrl is not reliably passed through.
+    If the VM does not register **CTRL + B**, try pressing **ESC + B** instead. Many BIOS-level environments and virtual
+    terminals interpret **ESC + B** as a fallback for **CTRL + B**, especially when CTRL is not reliably passed through.
 
     :::
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -104,7 +104,7 @@ impacted clusters until you've handled the below mentioned breaking changes and 
 
 - Earlier Palette releases carried a stop-gap patch to drain Portworx pods gracefully during node repaves. In this
   release, that patch has been moved to the
-  <VersionedLink text="Portworx CSI pack" url="/integrations/packs/?pack=csi-portworx-generic" /> from v3.2.3 onwards.
+  <VersionedLink text="Portworx CSI pack" url="/integrations/packs/?pack=csi-portworx-generic" /> from v3.2.3 or later.
   <!--prettier-ignore-end-->
 
   For any clusters using the Portworx CSI pack v3.2.2 or earlier, you must choose _one_ of the following actions to

--- a/vale-spellcheck-ignore.txt
+++ b/vale-spellcheck-ignore.txt
@@ -16,3 +16,11 @@ docs/docs-content/user-management/saml-sso/palette-sso-with-onelogin.md:42:34:Va
 docs/docs-content/user-management/saml-sso/palette-sso-with-entra-id.md:62:34:Vale.Spelling:Did you really mean 'userinfo'?
 docs/docs-content/user-management/saml-sso/palette-sso-with-adfs.md:53:34:Vale.Spelling:Did you really mean 'userinfo'?
 docs/docs-content/user-management/saml-sso/palette-sso-with-okta.md:41:34:Vale.Spelling:Did you really mean 'userinfo'?
+docs/docs-content/user-management/saml-sso/palette-sso-with-entra-id.md:78:5:Vale.Spelling:Did you really mean 'userinfo'?
+docs/docs-content/deployment-modes/agent-mode/install-agent-host.md:211:17:Vale.Spelling:Did you really mean 'firewalld'?
+docs/docs-content/clusters/public-cloud/gcp/required-permissions.md:119:104:Vale.Spelling:Did you really mean 'Recommender'?
+docs/docs-content/clusters/public-cloud/gcp/required-permissions.md:120:105:Vale.Spelling:Did you really mean 'Recommender'?
+docs/docs-content/clusters/public-cloud/aws/eks.md:285:84:Vale.Spelling:Did you really mean 'Nodepool'?
+docs/docs-content/clusters/public-cloud/aws/eks.md:323:16:Vale.Spelling:Did you really mean 'Nodepool'?
+docs/docs-content/release-notes/release-notes.md:470:19:Vale.Spelling:Did you really mean 'Loadbalancer'?
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-6`:
 - [docs: fix spelling errors (#7146)](https://github.com/spectrocloud/librarium/pull/7146)