### PR TITLE
[version 4-7] chore: refactor gitleaks

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - 'version-*'
-      - 'doc-2070-gitleaks-version-branches'
     paths:
       - '.gitleaksignore'
   workflow_dispatch:
@@ -109,7 +108,7 @@ jobs:
       if: success() && env.SHOULD_SYNC == 'true'
       uses: rtCamp/action-slack-notify@v2.3.3
       env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_TEST_WEBHOOK }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
         SLACK_COLOR: ${{ job.status }}
         SLACKIFY_MARKDOWN: true
         ENABLE_ESCAPES: true
@@ -119,7 +118,7 @@ jobs:
       if: ${{ failure() }}
       uses: rtCamp/action-slack-notify@v2.3.3
       env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_TEST_WEBHOOK }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
         SLACK_COLOR: ${{ job.status }}
         SLACKIFY_MARKDOWN: true
         ENABLE_ESCAPES: true

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -673,4 +673,3 @@ c0c63dc4222907cff4801266617c52c782fb01f7:docs/docs-content/vertex/install-palett
 c0c63dc4222907cff4801266617c52c782fb01f7:docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/install.md:docker-config-json:392
 c0c63dc4222907cff4801266617c52c782fb01f7:docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/install.md:docker-config-json:481
 e0ee671d59c7bfba4774d6babd3d79c9ad09ae64:docs/docs-content/troubleshooting/enterprise-install.md:docker-config-json:50
-fake-commit-hash-test:docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/airgap-install/install.md:docker-config-json:259


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR refactors the existing GHA workflow to align with the new security team scanning process.
The security team now requires all `.gitleaksignore` entries to be present in the master branch’s `.gitleaksignore` file, regardless of which version branch they originated from.

The updated workflow is triggered whenever a push updates the `.gitleaksignore` file in any `version-*` branch. It compares the new version against the ignore file in master. If new entries are found that are not already in master, the workflow automatically opens a pull request to sync those missing entries.

[This PR](https://github.com/spectrocloud/librarium/pull/7748) successfully tested the workflow, and [this commit](https://github.com/spectrocloud/librarium/actions/runs/16788985152/job/47546534672) tested the exit case, where no new entries need to be added.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [No public-facing changes]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2070](https://spectrocloud.atlassian.net/browse/DOC-2070)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2070]: https://spectrocloud.atlassian.net/browse/DOC-2070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ