### PR TITLE
docs: add 4.7.8 release notes DOC-2080

### DIFF
--- a/docs/docs-content/clusters/edge/networking/kubevip.md
+++ b/docs/docs-content/clusters/edge/networking/kubevip.md
@@ -32,7 +32,7 @@ these values when deploying a cluster or performing Day-2 cluster operations.
 | `vip_cidr`           | Sets the CIDR notation for the Virtual IP. A value of `32` denotes a single IP address in IPv4. | `32`          |
 | `cp_enable`          | Enables kube-vip control plane functionality.                                                   | `true`        |
 | `cp_namespace`       | The namespace where the lease will reside.                                                      | `kube-system` |
-| `vip_ddns`           | Enables Dynamic DNS support.                                                                    | `{{ .DDNS}}`  |
+| `vip_ddns`           | Enables Dynamic DNS support.                                                                    | `true`        |
 | `vip_leaderelection` | Enables Kubernetes LeaderElection.                                                              | `true`        |
 | `vip_leaseduration`  | Sets the lease duration in seconds.                                                             | `5`           |
 | `vip_renewdeadline`  | Specifies the deadline in seconds for renewing the lease.                                       | `3`           |
@@ -41,7 +41,8 @@ these values when deploying a cluster or performing Day-2 cluster operations.
 
 :::warning
 
-Do not modify the default `address` value. Changing this value makes the cluster inaccessible.
+Do not modify the default `address` value. Changing this value makes the cluster inaccessible. The `vip_ddns` value must
+be set to `true`.
 
 :::
 
@@ -53,7 +54,7 @@ Do not modify the default `address` value. Changing this value makes the cluster
 
 1. Log in to [Palette](https://console.spectrocloud.com/).
 
-2. From the left **Main Menu** click **Clusters ** and select **Add a New Cluster**.
+2. From the left **Main Menu** click **Clusters** and select **Add a New Cluster**.
 
 3. Choose **Edge Native** for the cluster type and click **Start Edge Native Configuration**.
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,20 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## August 4, 2025 - Release 4.7.8
+
+### Improvements
+
+- Palette now requires that the `cluster.kubevipArgs.vip_ddns` value be set to `true` for clusters that use `kube-vip`
+  to provide a virtual IP address for [Edge](../clusters/edge/edge.md) clusters. Refer to the
+  [Publish Cluster Services with Kube-vip](../clusters/edge/networking/kubevip.md) guide for further information.
+
+### Bug Fixes
+
+- Fixed an issue that caused [EKS clusters](../clusters/public-cloud/aws/eks.md) using
+  [custom AMI images](../clusters/public-cloud/aws/eks.md#cloud-configuration-settings) to be stuck in the Provisioning
+  status.
+
 ## July 31, 2025 - Release 4.7.7
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds release notes for 4.7.8. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release notes](https://deploy-preview-7657--docs-spectrocloud.netlify.app/release-notes/#august-4-2025---release-478)
💻 [Kube-vip](https://deploy-preview-7657--docs-spectrocloud.netlify.app/clusters/edge/networking/kubevip/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2080](https://spectrocloud.atlassian.net/browse/DOC-2080)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Only 4.7.

[DOC-2080]: https://spectrocloud.atlassian.net/browse/DOC-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ