### PR TITLE
docs: Add missing third-party binary link

### DIFF
--- a/_partials/self-hosted/_airgap-cluster-profile-packs.mdx
+++ b/_partials/self-hosted/_airgap-cluster-profile-packs.mdx
@@ -86,3 +86,4 @@ partial_name: airgap-cluster-profile-packs
 | `airgap-pack-spectro-k8s-dashboard-7.11.1.bin`                 | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-spectro-k8s-dashboard-7.11.1.bin                 |
 | `airgap-pack-tetragon-1.3.0.bin`                               | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-tetragon-1.3.0.bin                               |
 | `airgap-pack-zot-registry-0.1.66.bin`                          | https://software-private.spectrocloud.com/airgap/packs/airgap-pack-zot-registry-0.1.66.bin                          |
+| `airgap-thirdparty-4.6.bin`                                    | https://software-private.spectrocloud.com/airgap/thirdparty/airgap-thirdparty-4.6.bin                               |

--- a/_partials/vertex/_airgap-cluster-profile-packs.mdx
+++ b/_partials/vertex/_airgap-cluster-profile-packs.mdx
@@ -57,3 +57,4 @@ partial_name: airgap-cluster-profile-packs
 | `airgap-vertex-pack-kubernetes-rke2-1.32.3-rke2r1-build20250312.bin`  | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-kubernetes-rke2-1.32.3-rke2r1-build20250312.bin  |
 | `airgap-vertex-pack-registry-connect-0.1.0.bin`                       | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-registry-connect-0.1.0.bin                       |
 | `airgap-vertex-pack-zot-registry-fips-0.1.66.bin`                     | https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-zot-registry-fips-0.1.66.bin                     |
+| `airgap-thirdparty-4.6.bin`                                           | https://software-private.spectrocloud.com/airgap/thirdparty/airgap-thirdparty-4.6.bin                     |

--- a/docs/docs-content/downloads/palette-vertex/additional-packs.md
+++ b/docs/docs-content/downloads/palette-vertex/additional-packs.md
@@ -90,6 +90,6 @@ All binaries require the OCI environment variables to be set and for the registr
 
 In an airgap installation, you need to upload the conformance packs to the self-hosted OCI registry. The conformance
 binary contains the packs required to use the [Compliance Scan](../../clusters/cluster-management/compliance-scan.md)
-capabilities. The conformance binary can be found in the pack table above. The binary has the prefix
-`airgap-thirdparty-`. Follow the [Usage Instructions](#usage-instructions) to upload the conformance packs to the OCI
-registry.
+capabilities. The conformance binary can be found in the [Cluster Profile Packs](#cluster-profile-packs) table. The
+binary has the prefix `airgap-thirdparty-`. Follow the [Usage Instructions](#usage-instructions) to upload the
+conformance packs to the OCI registry.

--- a/docs/docs-content/downloads/self-hosted-palette/additional-packs.md
+++ b/docs/docs-content/downloads/self-hosted-palette/additional-packs.md
@@ -90,6 +90,6 @@ All binaries require the OCI environment variables to be set and for the registr
 
 In an airgap installation, you need to upload the conformance packs to the self-hosted OCI registry. The conformance
 binary contains the packs required to use the [Compliance Scan](../../clusters/cluster-management/compliance-scan.md)
-capabilities. The conformance binary can be found in the pack table above. The binary has the prefix
-`airgap-thirdparty-`. Follow the [Usage Instructions](#usage-instructions) to upload the conformance packs to the OCI
-registry.
+capabilities. The conformance binary can be found in the [Cluster Profile Packs](#cluster-profile-packs) table. The
+binary has the prefix `airgap-thirdparty-`. Follow the [Usage Instructions](#usage-instructions) to upload the
+conformance packs to the OCI registry.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds the third-party binary link that was missing previously.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Self-Hosted Palette - Additional Packs](https://deploy-preview-7205--docs-spectrocloud.netlify.app/downloads/self-hosted-palette/additional-packs/#cluster-profile-packs)
💻 [Palette VerteX - Additional Packs](https://deploy-preview-7205--docs-spectrocloud.netlify.app/downloads/palette-vertex/additional-packs/#cluster-profile-packs)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1874](https://spectrocloud.atlassian.net/browse/DOC-1874)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1874]: https://spectrocloud.atlassian.net/browse/DOC-1874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ