### PR TITLE
docs: Add regular TLS certificate example for Management Appliance

### DIFF
--- a/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
@@ -91,9 +91,19 @@ During the upgrade process, the {props.version} system and tenant consoles will 
 
 6. Upload the content bundle to the internal Zot registry using the Palette CLI. Replace `<content-bundle-zst>` with your downloaded content bundle file and `<management-vip>` with the VIP address of the {props.version} management cluster. If you have changed the default port or the base content path for the Zot registry, replace `30003` with the correct port number and `spectro-content` with the correct content path.
 
-   If you are using custom TLS certificates or choosing to skip TLS, use the appropriate flags as shown in the following examples.
+   If you are using regular TLS certificates, custom TLS certificates, or choosing to skip TLS, use the appropriate flags as shown in the following examples.
 
    <Tabs groupId="tls-palette-cli">
+
+   <TabItem label="Regular TLS Certificate" value="regular-tls-certificate">
+
+   ```shell
+   palette content push \
+   --registry <management-vip>:30003/spectro-content \
+   --file <content-bundle-zst>
+   ```
+
+   </TabItem>
 
    <TabItem label="Custom TLS Certificate" value="custom-tls-certificate">
 
@@ -197,9 +207,19 @@ When using an external registry, you must upload the content bundle to both the 
 
 6. Upload the file to your external registry using the Palette CLI. Replace `<content-bundle-zst>` with your downloaded content bundle file, `<registry-dns-or-ip>` with the DNS/IP address of your registry, and `<registry-port>` with the port number of your registry (if applicable). If you have changed the base content path from the default, replace `spectro-content` with the correct content path.
 
-   If you are using custom TLS certificates or choosing to skip TLS, use the appropriate flags as shown in the following examples.
+   If you are using regular TLS certificates, custom TLS certificates, or choosing to skip TLS, use the appropriate flags as shown in the following examples.
 
    <Tabs groupId="tls-palette-cli">
+
+   <TabItem label="Regular TLS Certificate" value="regular-tls-certificate">
+
+   ```shell
+   palette content push \
+   --registry <registry-dns-or-ip>:<registry-port>/spectro-content \
+   --file <content-bundle-zst>
+   ```
+
+   </TabItem>
 
    <TabItem label="Custom TLS Certificate" value="custom-tls-certificate">
 

--- a/_partials/self-hosted/management-appliance/_upload-packs-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upload-packs-enablement.mdx
@@ -69,9 +69,19 @@ partial_name: upload-packs-enablement
 
 6. Upload the pack bundles to the internal Zot registry using the Palette CLI. Replace `<pack-zst>` with your downloaded pack bundle file and `<management-vip>` with the VIP address of the {props.version} management cluster. If you have changed the default port or the base content path for the Zot registry, replace `30003` with the correct port number and `spectro-content` with the correct content path.
 
-   If you are using custom TLS certificates or choosing to skip TLS, use the appropriate flags as shown in the following examples.
+   If you are using regular TLS certificates, custom TLS certificates, or choosing to skip TLS, use the appropriate flags as shown in the following examples.
 
    <Tabs groupId="tls-palette-cli">
+
+   <TabItem label="Regular TLS Certificate" value="regular-tls-certificate">
+
+   ```shell
+   palette content push \
+   --registry <management-vip>:30003/spectro-content \
+   --file <pack-zst>
+   ```
+
+   </TabItem>
 
    <TabItem label="Custom TLS Certificate" value="custom-tls-certificate">
 
@@ -147,9 +157,19 @@ partial_name: upload-packs-enablement
 
 6. Upload the pack bundles to your external registry using the Palette CLI. Replace `<pack-zst>` with your downloaded pack bundle file, `<registry-dns-or-ip>` with the DNS/IP address of your registry, and `<registry-port>` with the port number of your registry (if applicable). If you have changed the base content path from the default, replace `spectro-content` with the correct content path.
 
-   If you are using custom TLS certificates or choosing to skip TLS, use the appropriate flags as shown in the following examples.
+   If you are using regular TLS certificates, custom TLS certificates, or choosing to skip TLS, use the appropriate flags as shown in the following examples.
 
    <Tabs groupId="tls-palette-cli">
+
+   <TabItem label="Regular TLS Certificate" value="regular-tls-certificate">
+
+   ```shell
+   palette content push \
+   --registry <registry-dns-or-ip>:<registry-port>/spectro-content \
+   --file <pack-zst>
+   ```
+
+   </TabItem>
 
    <TabItem label="Custom TLS Certificate" value="custom-tls-certificate">
 

--- a/_partials/self-hosted/management-appliance/_upload-third-party-packs-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upload-third-party-packs-enablement.mdx
@@ -91,9 +91,25 @@ partial_name: upload-third-party-packs-enablement
 
 6. Upload the packs to the internal Zot registry using the Palette CLI. Replace `<third-party-zst>` and `<third-party-conformance-zst>` with your downloaded Third Party pack ZST files and `<management-vip>` with the VIP address of the {props.version} management cluster. If you have changed the default port or the base content path for the Zot registry, replace `30003` with the correct port number and `spectro-content` with the correct content path.
 
-   If you are using custom TLS certificates or choosing to skip TLS, use the appropriate flags as shown in the following examples.
+   If you are using regular TLS certificates, custom TLS certificates, or choosing to skip TLS, use the appropriate flags as shown in the following examples.
 
    <Tabs groupId="tls-palette-cli">
+
+   <TabItem label="Regular TLS Certificate" value="regular-tls-certificate">
+
+   ```shell title="Upload Third Party Pack with Regular TLS Certificate"
+   palette content push \
+   --registry <management-vip>:30003/spectro-content \
+   --file <third-party-zst>
+   ```
+
+   ```shell title="Upload Third Party Conformance Pack with Regular TLS Certificate"
+   palette content push \
+   --registry <management-vip>:30003/spectro-content \
+   --file <third-party-conformance-zst>
+   ```
+
+   </TabItem>
 
    <TabItem label="Custom TLS Certificate" value="custom-tls-certificate">
 
@@ -196,9 +212,25 @@ partial_name: upload-third-party-packs-enablement
 
 8. Upload the packs to your external registry using the Palette CLI. Replace `<registry-dns-or-ip>` with the DNS/IP address of your registry and `<registry-port>` with the port number of your registry (if applicable). If you have changed the base content path from the default, replace `spectro-content` with the correct content path.
 
-   If you are using custom TLS certificates or choosing to skip TLS, use the appropriate flags as shown in the following examples.
+   If you are using regular TLS certificates, custom TLS certificates, or choosing to skip TLS, use the appropriate flags as shown in the following examples.
 
    <Tabs groupId="tls-palette-cli">
+
+   <TabItem label="Regular TLS Certificate" value="regular-tls-certificate">
+
+   ```shell title="Upload Third Party Pack with Regular TLS Certificate"
+   palette content push \
+   --registry <registry-dns-or-ip>:<registry-port>/spectro-content \
+   --file <third-party-zst>
+   ```
+
+   ```shell title="Upload Third Party Conformance Pack with Regular TLS Certificate"
+   palette content push \
+   --registry <registry-dns-or-ip>:<registry-port>/spectro-content \
+   --file <third-party-conformance-zst>
+   ```
+
+   </TabItem>
 
    <TabItem label="Custom TLS Certificate" value="custom-tls-certificate">
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds regular TLS cert examples for the Management Appliance when uploading packs using the Palette CLI.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Palette/VerteX Management Appliance - Installation](https://deploy-preview-7987--docs-spectrocloud.netlify.app/enterprise-version/install-palette/palette-management-appliance/)
💻 [Palette/VerteX Management Appliance - Upgrade](https://deploy-preview-7987--docs-spectrocloud.netlify.app/enterprise-version/upgrade/palette-management-appliance/)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
