### PR TITLE
[version-4-0] docs: backport/version-4-0/pr-7234

### DIFF
--- a/docs/docs-content/clusters/public-cloud/gcp/create-gcp-gke-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/create-gcp-gke-cluster.md
@@ -14,6 +14,8 @@ to create a Kubernetes cluster that is deployed to GKE and that Palette manages.
 
 - Autoscaling is not supported for GKE clusters.
 
+- GPU machine types cannot be used to configure node pools.
+
 ## Prerequisites
 
 Ensure the following requirements are met before you attempt to deploy a cluster to GCP.
@@ -79,9 +81,9 @@ Ensure the following requirements are met before you attempt to deploy a cluster
 
 :::info
 
-You can add new worker pools to customize specific worker nodes to run specialized workloads. For example, the default
-worker pool may be configured with the c2.standard-4 instance types for general-purpose workloads. You can configure
-another worker pool with instance type g2-standard-4 to run GPU workloads.
+    You can add new worker pools to customize specific worker nodes to run specialized workloads. For example, the
+    default worker pool may be configured with the c2.standard-4 instance types for general-purpose workloads. You can
+    configure another worker pool with instance type g2-standard-4 to run supported machine types.
 
 :::
 

--- a/docs/docs-content/clusters/public-cloud/gcp/create-gcp-iaas-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/create-gcp-iaas-cluster.md
@@ -9,6 +9,10 @@ sidebar_position: 20
 Palette supports creating and managing Kubernetes clusters deployed to a Google Cloud Platform (GCP) account. This
 section guides you to create an IaaS Kubernetes cluster in GCP that Palette manages.
 
+## Limitations
+
+- GPU machine types cannot be used to configure node pools.
+
 ## Prerequisites
 
 Ensure the following requirements are met before you attempt to deploy a cluster to GCP:
@@ -88,9 +92,9 @@ Ensure the following requirements are met before you attempt to deploy a cluster
 
 :::info
 
-You can add new worker pools to customize specific worker nodes to run specialized workloads. For example, the default
-worker pool may be configured with the c2.standard-4 instance types for general-purpose workloads. You can configure
-another worker pool with instance type g2-standard-4 to leverage GPU workloads.
+    You can add new worker pools to customize specific worker nodes to run specialized workloads. For example, the
+    default worker pool may be configured with the c2.standard-4 instance types for general-purpose workloads. You can
+    configure another worker pool with instance type g2-standard-4 to leverage supported machine types.
 
 :::
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR creates a manual backport for version-4-0 regarding [PR 7234](https://github.com/spectrocloud/librarium/pull/7234).

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Create and Manage GCP IaaS Cluster](https://deploy-preview-7255--docs-spectrocloud.netlify.app/clusters/public-cloud/gcp/create-gcp-iaas-cluster/#limitations)
- [Create and Manage GCP GKE Cluster](https://deploy-preview-7255--docs-spectrocloud.netlify.app/clusters/public-cloud/gcp/create-gcp-gke-cluster/#limitations)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1929](https://spectrocloud.atlassian.net/browse/DOC-1929)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Is the backport.

[DOC-1929]: https://spectrocloud.atlassian.net/browse/DOC-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ