### PR TITLE
docs: Specify that site user data ISO is not bootable

### DIFF
--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
@@ -26,7 +26,7 @@ as a USB stick.
 ## Create ISO
 
 1.  Create a file called `user-data` that contains the additional configurations you want to override or inject. Ensure
-    that the file starts with a line that only contains `#cloud-config`. Only include configurations you'd like to add
+    that the file starts with a line that only contains `#cloud-config`. Only include configurations you would like to add
     or override. There is no need to include user data that was already present when the ISO image was build in the
     [Build Edge Artifacts](../../edgeforge-workflow/palette-canvos/palette-canvos.md) step.
 

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
@@ -70,7 +70,7 @@ to a bootable device, such as a USB stick.
                fi
     ```
 
-2.  Create an empty `meta-data` file:
+2.  Create an empty `meta-data` file.
 
     ```shell
     touch meta-data

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
@@ -26,8 +26,8 @@ as a USB stick.
 ## Create ISO
 
 1.  Create a file called `user-data` that contains the additional configurations you want to override or inject. Ensure
-    that the file starts with a line that only contains `#cloud-config`. Only include configurations you would like to add
-    or override. There is no need to include user data that was already present when the ISO image was build in the
+    that the file starts with a line that only contains `#cloud-config`. Only include configurations you would like to
+    add or override. There is no need to include user data that was already present when the ISO image was build in the
     [Build Edge Artifacts](../../edgeforge-workflow/palette-canvos/palette-canvos.md) step.
 
     ```shell

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
@@ -10,8 +10,8 @@ tags: ["edge"]
 You can provide site-specific Edge Installer configuration user data if you need to apply new values or override default
 values from the Edge Installer user data you created in [EdgeForge](../../edgeforge-workflow/prepare-user-data.md).
 
-Use the following steps to create an ISO file containing the additional user data and load it
-to a bootable device, such as a USB stick.
+Use the following steps to create an ISO file containing the additional user data and load it to a bootable device, such
+as a USB stick.
 
 ## Prerequisites
 
@@ -25,10 +25,10 @@ to a bootable device, such as a USB stick.
 
 ## Create ISO
 
-1.  Create a file called `user-data` that contains the additional configurations you want to override or inject.
-    Ensure that the file starts with a line that only contains `#cloud-config`. Only include configurations you'd like
-    to add or override. There is no need to include user data that was already present when the ISO image was build in
-    the [Build Edge Artifacts](../../edgeforge-workflow/palette-canvos/palette-canvos.md) step.
+1.  Create a file called `user-data` that contains the additional configurations you want to override or inject. Ensure
+    that the file starts with a line that only contains `#cloud-config`. Only include configurations you'd like to add
+    or override. There is no need to include user data that was already present when the ISO image was build in the
+    [Build Edge Artifacts](../../edgeforge-workflow/palette-canvos/palette-canvos.md) step.
 
     ```shell
     touch user-data
@@ -106,19 +106,23 @@ to a bootable device, such as a USB stick.
     [balenaEtcher](https://www.balena.io/etcher). For a PXE server, there are open source projects such as
     [Fog](https://fogproject.org/download.php) or
     [Windows Deployment Services](https://learn.microsoft.com/en-us/windows/deployment/wds-boot-support) for Windows.
-    
+
     :::info
-    
-    The site user data ISO file is not bootable. It contains only configuration data, which the system reads after booting from the internal disk. If you use a tool like balenaEtcher to write the ISO file to a USB stick, it may display the corresponding warning. You can safely ignore it and continue writing the image to USB.
-    
+
+    The site user data ISO file is not bootable. It contains only configuration data, which the system reads after
+    booting from the internal disk. If you use a tool like balenaEtcher to write the ISO file to a USB stick, it may
+    display the corresponding warning. You can safely ignore it and continue writing the image to USB.
+
     :::
 
-5.  Once the Edge host arrives at the physical site, load the USB drive to the Edge host before powering it on. The system boots from the internal disk, detects the USB drive, and automatically applies the additional user data configuration during this first site boot.
+5.  Once the Edge host arrives at the physical site, load the USB drive to the Edge host before powering it on. The
+    system boots from the internal disk, detects the USB drive, and automatically applies the additional user data
+    configuration during this first site boot.
 
 ## Validate
 
-You can validate that the ISO file is not corrupted by attempting to flash a bootable device. Most software that
-creates a bootable device will validate the ISO file before the flash process.
+You can validate that the ISO file is not corrupted by attempting to flash a bootable device. Most software that creates
+a bootable device will validate the ISO file before the flash process.
 
 If you have SSH access, you can also SSH into the Edge host and locate your `user-data` file in either `/oem` or
 `/run/stylus`. The site-specific user data is named `user-data` while the original user data file is named something

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
@@ -10,7 +10,7 @@ tags: ["edge"]
 You can provide site-specific Edge Installer configuration user data if you need to apply new values or override default
 values from the Edge Installer user data you created in [EdgeForge](../../edgeforge-workflow/prepare-user-data.md).
 
-Use the following steps to create an ISO file containing the additional user data. You will load the newly created ISO
+Use the following steps to create an ISO file containing the additional user data and load it
 to a bootable device, such as a USB stick.
 
 ## Prerequisites
@@ -25,7 +25,7 @@ to a bootable device, such as a USB stick.
 
 ## Create ISO
 
-1.  Create a file called **user-data** that contains the additional configurations you want to override or inject.
+1.  Create a file called `user-data` that contains the additional configurations you want to override or inject.
     Ensure that the file starts with a line that only contains `#cloud-config`. Only include configurations you'd like
     to add or override. There is no need to include user data that was already present when the ISO image was build in
     the [Build Edge Artifacts](../../edgeforge-workflow/palette-canvos/palette-canvos.md) step.
@@ -34,7 +34,7 @@ to a bootable device, such as a USB stick.
     touch user-data
     ```
 
-    For example, you can include the following content in the **user-data** file to connect your Edge host to Wi-Fi.
+    For example, you can include the following content in the `user-data` file to connect your Edge host to Wi-Fi.
     Replace `wifi-network-name` with the name of your Wi-Fi network and the `wifi-password` with the password of your
     network. This requires wpa_supplicant to be included in your base OS image. For more information, refer to
     [Connect Intel NUC Edge Host to Wifi](../../networking/connect-wifi.md).
@@ -70,13 +70,13 @@ to a bootable device, such as a USB stick.
                fi
     ```
 
-2.  Create an empty **meta-data** file:
+2.  Create an empty `meta-data` file:
 
     ```shell
     touch meta-data
     ```
 
-3.  Create an ISO using the following command.
+3.  Create an ISO file using the following command.
 
       <Tabs>
 
@@ -98,29 +98,30 @@ to a bootable device, such as a USB stick.
 
       </Tabs>
 
-    This generates an ISO file called **site-user-data.iso** in the current directory.
+    This generates an ISO file called `site-user-data.iso` in the current directory.
 
 4.  Flash your bootable device such as a USB drive with the ISO file you just created.
-
-    :::info
 
     You can use several software tools to create a bootable USB drive, such as
     [balenaEtcher](https://www.balena.io/etcher). For a PXE server, there are open source projects such as
     [Fog](https://fogproject.org/download.php) or
     [Windows Deployment Services](https://learn.microsoft.com/en-us/windows/deployment/wds-boot-support) for Windows.
-
+    
+    :::info
+    
+    The site user data ISO file is not bootable. It contains only configuration data, which the system reads after booting from the internal disk. If you use a tool like balenaEtcher to write the ISO file to a USB stick, it may display the corresponding warning. You can safely ignore it and continue writing the image to USB.
+    
     :::
 
-5.  Once the Edge host arrives at the physical site. Load the USB drive to the Edge host before powering it on. The Edge
-    Installer will apply the new user data during the installation process.
+5.  Once the Edge host arrives at the physical site, load the USB drive to the Edge host before powering it on. The system boots from the internal disk, detects the USB drive, and automatically applies the additional user data configuration during this first site boot.
 
 ## Validate
 
-You can validate that the ISO image is not corrupted by attempting to flash a bootable device. Most software that
-creates a bootable device will validate the ISO image before the flash process.
+You can validate that the ISO file is not corrupted by attempting to flash a bootable device. Most software that
+creates a bootable device will validate the ISO file before the flash process.
 
-If you have SSH access, you can also SSH into the Edge host and locate your **user-data** file in either `/oem` or
-`/run/stylus`. The site-specific user data is named **user-data** while the original user data file is named something
+If you have SSH access, you can also SSH into the Edge host and locate your `user-data` file in either `/oem` or
+`/run/stylus`. The site-specific user data is named `user-data` while the original user data file is named something
 similar to `90_custom.yaml`. If you can find the files on the Edge host, it means the user data has been applied
 successfully.
 

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
@@ -110,8 +110,9 @@ as a USB stick.
     :::info
 
     The site user data ISO file is not bootable. It contains only configuration data, which the system reads after
-    booting from the internal disk. If you use a tool like [balenaEtcher](https://etcher.balena.io/) to write the ISO file to a USB stick, it may
-    display the corresponding warning. You can safely ignore it and continue writing the image to USB.
+    booting from the internal disk. If you use a tool like [balenaEtcher](https://etcher.balena.io/) to write the ISO
+    file to a USB stick, it may display the corresponding warning. You can safely ignore it and continue writing the
+    image to USB.
 
     :::
 

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
@@ -110,7 +110,7 @@ as a USB stick.
     :::info
 
     The site user data ISO file is not bootable. It contains only configuration data, which the system reads after
-    booting from the internal disk. If you use a tool like balenaEtcher to write the ISO file to a USB stick, it may
+    booting from the internal disk. If you use a tool like [balenaEtcher](https://etcher.balena.io/) to write the ISO file to a USB stick, it may
     display the corresponding warning. You can safely ignore it and continue writing the image to USB.
 
     :::


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR changes the wording across the Apply Site User Data page to highlight that site user data ISO is not bootable.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Apply Site User Data](https://deploy-preview-7175--docs-spectrocloud.netlify.app/clusters/edge/site-deployment/site-installation/site-user-data/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1891](https://spectrocloud.atlassian.net/browse/DOC-1891)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. 
- [ ] No. 

[DOC-1891]: https://spectrocloud.atlassian.net/browse/DOC-1891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ