### PR TITLE
docs: Document how to specify install folder for Agent mode

### DIFF
--- a/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
+++ b/docs/docs-content/clusters/edge/edge-configuration/installer-reference.md
@@ -37,15 +37,16 @@ listed in alphabetical order.
 | `stylus.installationMode`      | (Deprecated) Allowed values are `connected` and `airgap`. `connected` means the Edge host is connected to Palette; `airgap` means the Edge host has no connection. This parameter has been deprecated and will be removed in an future release. Use the `stylus.managementMode` parameter instead. | String  | `connected` |
 | `stylus.localUI.port`          | Specifies the port that the Local UI is exposed on.                                                                                                                                                                                                                                                | Integer | `5080`      |
 | `stylus.managementMode`        | Allowed values are `local` and `central`. `central` means the Edge host is connected to Palette; `local` means the Edge host has no connection to a Palette instance.                                                                                                                              | String  | `central`   |
-| `stylus.path`        | Specifies Stylus installation directory. Stylus appends its internal layout, `opt/spectrocloud`, to this path. If you omit this parameter, the system uses `/` as the default root and installs Stylus to `/opt/spectrocloud`.| String  | `/`   |
+| `stylus.path`                  | Specifies Stylus installation directory. Stylus appends its internal layout, `opt/spectrocloud`, to this path. If you omit this parameter, the system uses `/` as the default root and installs Stylus to `/opt/spectrocloud`.                                                                     | String  | `/`         |
 | `stylus.registryCredentials`   | Only used when a single external registry is in use and no mapping rules are needed. Refer to [Single External Registry](#single-external-registry) for more details.                                                                                                                              | Object  | None        |
 | `stylus.site`                  | Review [Site Parameters](#site-parameters) for more information.                                                                                                                                                                                                                                   | Object  | None        |
 | `stylus.trace`                 | Enable trace output. Allowed values are `true` or `false`.                                                                                                                                                                                                                                         | boolean | `false`     |
-| `stylus.vip.skip`              | When set to `true`, the installer skips the configuration of kube-vip and enables the use of an external load balancer instead.                                                                                                                           | boolean | `false`     |
+| `stylus.vip.skip`              | When set to `true`, the installer skips the configuration of kube-vip and enables the use of an external load balancer instead.                                                                                                                                                                    | boolean | `false`     |
 
 :::warning
 
-Using custom `stylus.path` values can lead to deployment issues in some configurations. Refer to [Known issues](../../../release-notes/known-issues.md) for details.
+Using custom `stylus.path` values can lead to deployment issues in some configurations. Refer to
+[Known issues](../../../release-notes/known-issues.md) for details.
 
 :::
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR:
1) Adds `stylus.path` parameter to user-data.
2) Adds a warning about this parameter linked to Known Issues.
3) Removes "Applicable only in agent deployment mode" note from the `stylus.vip.skip` parameter description, as it's applicable to all the stylus parameters.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Edge Installer Configuration Reference](https://deploy-preview-7161--docs-spectrocloud.netlify.app/clusters/edge/edge-configuration/installer-reference/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PE-6511](https://spectrocloud.atlassian.net/browse/PE-6511)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. 
- [ ] No. 

[PE-6511]: https://spectrocloud.atlassian.net/browse/PE-6511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ