### PR TITLE
docs: Fix gitleaks for pr-7525

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,5 @@
+c14571d1604aa8d955184a0ce3b4376bd3e10c41:docs/docs-content/downloads/self-hosted-palette/additional-packs.md:curl-auth-user:60
+c14571d1604aa8d955184a0ce3b4376bd3e10c41:docs/docs-content/downloads/palette-vertex/additional-packs.md:curl-auth-user:60
 3c207ae01566be13932ea02c0cc6c524e5cda15a:docs/docs-content/tutorials/getting-started/palette-edge/edge-cluster-profile.md:generic-api-key:157
 17d6bc43db10d33d36d0215d74e1c540427dc60a:docs/docs-content/integrations/spectro-k8s-dashboard.md:generic-api-key:179
 2e6256d3133f350673bcc16230387fb42e793692:docs/docs-content/clusters/edge/native.md:generic-api-key:169


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the Gitleaks issue that occurred during backporting PR-7509 to version 4.6.
## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 Not applicable

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫  Not applicable

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. 
- [x] No. The PR fixes the gitleaks issue that is specific for version 4.6.