### PR TITLE
chore: fix auto commit action

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -89,6 +90,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "ci: auto-formatting prettier issues"
+          branch: ${{ github.head_ref }}
 
   build:
     name: Build


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the prettier auto-commit failure that occurs when code suggestions are applied directly via the GitHub UI.

Every time someone applies a suggestion using GitHub's UI in a PR, GitHub creates a temporary commit directly on the PR, not on a branch that the GH Actions runner checks out. This causes the checkout GH action to land the runner in a detached HEAD (and with no branch name). The auto-commit action then tries to determine the current branch using HEAD, but fails with a `fatal: invalid reference: <branch-name>` error.

If the PR gets merged into a release branch with an unresolved Prettier issue, all subsequent PRs targeting that release branch will fail their Prettier checks.

Example of PR with the issue:   #7277

### Fixes:
- Added `branch: ${{ github.head_ref }}` to the auto-commit action to force the commit to be made against the correct PR branch, even if the runner is in a detached HEAD.
- Added `ref: github.head_ref` to the checkout action to ensure the PR's correct branch is checked out.

This fix was verified in PR #7299 by:
1. Adding a test table.
2. Applying a suggestion through the GitHub UI that broke the table.
3. Confirming that the auto-commit action executed successfully and fixed the issue.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [No public facing changes]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [Jira Ticket]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
