### PR TITLE
docs: DOC-2267: Update Vertex Management Appliance Ubuntu Version

### DIFF
--- a/docs/docs-content/vertex/install-palette-vertex/vertex-management-appliance.md
+++ b/docs/docs-content/vertex/install-palette-vertex/vertex-management-appliance.md
@@ -51,7 +51,7 @@ appliance.
 
 | **Layer**      | **Component**                                 | **Version** | **FIPS-compliant** |
 | -------------- | --------------------------------------------- | ----------- | ------------------ |
-| **OS**         | Ubuntu: Immutable [Kairos](https://kairos.io) | 20.04       | :white_check_mark: |
+| **OS**         | Ubuntu: Immutable [Kairos](https://kairos.io) | 22.04       | :white_check_mark: |
 | **Kubernetes** | Palette eXtended Kubernetes Edge (PXK-E)      | 1.32.3      | :white_check_mark: |
 | **CNI**        | Calico                                        | 3.29.2      | :white_check_mark: |
 | **CSI**        | Piraeus                                       | 2.8.1       | :white_check_mark: |


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the Ubuntu version used in VerteX Management Appliance from 20.04 > 22.04. The [Palette Management Appliance](https://docs.spectrocloud.com/enterprise-version/install-palette/palette-management-appliance/) page already references 22.04.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [VerteX Management Appliance](https://deploy-preview-8226--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/vertex-management-appliance/)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2267](https://spectrocloud.atlassian.net/browse/DOC-2267)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2267]: https://spectrocloud.atlassian.net/browse/DOC-2267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ