### PR TITLE
docs: Removing Missed 4.6.40 Bug Fixes

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -26,12 +26,6 @@ tags: ["release-notes"]
 ### Bug Fixes
 
 <!--prettier-ignore-start-->
-- Fixed an issue that prevented [Azure IaaS](../clusters/public-cloud/azure/create-azure-cluster.md) clusters from being
-  deployed or deleted when the same subnet was used for both the control plane and worker nodes.
-- Fixed an issue that caused multiple machine sets to be created following
-  [node repaves](../clusters/cluster-management/node-pool.md#repave-behavior-and-configuration) triggered by Palette
-  upgrades on [data center clusters](../clusters/data-center/data-center.md). This was caused by a discrepancy in
-  failure domain resources.
 - Fixed an issue that caused [edge hosts](../clusters/edge/edge.md) using a newer version of the Palette agent than the
 Palette instance itself to become unhealthy upon registration.
 - Fixed an issue that caused errors when using


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes two bug fixes that were accidentally excluded from the 4.6.40 patch. These bug fixes will be added back in the next patch.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
