### PR TITLE
[version-4-2] docs: Specify that site user data ISO is not bootable (#7175)

### DIFF
--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/site-user-data.md
@@ -11,8 +11,8 @@ You can provide site-specific Edge Installer configuration user data if you need
 values from the Edge Installer user data you created in the [Prepare Edge Hosts for Installation](../stage.md) step or,
 as often referenced, the _Installer Handoff_ phase.
 
-Use the following steps to create an ISO file containing the additional user data. You will load the newly created ISO
-to a bootable device, such as a USB stick.
+Use the following steps to create an ISO file containing the additional user data and load it to a bootable device, such
+as a USB stick.
 
 ## Prerequisites
 
@@ -24,19 +24,19 @@ to a bootable device, such as a USB stick.
 
 ## Create ISO
 
-1. Create a file called **user-data** that contains the additional configurations you want to override or inject.
+1. Create a file called `user-data` that contains the additional configurations you want to override or inject.
 
    ```shell
    touch user-data
    ```
 
-2. Create an empty **meta-data** file:
+2. Create an empty `meta-data` file:
 
    ```shell
    touch meta-data
    ```
 
-3. Create an ISO using the following command.
+3. Create an ISO file using the following command.
 
    MacOS/Linux:
 
@@ -50,26 +50,30 @@ to a bootable device, such as a USB stick.
    genisoimage -output site-user-data.iso -volid cidata -joliet -rock user-data meta-data
    ```
 
-   This generates an ISO file called site-user-data.iso in the current directory.
+   This generates an ISO file called `site-user-data.iso` in the current directory.
 
-4. Copy the ISO to a bootable device such as a USB drive.
-
-   :::info
+4. Copy the ISO file to a bootable device such as a USB drive.
 
    You can use several software tools to create a bootable USB drive, such as
    [balenaEtcher](https://www.balena.io/etcher). For a PXE server, there are open source projects such as
    [Fog](https://fogproject.org/download.php) or
    [Windows Deployment Services](https://learn.microsoft.com/en-us/windows/deployment/wds-boot-support) for Windows.
 
+   :::info
+
+   The site user data ISO file is not bootable. It contains only configuration data, which the system reads after
+   booting from the internal disk. If you use a tool like [balenaEtcher](https://etcher.balena.io/) to write the ISO
+   file to a USB stick, it may display the corresponding warning. You can safely ignore it and continue writing the
+   image to USB.
+
    :::
 
-5. Once the Edge host arrives at the physical site. Load the USB drive to the Edge host before powering it on. The Edge
-   Installer will apply the new user data during the installation process.
+5. Once the Edge host arrives at the physical site, load the USB drive to the Edge host before powering it on. The system boots from the internal disk, detects the USB drive, and automatically applies the additional user data.
 
 ## Validate
 
-You can validate that the ISO image is not corrupted by attempting to flash a bootable device. Most software that
-creates a bootable device will validate the ISO image before the flash process.
+You can validate that the ISO file is not corrupted by attempting to flash a bootable device. Most software that
+creates a bootable device will validate the ISO file before the flash process.
 
 ## Next Steps
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR backports changes from #7175 to version 4.2.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Apply Site User Data](https://deploy-preview-7189--docs-spectrocloud.netlify.app/clusters/edge/site-deployment/site-installation/site-user-data/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1891](https://spectrocloud.atlassian.net/browse/DOC-1891)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes.
- [x] No. Backport PR.


[DOC-1891]: https://spectrocloud.atlassian.net/browse/DOC-1891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ