### PR TITLE
docs: DOC-1989: Day-2 Support for kube-vip

### DIFF
--- a/docs/docs-content/clusters/edge/networking/kubevip.md
+++ b/docs/docs-content/clusters/edge/networking/kubevip.md
@@ -36,7 +36,7 @@ these values when deploying a cluster or performing Day-2 cluster operations.
 | `vip_leaderelection` | Enables Kubernetes LeaderElection.                                                              | `"true"`        |
 | `vip_leaseduration`  | Sets the lease duration in seconds.                                                             | `"5"`           |
 | `vip_renewdeadline`  | Specifies the deadline in seconds for renewing the lease.                                       | `"3"`           |
-| `vip_retryperiod`    | Number of times the leader will hold the lease for.                                             | `"1"`           |
+| `vip_retryperiod`    | Number of times the leader holds the lease for.                                             | `"1"`           |
 | `address`            | Template placeholder for the virtual IP address.                                                | `"{{ .VIP}}"`   |
 
 :::warning

--- a/docs/docs-content/clusters/edge/networking/kubevip.md
+++ b/docs/docs-content/clusters/edge/networking/kubevip.md
@@ -36,7 +36,7 @@ these values when deploying a cluster or performing Day-2 cluster operations.
 | `vip_leaderelection` | Enables Kubernetes LeaderElection.                                                              | `"true"`        |
 | `vip_leaseduration`  | Sets the lease duration in seconds.                                                             | `"5"`           |
 | `vip_renewdeadline`  | Specifies the deadline in seconds for renewing the lease.                                       | `"3"`           |
-| `vip_retryperiod`    | Number of times the leader holds the lease for.                                             | `"1"`           |
+| `vip_retryperiod`    | Number of times the leader holds the lease for.                                                 | `"1"`           |
 | `address`            | Template placeholder for the virtual IP address.                                                | `"{{ .VIP}}"`   |
 
 :::warning

--- a/docs/docs-content/clusters/edge/networking/kubevip.md
+++ b/docs/docs-content/clusters/edge/networking/kubevip.md
@@ -16,15 +16,14 @@ kube-vip, you can expose services inside your cluster externally with a virtual 
 control over your host's network. Kube-vip can also act as a load balancer for both your control plane and Kubernetes
 services of type `LoadBalancer`.
 
-## Limitations
+## Default Values
 
-Kube-vip has many environment variables you can use to customize its behavior. You can specify values for the
-environment variables with the `cluster.kubevipArgs` parameter. For a complete list of environment variables in
-kube-vip, refer to
+Kube-vip has many environment variables you can use to customize its behavior. To set values for kube-vip, use the `cluster.kubevipArgs` parameter. For a complete list environment variables, refer to the
 [kube-vip documentation](https://kube-vip.io/docs/installation/flags/?query=vip_interface#environment-variables).
-However, Palette has configured values for the following parameters and they cannot be changed:
 
-| Environment Variable | Description                                                                                     | Example Value   |
+By default, Palette uses the following `cluster.kubevipArgs` values during initial cluster deployment. You can change these values when deploying a cluster or performing Day-2 operations.
+
+| Environment Variable | Description                                                                                     | Default Value   |
 | -------------------- | ----------------------------------------------------------------------------------------------- | --------------- |
 | `vip_arp`            | Enables ARP broadcasts from leader.                                                             | `"true"`        |
 | `port`               | Specifies the port number that `kube-vip` will use.                                             | `"6443"`        |
@@ -33,10 +32,17 @@ However, Palette has configured values for the following parameters and they can
 | `cp_namespace`       | The namespace where the lease will reside.                                                      | `"kube-system"` |
 | `vip_ddns`           | Enables Dynamic DNS support.                                                                    | `"{{ .DDNS}}"`  |
 | `vip_leaderelection` | Enables Kubernetes LeaderElection.                                                              | `"true"`        |
-| `vip_leaseduration`  | Sets the lease duration in seconds.                                                             | `"30"`          |
-| `vip_renewdeadline`  | Specifies the deadline in seconds for renewing the lease.                                       | `"20"`          |
-| `vip_retryperiod`    | Number of times the leader will hold the lease for.                                             | `"4"`           |
+| `vip_leaseduration`  | Sets the lease duration in seconds.                                                             | `"5"`          |
+| `vip_renewdeadline`  | Specifies the deadline in seconds for renewing the lease.                                       | `"3"`          |
+| `vip_retryperiod`    | Number of times the leader will hold the lease for.                                             | `"1"`           |
 | `address`            | Template placeholder for the virtual IP address.                                                | `"{{ .VIP}}"`   |
+
+:::warning
+
+Do not modify the default `address` value. Changing this value makes the cluster inaccessible.
+
+:::
+
 
 ## Prerequisites
 

--- a/docs/docs-content/clusters/edge/networking/kubevip.md
+++ b/docs/docs-content/clusters/edge/networking/kubevip.md
@@ -19,11 +19,11 @@ services of type `LoadBalancer`.
 ## Default Values
 
 Kube-vip has many environment variables you can use to customize its behavior. To set values for kube-vip, use the
-`cluster.kubevipArgs` parameter. For a complete list environment variables, refer to the
+`cluster.kubevipArgs` parameter. For a complete list of environment variables, refer to the
 [kube-vip documentation](https://kube-vip.io/docs/installation/flags/?query=vip_interface#environment-variables).
 
 By default, Palette uses the following `cluster.kubevipArgs` values during initial cluster deployment. You can change
-these values when deploying a cluster or performing Day-2 operations.
+these values when deploying a cluster or performing Day-2 cluster operations.
 
 | Environment Variable | Description                                                                                     | Default Value   |
 | -------------------- | ----------------------------------------------------------------------------------------------- | --------------- |

--- a/docs/docs-content/clusters/edge/networking/kubevip.md
+++ b/docs/docs-content/clusters/edge/networking/kubevip.md
@@ -18,10 +18,12 @@ services of type `LoadBalancer`.
 
 ## Default Values
 
-Kube-vip has many environment variables you can use to customize its behavior. To set values for kube-vip, use the `cluster.kubevipArgs` parameter. For a complete list environment variables, refer to the
+Kube-vip has many environment variables you can use to customize its behavior. To set values for kube-vip, use the
+`cluster.kubevipArgs` parameter. For a complete list environment variables, refer to the
 [kube-vip documentation](https://kube-vip.io/docs/installation/flags/?query=vip_interface#environment-variables).
 
-By default, Palette uses the following `cluster.kubevipArgs` values during initial cluster deployment. You can change these values when deploying a cluster or performing Day-2 operations.
+By default, Palette uses the following `cluster.kubevipArgs` values during initial cluster deployment. You can change
+these values when deploying a cluster or performing Day-2 operations.
 
 | Environment Variable | Description                                                                                     | Default Value   |
 | -------------------- | ----------------------------------------------------------------------------------------------- | --------------- |
@@ -32,8 +34,8 @@ By default, Palette uses the following `cluster.kubevipArgs` values during initi
 | `cp_namespace`       | The namespace where the lease will reside.                                                      | `"kube-system"` |
 | `vip_ddns`           | Enables Dynamic DNS support.                                                                    | `"{{ .DDNS}}"`  |
 | `vip_leaderelection` | Enables Kubernetes LeaderElection.                                                              | `"true"`        |
-| `vip_leaseduration`  | Sets the lease duration in seconds.                                                             | `"5"`          |
-| `vip_renewdeadline`  | Specifies the deadline in seconds for renewing the lease.                                       | `"3"`          |
+| `vip_leaseduration`  | Sets the lease duration in seconds.                                                             | `"5"`           |
+| `vip_renewdeadline`  | Specifies the deadline in seconds for renewing the lease.                                       | `"3"`           |
 | `vip_retryperiod`    | Number of times the leader will hold the lease for.                                             | `"1"`           |
 | `address`            | Template placeholder for the virtual IP address.                                                | `"{{ .VIP}}"`   |
 
@@ -42,7 +44,6 @@ By default, Palette uses the following `cluster.kubevipArgs` values during initi
 Do not modify the default `address` value. Changing this value makes the cluster inaccessible.
 
 :::
-
 
 ## Prerequisites
 

--- a/docs/docs-content/clusters/edge/networking/kubevip.md
+++ b/docs/docs-content/clusters/edge/networking/kubevip.md
@@ -25,8 +25,8 @@ Kube-vip has many environment variables you can use to customize its behavior. T
 By default, Palette uses the following `cluster.kubevipArgs` values during initial cluster deployment. You can change
 these values when deploying a cluster or performing Day-2 cluster operations.
 
-| Environment Variable | Description                                                                                     | Default Value   |
-| -------------------- | ----------------------------------------------------------------------------------------------- | --------------- |
+| Environment Variable | Description                                                                                     | Default Value |
+| -------------------- | ----------------------------------------------------------------------------------------------- | ------------- |
 | `vip_arp`            | Enables ARP broadcasts from leader.                                                             | `true`        |
 | `port`               | Specifies the port number that `kube-vip` will use.                                             | `6443`        |
 | `vip_cidr`           | Sets the CIDR notation for the Virtual IP. A value of `32` denotes a single IP address in IPv4. | `32`          |

--- a/docs/docs-content/clusters/edge/networking/kubevip.md
+++ b/docs/docs-content/clusters/edge/networking/kubevip.md
@@ -27,17 +27,17 @@ these values when deploying a cluster or performing Day-2 cluster operations.
 
 | Environment Variable | Description                                                                                     | Default Value   |
 | -------------------- | ----------------------------------------------------------------------------------------------- | --------------- |
-| `vip_arp`            | Enables ARP broadcasts from leader.                                                             | `"true"`        |
-| `port`               | Specifies the port number that `kube-vip` will use.                                             | `"6443"`        |
-| `vip_cidr`           | Sets the CIDR notation for the Virtual IP. A value of `32` denotes a single IP address in IPv4. | `"32"`          |
-| `cp_enable`          | Enables kube-vip control plane functionality.                                                   | `"true"`        |
-| `cp_namespace`       | The namespace where the lease will reside.                                                      | `"kube-system"` |
-| `vip_ddns`           | Enables Dynamic DNS support.                                                                    | `"{{ .DDNS}}"`  |
-| `vip_leaderelection` | Enables Kubernetes LeaderElection.                                                              | `"true"`        |
-| `vip_leaseduration`  | Sets the lease duration in seconds.                                                             | `"5"`           |
-| `vip_renewdeadline`  | Specifies the deadline in seconds for renewing the lease.                                       | `"3"`           |
-| `vip_retryperiod`    | Number of times the leader holds the lease for.                                                 | `"1"`           |
-| `address`            | Template placeholder for the virtual IP address.                                                | `"{{ .VIP}}"`   |
+| `vip_arp`            | Enables ARP broadcasts from leader.                                                             | `true`        |
+| `port`               | Specifies the port number that `kube-vip` will use.                                             | `6443`        |
+| `vip_cidr`           | Sets the CIDR notation for the Virtual IP. A value of `32` denotes a single IP address in IPv4. | `32`          |
+| `cp_enable`          | Enables kube-vip control plane functionality.                                                   | `true`        |
+| `cp_namespace`       | The namespace where the lease will reside.                                                      | `kube-system` |
+| `vip_ddns`           | Enables Dynamic DNS support.                                                                    | `{{ .DDNS}}`  |
+| `vip_leaderelection` | Enables Kubernetes LeaderElection.                                                              | `true`        |
+| `vip_leaseduration`  | Sets the lease duration in seconds.                                                             | `5`           |
+| `vip_renewdeadline`  | Specifies the deadline in seconds for renewing the lease.                                       | `3`           |
+| `vip_retryperiod`    | Number of times the leader holds the lease for.                                                 | `1`           |
+| `address`            | Template placeholder for the virtual IP address.                                                | `{{ .VIP}}`   |
 
 :::warning
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR reworks the existing limitations section for kube-vip into a default values section, as day-2 operations are now allowed.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Publish Cluster Services with Kube-vip](https://deploy-preview-7231--docs-spectrocloud.netlify.app/clusters/edge/networking/kubevip/#default-values)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1989](https://spectrocloud.atlassian.net/browse/DOC-1989)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work.


[DOC-1989]: https://spectrocloud.atlassian.net/browse/DOC-1989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ