### PR TITLE
docs: Change header to #cloud-config in user-data

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/prepare-user-data.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/prepare-user-data.md
@@ -145,7 +145,7 @@ subject to change. For production workloads, create the `.arg` and `user-data` f
    `stylus` parameter.
 
    ```yaml
-   #cloud-init
+   #cloud-config
    stylus:
      managementMode: local
    ```
@@ -186,7 +186,7 @@ subject to change. For production workloads, create the `.arg` and `user-data` f
    installs Amazon Systems Manager agent on your Edge host during the `after-install-chroot` stage.
 
    ```yaml
-   #cloud-init
+   #cloud-config
    stages:
      after-install-chroot:
        - name: "Install SSM"
@@ -210,7 +210,7 @@ subject to change. For production workloads, create the `.arg` and `user-data` f
    the list of authorized keys for that user.
 
    ```yaml
-   #cloud-init
+   #cloud-config
    stages:
    initramfs:
      - users:
@@ -255,7 +255,7 @@ subject to change. For production workloads, create the `.arg` and `user-data` f
    the Edge host to power off automatically post-installation.
 
    ```yaml
-   #cloud-init
+   #cloud-config
    install:
      poweroff: true
    ```

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/prepare-user-data.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/prepare-user-data.md
@@ -212,15 +212,15 @@ subject to change. For production workloads, create the `.arg` and `user-data` f
    ```yaml
    #cloud-config
    stages:
-   initramfs:
-     - users:
-         USERNAME:
-           passwd: ******
-           groups:
-           - sudo
-           ssh_authorized_keys:
-           - ssh-rsa AAAAB3N…
-       name: Create user and assign SSH key
+     initramfs:
+       - users:
+           USERNAME:
+             passwd: ******
+             groups:
+               - sudo
+             ssh_authorized_keys:
+               - ssh-rsa AAAAB3N…
+         name: Create user and assign SSH key
    ```
 
 #### Configure Proxy Settings (Optional)


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR:

- Changes user-data files header from `#cloud-init` to `#cloud-config` according to https://docs.cloud-init.io/en/latest/explanation/about-cloud-config.html
- Fixed indentation in one example.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2212](https://spectrocloud.atlassian.net/browse/DOC-2212)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes.
- [ ] No.
