### PR TITLE
docs: DOC-2211: Multi-Line Cluster Profile Variable Limitation

### DIFF
--- a/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/define-profile-variables.md
+++ b/docs/docs-content/profiles/cluster-profiles/create-cluster-profiles/define-profile-variables/define-profile-variables.md
@@ -33,7 +33,9 @@ The following table describes the differences between profile variables and macr
 
 ## Limitations
 
-- Palette does not support nesting profile variables within macros or other profile variables.
+- Nesting profile variables within macros or other profile variables is not supported.
+
+- Multi-line cluster profile variables are not supported.
 
 - The variable must satisfy any existing schema constraint defined in the pack. Refer to the
   [Pack Constraints](../../../../registries-and-packs/pack-constraints.md) page for more information.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR clarifies that multi-line cluster profiles are not supported at this time. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Cluster Profile Variables]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2211](https://spectrocloud.atlassian.net/browse/DOC-2211)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
