### PR TITLE
DOC-2034 Management Appliance ISO is only supported on UEFI

### DIFF
--- a/_partials/self-hosted/appliance-framework/_installation-steps-prereqs.mdx
+++ b/_partials/self-hosted/appliance-framework/_installation-steps-prereqs.mdx
@@ -30,6 +30,12 @@ partial_name: installation-steps-prereqs
 - Relevant permissions to install Palette on the nodes including permission to attach or mount an ISO and set nodes to
   boot from it.
 
+  :::caution
+
+  The ISO is only supported on Unified Extensible Firmware Interface (UEFI) systems. Ensure that the nodes are set to boot from the ISO in UEFI mode.
+
+  :::
+
 - You can choose to use either an internal Zot registry that comes with Palette or an external registry of your choice. Depending on your choice, you will need to provide the following information during the Palette installation process.
 
   <Tabs>


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds an admonition to the Management Appliance prerequisites to clarify that the ISO only works on UEFI systems.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2034](https://spectrocloud.atlassian.net/browse/DOC-2034)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._
Release ticket.