### PR TITLE
docs: DOC-2275: Updating Palette CLI and Agent Versions

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
@@ -71,14 +71,15 @@ require a local Harbor registry. Built-in registries must be configured using ei
   clusters. [Download](../../../../downloads/cli-tools.md#palette-edge-cli) and use Palette Edge CLI version 4.5.20 or
   later to create content bundles.
 
-- Palette CLI versions earlier than 4.7.20 do not support building content for local Edge cluster deployment on Palette
-  4.7.20 or later because content created with older CLI versions lacks the required images.
-  [Download](../../../../downloads/cli-tools.md#palette-cli) and use Palette CLI version 4.7.20 or later to build
-  content for Palette 4.7.20 or later.
+- Palette CLI versions earlier than 4.7.2 do not support building content for local Edge cluster deployment on Palette
+  version 4.7.20 or later because content created with older CLI versions lacks the required images.
+  [Download](../../../../downloads/cli-tools.md#palette-cli) and use Palette CLI version 4.7.2 or later to build content
+  for Palette version 4.7.20 or later.
 
-- Palette Edge CLI does not support building content for local Edge cluster deployment in agent mode on Palette 4.7.20
-  (Palette agent version 4.7.12) or later. [Download](../../../../downloads/cli-tools.md#palette-cli) and use Palette
-  CLI version 4.7.20 or later instead. This limitation does not affect appliance mode cluster deployment.
+- The Palette Edge CLI does not support building content for local Edge cluster deployment in agent mode on Palette
+  version 4.7.20 or later (Palette agent version 4.7.13 or later).
+  [Download](../../../../downloads/cli-tools.md#palette-cli) and use Palette CLI version 4.7.2 or later instead. This
+  limitation does not affect appliance mode cluster deployment.
 
 ## Prerequisites
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle.md
@@ -79,7 +79,7 @@ require a local Harbor registry. Built-in registries must be configured using ei
 - The Palette Edge CLI does not support building content for local Edge cluster deployment in agent mode on Palette
   version 4.7.20 or later (Palette agent version 4.7.13 or later).
   [Download](../../../../downloads/cli-tools.md#palette-cli) and use Palette CLI version 4.7.2 or later instead. This
-  limitation does not affect appliance mode cluster deployment.
+  limitation does not affect appliance mode cluster deployments.
 
 ## Prerequisites
 

--- a/docs/docs-content/deployment-modes/agent-mode/architecture.md
+++ b/docs/docs-content/deployment-modes/agent-mode/architecture.md
@@ -35,15 +35,23 @@ The following are architectural highlights of clusters deployed using agent mode
   - Custom installation paths for Kubernetes and its dependencies in [agent mode](../)
   - [Network overlay](../../../clusters/edge/networking/vxlan-overlay/)
 
-- Edge clusters deployed in agent mode with the Palette agent versions prior to 4.7.20 do not support upgrading to the
-  following Kubernetes pack versions released in 4.7.20:
-  <VersionedLink text="Palette Optimized Canonical" url="/integrations/packs/?pack=edge-canonical" /> 1.32.8 and 1.33.4;
-  <VersionedLink text="Palette eXtended Kubernetes Edge (PXK-E)" url="/integrations/packs/?pack=edge-k8s" /> 1.31.12,
-  1.32.8, and 1.33.4. For locally managed clusters, refer to [Configure Palette Agent
-  Version](../../clusters/edge/cluster-management/agent-upgrade-airgap.md) to upgrade the agent to the latest version
-  before upgrading Kubernetes packs. For centrally managed clusters, do not [pause
-  upgrades](../../clusters/cluster-management/platform-settings/pause-platform-upgrades.md) so the agent can upgrade
-  automatically.
+<!-- prettier-ignore-start -->
+
+- Edge clusters deployed in agent mode with a Palette cluster agent version prior to 4.7.7 do not support upgrading to
+  the following Kubernetes pack versions released in 4.7.20:
+
+  - <VersionedLink text="Palette Optimized Canonical" url="/integrations/packs/?pack=edge-canonical" /> 1.32.8 and
+    1.33.4
+  - <VersionedLink text="Palette eXtended Kubernetes Edge (PXK-E)" url="/integrations/packs/?pack=edge-k8s" /> 1.31.12,
+    1.32.8, and 1.33.4
+
+  For locally managed clusters, refer to
+  [Configure Palette Agent Version](../../clusters/edge/cluster-management/agent-upgrade-airgap.md) to upgrade the agent
+  to the latest version before upgrading Kubernetes packs. For centrally managed clusters, do not
+  [pause upgrades](../../clusters/cluster-management/platform-settings/pause-platform-upgrades.md) so the agent can
+  upgrade automatically.
+
+<!-- prettier-ignore-end -->
 
 ## Supported Kubernetes Distributions
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -58,7 +58,7 @@ The following components have been updated for Palette version 4.7.20.
 
 The following component updates are applicable to this release:
 
-- [September 26, 2025 - Component Updates](#component-updates-2025-39)
+- [September 26, 2025 - Component Updates](#component-updates-2025-39) <!-- omit in toc -->
 
 ### Security Notices
 
@@ -116,37 +116,46 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 #### Breaking Changes
 
-- Palette CLI versions prior to 4.7.20 do not support building content for local Edge cluster deployment on Palette 4.7.20
+- Palette CLI versions prior to 4.7.2 do not support building content for local Edge cluster deployment on Palette version 4.7.20
   or later because content created with older CLI versions lacks the required images. We recommend
-  [downloading](downloads/cli-tools.md#palette-cli) and using Palette CLI version 4.7.20 or later to build content for
-  Palette 4.7.20 or later.
+  [downloading](downloads/cli-tools.md#palette-cli) and using Palette CLI version 4.7.2 or later to build content for
+  Palette version 4.7.20 or later.
 
 <!-- prettier-ignore-start -->
-- Edge clusters with the Palette agent versions prior to 4.7.20 do not support upgrading to the following Kubernetes pack
+
+- Edge clusters deployed in agent mode with a Palette cluster agent version prior to 4.7.7 do not support upgrading to the following Kubernetes pack
   versions released in 4.7.20:
-  <VersionedLink text="Palette Optimized Canonical" url="/integrations/packs/?pack=edge-canonical" /> 1.32.8 and 1.33.4;
-  <VersionedLink text="Palette eXtended Kubernetes Edge (PXK-E)" url="/integrations/packs/?pack=edge-k8s" /> 1.31.12,
-  1.32.8, and 1.33.4. This breaking change affects agent mode clusters only and does not impact appliance mode clusters.
+  
+  - <VersionedLink text="Palette Optimized Canonical" url="/integrations/packs/?pack=edge-canonical" /> 1.32.8 and 1.33.4
+  - <VersionedLink text="Palette eXtended Kubernetes Edge (PXK-E)" url="/integrations/packs/?pack=edge-k8s" /> 1.31.12,
+  1.32.8, and 1.33.4
+  
+  This breaking change affects agent mode clusters only and does not impact appliance mode clusters.
   For locally managed clusters, refer to [Configure Palette Agent
   Version](clusters/edge/cluster-management/agent-upgrade-airgap.md) to upgrade the agent to the latest version before
   upgrading Kubernetes packs. For centrally managed clusters, do not [pause
   upgrades](clusters/cluster-management/platform-settings/pause-platform-upgrades.md) so the agent can upgrade
   automatically.
+  
 <!-- prettier-ignore-end -->
 
-- Palette Edge CLI does not support building content for local Edge cluster deployment in agent mode on Palette 4.7.20
-  (Palette agent version 4.7.12) or later. We recommend [downloading](downloads/cli-tools.md#palette-cli) and using
-  Palette CLI version 4.7.20 or later instead. This breaking change affects agent mode clusters only and does not impact
-  appliance mode clusters.
+- The Palette Edge CLI does not support building content for local Edge cluster deployment in agent mode on Palette
+  version 4.7.20 or later (Palette host agent version 4.7.13 or later). We recommend
+  [downloading](downloads/cli-tools.md#palette-cli) and using Palette CLI version 4.7.2 or later instead. This breaking
+  change affects agent mode clusters only and does not impact appliance mode clusters.
 
 #### Improvements
 
-- [Edge host grid view](../clusters/edge/site-deployment/edge-host-view.md) now supports the Graphics Processing Unit (GPU) attribute. It contains information about the GPU of the Edge host, including the GPU model, vendor, memory, count, and Multi-Instance GPU (MIG) capability and strategy. MIG fields are applicable for Nvidia devices only.
-- [Local UI](../clusters/edge/local-ui/local-ui.md) now supports displaying all date and time values in Coordinated Universal Time (UTC), the browser’s local time zone, or both simultaneously.
+- [Edge host grid view](../clusters/edge/site-deployment/edge-host-view.md) now supports the Graphics Processing Unit
+  (GPU) attribute. It contains information about the GPU of the Edge host, including the GPU model, vendor, memory,
+  count, and Multi-Instance GPU (MIG) capability and strategy. MIG fields are applicable for Nvidia devices only.
+- [Local UI](../clusters/edge/local-ui/local-ui.md) now supports displaying all date and time values in Coordinated
+  Universal Time (UTC), the browser’s local time zone, or both simultaneously.
 
 #### Bug Fixes
 
-- Fixed an issue that caused incorrect [Kube-vip](../clusters/edge/networking/kubevip.md) validation errors to appear when worker nodes were removed and re-added to clusters.
+- Fixed an issue that caused incorrect [Kube-vip](../clusters/edge/networking/kubevip.md) validation errors to appear
+  when worker nodes were removed and re-added to clusters.
 - Fixed an issue that caused incorrect [Local UI](../clusters/edge/local-ui/local-ui.md) ports when using VIP addresses.
 
 ### VerteX
@@ -177,12 +186,13 @@ Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible ver
   now available. For more details, refer to the Terraform provider
   [release page](https://github.com/spectrocloud/terraform-provider-spectrocloud/releases).
 - Crossplane version 0.24.4 of the
-  [Spectro Cloud Crossplane provider](https://marketplace.upbound.io/providers/crossplane-contrib/provider-palette)
-  is now available. This version supports [Crossplane v2](https://docs.crossplane.io/latest/whats-new/).
+  [Spectro Cloud Crossplane provider](https://marketplace.upbound.io/providers/crossplane-contrib/provider-palette) is
+  now available. This version supports [Crossplane v2](https://docs.crossplane.io/latest/whats-new/).
 
 #### Bug Fixes
 
-- Fixed an issue that caused [EKS clusters](../clusters/public-cloud/aws/eks.md) to be recreated when private and public access CIDRs are changed through Terraform.
+- Fixed an issue that caused [EKS clusters](../clusters/public-cloud/aws/eks.md) to be recreated when private and public
+  access CIDRs are changed through Terraform.
 
 ### Packs
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the Palette CLI, Palette host agent, and Palette cluster agent versions with respect to the 4.7.20 release. I suspect when the 4.7.b placeholder was replaced, 4.7.20 was used across the board when it should not have been. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Release Notes](https://deploy-preview-8266--docs-spectrocloud.netlify.app/release-notes/#release-notes-4.7.b)
- [Build Content Bundle](https://deploy-preview-8266--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/build-content-bundle/#limitations)
- [Agent Mode Architecture](https://deploy-preview-8266--docs-spectrocloud.netlify.app/deployment-modes/agent-mode/architecture/#limitations)

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-2275](https://spectrocloud.atlassian.net/browse/DOC-2275)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] Yes. _Remember to add the relevant backport labels to your PR._
- [ ] No. _Please leave a short comment below about why this PR cannot be backported._


[DOC-2275]: https://spectrocloud.atlassian.net/browse/DOC-2275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ