### PR TITLE
DOC-2132 - Three control plane nodes mandatory for Management Appliance

### DIFF
--- a/_partials/self-hosted/management-appliance/_installation-steps-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_installation-steps-enablement.mdx
@@ -178,9 +178,9 @@ partial_name: installation-steps-enablement
 
     :::important
 
-    We recommend having at least three control plane nodes for high availability. You can remove the worker node
-    pool as it is not required for the {props.version} management cluster. If doing this, ensure that the **Allow worker
-    capability** option is enabled for the control plane node pool.
+    You must assign at least three control plane nodes for high availability. You can remove the worker node
+    pool as it is not required for the {props.version} management cluster. When doing this, ensure that the
+    **Allow worker capability** option is enabled for the control plane node pool.
 
     :::
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adjusts an existing admonition to state that three control plane nodes are mandatory for the Management Appliance.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2132](https://spectrocloud.atlassian.net/browse/DOC-2132)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
