### PR TITLE
docs: DOC-2086: Insecure Skip TLS Verify Not Applicable to VerteX

### DIFF
--- a/_partials/self-hosted/_smtp.mdx
+++ b/_partials/self-hosted/_smtp.mdx
@@ -40,7 +40,7 @@ Anonymous SMTP configuration introduces additional security risks. We recommend 
 
     | **Field**                    | **Description**                                                                                                                                                                           | **Required** |
     | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-    | **Insecure Skip TLS Verify** | This option disables Transport Layer Security (TLS) certificate verification. Enable this option if your SMTP server is using a self-signed certificate or has a certificate that is not trusted by the system.  | No |
+    | **Insecure Skip TLS Verify** | {props.tls_description}  | {props.tls_required} |
     | **Outgoing Server**          | The host name of the SMTP server. For example, `smtp.gmail.com`.                                                                                                                           | Yes |
     | **Outgoing Port**            | The port number of the SMTP server.                                                                                                                                                       | Yes |
     | **From Email**               | Emails sent by {props.version} will use this email address as the sender.                                                                      | Yes |

--- a/docs/docs-content/enterprise-version/system-management/smtp.md
+++ b/docs/docs-content/enterprise-version/system-management/smtp.md
@@ -9,4 +9,11 @@ tags: ["vertex", "management"]
 keywords: ["self-hosted", "vertex"]
 ---
 
-<PartialsComponent category="self-hosted" name="smtp" edition="Palette" version="Palette" tls_description="This option disables Transport Layer Security (TLS) certificate verification. Enable this option if your SMTP server is using a self-signed certificate or has a certificate that is not trusted by the system." tls_required="No" />
+<PartialsComponent
+  category="self-hosted"
+  name="smtp"
+  edition="Palette"
+  version="Palette"
+  tls_description="This option disables Transport Layer Security (TLS) certificate verification. Enable this option if your SMTP server is using a self-signed certificate or has a certificate that is not trusted by the system."
+  tls_required="No"
+/>

--- a/docs/docs-content/enterprise-version/system-management/smtp.md
+++ b/docs/docs-content/enterprise-version/system-management/smtp.md
@@ -9,4 +9,4 @@ tags: ["vertex", "management"]
 keywords: ["self-hosted", "vertex"]
 ---
 
-<PartialsComponent category="self-hosted" name="smtp" edition="Palette" version="Palette" />
+<PartialsComponent category="self-hosted" name="smtp" edition="Palette" version="Palette" tls_description="This option disables Transport Layer Security (TLS) certificate verification. Enable this option if your SMTP server is using a self-signed certificate or has a certificate that is not trusted by the system." tls_required="No" />

--- a/docs/docs-content/vertex/system-management/smtp.md
+++ b/docs/docs-content/vertex/system-management/smtp.md
@@ -9,4 +9,4 @@ tags: ["vertex", "management"]
 keywords: ["self-hosted", "vertex"]
 ---
 
-<PartialsComponent category="self-hosted" name="smtp" edition="VerteX" version="Palette VerteX" />
+<PartialsComponent category="self-hosted" name="smtp" edition="VerteX" version="Palette VerteX" tls_description="Due to FIPS compliance, Transport Layer Security (TLS) certificate verification cannot be disabled in Palette VerteX." tls_required="N/A" />

--- a/docs/docs-content/vertex/system-management/smtp.md
+++ b/docs/docs-content/vertex/system-management/smtp.md
@@ -9,4 +9,11 @@ tags: ["vertex", "management"]
 keywords: ["self-hosted", "vertex"]
 ---
 
-<PartialsComponent category="self-hosted" name="smtp" edition="VerteX" version="Palette VerteX" tls_description="Due to FIPS requirements, Transport Layer Security (TLS) certificate verification cannot be disabled in Palette VerteX." tls_required="N/A" />
+<PartialsComponent
+  category="self-hosted"
+  name="smtp"
+  edition="VerteX"
+  version="Palette VerteX"
+  tls_description="Due to FIPS requirements, Transport Layer Security (TLS) certificate verification cannot be disabled in Palette VerteX."
+  tls_required="N/A"
+/>

--- a/docs/docs-content/vertex/system-management/smtp.md
+++ b/docs/docs-content/vertex/system-management/smtp.md
@@ -9,4 +9,4 @@ tags: ["vertex", "management"]
 keywords: ["self-hosted", "vertex"]
 ---
 
-<PartialsComponent category="self-hosted" name="smtp" edition="VerteX" version="Palette VerteX" tls_description="Due to FIPS compliance, Transport Layer Security (TLS) certificate verification cannot be disabled in Palette VerteX." tls_required="N/A" />
+<PartialsComponent category="self-hosted" name="smtp" edition="VerteX" version="Palette VerteX" tls_description="Due to FIPS requirements, Transport Layer Security (TLS) certificate verification cannot be disabled in Palette VerteX." tls_required="N/A" />


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR specifies that **Insecure Skip TLS Verify** cannot be disabled for SMTP in Palette VerteX. At this time, you are able to mark the checkbox, but it is not functional. This field will be disabled in VerteX in the future.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Configure SMTP - Palette](https://deploy-preview-7721--docs-spectrocloud.netlify.app/enterprise-version/system-management/smtp/)
- [Configure SMTP - VerteX](https://deploy-preview-7721--docs-spectrocloud.netlify.app/vertex/system-management/smtp/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2086](https://spectrocloud.atlassian.net/browse/DOC-2086)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2086]: https://spectrocloud.atlassian.net/browse/DOC-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ