### PR TITLE
DOC-2054 - Manual stylus version change due to build failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,9 @@
         "@playwright/test": "^1.49.0",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/exec": "^7.1.0",
-        "@semantic-release/git": "*",
-        "@semantic-release/github": "*",
-        "@semantic-release/npm": "*",
+        "@semantic-release/git": "latest",
+        "@semantic-release/github": "latest",
+        "@semantic-release/npm": "latest",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@tsconfig/docusaurus": "^2.0.3",
@@ -78,7 +78,7 @@
         "test-links": "^0.0.1",
         "ts-jest": "^29.3.4",
         "typescript": "^5.7.2",
-        "typescript-plugin-css-modules": "^5.1.0",
+        "typescript-plugin-css-modules": "^5.2.0",
         "webpconvert": "^3.0.1",
         "xml2js": "^0.6.2"
       },
@@ -99,7 +99,8 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
       "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.17.7",
@@ -58818,9 +58819,10 @@
       "license": "MIT"
     },
     "node_modules/stylus": {
-      "version": "0.0.1-security",
+      "version": "0.62.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@adobe/css-tools": "~4.3.1",
         "debug": "^4.3.2",
@@ -60570,7 +60572,9 @@
       }
     },
     "node_modules/typescript-plugin-css-modules": {
-      "version": "5.1.0",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typescript-plugin-css-modules/-/typescript-plugin-css-modules-5.2.0.tgz",
+      "integrity": "sha512-c5pAU5d+m3GciDr/WhkFldz1NIEGBafuP/3xhFt9BEXS2gmn/LvjkoZ11vEBIuP8LkXfPNhOt1BUhM5efFuwOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -60588,8 +60592,10 @@
         "reserved-words": "^0.1.2",
         "sass": "^1.70.0",
         "source-map-js": "^1.0.2",
-        "stylus": "^0.0.1-security",
         "tsconfig-paths": "^4.2.0"
+      },
+      "optionalDependencies": {
+        "stylus": "^0.62.0"
       },
       "peerDependencies": {
         "typescript": ">=4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -58818,7 +58818,7 @@
       "license": "MIT"
     },
     "node_modules/stylus": {
-      "version": "0.62.0",
+      "version": "0.0.1-security",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -60588,7 +60588,7 @@
         "reserved-words": "^0.1.2",
         "sass": "^1.70.0",
         "source-map-js": "^1.0.2",
-        "stylus": "^0.62.0",
+        "stylus": "^0.0.1-security",
         "tsconfig-paths": "^4.2.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "test-links": "^0.0.1",
     "ts-jest": "^29.3.4",
     "typescript": "^5.7.2",
-    "typescript-plugin-css-modules": "^5.1.0",
+    "typescript-plugin-css-modules": "^5.2.0",
     "webpconvert": "^3.0.1",
     "xml2js": "^0.6.2"
   },


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR changes the Stylus dependency version to `0.0.1-security`. NPM removed and re-added the Stylus package due to a [detected security issue](https://github.com/mrmckeb/typescript-plugin-css-modules/issues/287).

However, the owner is reporting that this may be incorrect and is trying to get Stylus reinstated: https://github.com/stylus/stylus/issues/2938

In the interim, we need to get builds operating again, as they fail because NPM cannot find the Stylus version.

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2054](https://spectrocloud.atlassian.net/browse/DOC-2054)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2054]: https://spectrocloud.atlassian.net/browse/DOC-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ