### PR TITLE
docs: DOC-1929: GPU > Supported Machine Types GCP k8s Fix

### DIFF
--- a/docs/docs-content/clusters/public-cloud/gcp/create-gcp-gke-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/create-gcp-gke-cluster.md
@@ -82,7 +82,7 @@ Ensure the following requirements are met before you attempt to deploy a cluster
 
     You can add new worker pools to customize specific worker nodes to run specialized workloads. For example, the
     default worker pool may be configured with the c2.standard-4 instance types for general-purpose workloads. You can
-    configure another worker pool with instance type g2-standard-4 to run GPU workloads.
+    configure another worker pool with instance type g2-standard-4 to run supported machine types.
 
     :::
 

--- a/docs/docs-content/clusters/public-cloud/gcp/create-gcp-iaas-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/create-gcp-iaas-cluster.md
@@ -93,7 +93,7 @@ Ensure the following requirements are met before you attempt to deploy a cluster
 
     You can add new worker pools to customize specific worker nodes to run specialized workloads. For example, the
     default worker pool may be configured with the c2.standard-4 instance types for general-purpose workloads. You can
-    configure another worker pool with instance type g2-standard-4 to leverage GPU workloads.
+    configure another worker pool with instance type g2-standard-4 to leverage supported machine types.
 
     :::
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the verbiage associated with configuring Google IaaS and GKE machine pools. GPU machine types are not currently supported through the Palette UI.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Create and Manage GCP IaaS Cluster]()
- [Create and Manage GCP GKE Cluster]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1929](https://spectrocloud.atlassian.net/browse/DOC-1929)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
