### PR TITLE
DOC-2271 - Login requirement for Artifact Studio

### DIFF
--- a/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
+++ b/_partials/self-hosted/management-appliance/_installation-steps-prereqs.mdx
@@ -7,6 +7,12 @@ partial_name: installation-steps-prereqs
 
 - Access to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) to download the {props.iso} ISO.
 
+  :::tip
+
+  If you do not have access to Artifact Studio, contact your Spectro Cloud representative or [open a support ticket](https://support.spectrocloud.com/).
+
+  :::
+
 - {props.edition} can be installed on a single node or on three nodes. For production environments, we recommend that three nodes be provisioned in advance for the Palette installation. We recommended the following
   resources for each node. Refer to the Palette <PaletteVertexUrlMapper edition={props.edition} text="Size Guidelines" palettePath="/install-palette#size-guidelines" vertexPath="/install-palette-vertex#size-guidelines"/> for additional sizing information.
 

--- a/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-enablement.mdx
@@ -11,7 +11,7 @@ partial_name: upgrade-palette-enablement
 
 <TabItem label="Local UI Method" value="local-ui-method"> */}
 
-1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser, and under **Install {props.iso}**, click on the drop-down menu and select the version you want to upgrade your {props.app} to.
+1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser and log in. Under **Install {props.iso}**, click on the drop-down menu and select the version you want to upgrade your {props.app} to.
 
 2. Click **Show Artifacts** to display the **{props.iso} Artifacts** pop-up window. Click the **Download** button for the **Content bundle (including Ubuntu)**.
 
@@ -75,7 +75,7 @@ During the upgrade process, the {props.version} system and tenant consoles will 
 
 // The Palette CLI method is currently not working, so commenting this out until a future release.
 
-1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser, and under **Install {props.iso}**, click on the drop-down menu and select the version you want to upgrade your {props.app} to.
+1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser and log in. Under **Install {props.iso}**, click on the drop-down menu and select the version you want to upgrade your {props.app} to.
 
 2. Click **Show Artifacts** to display the **{props.iso} Artifacts** pop-up window. Click the **Download** button for the **Content bundle (including Ubuntu)**.
 
@@ -191,7 +191,7 @@ When using an external registry, you must upload the content bundle to both the 
 
 :::
 
-1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser, and under **Install {props.iso}**, click on the drop-down menu and select the version you want to upgrade your {props.app} to.
+1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser and log in. Under **Install {props.iso}**, click on the drop-down menu and select the version you want to upgrade your {props.app} to.
 
 2. Click **Show Artifacts** to display the **{props.iso} Artifacts** pop-up window. Click the **Download** button for the **Content bundle (including Ubuntu)**.
 

--- a/_partials/self-hosted/management-appliance/_upgrade-palette-prereqs.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-prereqs.mdx
@@ -13,4 +13,10 @@ partial_name: upgrade-palette-prereqs
 
 - Access to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) to download the content bundle for {props.version}.
 
+  :::tip
+
+  If you do not have access to Artifact Studio, contact your Spectro Cloud representative or [open a support ticket](https://support.spectrocloud.com/).
+
+  :::
+
   - Check that your upgrade path is supported by referring to the <PaletteVertexUrlMapper edition={props.edition} text="Supported Upgrade Paths" url="/upgrade#supported-upgrade-paths"/>.

--- a/_partials/self-hosted/management-appliance/_upload-packs-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upload-packs-enablement.mdx
@@ -11,7 +11,7 @@ partial_name: upload-packs-enablement
 
 <TabItem label="Local UI Method" value="local-ui-method">
 
-1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser, and under **Create pack bundle**, select **Build bundle**.
+1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser and log in. Under **Create pack bundle**, select **Build bundle**.
 
 2. Select the **{props.iso} Appliance** product on the **Product selection** step and build your pack
    bundles by following the prompts in the Artifact Studio.
@@ -46,7 +46,7 @@ partial_name: upload-packs-enablement
 
 <TabItem label="Palette CLI Method" value="palette-cli-method">
 
-1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser, and under **Create pack bundle**, select **Build bundle**.
+1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser and log in. Under **Create pack bundle**, select **Build bundle**.
 
 2. Select the **{props.iso} Appliance** product on the **Product selection** step and build your pack
    bundles by following the prompts in the Artifact Studio.
@@ -134,7 +134,7 @@ partial_name: upload-packs-enablement
 
 <TabItem value="external-registry" label="External Registry">
 
-1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser, and under **Create pack bundle**, select **Build bundle**.
+1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser and log in. Under **Create pack bundle**, select **Build bundle**.
 
 2. Select the **{props.iso} Appliance** product on the **Product selection** step and build your pack
    bundles by following the prompts in the Artifact Studio.

--- a/_partials/self-hosted/management-appliance/_upload-packs-prereqs.mdx
+++ b/_partials/self-hosted/management-appliance/_upload-packs-prereqs.mdx
@@ -5,6 +5,12 @@ partial_name: upload-packs-prereqs
 
 - Access to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) to download the {props.iso} pack bundles.
 
+  :::tip
+
+  If you do not have access to Artifact Studio, contact your Spectro Cloud representative or [open a support ticket](https://support.spectrocloud.com/).
+
+  :::
+
 - If using the internal Zot registry, ensure you have access to the Local UI of the leader node of the {props.version} management cluster. Also, verify that your local machine can access the Local UI, as airgapped environments may have strict network policies preventing direct access.
 
   - (Optional) The Palette CLI installed on your local machine if you prefer to use the command line for uploading packs. Refer to the <VersionedLink text="Palette CLI" url="/automation/palette-cli"/> guide for installation instructions.

--- a/_partials/self-hosted/management-appliance/_upload-third-party-packs-enablement.mdx
+++ b/_partials/self-hosted/management-appliance/_upload-third-party-packs-enablement.mdx
@@ -11,7 +11,7 @@ partial_name: upload-third-party-packs-enablement
 
 <TabItem label="Local UI Method" value="local-ui-method">
 
-1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser, and under **Create pack bundle**, select **Build bundle**.
+1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser and log in. Under **Create pack bundle**, select **Build bundle**.
 
 2. Select the **{props.iso} Appliance** product on the **Product selection** step and select your current version on the **Version selection** step.
 
@@ -57,7 +57,7 @@ partial_name: upload-third-party-packs-enablement
 
 <TabItem label="Palette CLI Method" value="palette-cli-method">
 
-1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser, and under **Create pack bundle**, select **Build bundle**.
+1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser and log in. Under **Create pack bundle**, select **Build bundle**.
 
 2. Select the **{props.iso} Appliance** product on the **Product selection** step and select your current version on the **Version selection** step.
 
@@ -178,7 +178,7 @@ partial_name: upload-third-party-packs-enablement
 
 <TabItem value="external-registry" label="External Registry">
 
-1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser, and under **Create pack bundle**, select **Build bundle**.
+1. Navigate to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) through a web browser and log in. Under **Create pack bundle**, select **Build bundle**.
 
 2. Select the **{props.iso} Appliance** product on the **Product selection** step and select your current version on the **Version selection** step.
 

--- a/_partials/self-hosted/management-appliance/_upload-third-party-packs-prereqs.mdx
+++ b/_partials/self-hosted/management-appliance/_upload-third-party-packs-prereqs.mdx
@@ -5,6 +5,12 @@ partial_name: upload-third-party-packs-prereqs
 
 - Access to the [Artifact Studio](https://artifact-studio.spectrocloud.com/) to download the Third Party packs.
 
+  :::tip
+
+  If you do not have access to Artifact Studio, contact your Spectro Cloud representative or [open a support ticket](https://support.spectrocloud.com/).
+
+  :::
+
 - If using the internal Zot registry, ensure you have access to the Local UI of the leader node of the {props.version} management cluster. Also, verify that your local machine can access the Local UI, as airgapped environments may have strict network policies preventing direct access.
 
   - (Optional) The Palette CLI installed on your local machine if you prefer to use the command line for uploading packs. Refer to the <VersionedLink text="Palette CLI" url="/automation/palette-cli"/> guide for installation instructions.

--- a/docs/docs-content/downloads/artifact-studio.md
+++ b/docs/docs-content/downloads/artifact-studio.md
@@ -35,9 +35,14 @@ There are four main artifact areas:
 
 :::
 
+## Access Artifact Studio
+
+Access to Artifact Studio is available to all Spectro Cloud customers. To gain access, contact your Spectro Cloud
+representative or [open a support ticket](https://support.spectrocloud.com/).
+
 ## Download Palette Enterprise
 
-1. Navigate to [Artifact Studio](https://artifact-studio.spectrocloud.com/).
+1. Navigate to [Artifact Studio](https://artifact-studio.spectrocloud.com/) and log in.
 
 2. In the **Install Palette Enterprise** section, use the drop-down to select the version needed, and select **Show
    Artifacts**.
@@ -57,7 +62,7 @@ for more information on deploying Palette locally.
 
 ## Download Palette VerteX
 
-1. Navigate to [Artifact Studio](https://artifact-studio.spectrocloud.com/).
+1. Navigate to [Artifact Studio](https://artifact-studio.spectrocloud.com/) and log in.
 
 2. In the **Install Palette VerteX** section, use the drop-down to select the version needed, and select **Show
    Artifacts**.
@@ -83,7 +88,7 @@ Agent mode binaries cannot be downloaded at this time.
 
 :::
 
-1. Navigate to [Artifact Studio](https://artifact-studio.spectrocloud.com/).
+1. Navigate to [Artifact Studio](https://artifact-studio.spectrocloud.com/) and log in.
 
 2. In the **Create pack bundle** section, select **Build bundle**.
 
@@ -199,7 +204,7 @@ information on how to verify the authenticity and integrity of your bundles, ref
 
 ## Download a Specific Pack
 
-1. Navigate to [Artifact Studio](https://artifact-studio.spectrocloud.com/).
+1. Navigate to [Artifact Studio](https://artifact-studio.spectrocloud.com/) and log in.
 
 2. In the **Create pack bundle** section, select **Browse Packs**.
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR documents that the Artifact Studio requires users to log in as of the 2025-39 platform release.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2271](https://spectrocloud.atlassian.net/browse/DOC-2271)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._
Release ticket

[DOC-2271]: https://spectrocloud.atlassian.net/browse/DOC-2271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ