### PR TITLE
docs: add mok key download from artifact studio PEM-8594

### DIFF
--- a/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
+++ b/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
@@ -83,12 +83,10 @@ Learn how to configure and install Secure Boot for Palette Management Appliance 
   1. Navigate to [Artifact Studio](https://artifact-studio.spectrocloud.com/).
   2. Select the version corresponding to your {props.edition} installer. Then, select **Show Artifacts**. The artifact list appears.
   3. **Download** the **MOK Key for Secure Boot** file.
-  4. Power on the server. Execute the following command to create a virtual CD/DVD drive containing an ISO file with the `MOK.der` certificate.
-
+  4. Power on the server. Execute the following command to create a virtual CD/DVD drive containing an ISO file with the `MOK.der` certificate. Alternatively, you can save the file to a FAT32-formatted USB drive.
       ```
       mkisofs -output key.iso -volid cidata -joliet -rock MOK.der
       ```
-    Alternatively, you can save the file to a FAT32-formatted USB drive.
   5. Reboot the server. When the Dell logo appears, press **F2**. The **System Setup** menu opens.
   6. Select **System BIOS** > **Boot Settings**.
   7. Ensure that the **Boot Mode** is set to **UEFI**.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates management appliance to download mok file from artifact studio.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Palette Management Appliance](https://deploy-preview-8157--docs-spectrocloud.netlify.app/enterprise-version/install-palette/palette-management-appliance/#prerequisites)
💻 [VerteX Management Appliance](https://deploy-preview-8157--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/vertex-management-appliance/#prerequisites)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-8594](https://spectrocloud.atlassian.net/browse/PEM-8594)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] No. _Please leave a short comment below about why this PR cannot be backported._


[PEM-8594]: https://spectrocloud.atlassian.net/browse/PEM-8594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ