### PR TITLE
docs: PCP-4752: MAAS Node Pool AZ Breaking Change

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -21,6 +21,8 @@ tags: ["release-notes"]
 
 #### Breaking Changes {#breaking-changes-4.7.a}
 
+- Availability zones are now required for MAAS [node pools](../clusters/cluster-management/node-pool.md) when deploying [MAAS clusters](../clusters/data-center/maas/create-manage-maas-clusters.md). Availability zones are _not_ required when performing Day-2 node pool updates on MAAS clusters deployed prior to Palette version 4.7.a. Changing availability zones post-cluster deployment will trigger a [node pool repave](../clusters/cluster-management/node-pool.md#repave-behavior-and-configuration). 
+
 #### Features
 
 #### Improvements


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a breaking change to the 4.7.a release notes, where availability zones are now required for MAAS node pools when deploying MAAS clusters.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PCP-4752](https://spectrocloud.atlassian.net/browse/PCP-4752)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work.
