### PR TITLE
DOC-2137 - Troubleshooting steps for stalled VerteX Management Appliance upgrade due to stuck Linstor satellite pods

### DIFF
--- a/docs/docs-content/troubleshooting/enterprise-install.md
+++ b/docs/docs-content/troubleshooting/enterprise-install.md
@@ -21,7 +21,24 @@ To resolve this issue, you can check whether the pods are using an incorrect ima
 
 ### Debug Steps
 
-1. Use the following command to check the status of these pods in the `piraeus-system` namespace.
+1. Log in to the Local UI of the leader node of your VerteX management cluster. By default, Local UI is accessible at
+   `https://<node-ip>:5080`. Replace `<node-ip>` with the IP address of the leader node.
+
+2. From the left main menu, click **Cluster**.
+
+3. Under **Environment**, download the **Admin Kubeconfig File** by clicking on the `<cluster-name>.kubeconfig`
+   hyperlink.
+
+4. Open a terminal session in an environment that has network access to the VerteX management cluster.
+
+5. Issue the following command to set the `KUBECONFIG` environment variable to the path of the kubeconfig file you
+   downloaded in step 3.
+
+   ```bash
+   export KUBECONFIG=<path-to-kubeconfig-file>
+   ```
+
+6. Use the following command to check the status of these pods in the `piraeus-system` namespace.
 
    ```bash
    kubectl get pods --namespace piraeus-system
@@ -45,7 +62,7 @@ To resolve this issue, you can check whether the pods are using an incorrect ima
    piraeusoperator-piraeus-controller-manager-6f8988d598-b2v57     1/1     Running                 1 (28m ago)      25h
    ```
 
-2. If any of the `linstor-satellite.*` pods are not in a **Running** state, use the following command to describe the
+7. If any of the `linstor-satellite.*` pods are not in a **Running** state, use the following command to describe the
    pods. Replace `<pod-name>` with the name of the Linstor satellite pod you want to inspect.
 
    ```bash
@@ -71,7 +88,7 @@ To resolve this issue, you can check whether the pods are using an incorrect ima
      Warning  BackOff    3m41s (x53 over 23m)  kubelet            Back-off restarting failed container drbd-module-loader in pod linstor-satellite.edge-c0913842383ebd183d13d1458bb762c5-78q97_piraeus-system(71ea7db5-cc2c-4585-b1f7-fcc19bf14891)
    ```
 
-3. If any of the `linstor-satellite.*` pods are using the `drbd9-jammy:v9.2.13` image, issue the following command to
+8. If any of the `linstor-satellite.*` pods are using the `drbd9-jammy:v9.2.13` image, issue the following command to
    create a manifest that corrects the image reference for the `drbd-module-loader` container.
 
    ```bash
@@ -95,28 +112,28 @@ To resolve this issue, you can check whether the pods are using an incorrect ima
    linstorsatelliteconfiguration.piraeus.io/custom-loader-image created
    ```
 
-4. Wait for the `linstor-satellite.*` pods to be recreated with the new image.
+9. Wait for the `linstor-satellite.*` pods to be recreated with the new image.
 
-5. Verify that the `drbd-module-loader` container is using the new image by describing the `linstor-satellite.*` pods.
-   Replace `<pod-name>` with the name of the pod you want to check. You may need to issue
-   `kubectl get pods --namespace piraeus-system` first as the pod names will have changed.
+10. Verify that the `drbd-module-loader` container is using the new image by describing the `linstor-satellite.*` pods.
+    Replace `<pod-name>` with the name of the pod you want to check. You may need to issue
+    `kubectl get pods --namespace piraeus-system` first as the pod names will have changed.
 
-   ```bash
-   kubectl describe pods <pod-name> --namespace piraeus-system
-   ```
+    ```bash
+    kubectl describe pods <pod-name> --namespace piraeus-system
+    ```
 
-   Look for events indicating that the `drbd-module-loader` container is now using the `dbrd-loader:v2.8.1` image.
+    Look for events indicating that the `drbd-module-loader` container is now using the `dbrd-loader:v2.8.1` image.
 
-   ```shell hideClipboard title="Example output" {6}
-   ...
-   Events:
+    ```shell hideClipboard title="Example output" {6}
+    ...
+    Events:
      Type    Reason     Age    From               Message
      ----    ------     ----   ----               -------
      Normal  Scheduled  4m44s  default-scheduler  Successfully assigned piraeus-system/linstor-satellite.edge-c0913842383ebd183d13d1458bb762c5-wfd4q to edge-c0913842383ebd183d13d1458bb762c5
      Normal  Pulled     4m45s  kubelet            Container image "us-docker.pkg.dev/palette-images-fips/packs/piraeus-operator/2.8.1/dbrd-loader:v2.8.1" already present on machine
      Normal  Created    4m45s  kubelet            Created container: drbd-module-loader
      Normal  Started    4m44s  kubelet            Started container drbd-module-loader
-   ```
+    ```
 
 The VerteX Management Appliance upgrade process will then continue. You can monitor the upgrade progress in Local UI.
 

--- a/docs/docs-content/troubleshooting/enterprise-install.md
+++ b/docs/docs-content/troubleshooting/enterprise-install.md
@@ -10,7 +10,7 @@ tags: ["troubleshooting", "self-hosted", "palette", "vertex"]
 
 Refer to the following sections to troubleshoot errors encountered when installing an Enterprise Cluster.
 
-## Scenario - VerteX Management Appliance Fails to Upgrade due to Stuck Linstor Satellite Pods
+## Scenario - VerteX Management Appliance Fails to Upgrade due to Stuck LINSTOR Satellite Pods
 
 When attempting to upgrade the VerteX Management Appliance, the `linstor-satellite.*` and `linstor-csi-node.*` pods may
 become stuck, which causes the upgrade process to stall. This is because the `linstor-satellite.*` pods may be using an
@@ -63,7 +63,7 @@ To resolve this issue, you can check whether the pods are using an incorrect ima
    ```
 
 7. If any of the `linstor-satellite.*` pods are not in a **Running** state, use the following command to describe the
-   pods. Replace `<pod-name>` with the name of the Linstor satellite pod you want to inspect.
+   pods. Replace `<pod-name>` with the name of the LINSTOR satellite pod you want to inspect.
 
    ```bash
    kubectl describe pod <pod-name> --namespace piraeus-system
@@ -92,7 +92,7 @@ To resolve this issue, you can check whether the pods are using an incorrect ima
    create a manifest that corrects the image reference for the `drbd-module-loader` container.
 
    ```bash
-   kubectl apply -f - <<EOF
+   kubectl apply --filename - <<EOF
    apiVersion: piraeus.io/v1
    kind: LinstorSatelliteConfiguration
    metadata:

--- a/docs/docs-content/vertex/upgrade/vertex-management-appliance.md
+++ b/docs/docs-content/vertex/upgrade/vertex-management-appliance.md
@@ -75,13 +75,20 @@ remain operational.
   :::caution
 
   If these steps are not performed, you may encounter content sync failures for these image tags on the **Content** page
-  in Local UI. These errors will occur after uploading the content bundle to Local UI.
-
-  In addition, if any other image tags fail to sync after the upgrade, you must manually delete those tags from the
-  internal Zot registry and any external registry you are using. The following image is an example of a content sync
-  failure in Local UI.
+  in Local UI. These errors will occur after uploading the content bundle to Local UI. The following image is an example
+  of a content sync failure in Local UI.
 
   ![Example content sync failure](/enterprise-version_upgrade_palette-management-appliance_content-sync-error_4.7.3.webp)
+
+  In addition, on the **Diagnostics** page within the **Logs** tab, errors may be displayed relating to these image tags
+  that are similar to the following:
+
+  ```shell
+  Aug 27 12:44:06 edge-1d3f3842cb0fdcef14b65cb510b5974f stylus-operator.sh[18752]: time="2025-08-27T12:44:06Z" level=error msg="failed to push artifact to registrywriting index: PUT https://10.11.12.13:30003/v2/spectro-content/us-docker.pkg.dev/palette-images-fips/k8s/pause/manifests/3.9: MANIFEST_INVALID: manifest invalid; map[description:During upload, manifests undergo several checks ensuring validity. If those checks fail, this error MAY be returned, unless a more specific error is included. The detail will contain information the failed validation. reason:changing manifest media-type from \"application/vnd.docker.distribution.manifest.v2+json\" to \"application/vnd.docker.distribution.manifest.list.v2+json\" is disallowed reference:3.9]" version=v4.7.2 cluster
+  ```
+
+  If any other image tags fail to sync with a similar error after the content bundle is uploaded, you must manually
+  delete those tags from the internal Zot registry and any external registry you are using.
 
   :::
 

--- a/docs/docs-content/vertex/upgrade/vertex-management-appliance.md
+++ b/docs/docs-content/vertex/upgrade/vertex-management-appliance.md
@@ -103,6 +103,15 @@ remain operational.
   app="VerteX Management Appliance"
 />
 
+:::info
+
+If the upgrade process stalls, this may be due to the `linstor-satellite.*` pods not using the correct image for the
+`drbd-module-loader` container. Refer to
+[Scenario - VerteX Management Appliance Fails to Upgrade due to Stuck Linstor Satellite Pods](../../troubleshooting/enterprise-install.md#scenario---vertex-management-appliance-fails-to-upgrade-due-to-stuck-linstor-satellite-pods)
+for more information.
+
+:::
+
 ## Validate
 
 <PartialsComponent


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR documents how to fix stalled Linstor satellite pods during a VerteX Management Appliance upgrade.

It also improves an admonition for an existing upgrade issue.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Troubleshooting - Enterprise Install](https://deploy-preview-7910--docs-spectrocloud.netlify.app/troubleshooting/enterprise-install/#scenario---vertex-management-appliance-fails-to-upgrade-due-to-stuck-linstor-satellite-pods)
💻 [Upgrade VerteX Management Appliance](https://deploy-preview-7910--docs-spectrocloud.netlify.app/vertex/upgrade/vertex-management-appliance/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2137](https://spectrocloud.atlassian.net/browse/DOC-2137)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2137]: https://spectrocloud.atlassian.net/browse/DOC-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ