### PR TITLE
docs: PCP-4725: AWS EKS AMI Node Pool Updates

### DIFF
--- a/docs/docs-content/clusters/public-cloud/aws/eks.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks.md
@@ -3,6 +3,7 @@ sidebar_label: "Create and Manage AWS EKS Cluster"
 title: "Create and Manage AWS EKS Cluster"
 description: "Learn how to deploy and manage AWS EKS clusters with Palette."
 hide_table_of_contents: false
+toc_max_heading_level: 5
 tags: ["public cloud", "aws", "eks"]
 sidebar_position: 30
 ---
@@ -275,59 +276,18 @@ an AWS account. This section guides you on how to create an EKS cluster in AWS t
     | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
     | **Node pool name**              | A descriptive name for the node pool.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
     | **Number of nodes in the pool** | Specify the number of nodes in the worker pool.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-    | **Additional Labels**           | You can add optional labels to nodes in key-value format. Review the [Assign an AMI to a Node Pool](#assign-an-ami-to-a-node-pool) section for guidance on assigning specific AMIs to node pools. For general information about applying labels, review the [Node Labels](../../cluster-management/node-labels.md) guide. Example: `"environment": "production"`                                                                                                                                                                                                                                                                                                                                                                                                                               |
-    | **Taints**                      | You can apply optional taint labels to a node pool during cluster creation or edit taint labels on an existing cluster. Review the [Node Pool](../../cluster-management/node-pool.md) management page and [Taints and Tolerations](../../cluster-management/taints.md) guide to learn more. Toggle the **Taint** button to create a taint label. When tainting is enabled, you need to provide a custom key-value pair. Use the **drop-down Menu** to choose one of the following **Effect** options:<br />**NoSchedule** - Pods are not scheduled onto nodes with this taint.<br />**PreferNoSchedule** - Kubernetes attempts to avoid scheduling pods onto nodes with this taint, but scheduling is not prohibited.<br />**NoExecute** - Existing pods on nodes with this taint are evicted. |
+    | **Additional Labels**           | You can add optional labels to nodes in key-value format. For general information about applying labels, review the [Node Labels](../../cluster-management/node-labels.md) guide. Example: `"environment": "production"`                                                                                                                                                                                                                                                                                                                                                                                                                               |
+    | **Taints**                      | You can apply optional taint labels to a node pool during cluster creation or edit taint labels on an existing cluster. Review the [Node Pool](../../cluster-management/node-pool.md) management page and [Taints and Tolerations](../../cluster-management/taints.md) guide to learn more. Toggle the **Taint** button to create a taint label. When tainting is enabled, you need to provide a custom key-value pair. Use the **drop-down Menu** to choose one of the following **Effect** options:<br /><br />- **NoSchedule** - Pods are not scheduled onto nodes with this taint.<br />- **PreferNoSchedule** - Kubernetes attempts to avoid scheduling pods onto nodes with this taint, but scheduling is not prohibited.<br />- **NoExecute** - Existing pods on nodes with this taint are evicted. |
 
-    ##### Assign an AMI to a Node Pool
-
-    :::warning
-
-    - Node pools configured with an AMI label cannot be configured with the **Enable Nodepool Customization** setting,
-      which allows you to specify an Amazon Machine Image (AMI) ID or disk type. Clusters with both configurations may
-      fail to provision.
-
-    - Nodes using Amazon Linux 2023 must configure IAM Roles for Service Accounts (IRSA) if you are using AWS CSI packs
-      such as Amazon EBS CSI, Amazon EFS CSI, and Amazon Cloud Native. It is also required if using the AWS Application
-      Loadbalancer. Refer to the
-      [Scenario - PV/PVC Stuck in Pending Status for EKS Cluster Using AL2023 AMI](../../../troubleshooting/cluster-deployment.md#scenario---pvpvc-stuck-in-pending-status-for-eks-cluster-using-al2023-ami)
-      troubleshooting guide for further information.
-
-    :::
-
-    Assign an AMI to a node pool by adding an additional label specifying the AMI to use. You can choose from one of the
-    following supported AMIs. Copy the exact label shown in the code block and paste it to the **Additional Labels**
-    option in the **Node Configuration Settings**.
-
-    ```shell title="Amazon Linux 2 (x86-64)"
-    spectrocloud.com/ami-type:AL2_x86_64
-    ```
-
-    ```shell title="Amazon Linux 2023 (x86-64)"
-    spectrocloud.com/ami-type:AL2023_x86_64_STANDARD
-    ```
-
-    ```shell title="Amazon Linux 2023 with AWS Neuron drivers (x86-64)"
-    spectrocloud.com/ami-type:AL2023_x86_64_NEURON
-    ```
-
-    ```shell title="Amazon Linux 2023 with NVIDIA drivers (x86-64)"
-    spectrocloud.com/ami-type:AL2023_x86_64_NVIDIA
-    ```
-
-    :::info
-
-    The **Amazon Linux 2 (x86-64)** AMI is used by default if no AMI is specified or there is a typo in the label.
-
-    :::
-
-    #### Cloud Configuration settings
+    #### Cloud Configuration Settings
 
     | **Parameter**                     | **Description**                                                                                                                                                                                                                                                                        |
     | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-    | **Instance Option**               | Choose a pricing method:<br />**On-Demand** instances provide stable and uninterrupted compute capacity at a higher cost.<br />**Spot** instances allow you to bid for unused EC2 capacity at a lower cost.<br />We recommend you base your choice on your application's requirements. |
+    | **Instance Option**               | Choose a pricing method:<br /><br />- **On-Demand** instances provide stable and uninterrupted compute capacity at a higher cost.<br />- **Spot** instances allow you to bid for unused EC2 capacity at a lower cost.<br />We recommend you base your choice on your application's requirements. |
     | **Instance Type**                 | Select the instance type to use for all nodes in the node pool.                                                                                                                                                                                                                        |
-    | **Enable Nodepool Customization** | To use a pre-configured VM image, toggle this option on and provide the Amazon Machine Image (AMI) ID. When this option is enabled, you can use the **drop-down Menu** to specify the disk type to use.                                                                                |
-    | **Root Disk size**                | You can choose disk size based on your requirements. The default size is `60`.                                                                                                                                                                                                         |
+    | **Amazon Machine Image (AMI) Type (Optional)** | Specify a base AMI to use for your worker nodes: **AL2_x86_64**, **AL2_x86_64_GPU**, **AL2023_x86_64_STANDARD**, **AL2023_x86_64_NEURON**, or **AL2023_x86_64_NVIDIA**. An **AL2_x86_64** AMI is used by default if no AMI is selected. <br /><br /> The AMI type cannot be modified post-deployment. Nodes using an Amazon Linux 2023 (AL2023) AMI must configure IAM Roles for Service Accounts (IRSA) if you are using AWS CSI packs such as Amazon EBS CSI, Amazon EFS CSI, and Amazon Cloud Native. IRSA is also required if using the AWS Application Loadbalancer. Refer to the [Scenario - PV/PVC Stuck in Pending Status for EKS Cluster Using AL2023 AMI](../../../troubleshooting/cluster-deployment.md#scenario---pvpvc-stuck-in-pending-status-for-eks-cluster-using-al2023-ami) troubleshooting guide for further information.
+    | **Enable Nodepool Customization (Optional)** | Activate additional node pool customization options: <br /><br />- **Amazon Machine Image (AMI) ID (Optional)** - Use a pre-configured VM image by providing the ID value of the AMI. The AMI ID can be updated post-deployment, but the base AMI type must always match the type specified in the **Amazon Machine Image (AMI) Type (Optional)** field. <br />- **Disk Type (Optional)** - Specify the disk type to use.                                                                                |
+    | **Root Disk size (GB)**                | You can choose a disk size based on your requirements. The default size is `60`.                                                                                                                                                                                                         |
 
     #### Fargate Profiles
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -35,6 +35,8 @@ tags: ["release-notes"]
   - `kube-system`
   - `cluster-<cluster-uid>`
 
+- [AWS EKS clusters] deployed through Palette now require an **Amazon Machine Image (AMI) Type** selection when configuring worker node pools. The default AMI type is **AL2_x86_64**. Previously, AMI types were specified using the **Additional Labels** field; a dedicated **Amazon Machine Image (AMI) Type** drop-down menu replaces this method. Refer to the [Create and Manage AWS EKS Cluster](../clusters/public-cloud/aws/eks.md#node-configuration-settings) cluster guide for more information on configuring EKS node pools.    
+
 #### Features
 
 #### Improvements


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the default method for specifying AMI types for node pools when deploying AWS EKS clusters. This change is a breaking change.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Create and Manage AWS EKS Cluster]()
- [Release Notes]

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PCP-4725](https://spectrocloud.atlassian.net/browse/PCP-4725?atlOrigin=eyJpIjoiNmU0ZDA1NzFkMTA4NDFhNmEwMzVkOTQ4ZGIwNjU1YzUiLCJwIjoiaiJ9)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work.
