### PR TITLE
docs: Add two-node architecture warnings

### DIFF
--- a/docs/docs-content/clusters/edge/architecture/two-node.md
+++ b/docs/docs-content/clusters/edge/architecture/two-node.md
@@ -32,12 +32,16 @@ probe will stop receiving responses and the surviving node will remain the leade
 
 ![Architectural diagram of a two-node architecture](/clusters_edge_architecture_two-node-diagram.webp)
 
+:::warning
+
 To create two-node Edge clusters, ensure you set the `TWO_NODE` argument to `true` during EdgeForge when building
 provider images, and toggle on **Two-Node Mode** during Edge cluster creation. For more information, refer to
 [Build Provider Images](../edgeforge-workflow/palette-canvos/build-provider-images.md) and
 [Create Cluster Definition](../site-deployment/cluster-deployment.md). If you create a two-node cluster, you must use
 exactly two nodes in the control plane. You will also not be able to change it to a regular etcd-backed cluster or
 change the number of nodes.
+
+:::
 
 ## Limitations
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images.md
@@ -148,10 +148,14 @@ artifacts at the same time.
     EOF
     ```
 
+    :::warning
+
     If you want your host eligible to become part of a two-node high availability cluster, you must set `TWO_NODE` to
     `true`. This setting cannot be changed later. A two-node provider image cannot be used to provision regular etcd
     clusters. We recommend you clearly mark two-node provider images in the custom tag argument. For more information
     about two-node high availability architecture, refer to [Two-Node Architecture](../../architecture/two-node.md).
+
+    :::
 
     Refer to [Edge Artifact Build Configurations](./arg.md) for all available configuration parameters.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR formats important information about two-node clusters creation as warnings so the users are less likely to miss it.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Build Provider Images](https://deploy-preview-7532--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/#build-provider-images)
💻[Two-Node Architecture](https://deploy-preview-7532--docs-spectrocloud.netlify.app/clusters/edge/architecture/two-node/#architecture-overview)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2036](https://spectrocloud.atlassian.net/browse/DOC-2036)
🎫 [DOC-2037](https://spectrocloud.atlassian.net/browse/DOC-2037)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes.
- [ ] No.


[DOC-2036]: https://spectrocloud.atlassian.net/browse/DOC-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-2037]: https://spectrocloud.atlassian.net/browse/DOC-2037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ