### PR TITLE
PEM-8122 -Increased disk recommendations in prerequisites for Mgmt Appliance

### DIFF
--- a/_partials/self-hosted/appliance-framework/_installation-steps-prereqs.mdx
+++ b/_partials/self-hosted/appliance-framework/_installation-steps-prereqs.mdx
@@ -13,10 +13,11 @@ partial_name: installation-steps-prereqs
 
   - 16 GB memory per node.
 
-  - 350 GB disk space per node.
+  - Two disks per node.
 
-    - The disk space must be split between at least two disks, with a minimum of 250 GB for the first disk and 100 GB
-      for the second disk. The first disk is used for the ISO stack, and the second disk is used for the storage pool.
+    - The first disk must be at least 250 GB and is used for the ISO stack.
+
+    - The second disk must be at least 500 GB and is used for the storage pool.
 
 - The following network ports must be accessible on each node for Palette to operate successfully.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR increases the minimum disk requirements for the Palette/VerteX Management Appliance.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-8122](https://spectrocloud.atlassian.net/browse/PEM-8122) - Doc changes made off the back of the findings.

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._
Release ticket.

[PEM-8122]: https://spectrocloud.atlassian.net/browse/PEM-8122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ