### PR TITLE
doc-2005: remove tech preview from EDGE API

### DIFF
--- a/docs/api-content/api-docs/1-introduction.md
+++ b/docs/api-content/api-docs/1-introduction.md
@@ -269,10 +269,6 @@ using embedded cluster definitions.
 You can find the Open API Swagger specification for the Edge Management API at the following location:
 https://raw.githubusercontent.com/spectrocloud/librarium/version-4-4/docs/api-content/api-docs/edge-v1/emc-api.json
 
-:::preview
-
-:::
-
 ### Authentication
 
 Use the `POST /v1/users/default/login` endpoint to generate an authentication token with your OS username and password.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes Tech Preview from Edge API page

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page](https://deploy-preview-7278--docs-spectrocloud.netlify.app/api/introduction/#edge-management-api)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-2005)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [X] No. _Please leave a short comment below about why this PR cannot be backported._

Targetted for 4.7.0 release
