### PR TITLE
docs: Add Cilium agent mode Edge configuration to release notes

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -102,6 +102,8 @@ Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible ver
 
 #### Pack Notes
 
+- Added instructions for configuring Cilium for agent mode Edge clusters to the <VersionedLink text="the pack's Additional Details" url="/integrations/packs/?pack=cni-cilium-oss&tab=additional-details" />. The instructions applies to Palette versions 4.2 and later.
+
 #### OS
 
 | Pack Name | New Version |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -102,7 +102,7 @@ Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible ver
 
 #### Pack Notes
 
-- Added instructions for configuring Cilium for agent mode Edge clusters to the <VersionedLink text="the pack's Additional Details" url="/integrations/packs/?pack=cni-cilium-oss&tab=additional-details" />. The instructions applies to Palette versions 4.2 and later.
+- Added instructions for configuring Cilium for agent mode Edge clusters to the <VersionedLink text="Cilium Additional Details" url="/integrations/packs/?pack=cni-cilium-oss&tab=custom" /> page. These instructions apply to Palette versions 4.2 and later.
 
 #### OS
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds Cilium agent mode Edge configuration introduced in #8129 to release notes.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release notes](https://deploy-preview-8130--docs-spectrocloud.netlify.app/release-notes/#packs)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PE-7417](https://spectrocloud.atlassian.net/browse/PE-7417)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes.
- [x] No. Release PR


[PE-7417]: https://spectrocloud.atlassian.net/browse/PE-7417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ