### PR TITLE
PCP-4838: inital warnings about port 6443 and update to network page

### DIFF
--- a/docs/docs-content/architecture/networking-ports.md
+++ b/docs/docs-content/architecture/networking-ports.md
@@ -40,6 +40,7 @@ The following ports must be reachable from a network perspective for Palette to 
 | :-------------- | :-------- | :----------------------------------------------------------- |
 | HTTPS (tcp/443) | INBOUND   | Browser/API access to management platform .                  |
 | HTTPS (tcp/443) | INBOUND   | gRPC communication between Palette and the workload cluster. |
+| HTTPS (tcp/6443) | OUTBOUND      | Workload K8s cluster API Server                                                         |
 
 ### Workload Cluster
 

--- a/docs/docs-content/clusters/public-cloud/aws/create-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/aws/create-cluster.md
@@ -55,6 +55,10 @@ The following prerequisites must be met before deploying a cluster to AWS:
   will need to either rename the existing security group before creating the cluster, or use a different cluster name.
   Otherwise, the cluster creation will fail due to duplicate resource name in the VPC.
 
+:::warning
+For static network deployments, you must have port 6443 open between Palette and the Workload cluster. Refer to the [Network Ports](../../../architecture/networking-ports.md) documentation for detailed network architecture diagrams and to learn more about the ports used for communication.
+:::
+
 ## Deploy an AWS Cluster
 
 Use the following steps to provision a new AWS cluster:

--- a/docs/docs-content/clusters/public-cloud/aws/eks.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks.md
@@ -206,6 +206,10 @@ an AWS account. This section guides you on how to create an EKS cluster in AWS t
 
   :::
 
+:::warning
+For static network deployments, you must have port 6443 open between Palette and the Workload cluster. Refer to the [Network Ports](../../../architecture/networking-ports.md) documentation for detailed network architecture diagrams and to learn more about the ports used for communication.
+:::
+
 ## Deploy an AWS EKS Cluster
 
 1. Log in to [Palette](https://console.spectrocloud.com/).

--- a/docs/docs-content/clusters/public-cloud/azure/aks.md
+++ b/docs/docs-content/clusters/public-cloud/azure/aks.md
@@ -53,6 +53,10 @@ explains how you can create an Azure AKS cluster managed by Palette.
   - Managed Disks
   - Virtual Network Address Translation (NAT) Gateway
 
+:::warning
+For static network deployments, you must have port 6443 open between Palette and the Workload cluster. Refer to the [Network Ports](../../../architecture/networking-ports.md) documentation for detailed network architecture diagrams and to learn more about the ports used for communication.
+:::
+
 ## Deploy an Azure AKS Cluster
 
 1.  Log in to [Palette](https://console.spectrocloud.com).
@@ -200,7 +204,6 @@ explains how you can create an Azure AKS cluster managed by Palette.
     | **Network Resource Group** | The logical container for grouping related Azure resources. |
     | **Virtual Network**        | Select the VNet.                                            |
     | **CIDR Block**             | Select the IP address CIDR range.                           |
-    | **Security Group Name**    | Select the security group name.                             |
     | **Control Plane Subnet**   | Select the control plane subnet.                            |
     | **Worker Subnet**          | Select the worker network.                                  |
 

--- a/docs/docs-content/clusters/public-cloud/azure/create-azure-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/azure/create-azure-cluster.md
@@ -54,6 +54,10 @@ to create an IaaS Kubernetes cluster in Azure that Palette manages.
   - Managed Disks
   - Virtual Network Address Translation (NAT) Gateway
 
+:::warning
+For static network deployments, you must have port 6443 open between Palette and the Workload cluster. Refer to the [Network Ports](../../../architecture/networking-ports.md) documentation for detailed network architecture diagrams and to learn more about the ports used for communication.
+:::
+
 - To enable the `fullyPrivateAddressing` parameter and use a Private API Server load balancer, you need a self-hosted
   Private Cloud Gateway (PCG) deployed in Azure. Ensure the Azure cloud account selected is connected to a PCG. For more
   information on deploying PCGs, refer to [Private Cloud Gateway](../../pcg/pcg.md). To learn how to connect a PCG to an
@@ -174,7 +178,6 @@ Use the following steps to deploy an Azure cluster.
     | **Network Resource Group** | The logical container for grouping related Azure resources. |
     | **Virtual Network**        | Select the VNet.                                            |
     | **CIDR Block**             | Select the IP address CIDR range.                           |
-    | **Security Group Name**    | Select the security group name.                             |
     | **Control Plane Subnet**   | Select the control plane subnet.                            |
     | **Worker Subnet**          | Select the worker network.                                  |
 

--- a/docs/docs-content/clusters/public-cloud/gcp/create-gcp-gke-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/create-gcp-gke-cluster.md
@@ -39,6 +39,10 @@ Ensure the following requirements are met before you attempt to deploy a cluster
   - Persistent Disks
   - Cloud Router
 
+:::warning
+For static network deployments, you must have port 6443 open between Palette and the Workload cluster. Refer to the [Network Ports](../../../architecture/networking-ports.md) documentation for detailed network architecture diagrams and to learn more about the ports used for communication.
+:::
+
 ## Deploy a GKE Cluster
 
 1. Log in to [Palette](https://console.spectrocloud.com/).

--- a/docs/docs-content/clusters/public-cloud/gcp/create-gcp-iaas-cluster.md
+++ b/docs/docs-content/clusters/public-cloud/gcp/create-gcp-iaas-cluster.md
@@ -40,6 +40,10 @@ Ensure the following requirements are met before you attempt to deploy a cluster
   - Persistent Disks
   - Cloud Router
 
+:::warning
+For static network deployments, you must have port 6443 open between Palette and the Workload cluster. Refer to the [Network Ports](../../../architecture/networking-ports.md) documentation for detailed network architecture diagrams and to learn more about the ports used for communication.
+:::
+
 ## Deploy a GCP Cluster
 
 1. Log in to [Palette](https://console.spectrocloud.com).


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a warning to public cluster creation pages about having port 6443 open. Also, added port 6443 to table.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket](https://spectrocloud.atlassian.net/browse/PCP-4838)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
