### PR TITLE
docs: remove Spectro Addon Repo references DOC-2066

### DIFF
--- a/docs/docs-content/integrations/cloudanix.mdx
+++ b/docs/docs-content/integrations/cloudanix.mdx
@@ -54,14 +54,14 @@ As a final step, apply the cluster profile to your cluster.
 ## Terraform
 
 ```hcl
-data "spectrocloud_registry" "public_add_on_repo" {
-  name = "Spectro Addon Repo"
+data "spectrocloud_registry" "community_registry" {
+  name = "Palette Community Registry"
 }
 
 data "spectrocloud_pack_simple" "cloudanix" {
   name         = "cloudanix"
   version      = "0.0.2"
   type         = "helm"
-  registry_uid = data.spectrocloud_registry.public_add_on_repo.id
+  registry_uid = data.spectrocloud_registry.community_registry.id
 }
 ```

--- a/docs/docs-content/integrations/cloudanix.mdx
+++ b/docs/docs-content/integrations/cloudanix.mdx
@@ -54,14 +54,14 @@ As a final step, apply the cluster profile to your cluster.
 ## Terraform
 
 ```hcl
-data "spectrocloud_registry" "community_registry" {
-  name = "Palette Community Registry"
+data "spectrocloud_registry" "public_registry" {
+ name = "Public Repo"
 }
 
 data "spectrocloud_pack_simple" "cloudanix" {
   name         = "cloudanix"
   version      = "0.0.2"
   type         = "helm"
-  registry_uid = data.spectrocloud_registry.community_registry.id
+  registry_uid = data.spectrocloud_registry.public_registry.id
 }
 ```

--- a/docs/docs-content/integrations/gatekeeper.mdx
+++ b/docs/docs-content/integrations/gatekeeper.mdx
@@ -43,14 +43,14 @@ tags: ["packs", "open-policy-agent", "security"]
 You can retrieve details about the Gatekeeper pack by using the following Terraform code.
 
 ```hcl
-data "spectrocloud_registry" "public_addon_registry" {
-  name = "Spectro Addon Repo"
+data "spectrocloud_registry" "community_registry" {
+  name = "Palette Community Registry"
 }
 
 data "spectrocloud_pack_simple" "gatekeeper" {
   name    = "gatekeeper"
   version = "3.8.0"
   type = "helm"
-  registry_uid = data.spectrocloud_registry.public_addon_registry.id
+  registry_uid = data.spectrocloud_registry.community_registry.id
 }
 ```

--- a/docs/docs-content/registries-and-packs/registries/registries.md
+++ b/docs/docs-content/registries-and-packs/registries/registries.md
@@ -51,7 +51,6 @@ Palette environments. The default registries are listed below:
 | Bitnami                    | Helm         | A Helm Chart registry containing Helm Charts maintained and supported by Bitnami. | `https://charts.bitnami.com/bitnami`           | -                 |
 | Public Spectro Helm Repo   | Helm         | A Helm Chart registry containing Helm Charts maintained and supported by us.      | `https://spectrocloud.github.io/helm-charts`   | -                 |
 | Public Repo                | Legacy Packs | A packs registry containing packs maintained and supported by us.                 | `https://registry.spectrocloud.com`            | -                 |
-| Spectro Addon Repo         | Legacy Packs | A packs registry containing add-on packs maintained and supported by us.          | `https://registry-addon.spectrocloud.com`      | -                 |
 | Palette Registry           | OCI          | A packs registry containing packs maintained and supported by us.                 | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `production`      |
 | Palette Registry FIPS      | OCI          | A packs registry containing FIPS packs maintained and supported by us.            | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `production-fips` |
 | Palette Community Registry | OCI          | A packs registry containing community packs.                                      | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `community`       |

--- a/docs/docs-content/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile.md
+++ b/docs/docs-content/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile.md
@@ -28,7 +28,7 @@ Follow these steps to create a new add-on profile that will be applied to your e
 4. Fill out the basic information and ensure you select **Add-on** for the type. Click on **Next** to continue.
 
 5. Select **Add New Pack**. In the next window that displays, enter **Virtual Machine Migration Assistant** in the
-   **Filter by name** search bar. The pack is in the **Spectro Addon Repo** registry. Select the pack when it appears.
+   **Filter by name** search bar. The pack is in the **Palette Community Registry**. Select the pack when it appears.
 
 6. Palette displays the YAML file in the editor on the right. You can edit the YAML as needed. Review the following
    service console parameters and adjust to your requirements as needed.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -307,7 +307,7 @@ const config = {
     [
       pluginPacksAndIntegrationsData,
       {
-        repositories: ["Palette Registry", "Public Repo", "Spectro Addon Repo", "Palette Community Registry"],
+        repositories: ["Palette Registry", "Public Repo", "Palette Community Registry"],
       },
     ],
     pluginImportFontAwesomeIcons,


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes all Spectro Addon Repo references from docs and the packs component.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Packs List](https://deploy-preview-7581--docs-spectrocloud.netlify.app/integrations/) - Removed Spectro Addon Repo.
💻 [Cloudanix pack](https://deploy-preview-7581--docs-spectrocloud.netlify.app/integrations/packs/?pack=cloudanix) - Updated TF snippet to Palette Community Registry. The pack page doesn't show up bc the pack is still hosted in the Spectro Addon Repo in prod. This will change after the release.
💻 [Gatekeeper pack](https://deploy-preview-7581--docs-spectrocloud.netlify.app/integrations/packs/?pack=gatekeeper) - Updated TF snippet to Palette Public Repo. 
💻 [Create a VM Migration Assistant Profile](https://deploy-preview-7581--docs-spectrocloud.netlify.app/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile/) - Replaced Spectro Addon Repo with Palette Community Registry.


## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2066](https://spectrocloud.atlassian.net/browse/DOC-2066)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [X] No. _Please leave a short comment below about why this PR cannot be backported._RELEASE PR


[DOC-2066]: https://spectrocloud.atlassian.net/browse/DOC-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ