### PR TITLE
docs: Removing Leftover Local UI Tech Preview Mentions

### DIFF
--- a/docs/deprecated/clusters/edge/edgeforge-workflow/build-artifacts.md
+++ b/docs/deprecated/clusters/edge/edgeforge-workflow/build-artifacts.md
@@ -234,7 +234,8 @@ Creating a content bundle provides several benefits that may address common use 
 
    The result is a content bundle that you can use to preload into your installer. For more information, refer to
    [Build Edge Artifacts with Content Bundle](./palette-canvos/build-artifacts.md) or
-   [Build Installer ISO](./palette-canvos/build-installer-iso.md). [Local UI](../local-ui/local-ui.md) also allows you to upload content bundles to a disconnected Edge deployment.
+   [Build Installer ISO](./palette-canvos/build-installer-iso.md). [Local UI](../local-ui/local-ui.md) also allows you
+   to upload content bundles to a disconnected Edge deployment.
 
    Alternatively, you can use the ISO version of the content bundle and transfer it to a USB drive to be used separately
    at the time of Edge host installation using the `-iso` flag in your build command. Doing so will override the file

--- a/docs/deprecated/clusters/edge/edgeforge-workflow/build-artifacts.md
+++ b/docs/deprecated/clusters/edge/edgeforge-workflow/build-artifacts.md
@@ -234,8 +234,7 @@ Creating a content bundle provides several benefits that may address common use 
 
    The result is a content bundle that you can use to preload into your installer. For more information, refer to
    [Build Edge Artifacts with Content Bundle](./palette-canvos/build-artifacts.md) or
-   [Build Installer ISO](./palette-canvos/build-installer-iso.md). Our Tech Preview feature
-   [Local UI](../local-ui/local-ui.md) also allows you to upload content bundles to a disconnected Edge deployment.
+   [Build Installer ISO](./palette-canvos/build-installer-iso.md). [Local UI](../local-ui/local-ui.md) also allows you to upload content bundles to a disconnected Edge deployment.
 
    Alternatively, you can use the ISO version of the content bundle and transfer it to a USB drive to be used separately
    at the time of Edge host installation using the `-iso` flag in your build command. Doing so will override the file

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
@@ -168,8 +168,9 @@ Use the following instructions to build the Edge Installer ISO. The optional ste
 
     :::tip
 
-    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation. However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can be updated in
-    Local UI.
+    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation.
+    However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can
+    be updated in Local UI.
 
     :::
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso.md
@@ -168,9 +168,8 @@ Use the following instructions to build the Edge Installer ISO. The optional ste
 
     :::tip
 
-    You can take advantage of the Tech Preview feature to edit user data in Local UI after installation. However, we
-    still recommend providing user data during EdgeForge when deploying production workloads, as this is a Tech Preview
-    feature and not all fields are editable in the Local UI.
+    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation. However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can be updated in
+    Local UI.
 
     :::
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/fips.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/fips.md
@@ -269,8 +269,9 @@ workaround.
 
     :::tip
 
-    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation. However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can be updated in
-    Local UI.
+    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation.
+    However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can
+    be updated in Local UI.
 
     :::
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/fips.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/fips.md
@@ -269,9 +269,8 @@ workaround.
 
     :::tip
 
-    You can take advantage of the Tech Preview feature to edit user data in Local UI after installation. However, we
-    still recommend you provide user data during EdgeForge for production workloads because this is a Tech Preview
-    feature and not all fields are available for edit in Local UI.
+    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation. However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can be updated in
+    Local UI.
 
     :::
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
@@ -232,7 +232,9 @@ customization.
 
     :::tip
 
-    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation. However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can be updated in Local UI.
+    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation.
+    However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can
+    be updated in Local UI.
 
     :::
 
@@ -732,8 +734,9 @@ required Edge artifacts.
 
     :::
 
-    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation. However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can be updated in
-    Local UI.
+    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation.
+    However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can
+    be updated in Local UI.
 
     :::info
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
@@ -232,9 +232,7 @@ customization.
 
     :::tip
 
-    You can take advantage of the Tech Preview feature to edit user data in Local UI after installation. However, we
-    still recommend you provide user data during EdgeForge for production workloads because this is a Tech Preview
-    feature and not all fields are available for edit in Local UI.
+    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation. However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can be updated in Local UI.
 
     :::
 
@@ -734,9 +732,7 @@ required Edge artifacts.
 
     :::
 
-    You can take advantage of the Tech Preview feature to edit user data in Local UI after installation. Refer to
-    [Edit User Data](../../local-ui/host-management/edit-user-data.md) for more information. However, we still recommend
-    you provide user data during EdgeForge for production workloads, because not all user data fields can be updated in
+    You can also [edit user data in Local UI](../../local-ui/host-management/edit-user-data.md) after installation. However, we recommend providing user data during EdgeForge for production workloads, as not all user data fields can be updated in
     Local UI.
 
     :::info

--- a/docs/docs-content/glossary-all.md
+++ b/docs/docs-content/glossary-all.md
@@ -124,7 +124,7 @@ etc.
 ## Local UI
 
 Local UI is a browser-based tool that allows you to manage your Edge host and perform tasks such as creating local
-clusters, upload content bundles, and configure network settings.
+clusters, uploading content bundles, and configuring network settings.
 
 ## Helm Charts
 

--- a/docs/docs-content/glossary-all.md
+++ b/docs/docs-content/glossary-all.md
@@ -124,8 +124,7 @@ etc.
 ## Local UI
 
 Local UI is a browser-based tool that allows you to manage your Edge host and perform tasks such as creating local
-clusters, upload content bundles, and configure network settings. Local UI is a Tech Preview feature and should not be
-used in production workloads.
+clusters, upload content bundles, and configure network settings.
 
 ## Helm Charts
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes leftover tech preview mentions related to Local UI, which exited tech preview in 4.6.c.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Build Installer ISO](https://deploy-preview-7268--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/build-installer-iso/#:~:text=You%20can%20also%20edit)
- [Build FIPS-Compliant Edge Artifacts](https://deploy-preview-7268--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/fips/#:~:text=You%20can%20also%20edit)
- [Build Edge Artifacts](https://deploy-preview-7268--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/#:~:text=You%20can%20also%20edit)
- [Glossary](https://deploy-preview-7268--docs-spectrocloud.netlify.app/glossary-all/#local-ui)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
