### PR TITLE
docs: DOC-2268 & DOC-2285: Expanding Overlay Network Support + Clarifying systemd Functionality

### DIFF
--- a/docs/docs-content/clusters/edge/architecture/architecture.md
+++ b/docs/docs-content/clusters/edge/architecture/architecture.md
@@ -41,7 +41,7 @@ The following are architectural highlights of Palette-provisioned Edge native cl
   - ARM64 architecture
   - Palette VerteX
   - Custom installation paths for Kubernetes and its dependencies in [agent mode](../../../deployment-modes/agent-mode/)
-  - [Network overlay](../networking/vxlan-overlay/)
+  - [Network overlay](../networking/vxlan-overlay/) in locally managed Edge clusters.
   - High availability mode with one or two nodes.
 
 - When scaling down a Palette Optimized Canonical Kubernetes cluster with two nodes, ensure you do not delete the leader

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/create-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/create-cluster.md
@@ -33,10 +33,13 @@ management.
 
 ## Prerequisites
 
-- If your hosts are deployed in agent mode, ensure that your hosts use `systemd-networkd` and `systemd-resolved` for
-  interface and DNS management. Refer to
+- (Agent Mode only) By default, Edge hosts deployed using
+  [Appliance Mode](../../../../deployment-modes/appliance-mode/appliance-mode.md) use `systemd-networkd` for interface
+  management and `systemd-resolved` for DNS resolution in overlay networks. If using
+  [Agent Mode](../../../../deployment-modes/agent-mode/agent-mode.md), you must confirm that `systemd-networkd` and
+  `systemd-resolved` are installed on your Edge hosts and properly configured. Refer to our
   [Configure networkd to Prepare Host for Overlay Network](../../../../deployment-modes/agent-mode/overlay-preparation.md)
-  for more information.
+  guide for more information.
 
 - Network access to the Edge device’s IP and port where Local UI is exposed. The default port is 5080.
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/create-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/create-cluster.md
@@ -22,13 +22,14 @@ management.
 
 - For hosts that are deployed in agent mode, all hosts must share the same Operating System (OS).
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore-start -->
+
 - For multi-node clusters, do not use the
   <VersionedLink text="Local Path Provisioner Pack" url="/integrations/packs/?pack=csi-local-path-provisioner" />. This
   is because whenever a node is drained during an upgrade or for any other reason, the volumes will not dynamically move
   with the local path provisioner.
 
-- Locally managed multi-node clusters deployed in [agent mode](../../../../deployment-modes/agent-mode/agent-mode.md) do not support network overlay.
+<!-- prettier-ignore-end -->
 
 ## Prerequisites
 

--- a/docs/docs-content/clusters/edge/networking/vxlan-overlay.md
+++ b/docs/docs-content/clusters/edge/networking/vxlan-overlay.md
@@ -8,6 +8,10 @@ sidebar_position: 30
 tags: ["edge"]
 ---
 
+:::preview
+
+:::
+
 Edge clusters are often deployed in locations where network environments are not managed by teams that maintain the Edge
 deployments. However, a Kubernetes cluster, specifically several control plane components, requires stable IP addresses.
 In the case of an extended network outage, it is possible that your cluster components would lose their original IP
@@ -23,9 +27,26 @@ cluster from an outage.
 
 ![VxLAN Overlay Architecture](/clusters_edge_site-installation_vxlan-overlay_architecture.webp)
 
-:::preview
+## Supported Clusters
+
+The following table lists the various cluster combinations that support overlay networks.
+
+:::info
+
+The **FIPS** column is based on the cluster's Kubernetes pack, not the host OS.
 
 :::
+
+<!-- prettier-ignore-start -->
+
+| **Distribution**                                                                  |     **Agent**      |   **Appliance**    |     **Local**      |    **Central**     |  **Single Node**   |   **Multi-Node**   |    **Non-FIPS**    |      **FIPS**      |
+| --------------------------------------------------------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| <VersionedLink text="Canonical" url="/integrations/packs/?pack=edge-canonical" /> | :white_check_mark: | :white_check_mark: |        :x:         | :white_check_mark: |        :x:         |        :x:         | :white_check_mark: |        :x:         |
+| <VersionedLink text="K3s" url="/integrations/packs/?pack=edge-k3s" />             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |
+| <VersionedLink text="PXK-E" url="/integrations/packs/?pack=edge-k8s" />           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| <VersionedLink text="RKE2" url="/integrations/packs/?pack=edge-rke2" />           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+<!-- prettier-ignore-end -->
 
 ## When Should You Consider Enabling Overlay Network?
 
@@ -64,7 +85,17 @@ server. The region experiences a bad weather event that causes a sustained outag
 ## Prerequisites
 
 - At least one Edge host registered with your Palette account.
-- Your cluster profile must have K3s, RKE2, or PXK-E as its Kubernetes distribution.
+
+<!-- prettier-ignore-start -->
+- Your cluster profile must have one of the following Kubernetes distributions:
+  
+  - <VersionedLink text="Palette eXtended Kubernetes Edge (PXK-E)" url="/integrations/packs/?pack=edge-k8s" />
+  - <VersionedLink text="Palette Optimized Canonical" url="/integrations/packs/?pack=edge-canonical" />
+  - <VersionedLink text="Palette Optimized K3s" url="/integrations/packs/?pack=edge-k3s" />
+  - <VersionedLink text="Palette Optimized RKE2" url="/integrations/packs/?pack=edge-rke2" />
+
+<!-- prettier-ignore-end -->
+
 - All Edge hosts must be on the same Layer-2 network.
 - Broadcast messages must be allowed between all Edge hosts participating in the cluster.
 

--- a/docs/docs-content/clusters/edge/networking/vxlan-overlay.md
+++ b/docs/docs-content/clusters/edge/networking/vxlan-overlay.md
@@ -123,10 +123,13 @@ server. The region experiences a bad weather event that causes a sustained outag
 - If your host's physical IP address is static, ensure that you configure the IP address using the
   [network block](../edge-configuration/installer-reference.md#site-network-parameters) in your `user-data` file.
 
-- If your hosts are deployed in [agent mode](../../../deployment-modes/agent-mode/agent-mode.md), ensure that your hosts
-  use `systemd-networkd` and `systemd-resolved` for interface and DNS management. Refer to
+- (Agent Mode only) By default, Edge hosts deployed using
+  [Appliance Mode](../../../deployment-modes/appliance-mode/appliance-mode.md) use `systemd-networkd` for interface
+  management and `systemd-resolved` for DNS resolution in overlay networks. If using
+  [Agent Mode](../../../deployment-modes/agent-mode/agent-mode.md), you must confirm that `systemd-networkd` and
+  `systemd-resolved` are installed on your Edge hosts and properly configured. Refer to our
   [Configure networkd to Prepare Host for Overlay Network](../../../deployment-modes/agent-mode/overlay-preparation.md)
-  for more information.
+  guide for more information.
 
 ## Enable Overlay Network
 

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
@@ -139,10 +139,14 @@ management mode to manage configurations, updates, and workloads.
     Required if you want Palette to manage Network Time Protocol (NTP).
   - [systemd-resolved](https://www.freedesktop.org/software/systemd/man/latest/systemd-resolved.service.html) - Required
     if you want Palette to manage Domain Name System (DNS) or if you plan to use overlay networks for clusters deployed
-    on your Edge host.
+    on your Edge host. Refer to our
+    [Configure networkd to Prepare Host for Overlay Network](../../../../../deployment-modes/agent-mode/overlay-preparation.md)
+    guide for information on installing and configuring `systemd-resolved`.
   - [systemd-networkd](https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd.html) - Required if you
     want Palette to manage static IP addresses or if you plan to use overlay networks for clusters deployed on your Edge
-    host.
+    host. Refer to our
+    [Configure networkd to Prepare Host for Overlay Network](../../../../../deployment-modes/agent-mode/overlay-preparation.md)
+    guide for information on installing and configuring `systemd-networkd`.
   - [conntrack](https://conntrack-tools.netfilter.org/downloads.html) - Required for clusters that use PXK-E as its
     Kubernetes layer.
   - [iptables](https://linux.die.net/man/8/iptables)

--- a/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
+++ b/docs/docs-content/clusters/public-cloud/aws/eks-hybrid-nodes/prepare-environment/prepare-edge-hosts.md
@@ -135,17 +135,18 @@ management mode to manage configurations, updates, and workloads.
   - [Zstandard](https://facebook.github.io/zstd/)
   - [rsync](https://github.com/RsyncProject/rsync)
   - [systemd](https://systemd.io/)
-  - [systemd-timesyncd](https://www.freedesktop.org/software/systemd/man/latest/systemd-timesyncd.service.html). This is
-    required if you want Palette to manage Network Time Protocol (NTP). If you don't want Palette to manage NTP, you can
-    skip this requirement.
-  - [systemd-resolved](https://www.freedesktop.org/software/systemd/man/latest/systemd-resolved.service.html). This is
-    required if you want Palette to manage Domain Name System (DNS). If you don't want Palette to manage DNS, you can
-    skip this requirement.
-  - [systemd-networkd](https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd.html). This requirement
-    is specific for clusters that use static IP addresses. You also need this if you want Palette to manage the Edge
-    host network.
+  - [systemd-timesyncd](https://www.freedesktop.org/software/systemd/man/latest/systemd-timesyncd.service.html) -
+    Required if you want Palette to manage Network Time Protocol (NTP).
+  - [systemd-resolved](https://www.freedesktop.org/software/systemd/man/latest/systemd-resolved.service.html) - Required
+    if you want Palette to manage Domain Name System (DNS) or if you plan to use overlay networks for clusters deployed
+    on your Edge host.
+  - [systemd-networkd](https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd.html) - Required if you
+    want Palette to manage static IP addresses or if you plan to use overlay networks for clusters deployed on your Edge
+    host.
+  - [conntrack](https://conntrack-tools.netfilter.org/downloads.html) - Required for clusters that use PXK-E as its
+    Kubernetes layer.
   - [iptables](https://linux.die.net/man/8/iptables)
-  - [rsyslog](https://github.com/rsyslog/rsyslog). This is required for audit logs.
+  - [rsyslog](https://github.com/rsyslog/rsyslog) - Required for audit logs.
 
   If you are using Ubuntu or any OS that uses apt or apt-get for package management, you can issue the following command
   to install all dependencies for installation with the following command:

--- a/docs/docs-content/deployment-modes/agent-mode/architecture.md
+++ b/docs/docs-content/deployment-modes/agent-mode/architecture.md
@@ -33,7 +33,7 @@ The following are architectural highlights of clusters deployed using agent mode
   - OS other than Ubuntu
   - Palette VerteX
   - Custom installation paths for Kubernetes and its dependencies in [agent mode](../)
-  - [Network overlay](../../../clusters/edge/networking/vxlan-overlay/)
+  - [Network overlay](../networking/vxlan-overlay/) in locally managed Edge clusters.
 
 <!-- prettier-ignore-start -->
 

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -69,19 +69,18 @@ Palette. You will then create a cluster profile and use the registered host to d
   - [Zstandard](https://facebook.github.io/zstd/)
   - [rsync](https://github.com/RsyncProject/rsync)
   - [systemd](https://systemd.io/)
-  - [systemd-timesyncd](https://www.freedesktop.org/software/systemd/man/latest/systemd-timesyncd.service.html). This is
-    required if you want Palette to manage Network Time Protocol (NTP). If you don't want Palette to manage NTP, you can
-    skip this requirement.
-  - [systemd-resolved](https://www.freedesktop.org/software/systemd/man/latest/systemd-resolved.service.html). This is
-    required if you want Palette to manage Domain Name System (DNS). If you don't want Palette to manage DNS, you can
-    skip this requirement
-  - [systemd-networkd](https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd.html). This requirement
-    is specific for clusters that use static IP addresses. You also need this if you want Palette to manage the Edge
-    host network
-  - [conntrack](https://conntrack-tools.netfilter.org/downloads.html). This requirement is specific for clusters that
-    use PXKE as the Kubernetes layer
+  - [systemd-timesyncd](https://www.freedesktop.org/software/systemd/man/latest/systemd-timesyncd.service.html) -
+    Required if you want Palette to manage Network Time Protocol (NTP).
+  - [systemd-resolved](https://www.freedesktop.org/software/systemd/man/latest/systemd-resolved.service.html) - Required
+    if you want Palette to manage Domain Name System (DNS) or if you plan to use overlay networks for clusters deployed
+    on your Edge host.
+  - [systemd-networkd](https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd.html) - Required if you
+    want Palette to manage static IP addresses or if you plan to use overlay networks for clusters deployed on your Edge
+    host.
+  - [conntrack](https://conntrack-tools.netfilter.org/downloads.html) - Required for clusters that use PXK-E as its
+    Kubernetes layer.
   - [iptables](https://linux.die.net/man/8/iptables)
-  - [rsyslog](https://github.com/rsyslog/rsyslog). This is required for audit logs.
+  - [rsyslog](https://github.com/rsyslog/rsyslog) - Required for audit logs.
   - (Local management mode only) [Palette Edge CLI](../../downloads/cli-tools.md#palette-edge-cli)
 
   If you are using Ubuntu or any OS that uses apt or apt-get for package management, you can issue the following command

--- a/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
+++ b/docs/docs-content/deployment-modes/agent-mode/install-agent-host.md
@@ -73,10 +73,12 @@ Palette. You will then create a cluster profile and use the registered host to d
     Required if you want Palette to manage Network Time Protocol (NTP).
   - [systemd-resolved](https://www.freedesktop.org/software/systemd/man/latest/systemd-resolved.service.html) - Required
     if you want Palette to manage Domain Name System (DNS) or if you plan to use overlay networks for clusters deployed
-    on your Edge host.
+    on your Edge host. Refer to our [Configure networkd to Prepare Host for Overlay Network](./overlay-preparation.md)
+    guide for information on installing and configuring `systemd-resolved`.
   - [systemd-networkd](https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd.html) - Required if you
     want Palette to manage static IP addresses or if you plan to use overlay networks for clusters deployed on your Edge
-    host.
+    host. Refer to our [Configure networkd to Prepare Host for Overlay Network](./overlay-preparation.md) guide for
+    information on installing and configuring `systemd-networkd`.
   - [conntrack](https://conntrack-tools.netfilter.org/downloads.html) - Required for clusters that use PXK-E as its
     Kubernetes layer.
   - [iptables](https://linux.die.net/man/8/iptables)

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -35,6 +35,15 @@ tags: ["release-notes"]
 
 #### Features
 
+<!-- prettier-ignore-start -->
+
+- Overlay networks are now supported for the following cluster types. Refer to our [Enable Overlay Network](../clusters/edge/networking/vxlan-overlay.md#supported-clusters) guide for a comprehensive list of supported cluster combinations.
+  
+  - <VersionedLink text="Palette eXtended Kubernetes Edge (PXK-E)" url="/integrations/packs/?pack=edge-k8s" /> - FIPS, single and multi-node clusters
+  - <VersionedLink text="Palette Optimized Canonical" url="/integrations/packs/?pack=edge-canonical" /> -  Agent Mode and Appliance Mode, centrally managed clusters
+
+<!-- prettier-ignore-end -->
+
 #### Improvements
 
 #### Bug Fixes


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

As a result of additional overlay support for 4.7.c, this PR adds a supported cluster types table to the overlay network page to clarify what combinations are and are not supported. It also clarifies the functionality of `systemd-networkd` and `systemd-resolved` in respect to overlay networks.

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Add Preview URL for Page]()

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

- [DOC-2268](https://spectrocloud.atlassian.net/browse/DOC-2268)
- [DOC-2285](https://spectrocloud.atlassian.net/browse/DOC-2285)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

Release work. 