### PR TITLE
DOC-2068 - Management Appliance default drive selection behaviour

### DIFF
--- a/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
+++ b/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
@@ -20,7 +20,7 @@ partial_name: installation-steps-prereqs
 
     :::tip
 
-    The largest drive is automatically chosen for the ISO stack. As such, it is recommended that the first disk has more storage than the second disk.
+    The largest drive is automatically selected for the ISO stack. Therefore, it is recommended that the first disk has more storage than the second disk.
 
     :::
 

--- a/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
+++ b/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
@@ -18,6 +18,12 @@ partial_name: installation-steps-prereqs
 
     - The second disk must be at least 500 GB and is used for the storage pool.
 
+    :::tip
+
+    The largest drive is automatically chosen for the ISO stack. As such, it is recommended that the first disk has more storage than the second disk.
+
+    :::
+
 - The following network ports must be accessible on each node for Palette to operate successfully.
 
   - TCP/443: Must be open between all Palette nodes and accessible for user connections to the Palette management


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR documents how the Management Appliance automatically selects the drive for installation.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Palette Management Appliance](https://deploy-preview-7725--docs-spectrocloud.netlify.app/enterprise-version/install-palette/palette-management-appliance/#prerequisites) - The same change also applies to the VerteX equivalent.

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2068](https://spectrocloud.atlassian.net/browse/DOC-2068)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2068]: https://spectrocloud.atlassian.net/browse/DOC-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ