### PR TITLE
docs: Remove Tech Preview for Harbor Edge-Native Config pack

### DIFF
--- a/docs/docs-content/integrations/harbor-edge-native-config.mdx
+++ b/docs/docs-content/integrations/harbor-edge-native-config.mdx
@@ -21,10 +21,6 @@ The Harbor Edge-Native Config pack is a system application pack. When you provis
 includes this pack, Palette automatically chooses the latest version of Harbor supported by Palette to install on the
 cluster. You cannot manually choose a version of this pack.
 
-:::preview
-
-:::
-
 ## Enable Harbor to Protect Against Outage
 
 You can use Harbor in an Edge cluster that is connected to external networks. Harbor stores all container images


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR removes Technical Preview from the Harbor Edge-Native Config pack additional information. The pack was deprecated in the 4.6.23 version.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Harbor Edge-Native Config - Additional Details](https://deploy-preview-7635--docs-spectrocloud.netlify.app/integrations/packs/?pack=harbor-edge-native-config&version=1.1.2&parent=1.1.x&tab=custom)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2006](https://spectrocloud.atlassian.net/browse/DOC-2006)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes.
- [x] No. A release PR


[DOC-2078]: https://spectrocloud.atlassian.net/browse/DOC-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOC-2006]: https://spectrocloud.atlassian.net/browse/DOC-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ