### PR TITLE
docs: Fix broken URLs found on 11th August 2025

### DIFF
--- a/docs/docs-content/automation/crossplane/crossplane.md
+++ b/docs/docs-content/automation/crossplane/crossplane.md
@@ -13,11 +13,11 @@ extending the Kubernetes API and enabling infrastructure resource provisioning a
 infrastructure providers.
 
 These resources, called
-[Managed Resources (MR)](https://docs.crossplane.io/v2.0/managed-resources/managed-resources/#managed-resource-fields) within
-the Crossplane environment, are essentially Kubernetes Custom Resource Definitions (CRDs) that represent infrastructure
-resources as native Kubernetes objects. Because they are Kubernetes objects, you can interact with them using standard
-commands like `kubectl describe`. When users create a managed resource, Crossplane interacts with the infrastructure
-provider API to request the creation of the resource within the provider's environment.
+[Managed Resources (MR)](https://docs.crossplane.io/v2.0/managed-resources/managed-resources/#managed-resource-fields)
+within the Crossplane environment, are essentially Kubernetes Custom Resource Definitions (CRDs) that represent
+infrastructure resources as native Kubernetes objects. Because they are Kubernetes objects, you can interact with them
+using standard commands like `kubectl describe`. When users create a managed resource, Crossplane interacts with the
+infrastructure provider API to request the creation of the resource within the provider's environment.
 
 ## Palette Provider
 

--- a/docs/docs-content/automation/crossplane/crossplane.md
+++ b/docs/docs-content/automation/crossplane/crossplane.md
@@ -13,7 +13,7 @@ extending the Kubernetes API and enabling infrastructure resource provisioning a
 infrastructure providers.
 
 These resources, called
-[Managed Resources (MR)](https://docs.crossplane.io/latest/concepts/managed-resources/#managed-resource-fields) within
+[Managed Resources (MR)](https://docs.crossplane.io/v2.0/managed-resources/managed-resources/#managed-resource-fields) within
 the Crossplane environment, are essentially Kubernetes Custom Resource Definitions (CRDs) that represent infrastructure
 resources as native Kubernetes objects. Because they are Kubernetes objects, you can interact with them using standard
 commands like `kubectl describe`. When users create a managed resource, Crossplane interacts with the infrastructure

--- a/docs/docs-content/devx/services/service-listings/redis-db.md
+++ b/docs/docs-content/devx/services/service-listings/redis-db.md
@@ -116,9 +116,9 @@ kubectl get secret  app-tarfful-redis-4-redis-auth \
 ## Next Steps
 
 You can add Redis to your application profile and start integrating Redis with your applications. To learn more about
-integrating Redis with your applications, check out the [Using Redis](https://redis.io/docs/manual/) documentation from
+integrating Redis with your applications, check out the [Using Redis](https://redis.io/docs/latest/) documentation from
 Redis.
 
 ## Resources
 
-- [Using Redis](https://redis.io/docs/manual/)
+- [Using Redis](https://redis.io/docs/latest/)


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes some broken URLs found with the Monday checks.

Note that https://www.intel.com/content/www/us/en/learn/what-is-a-trusted-platform-module.html was also registered as broken, but it was likely a transient error, as the URL works correctly.

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
