### PR TITLE
docs: fix default drive selection for Management Appliance

### DIFF
--- a/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
+++ b/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
@@ -14,15 +14,9 @@ partial_name: installation-steps-prereqs
 
   - Two disks per node.
 
-    - The first disk must be at least 250 GB and is used for the ISO stack.
+    - The first disk must be at least 250 GB and is used for the ISO stack. The default device selected is `/dev/sda`.
 
-    - The second disk must be at least 500 GB and is used for the storage pool.
-
-    :::tip
-
-    The largest drive is automatically selected for the ISO stack. Therefore, it is recommended that the first disk has more storage than the second disk.
-
-    :::
+    - The second disk must be at least 500 GB and is used for the storage pool. The default device selected is `/dev/sdb`.
 
 - The following network ports must be accessible on each node for Palette to operate successfully.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR corrects the default drive behaviour explanation for the Management Appliance.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Palette Management Appliance](https://deploy-preview-7801--docs-spectrocloud.netlify.app/enterprise-version/install-palette/palette-management-appliance/#prerequisites) - Same changes apply to VerteX Management Appliance.

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
