### PR TITLE
docs: add CanvOS version requirement for local management mode

### DIFF
--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -38,6 +38,8 @@ Palette. You will then create a cluster profile and use the registered host to d
 - The FIPS-compliant version of Agent Mode is only available for Red Hat Enterprise Linux (RHEL) and Rocky Linux 8
   systems.
 
+- CanvOS versions prior to 4.6.21 do not support local management mode.
+
 ## Prerequisites
 
 - A physical or virtual host with SSH access, access to the internet, and connection to Palette. For local management
@@ -551,6 +553,12 @@ for guidance.
 In local management mode, your host does not have a connection to Palette and may also have limited access to the
 internet.
 
+:::warning
+
+Ensure you use CanvOS version 4.6.21 or later to build Edge artifacts, as earlier versions do not support local management mode.
+
+:::
+
 1. In your terminal, use the following command to SSH into the host. Replace `</path/to/private/key>` with the path to
    your private SSH key and `<host-ip-or-domain>` with the host's IP address or hostname.
 
@@ -575,7 +583,7 @@ internet.
 
 3. Download the airgap agent installation package and save it as a TAR file. Replace `<architecture>` with the
    architecture of your CPU. If you have ARM64, use `arm64`. If you have AMD64 or x86_64, use `amd64`. Replace
-   `<version>` with the desired version number. In this example, we use `v4.5.0`. Refer to
+   `<version>` with the desired version number. In this example, we use `v4.6.24`. Refer to
    [Agent Mode Releases](https://github.com/spectrocloud/agent-mode/releases) for all the available releases.
 
    <PartialsComponent category="agent-mode" name="agent-mode-airgap-version" />
@@ -613,7 +621,7 @@ internet.
             groups:
               - sudo
             passwd: kairos
-       name: "Configure user"
+         name: "Configure user"
    EOF
    ```
 
@@ -642,7 +650,7 @@ internet.
             groups:
               - sudo
             passwd: kairos
-       name: "Configure user"
+         name: "Configure user"
    ```
 
 7. Reboot the host. The host will automatically start the installation process once it reboots.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR:

1. Adds a limitation about minimal CanvOS version that supports local management deployment mode.
2. Adds a warning about this for the Local Management mode section.
3. Changes the Agent Mode version 4.5.0 -> 4.6.24 as this version is confirmed as compatible with CanvOS 4.6.21 by the developers in the slack thread attached to the task.
4. Fixes user data samples.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2013](https://spectrocloud.atlassian.net/browse/DOC-2013)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. 
- [ ] No.
