### PR TITLE
docs: DOC-2007: Remove Cluster Definitions from Tech Preview

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
@@ -72,8 +72,8 @@ ISO can also contain the following components:
   profiles. You have the option to build content bundles into the Edge Installer ISO, which allows your Edge host to
   build clusters without a connection to external image registries.
 
-- **Cluster definition** - A cluster definition include one or more cluster profiles. You can export cluster
-  definitions from any existing cluster profiles in your Palette account. If you include a cluster definition in your
+- **Cluster definition** - A cluster definition includes one or more cluster profiles. You can export cluster
+  definitions from any existing cluster profile in your Palette account. If you include a cluster definition in your
   Edge Installer ISO, you can use the profiles contained within to build a cluster without a connection to a Palette
   instance.
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
@@ -63,16 +63,16 @@ An ISO file that bootstraps the installation is created in the EdgeForge process
 Installer that installs the Palette Edge host agent and metadata to perform the initial installation. The Edge Installer
 ISO can also contain the following components:
 
-- User data. User data includes essential configurations for the Edge Installer. The Edge Installer ISO requires user
+- **User data** - User data includes essential configurations for the Edge Installer. The Edge Installer ISO requires user
   data to function. If you choose to not supply user data in the ISO, you must supply it before the Edge Installer
   initiates with a site user data. You can also use site user data to override or supplement the user data supplied in
   the installer ISO.
 
-- Content bundle. Content bundles are archives of all the required container images required for specified cluster
+- **Content bundle** - Content bundles are archives of all the required container images required for specified cluster
   profiles. You have the option to build content bundles into the Edge Installer ISO, which allows your Edge host to
   build clusters without a connection to external image registries.
 
-- Cluster definition (Tech Preview). A cluster definition include one or more cluster profiles. You can export cluster
+- **Cluster definition** - A cluster definition include one or more cluster profiles. You can export cluster
   definitions from any existing cluster profiles in your Palette account. If you include a cluster definition in your
   Edge Installer ISO, you can use the profiles contained within to build a cluster without a connection to a Palette
   instance.

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
@@ -73,7 +73,7 @@ ISO can also contain the following components:
   build clusters without a connection to external image registries.
 
 - **Cluster definition** - A cluster definition includes one or more cluster profiles. You can export cluster
-  definitions from any existing cluster profile in your Palette account. If you include a cluster definition in your
+  definitions from any existing cluster profiles in your Palette account. If you include a cluster definition in your
   Edge Installer ISO, you can use the profiles contained within to build a cluster without a connection to a Palette
   instance.
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/edgeforge-workflow.md
@@ -63,8 +63,8 @@ An ISO file that bootstraps the installation is created in the EdgeForge process
 Installer that installs the Palette Edge host agent and metadata to perform the initial installation. The Edge Installer
 ISO can also contain the following components:
 
-- **User data** - User data includes essential configurations for the Edge Installer. The Edge Installer ISO requires user
-  data to function. If you choose to not supply user data in the ISO, you must supply it before the Edge Installer
+- **User data** - User data includes essential configurations for the Edge Installer. The Edge Installer ISO requires
+  user data to function. If you choose to not supply user data in the ISO, you must supply it before the Edge Installer
   initiates with a site user data. You can also use site user data to override or supplement the user data supplied in
   the installer ISO.
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
@@ -23,18 +23,18 @@ artifacts at the same time.
 
 You can build the following content into the Edge installer ISO to customize your installation:
 
-- **User data** - This is a YAML file that contains the configuration for the Edge Installer. For all available configuration
-  options, refer to [Installer Configuration](../../edge-configuration/installer-reference.md). User data is required
-  for the installer ISO. The build process validates the user data first before building the ISO.
+- **User data** - This is a YAML file that contains the configuration for the Edge Installer. For all available
+  configuration options, refer to [Installer Configuration](../../edge-configuration/installer-reference.md). User data
+  is required for the installer ISO. The build process validates the user data first before building the ISO.
   - If you do not include the user data file during the Edge Installer ISO build process, you must provide this
     configuration before the installation takes place with site user data. For more information, refer to
     [Apply Site User Data](../../site-deployment/site-installation/site-user-data.md).
 - **Content bundles** - This is an archive of all images, Helm charts and packs used for any number of specified cluster
   profiles. Content bundles are optional to include in an installer ISO.
-- **Cluster definition** - Cluster definitions contain cluster profiles and any profile variables used in the
-  profiles. When you include a cluster definition during the Edge Installer ISO build process, you can create a new
-  cluster that uses your imported cluster definition in your Edge host using Local UI. Cluster definitions are optional
-  to include in an installer ISO.
+- **Cluster definition** - Cluster definitions contain cluster profiles and any profile variables used in the profiles.
+  When you include a cluster definition during the Edge Installer ISO build process, you can create a new cluster that
+  uses your imported cluster definition in your Edge host using Local UI. Cluster definitions are optional to include in
+  an installer ISO.
 
 The benefits of building the installer configuration, content bundles, and cluster definition into the installer ISO is
 that you can ensure the standardization of your Edge deployments through the installer. Whether you build the content

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
@@ -31,7 +31,7 @@ You can build the following content into the Edge installer ISO to customize you
     [Apply Site User Data](../../site-deployment/site-installation/site-user-data.md).
 - **Content bundles** - This is an archive of all images, Helm charts and packs used for any number of specified cluster
   profiles. Content bundles are optional to include in an installer ISO.
-- **Cluster definition** - Cluster definitions contains cluster profiles and any profile variables used in the
+- **Cluster definition** - Cluster definitions contain cluster profiles and any profile variables used in the
   profiles. When you include a cluster definition during the Edge Installer ISO build process, you can create a new
   cluster that uses your imported cluster definition in your Edge host using Local UI. Cluster definitions are optional
   to include in an installer ISO.

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
@@ -23,22 +23,18 @@ artifacts at the same time.
 
 You can build the following content into the Edge installer ISO to customize your installation:
 
-- User data. This is a YAML file that contains the configuration for the Edge Installer. For all available configuration
+- **User data** - This is a YAML file that contains the configuration for the Edge Installer. For all available configuration
   options, refer to [Installer Configuration](../../edge-configuration/installer-reference.md). User data is required
   for the installer ISO. The build process validates the user data first before building the ISO.
   - If you do not include the user data file during the Edge Installer ISO build process, you must provide this
     configuration before the installation takes place with site user data. For more information, refer to
     [Apply Site User Data](../../site-deployment/site-installation/site-user-data.md).
-- Content bundles. This is an archive of all images, Helm charts and packs used for any number of specified cluster
+- **Content bundles** - This is an archive of all images, Helm charts and packs used for any number of specified cluster
   profiles. Content bundles are optional to include in an installer ISO.
-- Cluster definition (Tech Preview). Cluster definitions contains cluster profiles and any profile variables used in the
+- **Cluster definition** - Cluster definitions contains cluster profiles and any profile variables used in the
   profiles. When you include a cluster definition during the Edge Installer ISO build process, you can create a new
   cluster that uses your imported cluster definition in your Edge host using Local UI. Cluster definitions are optional
   to include in an installer ISO.
-
-  :::preview
-
-  :::
 
 The benefits of building the installer configuration, content bundles, and cluster definition into the installer ISO is
 that you can ensure the standardization of your Edge deployments through the installer. Whether you build the content
@@ -210,7 +206,7 @@ a locally managed Edge host via [Local UI](../../local-ui/local-ui.md). For more
 
 13. Place the directory containing the content bundle file in the root directory of the `CanvOS` directory.
 
-### Prepare Cluster Definition (Tech Preview)
+### Prepare Cluster Definition
 
 Optionally, you can include a cluster definition in your Edge Installer ISO. Cluster definitions include one or more
 cluster profile and any dynamic values used in the cluster profiles. Cluster definitions can be exported from an Palette


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes all mentions of tech preview associated with cluster definitions and includes minor grammar/formatting fixes. The grammar/formatting fixes are also included in [PR 7267](https://github.com/spectrocloud/librarium/pull/7267) for backporting purposes.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [EdgeForge Workflow](https://deploy-preview-7266--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/#edge-installer-iso)
- [Build Installer ISO](https://deploy-preview-7266--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso/)


## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2007](https://spectrocloud.atlassian.net/browse/DOC-2007)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work.


[DOC-2007]: https://spectrocloud.atlassian.net/browse/DOC-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ