### PR TITLE
[version-4-2] docs: add developer portals to status checking (#7935)

### DIFF
--- a/.github/workflows/url-checks.yaml
+++ b/.github/workflows/url-checks.yaml
@@ -36,8 +36,8 @@ jobs:
       - name: URL Rate Limit Checker
         run: make verify-rate-limited-links-ci
 
-      - name: Check for Broken Github Links
-        run: make verify-github-links
+      - name: Check for Broken Developer Portal Links
+        run: make verify-developer-portal-links
         env:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
   

--- a/Makefile
+++ b/Makefile
@@ -324,11 +324,11 @@ verify-rate-limited-links-ci: ## Check for broken URLs in production in a GitHub
 	@rm temp_rate_limit_report.json
 	@mv filtered_rate_limit_report.json scripts/link_rate_limit_report.json
 
-verify-github-links: ## Check for broken GitHub links
-	@echo "Checking for broken GitHub links in CI environment..."
-	@rm link_report_github.txt || echo "No report exists. Proceeding to scan step"
-	./scripts/url-checker-github.sh
-	@mv link_report_github.txt scripts/link_report_github.txt
+verify-developer-portal-links: ## Check for broken Developer Portal links
+	@echo "Checking for broken Developer Portal links in CI environment..."
+	@rm link_report_developer_portals.txt || echo "No report exists. Proceeding to scan step"
+	./scripts/url-checker-developer-portals.sh
+	@mv link_report_developer_portals.txt scripts/link_report_developer_portals.txt
 
 ###@ Image Formatting
 

--- a/linkinator/linkinator-ci.config.json
+++ b/linkinator/linkinator-ci.config.json
@@ -19,7 +19,9 @@
     "https://linux.die.net/man/.*$$",
     "https://mysql.com/.*.*$$",
     "https://dev.mysql.com/doc/.*$$",
-    "^https://github.com.*$$"
+    "^https://github.com.*$$",
+    "^https://developers.redhat.com.*$$",
+    "^https://www.intel.com.*$$"
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/linkinator/linkinator-rate-limit-ci.config.json
+++ b/linkinator/linkinator-rate-limit-ci.config.json
@@ -20,7 +20,8 @@
     "https://mysql.com/.*.*$$",
     "https://dev.mysql.com/doc/.*$$",
     "^https://github.com.*$$",
-    "https://www.intel.com/content/www/us/en/learn/what-is-a-trusted-platform-module.html"
+    "^https://developers.redhat.com.*$$",
+    "^https://www.intel.com.*$$"
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/linkinator/linkinator-rate-limit.config.json
+++ b/linkinator/linkinator-rate-limit.config.json
@@ -20,7 +20,9 @@
     "https://linux.die.net/man/.*$$",
     "https://mysql.com/.*.*$$",
     "https://dev.mysql.com/doc/.*$$",
-    "^https://github.com.*$$"
+    "^https://github.com.*$$",
+    "^https://developers.redhat.com.*$$",
+    "^https://www.intel.com.*$$"
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/linkinator/linkinator.config.json
+++ b/linkinator/linkinator.config.json
@@ -19,7 +19,9 @@
     "https://linux.die.net/man/.*$$",
     "https://mysql.com/.*.*$$",
     "https://dev.mysql.com/doc/.*$$",
-    "^https://github.com.*$$"
+    "^https://github.com.*$$",
+    "^https://developers.redhat.com.*$$",
+    "^https://www.intel.com.*$$"
   ],
   "verbosity": "error",
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"

--- a/scripts/url-checker-developer-portals.sh
+++ b/scripts/url-checker-developer-portals.sh
@@ -3,9 +3,15 @@
 # Set variables for GitHub API
 ACCESS_TOKEN=$ACCESS_TOKEN
 DELAY=1  # seconds between requests
-LINKS_FILE="all_github_links.txt"
-BROKEN_LINKS_FILE="link_report_github.txt"
-CACHE_FILE="github_cache.txt"
+# Developer portal links to check with dots (.) escaped
+DEVELOPER_PORTAL_LINKS=(
+    "developers\.redhat\.com"
+    "www\.intel\.com"
+    "github\.com"
+)
+LINKS_FILE="all_links.txt"
+BROKEN_LINKS_FILE="link_report_developer_portals.txt"
+CACHE_FILE="developer_portal_cache.txt"
 TOO_MANY_REQUESTS=429
 MAX_RETRIES=5 # maximum number of retries for a single URL
 RETRY_DELAY=10  # increment seconds to wait before retrying
@@ -13,17 +19,20 @@ RETRY_DELAY=10  # increment seconds to wait before retrying
 # Create cache file if it doesn't exist
 touch "$CACHE_FILE"
 touch "$BROKEN_LINKS_FILE"
+touch "$LINKS_FILE"
 
-echo "⏭️ Starting checks for Github URLs in Docs."
+echo "⏭️ Starting checks for Developer Portal URLs in Docs."
 
-# Find all GitHub links in the documentation /docs and /partials directories.
+# Find all Developer Portal links in the documentation /docs and /partials directories.
 # Strip all parentheses and anchors from the links, as they will be heavily throttled by GitHub.
-grep -rHoE '\(https?://github\.com/[^") ]+' \
-    --include="*.md" \
-    --include="*.mdx" \
-    ./docs ./_partials | \
-    sed 's/[()]//g' | \
-    sed 's/#.*$//' > "$LINKS_FILE"
+for portal in "${DEVELOPER_PORTAL_LINKS[@]}"; do
+    grep -rHoE '\(https?://'"$portal"'/[^") ]+' \
+        --include="*.md" \
+        --include="*.mdx" \
+        ./docs ./_partials | \
+        sed 's/[()]//g' | \
+        sed 's/#.*$//' >> "$LINKS_FILE"
+done
 
 if [[ -n "$ACCESS_TOKEN" ]]; then
     echo "🔏 Access token found. We will use it for authentication where possible."
@@ -31,18 +40,27 @@ else
     echo "🟡 Access token not found. You may be rate-limited by GitHub."
 fi
 
-# Function to make a request to the URL and get the status code.
+# Function to make a request to the URL and get the status code for GitHub.
 # Params:
 # $1 - url
-make_request () {
+make_request_github () {
     url=$1
     status_code=""
     if [[ -n "$ACCESS_TOKEN" ]]; then
         status_code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: token $ACCESS_TOKEN" -A "Spectro-URL-Checker" "$url")
     else
-        status_code=$(curl -s -o /dev/null -w "%{http_code}" -A "URL-Checker" "$url")
+        status_code=$(make_request "$url")
     fi
     
+    echo "$status_code"
+}
+
+# Function to make a request to the URL and get the status code.
+# Params:
+# $1 - url
+make_request () {
+    url=$1
+    status_code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
     echo "$status_code"
 }
 
@@ -56,7 +74,11 @@ retry_url_get() {
 
     while [[ $retries -lt $MAX_RETRIES ]]; do
         # Make the request and get the status code
-        status_code=$(make_request "$url")
+        if [[ $url == *"github"* ]]; then
+            status_code=$(make_request_github "$url")
+        else
+            status_code=$(make_request "$url")
+        fi
 
         code=$(echo "$status_code" | cut -d' ' -f1)
         # Check if the status code is 429 (Too Many Requests)
@@ -106,7 +128,7 @@ while IFS= read -r line; do
     # Skip if the URL is empty
     [[ -z "$url" ]] && continue
 
-    # Get the status code, either from GH or from the cache
+    # Get the status code, either from the remote or from the cache
     status_code=$(get_url_status_code "$url")
 
     code=$(echo "$status_code" | cut -d' ' -f1)
@@ -119,7 +141,7 @@ while IFS= read -r line; do
     sleep $DELAY
 done < "$LINKS_FILE"
 
-echo "✅ Completed checks for Github URLs in Docs."
+echo "✅ Completed checks for Developer Portal URLs in Docs."
 
 # Cleanup
 rm -f $LINKS_FILE

--- a/scripts/url-checker.sh
+++ b/scripts/url-checker.sh
@@ -29,10 +29,10 @@ echo "Pull request number: $PR_NUMBER"
 # Read JSON file contents into a variable
 JSON_CONTENT=$(cat link_report.json)
 JSON_RATE_LIMIT_CONTENT=$(cat link_rate_limit_report.json)
-GITHUB_BROKEN_LINKS_CONTENT=$(cat link_report_github.txt)
+DEVELOPER_PORTAL_BROKEN_LINKS_CONTENT=$(cat link_report_developer_portals.txt)
 
 # Check if files are empty
-if [[ -z "$JSON_CONTENT" ]] && [[ -z "$JSON_RATE_LIMIT_CONTENT" ]] && [[ -z "$GITHUB_BROKEN_LINKS_CONTENT" ]]; then
+if [[ -z "$JSON_CONTENT" ]] && [[ -z "$JSON_RATE_LIMIT_CONTENT" ]] && [[ -z "$DEVELOPER_PORTAL_BROKEN_LINKS_CONTENT" ]]; then
   echo "No broken links found"
   exit 0
 fi
@@ -72,7 +72,7 @@ for link in $(echo "${JSON_RATE_LIMIT_CONTENT}" | jq -c '.[]'); do
     COMMENT="${COMMENT}\n\n:link: Broken URL: ${url}  \n:red_circle: State: ${state}  \n:arrow_up: Parent Page: ${parent}\n\n"
 done
 
-for link in $(echo "${GITHUB_BROKEN_LINKS_CONTENT}"); do
+for link in $(echo "${DEVELOPER_PORTAL_BROKEN_LINKS_CONTENT}"); do
     ((BROKEN_LINK_COUNT++)) # All the links in this file are broken
     filename="${link%%:*}"  # everything before the first colon
     url="${link#*:}"        # everything after the first colon


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-2`:
 - [docs: add developer portals to status checking (#7935)](https://github.com/spectrocloud/librarium/pull/7935)