### PR TITLE
DOC-2049 - Public registry limitation for Management Appliance

### DIFF
--- a/docs/docs-content/enterprise-version/install-palette/palette-management-appliance.md
+++ b/docs/docs-content/enterprise-version/install-palette/palette-management-appliance.md
@@ -20,8 +20,9 @@ The Palette Management Appliance is downloadable as an ISO file and is a solutio
 your infrastructure. The ISO file contains all the necessary components needed for Palette to function. The ISO file is
 used to boot the nodes, which are then clustered to form a Palette management cluster.
 
-Once Palette has been installed, you can download pack bundles to create your cluster profiles. You will then be able to
-deploy clusters in your environment.
+Once Palette has been installed, you can download pack bundles and upload them to the internal Zot registry or an
+external registry. These pack bundles are used to create your cluster profiles. You will then be able to deploy clusters
+in your environment.
 
 ## Architecture
 
@@ -47,6 +48,10 @@ The Palette Management Appliance can be used on the following infrastructure pla
 - VMware vSphere
 - Bare Metal
 - Machine as a Service (MAAS)
+
+## Limitations
+
+- Only public image registries are supported if you are choosing to use an external registry for your pack bundles.
 
 ## Installation Steps
 

--- a/docs/docs-content/vertex/install-palette-vertex/vertex-management-appliance.md
+++ b/docs/docs-content/vertex/install-palette-vertex/vertex-management-appliance.md
@@ -20,8 +20,9 @@ The VerteX Management Appliance is downloadable as an ISO file and is a solution
 infrastructure. The ISO file contains all the necessary components needed for Palette to function. The ISO file is used
 to boot the nodes, which are then clustered to form a Palette management cluster.
 
-Once Palette VerteX has been installed, you can download pack bundles to create your cluster profiles. You will then be
-able to deploy clusters in your environment.
+Once Palette VerteX has been installed, you can download pack bundles and upload them to the internal Zot registry or an
+external registry. These pack bundles are used to create your cluster profiles. You will then be able to deploy clusters
+in your environment.
 
 ## Architecture
 
@@ -49,6 +50,10 @@ The VerteX Management Appliance can be used on the following infrastructure plat
 - VMware vSphere
 - Bare Metal
 - Machine as a Service (MAAS)
+
+## Limitations
+
+- Only public image registries are supported if you are choosing to use an external registry for your pack bundles.
 
 ## Installation Steps
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR documents that the Palette/VerteX Management Appliance can only support public registry connections if users use an external registry for their pack bundles.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Palette Management Appliance](https://deploy-preview-7461--docs-spectrocloud.netlify.app/enterprise-version/install-palette/palette-management-appliance/#limitations)
💻 [VerteX Management Appliance](https://deploy-preview-7461--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/vertex-management-appliance/#limitations)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2049](https://spectrocloud.atlassian.net/browse/DOC-2049)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2049]: https://spectrocloud.atlassian.net/browse/DOC-2049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ