### PR TITLE
docs: add isTwoNodeCluster to release notes DOC-2084

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -213,6 +213,16 @@ Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible ver
 
 :::
 
+#### Breaking Changes {#breaking-changes-automation-4.7.0}
+
+- A new field `isTwoNodeCluster` has been introduced to the request body of the
+  [Updates the cluster configuration information](api/v1/v-1-cloud-configs-edge-native-uid-cluster-config) API endpoint.
+  This field must now be set to `true` before setting the `twoNodeCandidatePriority` field on Edge hosts using the
+  [Creates an Hybrid AWS cloud config's Edge-Native machine pool](/api/v1/v-1-aws-cloud-configs-edge-native-uid-machine-pool-create/)
+  and
+  [Updates the specified Hybrid AWS cluster cloud config's Edge-Native machine pool](/api/v1/v-1-aws-cloud-configs-edge-native-machine-pool-update/)
+  API endpoints.
+
 #### Features
 
 - The `content build` command of the [Palette CLI](../automation/palette-cli/palette-cli.md) now includes the

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -216,8 +216,9 @@ Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible ver
 #### Breaking Changes {#breaking-changes-automation-4.7.0}
 
 - A new field `isTwoNodeCluster` has been introduced to the request body of the
-  [Updates the cluster configuration information](api/v1/v-1-cloud-configs-edge-native-uid-cluster-config) API endpoint.
-  This field must now be set to `true` before setting the `twoNodeCandidatePriority` field on Edge hosts using the
+  [Updates the cluster configuration information](/api/v1/v-1-cloud-configs-edge-native-uid-cluster-config) API
+  endpoint. This field must now be set to `true` before setting the `twoNodeCandidatePriority` field on Edge hosts using
+  the
   [Creates an Hybrid AWS cloud config's Edge-Native machine pool](/api/v1/v-1-aws-cloud-configs-edge-native-uid-machine-pool-create/)
   and
   [Updates the specified Hybrid AWS cluster cloud config's Edge-Native machine pool](/api/v1/v-1-aws-cloud-configs-edge-native-machine-pool-update/)


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a missing breaking change from the 4.7.0 release notes.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Automation](https://deploy-preview-7708--docs-spectrocloud.netlify.app/release-notes/#breaking-changes-automation-4.7.0)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2084](https://spectrocloud.atlassian.net/browse/DOC-2084)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Only 4.7

[DOC-2084]: https://spectrocloud.atlassian.net/browse/DOC-2084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ