### PR TITLE
docs: DOC-1975: Update Default AWS ECR Endpoint for VerteX

### DIFF
--- a/docs/docs-content/registries-and-packs/registries/registries.md
+++ b/docs/docs-content/registries-and-packs/registries/registries.md
@@ -53,7 +53,7 @@ Palette environments. The default registries are listed below:
 | Public Repo                | Legacy Packs | A packs registry containing packs maintained and supported by us.                 | `https://registry.spectrocloud.com`            | -                 |
 | Spectro Addon Repo         | Legacy Packs | A packs registry containing add-on packs maintained and supported by us.          | `https://registry-addon.spectrocloud.com`      | -                 |
 | Palette Registry           | OCI          | A packs registry containing packs maintained and supported by us.                 | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `production`      |
-| Palette Registry FIPS      | OCI          | A packs registry containing FIPS packs maintained and supported by us.            | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `production-fips` |
+| Palette Registry FIPS      | OCI          | A packs registry containing FIPS packs maintained and supported by us.            | `415789037893.dkr.ecr.us-west-2.amazonaws.com` | `production-fips` |
 | Palette Community Registry | OCI          | A packs registry containing community packs.                                      | `415789037893.dkr.ecr.us-east-1.amazonaws.com` | `community`       |
 
 :::info


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the default AWS ECR registry endpoint for VerteX from `http://415789037893.dkr.ecr.us-east-1.amazonaws.com` > `http://415789037893.dkr.ecr.us-west-2.amazonaws.com`.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Registries](https://deploy-preview-7593--docs-spectrocloud.netlify.app/registries-and-packs/registries/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1975](https://spectrocloud.atlassian.net/browse/DOC-1975)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-1975]: https://spectrocloud.atlassian.net/browse/DOC-1975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ