### PR TITLE
chore: fix backport logic to avoid false slack messages

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -48,8 +48,8 @@ jobs:
         run: |
           PR_COUNT=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/pulls?state=open&per_page=100" | \
-            jq '[.[] | select(.user.login == "vault-token-factory-spectrocloud[bot]")] | length')
-          echo "Number of PRs created by vault-token-factory-spectrocloud: $PR_COUNT"
+            jq --arg n "${{ github.event.pull_request.number }}" '[.[] | select(.user.login == "vault-token-factory-spectrocloud[bot]" and (.title | contains("(#\($n))")))] | length')
+          echo "Number of backport PRs created by vault-token-factory-spectrocloud for this PR: $PR_COUNT"
           echo "pr_count=$PR_COUNT" >> $GITHUB_OUTPUT
 
       - name: Determine branch name
@@ -96,14 +96,14 @@ jobs:
           BEFORE_BACKPORTS=${{ steps.count_prs.outputs.pr_count }}
           NEW_COUNT=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/pulls?state=open&per_page=100" | \
-            jq '[.[] | select(.user.login == "vault-token-factory-spectrocloud[bot]")] | length')
-          
+            jq --arg n "${{ github.event.pull_request.number }}" '[.[] | select(.user.login == "vault-token-factory-spectrocloud[bot]" and (.title | contains("(#\($n))")))] | length')
+
           MATCHED=${{ steps.check_labels.outputs.matched }}
-      
+
           echo "Before Backports Count: $BEFORE_BACKPORTS"
           echo "New PR Count: $NEW_COUNT"
           echo "Matched Backport Labels: $MATCHED"
-      
+
           if [ $((NEW_COUNT - BEFORE_BACKPORTS)) -eq $MATCHED ]; then
             echo "PR count increased by the expected amount."
             echo "missing_prs=0" >> $GITHUB_OUTPUT
@@ -113,7 +113,6 @@ jobs:
             echo "missing_prs=$MISSING_PR_COUNT" >> $GITHUB_OUTPUT
             exit 1
           fi
-      
 
       - name: Slack Notification
         if: ${{ failure() }}


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the backport GHA workflow so that when two backport actions run simultaneously, the PR count only reflects the backport PRs created by that specific PR, not all PRs generated by the bot.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [No visual changes]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2051](https://spectrocloud.atlassian.net/browse/DOC-2051)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [X ] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._
