### PR TITLE
docs: update release branch naming DOC-2085

### DIFF
--- a/.github/workflows/aloglia_crawler.yaml
+++ b/.github/workflows/aloglia_crawler.yaml
@@ -4,7 +4,7 @@
 # However, in the event we have to stop using the Algolia DocSearch v3 crawler. We can revert to our own custom crawler and index by uncommenting the code below.
 # We just need to make sure we update the GitHub Secrets with the Algolia App ID and Admin Key.
 # The Algolia App ID and Admin Key can be found in the Algolia dashboard. 
-# Refer to the internal team documenation https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/2203516932/Algolia for more information.
+# Refer to the internal team documentation https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/2203516932/Algolia for more information.
 # This workflow supports on-demand execution using the workflow_dispatch event.
 
 name: Algolia Crawler

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -109,7 +109,7 @@ jobs:
       - run: npm ci
 
       - name: Versions on Release Branch Only
-        if: ${{ startsWith(github.head_ref, 'release-') }}
+        if: ${{ startsWith(github.head_ref, 'docs-rel-') }}
         run: |
           make versions
 

--- a/.github/workflows/release-branch-pr.yaml
+++ b/.github/workflows/release-branch-pr.yaml
@@ -1,4 +1,4 @@
-# This workflow is trigged when a PR is opened, synchronized, reopened, or ready for review, and the branch name matches the pattern release-[0-9]-[0-9], release-[0-9]-[0-9]-[0-9] or release-[0-9]-[0-9]-[a-z].
+# This workflow is trigged when a PR is opened, synchronized, reopened, or ready for review, and the branch name matches the pattern docs-rel-[0-9]-[0-9], docs-rel-[0-9]-[0-9]-[0-9] or docs-rel-[0-9]-[0-9]-[a-z].
 # In simple terms, this workflow targers a release preview branch.
 # Workflow attempts to build the site and configure Netlify to allow for preview builds. By default, Netlify does not create preview builds for pull requests that are not targeting the main branch.
 # The workflow uses the Netlify API to add the branch to the branch deploy list of branches that Netlify will build previews for.
@@ -13,9 +13,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - "release-[0-9]-[0-9]"
-      - "release-[0-9]-[0-9]-[0-9]"
-      - "release-[0-9]-[0-9]-[a-z]"
+      - "docs-rel-[0-9]-[0-9]"
+      - "docs-rel-[0-9]-[0-9]-[0-9]"
+      - "docs-rel-[0-9]-[0-9]-[a-z]"
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -1,4 +1,4 @@
-# This workflow is triggered on push to any branch that starts with "release-". The primary purpose of this workflow is to create a preview of the upcoming release content and simulate the look and feel of the production site. 
+# This workflow is triggered on push to any branch that starts with "docs-rel-". The primary purpose of this workflow is to create a preview of the upcoming release content and simulate the look and feel of the production site. 
 # The domain used for the preview is docs-latest.spectrocloud.com. The workflow builds the site and uploads the content to an S3 bucket. The S3 bucket is configured to serve the content as a static website.
 # No update will occur in the event the build is unable to complete successfully. This is due to a scenario where an immediate failover from docs.specrocloud.com to docs-latest.spectrocloud.com is needed.
 # The workflow also posts a comment to the PR with the Netlify preview URL.
@@ -9,9 +9,9 @@ name: Release Branch Preview
 on:
   push:
     branches:
-      - "release-[0-9]-[0-9]"
-      - "release-[0-9]-[0-9]-[0-9]"
-      - "release-[0-9]-[0-9]-[a-z]"
+      - "docs-rel-[0-9]-[0-9]"
+      - "docs-rel-[0-9]-[0-9]-[0-9]"
+      - "docs-rel-[0-9]-[0-9]-[a-z]"
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -12,7 +12,7 @@ name: Visual Comparison
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-    branches-ignore: ["version-*", "release-*"]
+    branches-ignore: ["version-*", "docs-rel-*"]
 
 
 env:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,20 @@
+#!/bin/sh
+
 lint-staged
 
 npm run clean-api-docs
 
 make format-images
+
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+
+# Don't allow commits to branches that contain "release" in their name
+DISALLOWED_PATTERNS=(".*release.*")
+
+for pattern in "${DISALLOWED_PATTERNS[@]}"; do
+  if [[ "$BRANCH_NAME" =~ $pattern ]]; then
+    echo "❌ Commit blocked: '$BRANCH_NAME' contains the word release."
+    echo "ℹ️ Rename your branch using the command git branch -m and commit again."
+    exit 1
+  fi
+done

--- a/README.md
+++ b/README.md
@@ -1209,11 +1209,11 @@ make format
 
 To create a new release, use the following steps:
 
-1. Create a release branch. Use the following naming pattern `release-X-X`
-2. Create a commit using the following commit message `feat: updating documentation for release-X-X`. Replace x-x with
+1. Create a release branch. Use the following naming pattern `docs-rel-X-X`
+2. Create a commit using the following commit message `feat: updating documentation for `docs-rel-X-X`. Replace x-x with
    the upcoming release number.
 3. Push up the commit and create a new pull request (PR).
-4. Merge PRs related to the upcoming release into the `release-X-X` branch.
+4. Merge PRs related to the upcoming release into the `docs-rel-X-X` branch.
 5. Merge the release branch.
 6. Create a new branch from the `master` branch. Use the following naming pattern `version-X-X`. This brach is used for
    versioning the documentation.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the names of release branches.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

_No user facing changes._

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2085](https://spectrocloud.atlassian.net/browse/DOC-2085)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
Backport everywhere. 

[DOC-2085]: https://spectrocloud.atlassian.net/browse/DOC-2085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ