### PR TITLE
docs: DOC-2011 and DOC-2012: Additional VMXNET3 Adapter Guidance due to Known Issue

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
@@ -215,8 +215,18 @@ customization.
 
     :::warning
 
-    If you haven't set a default project for the registration token, ensure that you provide the
+    - If you haven't set a default project for the registration token, ensure that you provide the
     `stylus.site.projectName` parameter with the value `Default` in `user-data`.
+    - If your host is a virtual machine using an VMXNET3 adapter and you are planning to enable an [overlay network](../../networking/vxlan-overlay.md) on your Edge cluster, or if you are planning to use <VersionedLink text="Flannel" url="/integrations/cni-flannel" /> for your CNI, include the following `initramfs` stage in your `user-data` file. This is due to a [known issue with VMware's VMXNET3 adapter](https://github.com/cilium/cilium/issues/13096#issuecomment-723901955), which is widely used in different virtual machine management services, including VMware vSphere and Hyper-V.
+
+    ```shell
+      stages:
+        initramfs:
+          - name: "Disable UDP segmentation"
+            commands:
+              - ethtool --offload <interface-name> tx-udp_tnl-segmentation off
+              - ethtool --offload <interface-name> tx-udp_tnl-csum-segmentation off 
+    ```
 
     :::
 

--- a/docs/docs-content/clusters/edge/networking/vxlan-overlay.md
+++ b/docs/docs-content/clusters/edge/networking/vxlan-overlay.md
@@ -72,8 +72,7 @@ server. The region experiences a bad weather event that causes a sustained outag
     broadcasts between hosts.
   - Switches cannot implement features that block broadcasts between ports where Edge hosts are connected.
 
-- If you are launching your Edge hosts in virtual machine environments and you are using either Cilium or Flannel as
-  your Container Network Interface (CNI), ensure that you add the following commands in the `user-data` file at the boot
+- If you are launching your Edge hosts in virtual machine environments using VMXNET3 adapters, ensure that you add the following commands in the `user-data` file at the boot
   stage. Replace `<interface-name>` with the name of the network interface on your Edge host.
 
   ```yaml {2-6}

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
@@ -273,6 +273,21 @@ management mode to manage configurations, updates, and workloads.
              passwd: kairos
    ```
 
+  :::warning
+
+  If your host is a virtual machine using an VMXNET3 adapter and you are planning to use <VersionedLink text="Flannel" url="/integrations/cni-flannel" /> for your CNI, include the following `initramfs` stage in your `user-data` file. This is due to a [known issue with VMware's VMXNET3 adapter](https://github.com/cilium/cilium/issues/13096#issuecomment-723901955), which is widely used in different virtual machine management services, including VMware vSphere and Hyper-V.
+
+    ```shell
+      stages:
+        initramfs:
+          - name: "Disable UDP segmentation"
+            commands:
+              - ethtool --offload <interface-name> tx-udp_tnl-segmentation off
+              - ethtool --offload <interface-name> tx-udp_tnl-csum-segmentation off 
+    ```
+
+  :::
+
 5. Export the path to your user data file.
 
    ```shell
@@ -651,6 +666,21 @@ required Edge artifacts.
     You can follow the steps in
     [Validate User Data](../../../../edge/edgeforge-workflow/validate-user-data.md#validate-user-data) to validate your
     **user-data** file after creation.
+
+  :::warning
+
+  If your host is a virtual machine using an VMXNET3 adapter and you are planning to use <VersionedLink text="Flannel" url="/integrations/cni-flannel" /> for your CNI, include the following `initramfs` stage in your `user-data` file. This is due to a [known issue with VMware's VMXNET3 adapter](https://github.com/cilium/cilium/issues/13096#issuecomment-723901955), which is widely used in different virtual machine management services, including VMware vSphere and Hyper-V.
+
+    ```shell
+      stages:
+        initramfs:
+          - name: "Disable UDP segmentation"
+            commands:
+              - ethtool --offload <interface-name> tx-udp_tnl-segmentation off
+              - ethtool --offload <interface-name> tx-udp_tnl-csum-segmentation off 
+    ```
+
+  :::
 
 11. CanvOS utility uses [Earthly](https://earthly.dev/) to build the target artifacts. Issue the following command to
     start the build process.

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -445,6 +445,21 @@ Palette. You will then create a cluster profile and use the registered host to d
              passwd: kairos
    ```
 
+  :::warning
+
+  If your host is a virtual machine using an VMXNET3 adapter and you are planning to enable an [overlay network](../../networking/vxlan-overlay.md) on your Edge cluster, or if you are planning to use <VersionedLink text="Flannel" url="/integrations/cni-flannel" /> for your CNI, include the following `initramfs` stage in your `user-data` file. This is due to a [known issue with VMware's VMXNET3 adapter](https://github.com/cilium/cilium/issues/13096#issuecomment-723901955), which is widely used in different virtual machine management services, including VMware vSphere and Hyper-V.
+
+    ```shell
+      stages:
+        initramfs:
+          - name: "Disable UDP segmentation"
+            commands:
+              - ethtool --offload <interface-name> tx-udp_tnl-segmentation off
+              - ethtool --offload <interface-name> tx-udp_tnl-csum-segmentation off 
+    ```
+
+  ::: 
+
 5. Export the path to your user data file.
 
    ```shell
@@ -642,6 +657,21 @@ building a custom Edge ISO, ensure you use CanvOS version 4.6.21 or later as wel
          name: "Configure user"
    EOF
    ```
+
+  :::warning
+
+  If your host is a virtual machine using an VMXNET3 adapter and you are planning to enable an [overlay network](../../networking/vxlan-overlay.md) on your Edge cluster, or if you are planning to use <VersionedLink text="Flannel" url="/integrations/cni-flannel" /> for your CNI, include the following `initramfs` stage in your `user-data` file. This is due to a [known issue with VMware's VMXNET3 adapter](https://github.com/cilium/cilium/issues/13096#issuecomment-723901955), which is widely used in different virtual machine management services, including VMware vSphere and Hyper-V.
+
+    ```shell
+      stages:
+        initramfs:
+          - name: "Disable UDP segmentation"
+            commands:
+              - ethtool --offload <interface-name> tx-udp_tnl-segmentation off
+              - ethtool --offload <interface-name> tx-udp_tnl-csum-segmentation off 
+    ```
+
+  ::: 
 
 6. Issue the following command confirm that your user data file was created successfully at the correct location.
 

--- a/docs/docs-content/integrations/cni-calico.mdx
+++ b/docs/docs-content/integrations/cni-calico.mdx
@@ -51,6 +51,28 @@ install:
     - /var/lib/calico
 ```
 
+### Connectivity Issues in Virtual Machine Environments
+
+Due to a [known issue with VMware's VMXNET3 adapter](https://github.com/cilium/cilium/issues/13096#issuecomment-723901955),
+which is widely used in different virtual machine management services, including VMware vSphere and Hyper-V, Calico Pods may face network connectivity issues.
+
+Before deploying clusters with Calico in VXLAN mode, disable checksum offloading on your virtual host using the following the command. Replace `<interface-name>` with the name of the network interface on your host. Refer to the [Calico known issue](github.com/projectcalico/calico/issues/9433) thread for more information.
+
+```shell
+ethtool -K <interface-name> tx off
+```
+
+Alternatively, if deploying an Edge host in a virtual machine environment using an VMXNET3 adapter and enabling an <VersionedLink text="overlay network" url="/clusters/edge/networking/vxlan-overlay /> for your cluster, add the following commands in the `user-data` file at the boot stage. Replace `<interface-name>` with the name of the network interface on your Edge host.
+
+  ```yaml {2-6}
+  stages:
+    initramfs:
+      - name: "Disable UDP segmentation"
+        commands:
+          - ethtool --offload <interface-name> tx-udp_tnl-segmentation off
+          - ethtool --offload <interface-name> tx-udp_tnl-csum-segmentation off
+  ```
+
 </TabItem>
 
 <TabItem label="3.26.x" value="3.26.x">

--- a/docs/docs-content/integrations/cni-cilium-oss.mdx
+++ b/docs/docs-content/integrations/cni-cilium-oss.mdx
@@ -24,6 +24,23 @@ If you are using Bring Your Own Operating System (BYOOS), then HWE (Hardware Ena
 
 :::
 
+## Disable UDP Segmentation on VMXNET3 Edge Hosts for Clusters with Overlay Networks
+
+Due to a [known issue with VMware's VMXNET3 adapter](https://github.com/cilium/cilium/issues/13096#issuecomment-723901955),
+which is widely used in different virtual machine management services, including VMware vSphere and Hyper-V, Cilium Pods may face network connectivity issues.
+
+If deploying an Edge host in a virtual machine environment using an VMXNET3 adapter and enabling an <VersionedLink text="overlay network" url="/clusters/edge/networking/vxlan-overlay /> for your cluster, add the following commands in the `user-data` file at the boot stage. Replace `<interface-name>` with the name of the network interface on your Edge host.
+
+  ```yaml {2-6}
+  stages:
+    initramfs:
+      - name: "Disable UDP segmentation"
+        commands:
+          - ethtool --offload <interface-name> tx-udp_tnl-segmentation off
+          - ethtool --offload <interface-name> tx-udp_tnl-csum-segmentation off
+
+  ```
+
 ## Troubleshooting
 
 ### Scenario - I/O Timeout Error on VMware

--- a/docs/docs-content/integrations/cni-flannel.mdx
+++ b/docs/docs-content/integrations/cni-flannel.mdx
@@ -74,6 +74,23 @@ charts:
     keepaliveInterval: 0
 ```
 
+### Disable UDP Segmentation on VMXNET3 Edge Hosts
+
+Due to a [known issue with VMware's VMXNET3 adapter](https://github.com/cilium/cilium/issues/13096#issuecomment-723901955),
+which is widely used in different virtual machine management services, including VMware vSphere and Hyper-V, Flannel Pods may face network connectivity issues.
+
+If deploying an Edge host in a virtual machine environment using an VMXNET3 adapter, add the following commands in the `user-data` file at the boot
+stage. Replace `<interface-name>` with the name of the network interface on your Edge host.
+
+  ```yaml {2-6}
+  stages:
+    initramfs:
+      - name: "Disable UDP segmentation"
+        commands:
+          - ethtool --offload <interface-name> tx-udp_tnl-segmentation off
+          - ethtool --offload <interface-name> tx-udp_tnl-csum-segmentation off
+  ```
+
 </TabItem>
 <TabItem value="0.22.x" label="0.22.x">
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR expands upon the existing workaround for virtual hosts with VMXNET3 adapters. Originally, this issue was only applicable to clusters using Cilium and Flannel in overlay networks, but it has since expanded; thus we are updating the guidance to include _any_ virtual host with a VMXNET3 adapter that:
- Is being used in an Edge cluster with an overlay network
- Is using Flannel as its CNI 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

- [DOC-2011]()
- [DOC-2012]()

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
