### PR TITLE
DOC-2063 - Karpenter read-only support for EKS

### DIFF
--- a/docs/docs-content/clusters/public-cloud/aws/architecture.md
+++ b/docs/docs-content/clusters/public-cloud/aws/architecture.md
@@ -42,6 +42,10 @@ highlights pertaining to EKS when managed by Palette.
 
 - Spot instance support
 
+- Nodes provisioned through [Karpenter](https://karpenter.sh/docs/) are visible in Palette and supported for read-only
+  operations, such as billing and monitoring. However,
+  [Day-2 operations](../../cluster-management/cluster-management.md) are not supported.
+
 ![eks_cluster_architecture.webp](/clusters_aws_create-and-manage-aws-eks-cluster_architecture.webp)
 
 ### Worker Node Requirements

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -44,6 +44,10 @@ tags: ["release-notes"]
 
 #### Improvements
 
+- Nodes provisioned through [Karpenter](https://karpenter.sh/docs/) are now visible in Palette and supported for
+  read-only operations, such as billing and monitoring. However,
+  [Day-2 operations](../clusters/cluster-management/cluster-management.md) are not supported.
+
 #### Deprecations and Removals
 
 ### Edge


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR documents Karpenter read-only support in Palette for EKS clusters.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2063](https://spectrocloud.atlassian.net/browse/DOC-2063)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._
Release ticket.