### PR TITLE
docs: Fix Palette agent terminology

### DIFF
--- a/docs/docs-content/troubleshooting/edge/collect-support-bundles.md
+++ b/docs/docs-content/troubleshooting/edge/collect-support-bundles.md
@@ -18,9 +18,9 @@ ticket.
 
 - Only the `support-bundle-edge.sh` script is embedded and can run on hosts without an internet connection. The
   `support-bundle-infra.sh` script is not embedded and requires internet access.
-- The embedded `support-bundle-edge.sh` script is included with the version of Palette agent that was in use at the time of
-  provisioning. It is updated only when Palette agent is upgraded through an ISO or a Palette update. To ensure you are using
-  the most current version, download and run the script manually.
+- The embedded `support-bundle-edge.sh` script is included with the version of Palette agent that was in use at the time
+  of provisioning. It is updated only when Palette agent is upgraded through an ISO or a Palette update. To ensure you
+  are using the most current version, download and run the script manually.
 
 ## Prerequisites
 

--- a/docs/docs-content/troubleshooting/edge/collect-support-bundles.md
+++ b/docs/docs-content/troubleshooting/edge/collect-support-bundles.md
@@ -18,8 +18,8 @@ ticket.
 
 - Only the `support-bundle-edge.sh` script is embedded and can run on hosts without an internet connection. The
   `support-bundle-infra.sh` script is not embedded and requires internet access.
-- The embedded `support-bundle-edge.sh` script is included with the version of Stylus that was in use at the time of
-  provisioning. It is updated only when Stylus is upgraded through an ISO or a Palette update. To ensure you are using
+- The embedded `support-bundle-edge.sh` script is included with the version of Palette agent that was in use at the time of
+  provisioning. It is updated only when Palette agent is upgraded through an ISO or a Palette update. To ensure you are using
   the most current version, download and run the script manually.
 
 ## Prerequisites


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR replaces the "Stylus" term that shouldn't be used in the official documentation with "Palette agent" (the correct term).

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Collect Support Bundles for Edge Cluster Troubleshooting](https://deploy-preview-7430--docs-spectrocloud.netlify.app/troubleshooting/edge/collect-support-bundles/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PE-7140](https://spectrocloud.atlassian.net/browse/PE-7140)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes.
- [ ] No.


[PE-7140]: https://spectrocloud.atlassian.net/browse/PE-7140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ