### PR TITLE
docs: PLT-1948: Palette CLI Breaking Change

### DIFF
--- a/docs/docs-content/automation/palette-cli/commands/ec.md
+++ b/docs/docs-content/automation/palette-cli/commands/ec.md
@@ -25,10 +25,10 @@ The `ec` command exposes the following subcommand.
 ## Limitations
 
 - Passwords set using Palette CLI version 4.7.1 or earlier are not compatible with Palette CLI version 4.7.2 or later.
-  As a result, users cannot use existing configuration files created using version 4.7.1 or earlier to perform Palette
-  CLI operations after upgrading to version 4.7.2 or later. Users must update their password by either running the
-  command `palette ec install --config-file <ec-yaml-location> --update-passwords` and completing the subsequent prompts
-  or deleting the existing `ec.yaml` file.
+  As a result, users cannot use configuration files created using version 4.7.1 or earlier to perform Palette CLI
+  operations after upgrading to version 4.7.2 or later. Users must update their password by either running the command
+  `palette ec install --config-file <ec-yaml-location> --update-passwords` and completing the subsequent prompts or
+  deleting the existing `ec.yaml` file.
 
 ## Prerequisites
 

--- a/docs/docs-content/automation/palette-cli/commands/ec.md
+++ b/docs/docs-content/automation/palette-cli/commands/ec.md
@@ -22,6 +22,14 @@ The `ec` command exposes the following subcommand.
 - `install` - Install a Palette Enterprise Cluster through an interactive wizard. A container runtime is required to
   install an EC cluster.
 
+## Limitations
+
+- Passwords set using Palette CLI version 4.7.1 or earlier are not compatible with Palette CLI version 4.7.2 or later.
+  As a result, users cannot use existing configuration files created using version 4.7.1 or earlier to perform Palette
+  CLI operations after upgrading to version 4.7.2 or later. Users must update their password by either running the
+  command `palette ec install --config-file <ec-yaml-location> --update-passwords` and completing the subsequent prompts
+  or deleting the existing `ec.yaml` file.
+
 ## Prerequisites
 
 - Docker is required to install a PCG cluster. Refer to the [Docker](https://docs.docker.com/get-docker/) documentation

--- a/docs/docs-content/automation/palette-cli/commands/pcg.md
+++ b/docs/docs-content/automation/palette-cli/commands/pcg.md
@@ -23,10 +23,10 @@ The `pcg` command exposes the following subcommand.
 ## Limitations
 
 - Passwords set using Palette CLI version 4.7.1 or earlier are not compatible with Palette CLI version 4.7.2 or later.
-  As a result, users cannot use existing configuration files created using version 4.7.1 or earlier to perform Palette
-  CLI operations after upgrading to version 4.7.2 or later. Users must update their password by either running the
-  command `palette pcg install --config-file <pcg-yaml-location> --update-passwords` and completing the subsequent
-  prompts or deleting the existing `pcg.yaml` file.
+  As a result, users cannot use configuration files created using version 4.7.1 or earlier to perform Palette CLI
+  operations after upgrading to version 4.7.2 or later. Users must update their password by either running the command
+  `palette pcg install --config-file <pcg-yaml-location> --update-passwords` and completing the subsequent prompts or
+  deleting the existing `pcg.yaml` file.
 
 ## Prerequisites
 

--- a/docs/docs-content/automation/palette-cli/commands/pcg.md
+++ b/docs/docs-content/automation/palette-cli/commands/pcg.md
@@ -20,6 +20,14 @@ The `pcg` command exposes the following subcommand.
 
 - `install` - Install a PCG through an interactive wizard. A container runtime is required to install a PCG cluster.
 
+## Limitations
+
+- Passwords set using Palette CLI version 4.7.1 or earlier are not compatible with Palette CLI version 4.7.2 or later.
+  As a result, users cannot use existing configuration files created using version 4.7.1 or earlier to perform Palette
+  CLI operations after upgrading to version 4.7.2 or later. Users must update their password by either running the
+  command `palette pcg install --config-file <pcg-yaml-location> --update-passwords` and completing the subsequent
+  prompts or deleting the existing `pcg.yaml` file.
+
 ## Prerequisites
 
 - Docker is required to install a PCG cluster. Refer to the [Docker](https://docs.docker.com/get-docker/) documentation

--- a/docs/docs-content/automation/palette-cli/install-palette-cli.md
+++ b/docs/docs-content/automation/palette-cli/install-palette-cli.md
@@ -22,10 +22,9 @@ The Palette CLI is available for the following operating systems and architectur
 ## Limitations
 
 - Passwords set using Palette CLI version 4.7.1 or earlier are not compatible with Palette CLI version 4.7.2 or later.
-  As a result, users cannot use existing configuration files created using version 4.7.1 or earlier to perform Palette
-  CLI operations after upgrading to version 4.7.2 or later. Users must update their password by either running the
-  command `palette login --api-key <key>` and completing the subsequent prompts or deleting the existing `palette.yaml`
-  file.
+  As a result, users cannot use configuration files created using version 4.7.1 or earlier to perform Palette CLI
+  operations after upgrading to version 4.7.2 or later. Users must update their password by either running the command
+  `palette login --api-key <key>` and completing the subsequent prompts or deleting the existing `palette.yaml` file.
 
 ## Prerequisites
 

--- a/docs/docs-content/automation/palette-cli/install-palette-cli.md
+++ b/docs/docs-content/automation/palette-cli/install-palette-cli.md
@@ -19,6 +19,14 @@ The Palette CLI is available for the following operating systems and architectur
 | -------------------- | ---------------- |
 | Linux                | amd64            |
 
+## Limitations
+
+- Passwords set using Palette CLI version 4.7.1 or earlier are not compatible with Palette CLI version 4.7.2 or later.
+  As a result, users cannot use existing configuration files created using version 4.7.1 or earlier to perform Palette
+  CLI operations after upgrading to version 4.7.2 or later. Users must update their password by either running the
+  command `palette login --api-key <key>` and completing the subsequent prompts or deleting the existing `palette.yaml`
+  file.
+
 ## Prerequisites
 
 - A Palette account. Click [here](https://console.spectrocloud.com/) to create a Palette account.

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -30,9 +30,9 @@ tags: ["release-notes"]
   following the subsequent prompts or deleting the respective configuration files:
   - [Palette CLI](../automation/palette-cli/install-palette-cli.md) (`palette.yaml`) - `palette login --api-key <key>`
   - [Enterprise Cluster (EC)](../automation/palette-cli/commands/ec.md) (`ec.yaml`) -
-    `palette ec install --config-file ec.yaml --update-passwords`
+    `palette ec install --config-file <ec-yaml-location> --update-passwords`
   - [Private Cloud Gateway (PGC)](../automation/palette-cli/commands/pcg.md) (`pcg.yaml`) -
-    `palette pcg install --config-file pcg.yaml --update-passwords`
+    `palette pcg install --config-file <pcg-yaml-location> --update-passwords`
 
 #### Features
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -24,6 +24,15 @@ tags: ["release-notes"]
 - The `spec.jsonCredentialsFileUid` field in API requests is no longer available. Users who create GCP cloud accounts
   using the API should use the `spec.jsonCredentials` field to supply their credentials in JSON format. Refer to the
   [API documentation](/api/introduction) for further details.
+- The previous encryption library used in the [Palette CLI](../automation/palette-cli/palette-cli.md) has been
+  deprecated. As a result, users cannot use their existing configuration files to perform operations after upgrading to
+  Palette CLI version 4.7.2 or later. Users must update their passwords by either running the applicable commands and
+  following the subsequent prompts or deleting the respective configuration files:
+  - [Palette CLI](../automation/palette-cli/install-palette-cli.md) (`palette.yaml`) - `palette login --api-key <key>`
+  - [Enterprise Cluster (EC)](../automation/palette-cli/commands/ec.md) (`ec.yaml`) -
+    `palette ec install --config-file ec.yaml --update-passwords`
+  - [Private Cloud Gateway (PGC)](../automation/palette-cli/commands/pcg.md) (`pcg.yaml`) -
+    `palette pcg install --config-file pcg.yaml --update-passwords`
 
 #### Features
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a breaking change re: Palette CLI authentication to the release notes and a limitation to the respective Palette CLI pages.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Release Notes](https://deploy-preview-8076--docs-spectrocloud.netlify.app/release-notes/#breaking-changes-4.7.b)
- [Palette CLI - Install](https://deploy-preview-8076--docs-spectrocloud.netlify.app/automation/palette-cli/install-palette-cli/#limitations)
- [Palette CLI - EC](https://deploy-preview-8076--docs-spectrocloud.netlify.app/automation/palette-cli/commands/ec/#limitations)
- [Palette CLI - PCG](https://deploy-preview-8076--docs-spectrocloud.netlify.app/automation/palette-cli/commands/pcg/#limitations)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PLT-1948](https://spectrocloud.atlassian.net/browse/PLT-1948)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work.

[PLT-1948]: https://spectrocloud.atlassian.net/browse/PLT-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ