### PR TITLE
docs: Add information about agent upgrade

### DIFF
--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -10,7 +10,7 @@ tags: ["edge", "architecture"]
 In centrally managed clusters, the Palette agent gets upgraded automatically with Palette upgrades, unless you
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
-In local clusters, this happens automatically only if you upload a content bundle built after a Palette version upgrade, along with a modified cluster definition, and update the cluster through the Local UI.
+In local clusters, this happens automatically only if you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and then update the cluster through Local UI.
 
 When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version of a Palette instance, as well as how to specify a Palette agent package in the Operating System (OS) pack of a cluster profile. This is useful for upgrading the Palette agent on a local Edge cluster and for launching new centrally managed clusters while using an older version of the
 Palette agent.

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -10,10 +10,7 @@ tags: ["edge", "architecture"]
 In centrally managed clusters, the Palette agent gets upgraded automatically with Palette upgrades, unless you
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
-In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition
-and content bundle built from a Palette instance after a version upgrade, and apply the update through the Local UI. The
-Palette agent is then upgraded to match the version of the Palette instance. This may result in an upgrade if the
-instance is newer than your Palette agent, or a downgrade if it is older.
+In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition and content bundle built from a Palette instance after a version upgrade. The Palette agent is then upgraded to match the version of the Palette instance. This may result in an upgrade if the instance is newer than your Palette agent, or a downgrade if it is older.
 
 When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster
 profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -10,10 +10,14 @@ tags: ["edge", "architecture"]
 In centrally managed clusters, the Palette agent gets upgraded automatically with Palette upgrades, unless you
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
-In local clusters, this happens automatically only if you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and then update the cluster through Local UI.
+In local clusters, this happens automatically only if you upload a modified cluster definition along with a content
+bundle built after a Palette version upgrade, and then update the cluster through Local UI.
 
-When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version of a Palette instance, as well as how to specify a Palette agent package in the Operating System (OS) pack of a cluster profile. This is useful for upgrading the Palette agent on a local Edge cluster and for launching new centrally managed clusters while using an older version of the
-Palette agent.
+When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster
+profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version
+of a Palette instance, as well as how to specify a Palette agent package in the Operating System (OS) pack of a cluster
+profile. This is useful for upgrading the Palette agent on a local Edge cluster and for launching new centrally managed
+clusters while using an older version of the Palette agent.
 
 ## Prerequisites
 

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -8,13 +8,11 @@ tags: ["edge", "architecture"]
 ---
 
 In centrally managed clusters, the Palette agent gets upgraded automatically with Palette upgrades, unless you
-explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md). In local clusters,
-this does not happen automatically. When you want to upgrade the agent version, you can include the new agent version in
-a new cluster profile, and upgrade the cluster using the new profile.
+explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
-This page teaches you how to identify the matching agent version of a Palette instance, as well as how to specify a
-Palette agent package in the Operating System (OS) pack of a cluster profile. This is useful for upgrading the Palette
-agent on a local Edge cluster and for launching new centrally managed clusters while using an older version of the
+In local clusters, this happens automatically only if you upload a content bundle built after a Palette version upgrade, along with a modified cluster definition, and update the cluster through the Local UI.
+
+When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version of a Palette instance, as well as how to specify a Palette agent package in the Operating System (OS) pack of a cluster profile. This is useful for upgrading the Palette agent on a local Edge cluster and for launching new centrally managed clusters while using an older version of the
 Palette agent.
 
 ## Prerequisites

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -10,7 +10,10 @@ tags: ["edge", "architecture"]
 In centrally managed clusters, the Palette agent gets upgraded automatically with Palette upgrades, unless you
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
-In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition and content bundle built from a Palette instance after a version upgrade, and apply the update through the Local UI. The Palette agent is then upgraded to match the version of the Palette instance. This may result in an upgrade if the instance is newer than your Palette agent, or a downgrade if it is older.
+In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition
+and content bundle built from a Palette instance after a version upgrade, and apply the update through the Local UI. The
+Palette agent is then upgraded to match the version of the Palette instance. This may result in an upgrade if the
+instance is newer than your Palette agent, or a downgrade if it is older.
 
 When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster
 profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -10,9 +10,7 @@ tags: ["edge", "architecture"]
 In centrally managed clusters, the Palette agent gets upgraded automatically with Palette upgrades, unless you
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
-In local clusters, this happens automatically only if you upload a modified cluster definition along with a content
-bundle built after a Palette version upgrade, and then update the cluster through Local UI. The Palette agent is then
-upgraded to match the version included in the content bundle.
+In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition and content bundle built from a Palette instance after a version upgrade, and apply the update through the Local UI. The Palette agent is then upgraded to match the version of the Palette instance. This may result in an upgrade if the instance is newer than your Palette agent, or a downgrade if it is older.
 
 When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster
 profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -11,7 +11,7 @@ In centrally managed clusters, the Palette agent gets upgraded automatically wit
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
 In local clusters, this happens automatically only if you upload a modified cluster definition along with a content
-bundle built after a Palette version upgrade, and then update the cluster through Local UI.
+bundle built after a Palette version upgrade, and then update the cluster through Local UI. The Palette agent is then upgraded to match the version included in the content bundle.
 
 When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster
 profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -10,7 +10,10 @@ tags: ["edge", "architecture"]
 In centrally managed clusters, the Palette agent gets upgraded automatically with Palette upgrades, unless you
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
-In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition and content bundle built on a Palette instance after a version update. The Palette agent is then updated to match the version of the Palette instance. This may result in an upgrade if the instance is newer than your Palette agent, or a downgrade if it is older.
+In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition
+and content bundle built on a Palette instance after a version update. The Palette agent is then updated to match the
+version of the Palette instance. This may result in an upgrade if the instance is newer than your Palette agent, or a
+downgrade if it is older.
 
 When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster
 profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -11,7 +11,8 @@ In centrally managed clusters, the Palette agent gets upgraded automatically wit
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
 In local clusters, this happens automatically only if you upload a modified cluster definition along with a content
-bundle built after a Palette version upgrade, and then update the cluster through Local UI. The Palette agent is then upgraded to match the version included in the content bundle.
+bundle built after a Palette version upgrade, and then update the cluster through Local UI. The Palette agent is then
+upgraded to match the version included in the content bundle.
 
 When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster
 profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -10,7 +10,7 @@ tags: ["edge", "architecture"]
 In centrally managed clusters, the Palette agent gets upgraded automatically with Palette upgrades, unless you
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
-In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition and content bundle built on a Palette instance after a version upgrade. The Palette agent is then upgraded to match the version of the Palette instance. This may result in an upgrade if the instance is newer than your Palette agent, or a downgrade if it is older.
+In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition and content bundle built on a Palette instance after a version update. The Palette agent is then updated to match the version of the Palette instance. This may result in an upgrade if the instance is newer than your Palette agent, or a downgrade if it is older.
 
 When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster
 profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version

--- a/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
+++ b/docs/docs-content/clusters/edge/cluster-management/agent-upgrade-airgap.md
@@ -10,7 +10,7 @@ tags: ["edge", "architecture"]
 In centrally managed clusters, the Palette agent gets upgraded automatically with Palette upgrades, unless you
 explicitly [pause upgrades](../../cluster-management/platform-settings/pause-platform-upgrades.md).
 
-In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition and content bundle built from a Palette instance after a version upgrade. The Palette agent is then upgraded to match the version of the Palette instance. This may result in an upgrade if the instance is newer than your Palette agent, or a downgrade if it is older.
+In local clusters, the Palette agent is upgraded automatically only if you update a cluster with a cluster definition and content bundle built on a Palette instance after a version upgrade. The Palette agent is then upgraded to match the version of the Palette instance. This may result in an upgrade if the instance is newer than your Palette agent, or a downgrade if it is older.
 
 When you want to explicitly trigger the agent version update, you can include the new agent version in a new cluster
 profile, and upgrade the cluster using the new profile. This page teaches you how to identify the matching agent version

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
@@ -12,7 +12,7 @@ host. A cluster definition contains one or more cluster profiles, including the 
 
 :::info
    
-If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and update the cluster through the Local UI, it will lead to the Palette agent being upgraded in accordance with the version included in the content bundle.
+If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and then update the cluster through Local UI, the Palette agent will be upgraded to match the version specified in the content bundle.
 
 :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
@@ -15,7 +15,7 @@ profiles.
 
 If you create a new cluster or update an existing one with a cluster definition and content bundle built on a Palette
 instance, your Palette agent will be updated to match the version of that Palette instance. This may result in an
-upgrade if the instance is newer than your current Palette agent, or a downgrade if it is older.
+upgrade if the instance is newer than your Palette agent, or a downgrade if it is older.
 
 :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
@@ -7,8 +7,14 @@ sidebar_position: 10
 tags: ["edge"]
 ---
 
-You can export cluster definitions from a cluster in Palette and use the definition to provision a cluster in an Edge
+You can export cluster definitions from a cluster in Palette and use the definition to provision or update a cluster in an Edge
 host. A cluster definition contains one or more cluster profiles, including the profile variables used in the profiles.
+
+:::info
+   
+If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and update the cluster through the Local UI, it will lead to the Palette agent being upgraded in accordance with the version included in the content bundle.
+
+:::
 
 You can export the cluster definition using the Palette CLI, Palette Edge CLI, or Palette API. The CLI offers a more
 user-friendly interface but requires a machine with X86_64 architecture. If you are using an ARM64 machine, such as
@@ -366,9 +372,3 @@ deployment using Local UI during cluster creation.
 - [Build Edge Installer ISO](../../edgeforge-workflow/palette-canvos/build-installer-iso.md)
 
 - [Create Local Cluster](../cluster-management/create-cluster.md)
-
-:::info
-   
-If you upload a content bundle built after a Palette version upgrade, along with a modified cluster definition, and update the cluster through the Local UI, it will lead to the Palette agent being upgraded in accordance with the version included in the content bundle.
-
-:::

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
@@ -13,9 +13,7 @@ profiles.
 
 :::info
 
-If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and then
-update the cluster through Local UI, the Palette agent will be upgraded to match the version specified in the content
-bundle.
+If you create a new cluster or update an existing one with a cluster definition and content bundle built on a Palette instance, your Palette agent will be updated to match the version of that Palette instance. This may result in an upgrade if the instance is newer than your current Palette agent, or a downgrade if it is older.
 
 :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
@@ -13,7 +13,9 @@ profiles.
 
 :::info
 
-If you create a new cluster or update an existing one with a cluster definition and content bundle built on a Palette instance, your Palette agent will be updated to match the version of that Palette instance. This may result in an upgrade if the instance is newer than your current Palette agent, or a downgrade if it is older.
+If you create a new cluster or update an existing one with a cluster definition and content bundle built on a Palette
+instance, your Palette agent will be updated to match the version of that Palette instance. This may result in an
+upgrade if the instance is newer than your current Palette agent, or a downgrade if it is older.
 
 :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
@@ -366,3 +366,9 @@ deployment using Local UI during cluster creation.
 - [Build Edge Installer ISO](../../edgeforge-workflow/palette-canvos/build-installer-iso.md)
 
 - [Create Local Cluster](../cluster-management/create-cluster.md)
+
+:::info
+   
+If you upload a content bundle built after a Palette version upgrade, along with a modified cluster definition, and update the cluster through the Local UI, it will lead to the Palette agent being upgraded in accordance with the version included in the content bundle.
+
+:::

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/export-cluster-definition.md
@@ -7,12 +7,15 @@ sidebar_position: 10
 tags: ["edge"]
 ---
 
-You can export cluster definitions from a cluster in Palette and use the definition to provision or update a cluster in an Edge
-host. A cluster definition contains one or more cluster profiles, including the profile variables used in the profiles.
+You can export cluster definitions from a cluster in Palette and use the definition to provision or update a cluster in
+an Edge host. A cluster definition contains one or more cluster profiles, including the profile variables used in the
+profiles.
 
 :::info
-   
-If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and then update the cluster through Local UI, the Palette agent will be upgraded to match the version specified in the content bundle.
+
+If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and then
+update the cluster through Local UI, the Palette agent will be upgraded to match the version specified in the content
+bundle.
 
 :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -58,7 +58,7 @@ version. This guide explains how to update an existing cluster in Local UI.
 
    :::info
    
-   If you upload a content bundle built after a Palette version upgrade, along with a modified cluster definition, and update the cluster through the Local UI, it will lead to the Palette agent being upgraded in accordance with the version included in the content bundle.
+   If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and update the cluster through the Local UI, it will lead to the Palette agent being upgraded in accordance with the version included in the content bundle.
 
    :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -58,7 +58,9 @@ version. This guide explains how to update an existing cluster in Local UI.
 
    :::info
 
-   If you update a cluster with a modified cluster definition and content bundle built on a Palette instance, your Palette agent will be updated to match the version of that Palette instance. This may result in an upgrade if the instance is newer than your current Palette agent, or a downgrade if it is older.
+   If you update a cluster with a modified cluster definition and content bundle built on a Palette instance, your
+   Palette agent will be updated to match the version of that Palette instance. This may result in an upgrade if the
+   instance is newer than your current Palette agent, or a downgrade if it is older.
 
    :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -58,9 +58,7 @@ version. This guide explains how to update an existing cluster in Local UI.
 
    :::info
 
-   If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and
-   then update the cluster using the Local UI, the Palette agent will be upgraded to match the version specified in the
-   content bundle.
+   If you update a cluster with a modified cluster definition and content bundle built on a Palette instance, your Palette agent will be updated to match the version of that Palette instance. This may result in an upgrade if the instance is newer than your current Palette agent, or a downgrade if it is older.
 
    :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -60,7 +60,7 @@ version. This guide explains how to update an existing cluster in Local UI.
 
    If you update a cluster with a modified cluster definition and content bundle built on a Palette instance, your
    Palette agent will be updated to match the version of that Palette instance. This may result in an upgrade if the
-   instance is newer than your current Palette agent, or a downgrade if it is older.
+   instance is newer than your Palette agent, or a downgrade if it is older.
 
    :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -57,8 +57,10 @@ version. This guide explains how to update an existing cluster in Local UI.
 9. In the bottom-left corner, click **Update**.
 
    :::info
-   
-   If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and then update the cluster using the Local UI, the Palette agent will be upgraded to match the version specified in the content bundle.
+
+   If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and
+   then update the cluster using the Local UI, the Palette agent will be upgraded to match the version specified in the
+   content bundle.
 
    :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -58,7 +58,7 @@ version. This guide explains how to update an existing cluster in Local UI.
 
    :::info
    
-   If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and update the cluster through the Local UI, it will lead to the Palette agent being upgraded in accordance with the version included in the content bundle.
+   If you upload a modified cluster definition along with a content bundle built after a Palette version upgrade, and then update the cluster using the Local UI, the Palette agent will be upgraded to match the version specified in the content bundle.
 
    :::
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -56,6 +56,12 @@ version. This guide explains how to update an existing cluster in Local UI.
 
 9. In the bottom-left corner, click **Update**.
 
+   :::info
+   
+   If you upload a content bundle built after a Palette version upgrade, along with a modified cluster definition, and update the cluster through the Local UI, it will lead to the Palette agent being upgraded in accordance with the version included in the content bundle.
+
+   :::
+
 ## Validate
 
 1. Log in to Local UI.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds information about the conditions under which the Palette agent gets upgraded to match the version specified in the content bundle.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Configure Palette Agent Version](https://deploy-preview-7579--docs-spectrocloud.netlify.app/clusters/edge/cluster-management/agent-upgrade-airgap/)
💻 [Export Cluster Definition](https://deploy-preview-7579--docs-spectrocloud.netlify.app/clusters/edge/local-ui/cluster-management/export-cluster-definition/)
💻 [Update Local Cluster](https://deploy-preview-7579--docs-spectrocloud.netlify.app/clusters/edge/local-ui/cluster-management/update-cluster/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2072](https://spectrocloud.atlassian.net/browse/DOC-2072)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2072]: https://spectrocloud.atlassian.net/browse/DOC-2072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ