### PR TITLE
docs: add Zot password warning DOC-2213

### DIFF
--- a/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
@@ -45,6 +45,16 @@ partial_name: upgrade-palette-enablement
 
 10. Click the **Update** drop-down menu and select **Review Changes**.
 
+   :::warning
+
+   Ensure that the configured Zot password matches the password that you used in
+   the <VersionedLink text="Palette Management Appliance installation" url="/enterprise-version/install-palette/palette-management-appliance"/>.
+   The Zot registry will be inaccessible post upgrade if the passwords do not match.
+
+   If you have forgotten the Zot password, you can connect to your Kubernetes cluster and retrieve it from the Zot secret.
+   
+   :::
+
 11. Review the changes for each profile carefully and ensure you are satisfied with the proposed updates. There may be changes to the profiles between versions that include the addition or removal of properties.
 
     :::warning

--- a/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
@@ -47,11 +47,11 @@ partial_name: upgrade-palette-enablement
 
     :::warning
 
-    Ensure that the configured Zot password matches the password that you used in
-    the <VersionedLink text="Palette Management Appliance installation" url="/enterprise-version/install-palette/palette-management-appliance"/>.
-    The Zot registry will be inaccessible post upgrade if the passwords do not match.
+    Ensure that the configured Zot password matches the password that you used when
+    installing <VersionedLink text="Palette Management Appliance" url="/enterprise-version/install-palette/palette-management-appliance"/>.
+    You cannot access the Zot registry post-upgrade if the passwords do not match.
 
-    If you have forgotten the Zot password, you can connect to your Kubernetes cluster and retrieve it from the Zot secret.
+    If you have forgotten your Zot password, you can connect to your Kubernetes cluster and retrieve it from the Zot secret.
    
     :::
 

--- a/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
@@ -48,7 +48,7 @@ partial_name: upgrade-palette-enablement
     :::warning
 
     Ensure that the configured Zot password matches the password that you used when
-    installing <PaletteVertexUrlMapper edition={props.edition} text="Palette Management Appliance" url="/install-palette/palette-management-appliance"/>.
+    installing Palette Management Appliance.
     You cannot access the Zot registry post-upgrade if the passwords do not match.
 
     If you have forgotten your Zot password, you can connect to your Kubernetes cluster and retrieve it from the Zot secret.

--- a/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
@@ -48,7 +48,7 @@ partial_name: upgrade-palette-enablement
     :::warning
 
     Ensure that the configured Zot password matches the password that you used when
-    installing <VersionedLink text="Palette Management Appliance" url="/enterprise-version/install-palette/palette-management-appliance"/>.
+    installing <<PaletteVertexUrlMapper edition={props.edition} text="Palette Management Appliance" url="/install-palette/palette-management-appliance"/>.
     You cannot access the Zot registry post-upgrade if the passwords do not match.
 
     If you have forgotten your Zot password, you can connect to your Kubernetes cluster and retrieve it from the Zot secret.

--- a/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
@@ -48,7 +48,7 @@ partial_name: upgrade-palette-enablement
     :::warning
 
     Ensure that the configured Zot password matches the password that you used when
-    installing <<PaletteVertexUrlMapper edition={props.edition} text="Palette Management Appliance" url="/install-palette/palette-management-appliance"/>.
+    installing <PaletteVertexUrlMapper edition={props.edition} text="Palette Management Appliance" url="/install-palette/palette-management-appliance"/>.
     You cannot access the Zot registry post-upgrade if the passwords do not match.
 
     If you have forgotten your Zot password, you can connect to your Kubernetes cluster and retrieve it from the Zot secret.

--- a/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
@@ -45,15 +45,15 @@ partial_name: upgrade-palette-enablement
 
 10. Click the **Update** drop-down menu and select **Review Changes**.
 
-   :::warning
+    :::warning
 
-   Ensure that the configured Zot password matches the password that you used in
-   the <VersionedLink text="Palette Management Appliance installation" url="/enterprise-version/install-palette/palette-management-appliance"/>.
-   The Zot registry will be inaccessible post upgrade if the passwords do not match.
+    Ensure that the configured Zot password matches the password that you used in
+    the <VersionedLink text="Palette Management Appliance installation" url="/enterprise-version/install-palette/palette-management-appliance"/>.
+    The Zot registry will be inaccessible post upgrade if the passwords do not match.
 
-   If you have forgotten the Zot password, you can connect to your Kubernetes cluster and retrieve it from the Zot secret.
+    If you have forgotten the Zot password, you can connect to your Kubernetes cluster and retrieve it from the Zot secret.
    
-   :::
+    :::
 
 11. Review the changes for each profile carefully and ensure you are satisfied with the proposed updates. There may be changes to the profiles between versions that include the addition or removal of properties.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR  adds a warning about the Zot password to the Palette management appliance upgrade.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Upgrade](https://deploy-preview-8075--docs-spectrocloud.netlify.app/enterprise-version/upgrade/palette-management-appliance/#upgrade-palette)
💻 [Vertex Upgrade](https://deploy-preview-8075--docs-spectrocloud.netlify.app/vertex/upgrade/vertex-management-appliance/#upgrade-palette-vertex)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2213](https://spectrocloud.atlassian.net/browse/DOC-2213)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2213]: https://spectrocloud.atlassian.net/browse/DOC-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ