### PR TITLE
[version-4-2] docs: backport/version-4-2/pr-7721

### DIFF
--- a/_partials/self-hosted/_smtp.mdx
+++ b/_partials/self-hosted/_smtp.mdx
@@ -34,14 +34,14 @@ invitation email.
 
 4. Fill out the following fields.
 
-  | **Field**                    | **Description**                                                                                                                                                                           | **Required** |
-  | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-  | **Outgoing Server**          | The host name of the SMTP server. For example, `smtp.gmail.com`.                                                                                                                           | Yes |
-  | **Outgoing Port**            | The port number of the SMTP server.                                                                                                                                                       | Yes |
-  | **From Email**               | The email address from which emails will be sent. Emails sent from {props.version} will be sent from this email address.                                                                      | Yes |
-  | **Username**                 | The username of the SMTP server.                                                                                                                                                          | Yes |
-  | **Password**                 | The password of the SMTP server. Certain SMTP servers, such as `smtp.gmail.com`, require app passwords instead of user passwords.                                                                                                                                                         | Yes |
-  | **Insecure Skip TLS Verify** | This option disables Transport Layer Security (TLS) certificate verification. Enable this option if your SMTP server is using a self-signed certificate or has a certificate that is not trusted by the system.  | No |
+    | **Field**                    | **Description**                                                                                                                                                                           | **Required** |
+    | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+    | **Insecure Skip TLS Verify** | {props.tls_description}  | {props.tls_required} |
+    | **Outgoing Server**          | The host name of the SMTP server. For example, `smtp.gmail.com`.                                                                                                                           | Yes |
+    | **Outgoing Port**            | The port number of the SMTP server.                                                                                                                                                       | Yes |
+    | **From Email**               | Emails sent by {props.version} will use this email address as the sender.                                                                      | Yes |
+    | **Username**                 | The username of the SMTP server. This is required for authenticated SMTP. If you are using anonymous SMTP, do not include a username or password.                                                                                                                                                         | No |
+    | **Password**                 | The password of the SMTP server. This is required for authenticated SMTP. Certain SMTP servers, such as `smtp.gmail.com`, require app passwords instead of user passwords. If you are using anonymous SMTP configuration, do not include a username or password.                                                                                                                                                         | No |
 
 5. Click **Validate configuration**. A success message is displayed if the configuration is valid; otherwise, an error message is displayed. Additional error details can be found in the {props.version} `system-<ID>-<ID>` container logs, located in the `hubble-system` namespace.
 

--- a/docs/docs-content/enterprise-version/system-management/smtp.md
+++ b/docs/docs-content/enterprise-version/system-management/smtp.md
@@ -9,4 +9,11 @@ tags: ["vertex", "management"]
 keywords: ["self-hosted", "vertex"]
 ---
 
-<PartialsComponent category="self-hosted" name="smtp" edition="Palette" version="Palette" />
+<PartialsComponent
+  category="self-hosted"
+  name="smtp"
+  edition="Palette"
+  version="Palette"
+  tls_description="This option disables Transport Layer Security (TLS) certificate verification. Enable this option if your SMTP server is using a self-signed certificate or has a certificate that is not trusted by the system."
+  tls_required="No"
+/>

--- a/docs/docs-content/vertex/system-management/smtp.md
+++ b/docs/docs-content/vertex/system-management/smtp.md
@@ -9,4 +9,11 @@ tags: ["vertex", "management"]
 keywords: ["self-hosted", "vertex"]
 ---
 
-<PartialsComponent category="self-hosted" name="smtp" edition="VerteX" version="Palette VerteX" />
+<PartialsComponent
+  category="self-hosted"
+  name="smtp"
+  edition="VerteX"
+  version="Palette VerteX"
+  tls_description="Due to FIPS requirements, Transport Layer Security (TLS) certificate verification cannot be disabled in Palette VerteX."
+  tls_required="N/A"
+/>


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR creates a manual backport for [PR 7721 ](https://github.com/spectrocloud/librarium/pull/7721) for version-4-2.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Configure SMTP - Palette](https://deploy-preview-7721--docs-spectrocloud.netlify.app/enterprise-version/system-management/smtp/)
- [Configure SMTP - VerteX](https://deploy-preview-7721--docs-spectrocloud.netlify.app/vertex/system-management/smtp/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2086](https://spectrocloud.atlassian.net/browse/DOC-2086)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Is the backport

[DOC-2086]: https://spectrocloud.atlassian.net/browse/DOC-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ