### PR TITLE
docs: PCP-4752: Updated Breaking Change re: MAAS AZ Node Pool 

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -22,8 +22,13 @@ tags: ["release-notes"]
 #### Breaking Changes {#breaking-changes-4.7.a}
 
 - Availability zones are now required when creating MAAS [node pools](../clusters/cluster-management/node-pool.md).
-  - For [MAAS clusters](../clusters/data-center/maas/create-manage-maas-clusters.md) deployed prior to Palette version 4.7.a, selecting an availability zone is required when creating a new node pool; however, selecting an availability zone is _not_ required when modifying an existing node pool, as modifying availability zones post-cluster deployment will trigger a [node pool repave](../clusters/cluster-management/node-pool.md#repave-behavior-and-configuration).
-  - For MAAS clusters deployed prior to 4.7.a, we recommend creating a new node pool with an availability zone selected and migrating existing workloads to the new node pool when convenient. For guidance on migrating workloads, refer to the [Taints and Tolerations](../clusters/cluster-management/taints.md) guide.
+  - For [MAAS clusters](../clusters/data-center/maas/create-manage-maas-clusters.md) deployed prior to Palette version
+    4.7.a, selecting an availability zone is required when creating a new node pool; however, selecting an availability
+    zone is _not_ required when modifying an existing node pool, as modifying availability zones post-cluster deployment
+    will trigger a [node pool repave](../clusters/cluster-management/node-pool.md#repave-behavior-and-configuration).
+  - For MAAS clusters deployed prior to 4.7.a, we recommend creating a new node pool with an availability zone selected
+    and migrating existing workloads to the new node pool when convenient. For guidance on migrating workloads, refer to
+    the [Taints and Tolerations](../clusters/cluster-management/taints.md) guide.
 
 #### Features
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR provides additional guidance re: how customers with existing MAAS clusters should handle the new requirement to select an availability zone for MAAS node pools. It expands upon [PR 7659](https://github.com/spectrocloud/librarium/pull/7659).

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-7715--docs-spectrocloud.netlify.app/release-notes/#breaking-changes-4.7.a)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PCP-4752](https://spectrocloud.atlassian.net/browse/PCP-4752)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work

[PCP-4752]: https://spectrocloud.atlassian.net/browse/PCP-4752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ