### PR TITLE
docs: DOC-1899: ECR S3 Endpoint for Restricted Environments

### DIFF
--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-helm.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-helm.md
@@ -19,7 +19,7 @@ You can add an OCI type Helm registry to Palette and use the Helm Charts in your
 - If the OCI registry is using a self-signed certificate, or a certificate that is not signed by a trusted certificate
   authority (CA), you will need the certificate to add the registry to Palette.
 
-- If you are using an Amazon ECR in an airgapped or restricted network, you must whitelist the S3 endpoint that corresponds to the region of your Amazon ECR. This is because image layers are stored in S3, not the registry. The S3 endpoint uses the following format. Replace `<region>` with the region your ECR is hosted in.
+- If you are using an Amazon ECR and your [Palette](../../../enterprise-version/enterprise-version.md) or [Palette VerteX](../../../vertex/vertex.md) instance is installed in an airgapped environment or an environment with limited internet access, you must whitelist the S3 endpoint that corresponds to the region of your Amazon ECR. This is because image layers are stored in S3, not the registry. The S3 endpoint uses the following format. Replace `<region>` with the region your ECR is hosted in.
 
   ```shell
   prod-<region>-starport-layer-bucket.s3.<region>.amazonaws.com

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-helm.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-helm.md
@@ -25,6 +25,10 @@ You can add an OCI type Helm registry to Palette and use the Helm Charts in your
   prod-<region>-starport-layer-bucket.s3.<region>.amazonaws.com
   ```
 
+  ```shell hideClipboard title="Example S3 endpoint"
+  prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com
+  ```
+
 - If you are using an Amazon ECR, ensure you have the following Identity Access Management (IAM) permissions
   attached to the IAM user or IAM role that Palette will use to access the registry. You can reduce the `Resource` scope
   from `*` to the specific Amazon Resource Name (ARN) of the ECR you are using.

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-helm.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-helm.md
@@ -11,17 +11,23 @@ You can add an OCI type Helm registry to Palette and use the Helm Charts in your
 
 ## Prerequisites
 
-- Credentials to access the OCI registry. If you are using an AWS ECR registry, you must have the AWS credentials to an
+- Tenant admin access to Palette.
+
+- Credentials to access the OCI registry. If you are using an Amazon Elastic Container Registry (ECR), you must have the AWS credentials to an
   IAM user or add a trust relationship to an IAM role so that Palette can access the registry.
 
 - If the OCI registry is using a self-signed certificate, or a certificate that is not signed by a trusted certificate
   authority (CA), you will need the certificate to add the registry to Palette.
 
-- Tenant admin access to Palette.
+- If you are using an Amazon ECR in an airgapped or restricted network, you must whitelist the S3 endpoint that corresponds to the region of your Amazon ECR. This is because image layers are stored in S3, not the registry. The S3 endpoint uses the following format. Replace `<region>` with the region your ECR is hosted in.
 
-- If you are using an AWS ECR registry, ensure you have the following Identity Access Management (IAM) permissions
+  ```shell
+  prod-<region>-starport-layer-bucket.s3.<region>.amazonaws.com
+  ```
+
+- If you are using an Amazon ECR, ensure you have the following Identity Access Management (IAM) permissions
   attached to the IAM user or IAM role that Palette will use to access the registry. You can reduce the `Resource` scope
-  from `*` to the specific Amazon Resource Name (ARN) of the AWS ECR registry you are using.
+  from `*` to the specific Amazon Resource Name (ARN) of the ECR you are using.
 
   ```json
   {
@@ -106,7 +112,7 @@ registry you are adding.
 
 </TabItem>
 
-<TabItem value="aws" label="AWS ECR">
+<TabItem value="aws" label="Amazon ECR">
 
 1. Log in to the [Palette](https://console.spectrocloud.com) as a Tenant administrator.
 
@@ -124,11 +130,11 @@ registry you are adding.
 
 8. Provide the registry URL in the **Endpoint** field. Exclude the `https://` prefix.
 
-9. If you are using a private ECR registry, toggle the **Enable Authentication** option to expose the authentication
+9. If you are using a private ECR, toggle the **Enable Authentication** option to expose the authentication
    fields.
 
 10. Select the **AWS Authentication Method**. Choose **Credentials** if you want to provide the static AWS credentials
-    for an IAM user. Choose **STS** if you want to Palette to assume an IAM role that has access to the ECR registry
+    for an IAM user. Choose **STS** if you want to Palette to assume an IAM role that has access to the ECR
     through the Security Token Service (STS). Refer to the table below to learn more about each credential type.
 
 #### Credentials
@@ -149,7 +155,7 @@ registry you are adding.
 :::warning
 
 If you selected **STS** as the authentication method, you must add a trust relationship to the IAM role you are using to
-access the ECR registry. Refer to the instructions exposed in the side-drawer to the right of the input field to review
+access the ECR. Refer to the instructions exposed in the side-drawer to the right of the input field to review
 the IAM trust relationship changes you must add to your IAM role. Failure to add the trust relationship will result in
 an error when you attempt to validate the registry.
 

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-packs.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-packs.md
@@ -34,6 +34,10 @@ For guidance on how to add a custom pack to an OCI pack registry, check out the
   prod-<region>-starport-layer-bucket.s3.<region>.amazonaws.com
   ```
 
+  ```shell hideClipboard title="Example S3 endpoint"
+  prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com
+  ```
+
 - If you are using an Amazon ECR, ensure you have the following Identity Access Management (IAM) permissions
   attached to the IAM user or IAM role that Palette will use to access the registry. You can reduce the `Resource` scope
   from `*` to the specific Amazon Resource Name (ARN) of the ECR you are using.

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-packs.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-packs.md
@@ -20,17 +20,23 @@ For guidance on how to add a custom pack to an OCI pack registry, check out the
 
 ## Prerequisites
 
-- Credentials to access the OCI registry. If you are using an AWS ECR registry, you must have the AWS credentials to an
+- Tenant admin access to Palette.
+
+- Credentials to access the OCI registry. If you are using an Amazon Elastic Container Registry (ECR), you must have the AWS credentials to an
   IAM user or add a trust relationship to an IAM role so that Palette can access the registry.
 
 - If the OCI registry is using a self-signed certificate, or a certificate that is not signed by a trusted certificate
   authority (CA), you will need the certificate to add the registry to Palette.
 
-- Tenant admin access to Palette.
+- If you are using an Amazon ECR in an airgapped or restricted network, you must whitelist the S3 endpoint that corresponds to the region of your Amazon ECR. This is because image layers are stored in S3, not the registry. The S3 endpoint uses the following format. Replace `<region>` with the region your ECR is hosted in.
 
-- If you are using an AWS ECR registry, ensure you have the following Identity Access Management (IAM) permissions
+  ```shell
+  prod-<region>-starport-layer-bucket.s3.<region>.amazonaws.com
+  ```
+
+- If you are using an Amazon ECR, ensure you have the following Identity Access Management (IAM) permissions
   attached to the IAM user or IAM role that Palette will use to access the registry. You can reduce the `Resource` scope
-  from `*` to the specific Amazon Resource Name (ARN) of the AWS ECR registry you are using.
+  from `*` to the specific Amazon Resource Name (ARN) of the ECR you are using.
 
   ```json
   {
@@ -112,7 +118,7 @@ registry you are adding.
 
 </TabItem>
 
-<TabItem value="aws" label="AWS ECR">
+<TabItem value="aws" label="Amazon ECR">
 
 1. Log in to the [Palette](https://console.spectrocloud.com) as a Tenant administrator.
 
@@ -134,11 +140,11 @@ registry you are adding.
    if the OCI registry URL is `https://registry.example.com` and the OCI Packs are stored in the `custom` repository,
    the base content path is `custom`.
 
-10. If you are using a private ECR registry, toggle the **Enable Authentication** option to expose the authentication
+10. If you are using a private ECR, toggle the **Enable Authentication** option to expose the authentication
     fields.
 
 11. Select the **AWS Authentication Method**. Choose **Credentials** if you want to provide the static AWS credentials
-    for an IAM user. Choose **STS** if you want to Palette to assume an IAM role that has access to the ECR registry
+    for an IAM user. Choose **STS** if you want to Palette to assume an IAM role that has access to the ECR
     through the Security Token Service (STS). Refer to the table below to learn more about each credential type.
 
 #### Credentials
@@ -159,7 +165,7 @@ registry you are adding.
 :::warning
 
 If you selected **STS** as the authentication method, you must add a trust relationship to the IAM role you are using to
-access the ECR registry. Refer to the instructions exposed in the side-drawer to the right of the input field to review
+access the ECR. Refer to the instructions exposed in the side-drawer to the right of the input field to review
 the IAM trust relationship changes you must add to your IAM role. Failure to add the trust relationship will result in
 an error when you attempt to validate the registry.
 

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-packs.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-packs.md
@@ -28,7 +28,7 @@ For guidance on how to add a custom pack to an OCI pack registry, check out the
 - If the OCI registry is using a self-signed certificate, or a certificate that is not signed by a trusted certificate
   authority (CA), you will need the certificate to add the registry to Palette.
 
-- If you are using an Amazon ECR in an airgapped or restricted network, you must whitelist the S3 endpoint that corresponds to the region of your Amazon ECR. This is because image layers are stored in S3, not the registry. The S3 endpoint uses the following format. Replace `<region>` with the region your ECR is hosted in.
+- If you are using an Amazon ECR and your [Palette](../../../enterprise-version/enterprise-version.md) or [Palette VerteX](../../../vertex/vertex.md) instance is installed in an airgapped environment or an environment with limited internet access, you must whitelist the S3 endpoint that corresponds to the region of your Amazon ECR. This is because image layers are stored in S3, not the registry. The S3 endpoint uses the following format. Replace `<region>` with the region your ECR is hosted in.
 
   ```shell
   prod-<region>-starport-layer-bucket.s3.<region>.amazonaws.com


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds guidance for users adding Amazon ECRs to restricted Palette/VerteX environments, stating that they must also whitelist the S3 endpoint that corresponds with the region their ECR is hosted in. It also updates ECR to use the correct terminology (AWS ECR registry > Amazon ECR).

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Add OCI Helm Registry]()
- [Add OCI Packs Registry]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1899](https://spectrocloud.atlassian.net/browse/DOC-1899)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
