### PR TITLE
docs: Update terminology on the Appliance Mode page

### DIFF
--- a/docs/docs-content/deployment-modes/appliance-mode/appliance-mode.md
+++ b/docs/docs-content/deployment-modes/appliance-mode/appliance-mode.md
@@ -17,8 +17,10 @@ need to create two artifacts: an installer ISO file and a provider image. The in
 supported distribution, with the Palette agent natively installed. The provider image is an image that combines the OS
 and the Kubernetes layer for your cluster.
 
-Depending on your business needs, you can deploy centrally managed or locally managed clusters in appliance mode. If you deploy a centrally managed cluster, your hosts will register with Palette based on the registration token you provide during
-the installer build. Once registered, you can use the hosts as control plane or worker nodes to create a cluster. Alternatively, you can use [Local UI](../../clusters/edge/local-ui/local-ui.md) to create a locally managed cluster,
+Depending on your business needs, you can deploy centrally managed or locally managed clusters in appliance mode. If you
+deploy a centrally managed cluster, your hosts will register with Palette based on the registration token you provide
+during the installer build. Once registered, you can use the hosts as control plane or worker nodes to create a cluster.
+Alternatively, you can use [Local UI](../../clusters/edge/local-ui/local-ui.md) to create a locally managed cluster,
 which does not require a connection to Palette.
 
 ![Architecture Diagram for Appliance Mode](/deployment-modes_appliance-mode.webp)


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates terminology on the Appliance mode page:
- airgapped → locally managed
- connected → centrally managed

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Appliance mode](https://deploy-preview-7882--docs-spectrocloud.netlify.app/deployment-modes/appliance-mode/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2136](https://spectrocloud.atlassian.net/browse/DOC-2136)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes.
- [ ] No.


[DOC-2136]: https://spectrocloud.atlassian.net/browse/DOC-2136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ