### PR TITLE
[version-4-3] docs: add component update generation DOC-2277 (#8289)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,6 +362,10 @@ generate-release-notes: ## Generate release notes only
 	./scripts/release/generate-release-notes.sh
 	make -s format > /dev/null 2>&1
 
+generate-component-updates: ## Generate component updates only
+	./scripts/release/generate-component-updates.sh
+	make -s format > /dev/null 2>&1
+
 generate-release: ## Generate all release files except release notes
 	./scripts/release/generate-spectro-cli-reference.sh
 	./scripts/release/generate-downloads.sh
@@ -372,20 +376,29 @@ generate-release: ## Generate all release files except release notes
 	make -s format > /dev/null 2>&1
 
 init-release:
-	grep -q "^export RELEASE_NAME=" .env || echo "\nexport RELEASE_NAME=" >> .env
-	grep -q "^export RELEASE_VERSION=" .env || echo "\nexport RELEASE_VERSION=" >> .env
-	grep -q "^export RELEASE_DATE=" .env || echo "\nexport RELEASE_DATE=" >> .env
-	grep -q "^export RELEASE_PALETTE_CLI_VERSION=" .env || echo "\nexport RELEASE_PALETTE_CLI_VERSION=" >> .env
-	grep -q "^export RELEASE_PALETTE_CLI_SHA=" .env || echo "\nexport RELEASE_PALETTE_CLI_SHA=" >> .env
-	grep -q "^export RELEASE_EDGE_CLI_VERSION=" .env || echo "\nexport RELEASE_EDGE_CLI_VERSION=" >> .env
-	grep -q "^export RELEASE_EDGE_CLI_SHA=" .env || echo "\nexport RELEASE_EDGE_CLI_SHA=" >> .env
-	grep -q "^export RELEASE_REGISTRY_VERSION=" .env || echo "\nexport RELEASE_REGISTRY_VERSION=" >> .env
-	grep -q "^export RELEASE_SPECTRO_CLI_VERSION=" .env || echo "\nexport RELEASE_SPECTRO_CLI_VERSION=" >> .env
-	grep -q "^export RELEASE_VMWARE_KUBERNETES_VERSION=" .env || echo "\nexport RELEASE_VMWARE_KUBERNETES_VERSION=" >> .env
-	grep -q "^export RELEASE_VMWARE_OVA_URL=" .env || echo "\nexport RELEASE_VMWARE_OVA_URL=" >> .env
-	grep -q "^export RELEASE_VMWARE_FIPS_OVA_URL=" .env || echo "\nexport RELEASE_VMWARE_FIPS_OVA_URL=" >> .env
-	grep -q "^export RELEASE_HIGHEST_KUBERNETES_VERSION=" .env || echo "\nexport RELEASE_HIGHEST_KUBERNETES_VERSION=" >> .env
-	grep -q "^export RELEASE_PCG_KUBERNETES_VERSION=" .env || echo "\nexport RELEASE_PCG_KUBERNETES_VERSION=" >> .env	
+	grep -q "^# RELEASE NOTES" .env || echo "\n# RELEASE NOTES" >> .env
+	grep -q "^export RELEASE_NAME=" .env || echo "export RELEASE_NAME=" >> .env
+	grep -q "^export RELEASE_VERSION=" .env || echo "export RELEASE_VERSION=" >> .env
+	grep -q "^export RELEASE_DATE=" .env || echo "export RELEASE_DATE=" >> .env
+	grep -q "^export RELEASE_CANVOS=" .env || echo "export RELEASE_CANVOS=" >> .env
+	grep -q "^export RELEASE_TERRAFORM_VERSION=" .env || echo "export RELEASE_TERRAFORM_VERSION=" >> .env
+	grep -q "^# COMPONENT UPDATES" .env || echo "\n# COMPONENT UPDATES" >> .env
+	grep -q "^export RELEASE_COMPONENT_YEAR=" .env || echo "export RELEASE_COMPONENT_YEAR=" >> .env
+	grep -q "^export RELEASE_COMPONENT_WEEK=" .env || echo "export RELEASE_COMPONENT_WEEK=" >> .env
+	grep -q "^export RELEASE_COMPONENT_START_VERSION=" .env || echo "export RELEASE_COMPONENT_START_VERSION=" >> .env
+	grep -q "^export RELEASE_COMPONENT_END_VERSION=" .env || echo "export RELEASE_COMPONENT_END_VERSION=" >> .env
+	grep -q "^# OTHER RELEASE UPDATES" .env || echo "\n# OTHER RELEASE UPDATES" >> .env
+	grep -q "^export RELEASE_PALETTE_CLI_VERSION=" .env || echo "export RELEASE_PALETTE_CLI_VERSION=" >> .env
+	grep -q "^export RELEASE_PALETTE_CLI_SHA=" .env || echo "export RELEASE_PALETTE_CLI_SHA=" >> .env
+	grep -q "^export RELEASE_EDGE_CLI_VERSION=" .env || echo "export RELEASE_EDGE_CLI_VERSION=" >> .env
+	grep -q "^export RELEASE_EDGE_CLI_SHA=" .env || echo "export RELEASE_EDGE_CLI_SHA=" >> .env
+	grep -q "^export RELEASE_REGISTRY_VERSION=" .env || echo "export RELEASE_REGISTRY_VERSION=" >> .env
+	grep -q "^export RELEASE_SPECTRO_CLI_VERSION=" .env || echo "export RELEASE_SPECTRO_CLI_VERSION=" >> .env
+	grep -q "^export RELEASE_VMWARE_KUBERNETES_VERSION=" .env || echo "export RELEASE_VMWARE_KUBERNETES_VERSION=" >> .env
+	grep -q "^export RELEASE_VMWARE_OVA_URL=" .env || echo "export RELEASE_VMWARE_OVA_URL=" >> .env
+	grep -q "^export RELEASE_VMWARE_FIPS_OVA_URL=" .env || echo "export RELEASE_VMWARE_FIPS_OVA_URL=" >> .env
+	grep -q "^export RELEASE_HIGHEST_KUBERNETES_VERSION=" .env || echo "export RELEASE_HIGHEST_KUBERNETES_VERSION=" >> .env
+	grep -q "^export RELEASE_PCG_KUBERNETES_VERSION=" .env || echo "export RELEASE_PCG_KUBERNETES_VERSION=" >> .env
 
 ###@ Aloglia Indexing
 

--- a/README.md
+++ b/README.md
@@ -1270,11 +1270,29 @@ The scripts update the following files.
 The following table provides an overview of all the environment variables and which pages they are used on. For ease of
 recognition, all environment variables used by these scripts are named using the `RELEASE_` prefix.
 
+#### Release Notes
+
+| **Environment Variable**    | **Description**                                       | **Example Value**  |
+| --------------------------- | ----------------------------------------------------- | ------------------ |
+| `RELEASE_NAME`              | The internal release name.                            | `4-7-c`            |
+| `RELEASE_VERSION`           | The external release version.                         | `4.7.6`            |
+| `RELEASE_DATE`              | The date that the release takes place.                | `"March 18, 2025"` |
+| `RELEASE_CANVOS`            | The CanvOS version.                                   | `4.7.13`           |
+| `RELEASE_TERRAFORM_VERSION` | The version of the Terraform and Crossplane provider. | `0.24.5`           |
+
+#### Component Updates
+
+| **Environment Variable**          | **Description**                                                 | **Example Value** |
+| --------------------------------- | --------------------------------------------------------------- | ----------------- |
+| `RELEASE_COMPONENT_YEAR`          | The year of the component update.                               | `2025`            |
+| `RELEASE_COMPONENT_WEEK`          | The week number of the component update.                        | `39`              |
+| `RELEASE_COMPONENT_START_VERSION` | The first Palette version that the component update applies to. | `4.7.20`          |
+| `RELEASE_COMPONENT_END_VERSION`   | The last Palette version that the component update applies to.  | `4.7.21`          |
+
+#### Other Release Updates
+
 | **Environment Variable**             | **Description**                                                                                                                                                                                    | **Example Value**                                                     |
 | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `RELEASE_NAME`                       | The internal release name.                                                                                                                                                                         | `4-5-c`                                                               |
-| `RELEASE_VERSION`                    | The external release version.                                                                                                                                                                      | `4.6.6`                                                               |
-| `RELEASE_DATE`                       | The date that the release takes place.                                                                                                                                                             | `"March 18, 2025"`                                                    |
 | `RELEASE_PALETTE_CLI_VERSION`        | The Palette CLI version.                                                                                                                                                                           | `4.6.0`                                                               |
 | `RELEASE_PALETTE_CLI_SHA`            | The SHA of the Palette CLI corresponding to the provided version.                                                                                                                                  | `07d63693a8c90483f6f000d4580cfd86f81178e4b96cfbd32e0f50955d57eec7`    |
 | `RELEASE_EDGE_CLI_VERSION`           | The Palette Edge CLI version.                                                                                                                                                                      | `4.6.3`                                                               |
@@ -1291,5 +1309,6 @@ recognition, all environment variables used by these scripts are named using the
 
 - `make init-release` creates placeholders for all the release related environment variables in your `.env` file. Use
   the placeholders to fill in the values relevant to the Palette release.
+- `make generate-component-updates` creates only the component updates skeleton in the Palette release notes.
 - `make generate-release-notes` creates only the release notes changes for the Palette release.
 - `make generate-release` creates all Palette release related updates, excluding release notes.

--- a/scripts/release/generate-component-updates.sh
+++ b/scripts/release/generate-component-updates.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Import utility functions
+source scripts/release/utilities.sh
+
+# Define release note related files
+RELEASE_NOTES_FILE="docs/docs-content/release-notes/release-notes.md"
+COMPONENT_UPDATES_TEMPLATE_FILE="scripts/release/templates/component-updates.md"
+COMPONENT_UPDATES_CROSS_LINK_TEMPLATE_FILE="scripts/release/templates/component-updates-cross-link.md"
+COMPONENT_UPDATES_HEADING_TEMPLATE_FILE="scripts/release/templates/component-updates-heading.md"
+COMPONENT_UPDATES_PARAMETERISED_FILE="scripts/release/component-updates-output.md"
+COMPONENT_UPDATES_HEADING_PARAMETERISED_FILE="scripts/release/component-updates-heading-output.md"
+COMPONENT_UPDATES_CROSS_LINK_PARAMETERISED_FILE="scripts/release/templates/component-updates-cross-link-output.md"
+
+if ! check_env "RELEASE_DATE" || 
+   ! check_env "RELEASE_COMPONENT_YEAR" ||  
+   ! check_env "RELEASE_COMPONENT_WEEK" ||  
+   ! check_env "RELEASE_COMPONENT_START_VERSION" ||  
+   ! check_env "RELEASE_COMPONENT_END_VERSION" ||  
+   ! check_env "RELEASE_TERRAFORM_VERSION" ; then
+    echo "‼️  Skipping component updates in $RELEASE_NOTES_FILE due to missing environment variables. ‼️"
+    exit 0
+fi
+
+generate_parameterised_file $COMPONENT_UPDATES_TEMPLATE_FILE $COMPONENT_UPDATES_PARAMETERISED_FILE
+generate_parameterised_file $COMPONENT_UPDATES_CROSS_LINK_TEMPLATE_FILE $COMPONENT_UPDATES_CROSS_LINK_PARAMETERISED_FILE
+generate_parameterised_file $COMPONENT_UPDATES_HEADING_TEMPLATE_FILE $COMPONENT_UPDATES_HEADING_PARAMETERISED_FILE
+
+existing_notes=$(search_line "{#component-updates-$RELEASE_COMPONENT_YEAR-$RELEASE_COMPONENT_WEEK}" $RELEASE_NOTES_FILE)
+if [[ -n "$existing_notes" && "$existing_notes" -ne 0 ]]; then
+    echo "ℹ️ Component updates for $RELEASE_COMPONENT_YEAR - $RELEASE_COMPONENT_WEEK have already been generated in $RELEASE_NOTES_FILE"
+    replace_line $existing_notes $COMPONENT_UPDATES_HEADING_PARAMETERISED_FILE $RELEASE_NOTES_FILE
+    echo "✅ Replaced component updates heading in $RELEASE_NOTES_FILE"
+else
+    insert_file_after "<ReleaseNotesVersions />" $COMPONENT_UPDATES_PARAMETERISED_FILE $RELEASE_NOTES_FILE
+    echo "✅ Parameterised component updates inserted into $RELEASE_NOTES_FILE"
+fi
+
+# Search all lines containing the component updates links and update them
+cross_link_regex="- \[.* - Component Updates\](#component-updates-$RELEASE_COMPONENT_YEAR-$RELEASE_COMPONENT_WEEK)"
+grep -n -- "$cross_link_regex" "$RELEASE_NOTES_FILE" \
+  | cut -d: -f1 \
+  | while IFS= read -r line_number; do
+      replace_line "$line_number" "$COMPONENT_UPDATES_CROSS_LINK_PARAMETERISED_FILE" "$RELEASE_NOTES_FILE"
+    done
+echo "✅ Updated component updates cross-links in $RELEASE_NOTES_FILE"
+
+cleanup $COMPONENT_UPDATES_PARAMETERISED_FILE
+cleanup $COMPONENT_UPDATES_HEADING_PARAMETERISED_FILE
+cleanup $COMPONENT_UPDATES_CROSS_LINK_PARAMETERISED_FILE

--- a/scripts/release/generate-release-notes.sh
+++ b/scripts/release/generate-release-notes.sh
@@ -11,6 +11,8 @@ RELEASE_NOTES_HEADING_PARAMETERISED_FILE="scripts/release/release-notes-heading-
 
 if ! check_env "RELEASE_DATE" || 
    ! check_env "RELEASE_NAME" ||  
+   ! check_env "RELEASE_CANVOS" ||  
+   ! check_env "RELEASE_TERRAFORM_VERSION" ||  
    ! check_env "RELEASE_VERSION" ; then
     echo "‼️  Skipping generate $RELEASE_NOTES_FILE due to missing environment variables. ‼️"
     exit 0

--- a/scripts/release/templates/component-updates-cross-link.md
+++ b/scripts/release/templates/component-updates-cross-link.md
@@ -1,0 +1,1 @@
+- [{{RELEASE_DATE}} - Component Updates](#component-updates-{{RELEASE_COMPONENT_YEAR}}-{{RELEASE_COMPONENT_WEEK}}) <!-- omit in toc -->

--- a/scripts/release/templates/component-updates-heading.md
+++ b/scripts/release/templates/component-updates-heading.md
@@ -1,0 +1,1 @@
+## {{RELEASE_DATE}} - Component Updates {#component-updates-{{RELEASE_COMPONENT_YEAR}}-{{RELEASE_COMPONENT_WEEK}}}

--- a/scripts/release/templates/component-updates.md
+++ b/scripts/release/templates/component-updates.md
@@ -1,0 +1,17 @@
+## {{RELEASE_DATE}} - Component Updates {#component-updates-{{RELEASE_COMPONENT_YEAR}}-{{RELEASE_COMPONENT_WEEK}}}
+
+The following components have been updated for Palette version {{RELEASE_COMPONENT_START_VERSION}} - {{RELEASE_COMPONENT_END_VERSION}}.
+
+| Component | Version |
+|-------------------------------------------------------------------------------------------------------------------------| -------|
+| [Spectro Cloud Terraform provider](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs) | {{RELEASE_TERRAFORM_VERSION}} |
+| [Spectro Cloud Crossplane provider](https://marketplace.upbound.io/providers/crossplane-contrib/provider-palette) | {{RELEASE_TERRAFORM_VERSION}}|
+
+### Bug Fixes
+
+### Packs
+
+#### Pack Notes
+
+| Pack Name | Layer | FIPS | New Version |
+| --------- | ----- | ---- | ----------- |

--- a/scripts/release/templates/release-notes.md
+++ b/scripts/release/templates/release-notes.md
@@ -16,6 +16,12 @@
 
 ### Edge
 
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the {{RELEASE_VERSION}} Palette release is {{RELEASE_CANVOS}}.
+
+:::
+
 #### Features
 
 #### Improvements
@@ -29,6 +35,24 @@
 - Includes all Palette features, improvements, breaking changes, and deprecations in this release. Refer to the [Palette section](#palette-enterprise-{{RELEASE_NAME}}) for more details.
 
 ### Automation
+
+:::info
+
+Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible version of the Palette CLI.
+
+:::
+
+#### Features
+
+- Terraform version {{RELEASE_TERRAFORM_VERSION}} of the
+  [Spectro Cloud Terraform provider](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs) is
+  now available. For more details, refer to the Terraform provider
+  [release page](https://github.com/spectrocloud/terraform-provider-spectrocloud/releases).
+- Crossplane version {{RELEASE_TERRAFORM_VERSION}} of the
+  [Spectro Cloud Crossplane provider](https://marketplace.upbound.io/providers/crossplane-contrib/provider-palette) is
+  now available.
+
+#### Improvements
 
 ### Docs and Education
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-6`:
 - [docs: add component update generation DOC-2277 (#8289)](https://github.com/spectrocloud/librarium/pull/8289)