### PR TITLE
docs: password policy maximum character enforcement PEM-8603

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -21,6 +21,9 @@ tags: ["release-notes"]
 
 #### Breaking Changes {#breaking-changes-4.7.c}
 
+- Palette and VerteX [password policies](../tenant-settings/password-policy.md) are now capped to a maximum of 128
+  characters. This change applies to new passwords only.
+
 #### Features
 
 #### Improvements

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -22,7 +22,7 @@ tags: ["release-notes"]
 #### Breaking Changes {#breaking-changes-4.7.c}
 
 - Palette and VerteX [password policies](../tenant-settings/password-policy.md) are now capped to a maximum of 128
-  characters. This change applies to new passwords only.
+  characters. This change applies only to new passwords.
 
 #### Features
 

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -32,7 +32,7 @@ If you want to change the default password policy, follow the steps below.
 
 3. From the **Tenant Settings Menu**, select **Password Policy**.
 
-4. Configure the password policy using the configuration fields.
+4. Set up the password policy using the configuration fields.
 
    | **Configuration**                    | **Description**                                                                                                                             |
    | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -1,0 +1,61 @@
+---
+sidebar_label: "Password Policy"
+title: "Password Policy"
+description: "Learn how to configure the password policy for your Palette tenant."
+icon: ""
+hide_table_of_contents: false
+sidebar_position: 40
+tags: ["tenant-administration", "session-timeout"]
+---
+
+Tenant administrators can update the password policy for Palette users. The default password policy is as follows.
+
+- The password must be at least 6 characters long.
+- The password must be at most 64 characters long.
+- The password expires after 365 days.
+- The password must contain at least one uppercase letter.
+- The password must contain at least one lowercase letter.
+- The password must contain at least one digit.
+- The password must contain at least one special character.
+
+If you want to change the default password, follow the steps below.
+
+## Prerequisites
+
+- Palette tenant admin access.
+
+## Update Password Policy
+
+1. Log in to [Palette](https://console.spectrocloud.com) as a tenant admin.
+
+2. Navigate to the left **Main Menu** and select **Tenant Settings**.
+
+3. From the **Tenant Settings Menu**, select **Password Policy**.
+
+4. Configure the password policy using the configuration fields.
+
+   | **Configuration**                    | **Description**                                                                                                                             |
+   | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Enable Regex**                     | Enable if you want to specify the password policy using a regular expression.                                                               |
+   | **Regex**                            | Specify a regular expression that the passwords must conform to.                                                                            |
+   | **Expiry Duration**                  | Set a password expiry time. Select from **3 months**, **6 months** and **Custom**.                                                          |
+   | **Expiry Duration (Days)**           | If you have selected custom expiry duration, specify a number of days for password expiry.                                                  |
+   | **First Reminder (Days)**            | Specify when to send out a password expiry reminder email to users.                                                                         |
+   | **Min Length**                       | Specify the minimum length of the password. The configured value must be between 6 and 128 and should not exceed the **Max Length**.        |
+   | **Max Length**                       | Specify the maximum length of the password. The configured value must be between 6 and 128 and should not be less than then **Min Length**. |
+   | **Min Number Of Block Letters**      | Specify the minimum number of uppercase letters in the password. The configured value must be larger than 1.                                |
+   | **Min Number Of Digits**             | Specify the minimum number of digits in the password. The configured value must be larger than 1.                                           |
+   | **Min Number Of Small Letters**      | Specify the minimum number of lowercase letters in the password. The configured value must be larger than 1.                                |
+   | **Min Number Of Special Characters** | Specify the minimum number of special characters in the password. The configured value must be larger than 1.                               |
+
+5. Click on **Save** to save the changes.
+
+### Validate
+
+1. Log in to [Palette](https://console.spectrocloud.com) as a tenant admin.
+
+2. Navigate to your username and select **My Profile**.
+
+3. Enter a new password in the **New Password** field. You can test the password policy with different values. For
+   example, you can enter an all lowercase password to ensure that the configured number of uppercase characters is
+   enforced.

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -5,7 +5,7 @@ description: "Learn how to configure the password policy for your Palette tenant
 icon: ""
 hide_table_of_contents: false
 sidebar_position: 40
-tags: ["tenant-administration", "session-timeout"]
+tags: ["tenant-administration", "security", "password"]
 ---
 
 Tenant administrators can update the password policy for Palette users. The default password policy is as follows.

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -50,7 +50,7 @@ If you want to change the default password, follow the steps below.
 
 5. Click on **Save** to save the changes.
 
-### Validate
+## Validate
 
 1. Log in to [Palette](https://console.spectrocloud.com) as a tenant admin.
 

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -39,7 +39,7 @@ If you want to change the default password policy, follow the steps below.
    | **Enable Regex**                     | Enable if you want to specify the password policy using a regular expression.                                                               |
    | **Regex**                            | Specify a regular expression that the passwords must conform to.                                                                            |
    | **Expiry Duration**                  | Set a password expiry time. Select from **3 months**, **6 months**, and **Custom**.                                                          |
-   | **Expiry Duration (Days)**           | If you have selected custom expiry duration, specify a number of days for password expiry.                                                  |
+   | **Expiry Duration (Days)**           | If you have selected **Custom** expiry duration, specify a number of days for password expiry.                                                  |
    | **First Reminder (Days)**            | Specify when to send out a password expiry reminder email to users.                                                                         |
    | **Min Length**                       | Specify the minimum length of the password. The configured value must be between 6 and 128 and should not exceed the **Max Length**.        |
    | **Max Length**                       | Specify the maximum length of the password. The configured value must be between 6 and 128 and should not be less than then **Min Length**. |

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -4,7 +4,7 @@ title: "Password Policy"
 description: "Learn how to configure the password policy for your Palette tenant."
 icon: ""
 hide_table_of_contents: false
-sidebar_position: 40
+sidebar_position: 50
 tags: ["tenant-administration", "security", "password"]
 ---
 

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -38,7 +38,7 @@ If you want to change the default password policy, follow the steps below.
    | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
    | **Enable Regex**                     | Enable if you want to specify the password policy using a regular expression.                                                               |
    | **Regex**                            | Specify a regular expression that the passwords must conform to.                                                                            |
-   | **Expiry Duration**                  | Set a password expiry time. Select from **3 months**, **6 months** and **Custom**.                                                          |
+   | **Expiry Duration**                  | Set a password expiry time. Select from **3 months**, **6 months**, and **Custom**.                                                          |
    | **Expiry Duration (Days)**           | If you have selected custom expiry duration, specify a number of days for password expiry.                                                  |
    | **First Reminder (Days)**            | Specify when to send out a password expiry reminder email to users.                                                                         |
    | **Min Length**                       | Specify the minimum length of the password. The configured value must be between 6 and 128 and should not exceed the **Max Length**.        |

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -34,19 +34,19 @@ If you want to change the default password policy, follow the steps below.
 
 4. Set up the password policy using the configuration fields.
 
-   | **Configuration**                    | **Description**                                                                                                                             |
-   | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-   | **Enable Regex**                     | Enable if you want to specify the password policy using a regular expression.                                                               |
-   | **Regex**                            | Specify a regular expression that the passwords must conform to.                                                                            |
-   | **Expiry Duration**                  | Set a password expiry time. Select from **3 months**, **6 months**, and **Custom**.                                                          |
-   | **Expiry Duration (Days)**           | If you have selected **Custom** expiry duration, specify a number of days for password expiry.                                                  |
-   | **First Reminder (Days)**            | Specify the number of days before the password expires to send the first reminder email to users.|
-   | **Min Length**                       | Specify the minimum length of the password. The configured value must be between 6 and 128 and should not exceed the **Max Length**.        |
+   | **Configuration**                    | **Description**                                                                                                                            |
+   | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+   | **Enable Regex**                     | Enable if you want to specify the password policy using a regular expression.                                                              |
+   | **Regex**                            | Specify a regular expression that the passwords must conform to.                                                                           |
+   | **Expiry Duration**                  | Set a password expiry time. Select from **3 months**, **6 months**, and **Custom**.                                                        |
+   | **Expiry Duration (Days)**           | If you have selected **Custom** expiry duration, specify a number of days for password expiry.                                             |
+   | **First Reminder (Days)**            | Specify the number of days before the password expires to send the first reminder email to users.                                          |
+   | **Min Length**                       | Specify the minimum length of the password. The configured value must be between 6 and 128 and should not exceed the **Max Length**.       |
    | **Max Length**                       | Specify the maximum length of the password. The configured value must be between 6 and 128 and should not be less than the **Min Length**. |
-   | **Min Number Of Block Letters**      | Specify the minimum number of uppercase letters in the password. The configured value must be larger than 1.                                |
-   | **Min Number Of Digits**             | Specify the minimum number of digits in the password. The configured value must be larger than 1.                                           |
-   | **Min Number Of Small Letters**      | Specify the minimum number of lowercase letters in the password. The configured value must be larger than 1.                                |
-   | **Min Number Of Special Characters** | Specify the minimum number of special characters in the password. The configured value must be larger than 1.                               |
+   | **Min Number Of Block Letters**      | Specify the minimum number of uppercase letters in the password. The configured value must be larger than 1.                               |
+   | **Min Number Of Digits**             | Specify the minimum number of digits in the password. The configured value must be larger than 1.                                          |
+   | **Min Number Of Small Letters**      | Specify the minimum number of lowercase letters in the password. The configured value must be larger than 1.                               |
+   | **Min Number Of Special Characters** | Specify the minimum number of special characters in the password. The configured value must be larger than 1.                              |
 
 5. Click on **Save** to apply the changes.
 

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -28,7 +28,7 @@ If you want to change the default password policy, follow the steps below.
 
 1. Log in to [Palette](https://console.spectrocloud.com) as a tenant admin.
 
-2. Navigate to the left **Main Menu** and select **Tenant Settings**.
+2. Navigate to the left main menu and select **Tenant Settings**.
 
 3. From the **Tenant Settings Menu**, select **Password Policy**.
 

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -18,7 +18,7 @@ Tenant administrators can update the password policy for Palette users. The defa
 - The password must contain at least one digit.
 - The password must contain at least one special character.
 
-If you want to change the default password, follow the steps below.
+If you want to change the default password policy, follow the steps below.
 
 ## Prerequisites
 

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -10,7 +10,7 @@ tags: ["tenant-administration", "security", "password"]
 
 Tenant administrators can update the password policy for Palette users. The default password policy is as follows.
 
-- The password must be at least 6 characters long.
+- The password must be at least six characters long.
 - The password must be at most 64 characters long.
 - The password expires after 365 days.
 - The password must contain at least one uppercase letter.

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -40,7 +40,7 @@ If you want to change the default password policy, follow the steps below.
    | **Regex**                            | Specify a regular expression that the passwords must conform to.                                                                            |
    | **Expiry Duration**                  | Set a password expiry time. Select from **3 months**, **6 months**, and **Custom**.                                                          |
    | **Expiry Duration (Days)**           | If you have selected **Custom** expiry duration, specify a number of days for password expiry.                                                  |
-   | **First Reminder (Days)**            | Specify when to send out a password expiry reminder email to users.                                                                         |
+   | **First Reminder (Days)**            | Specify the number of days before the password expires to send the first reminder email to users.|
    | **Min Length**                       | Specify the minimum length of the password. The configured value must be between 6 and 128 and should not exceed the **Max Length**.        |
    | **Max Length**                       | Specify the maximum length of the password. The configured value must be between 6 and 128 and should not be less than the **Min Length**. |
    | **Min Number Of Block Letters**      | Specify the minimum number of uppercase letters in the password. The configured value must be larger than 1.                                |

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -42,7 +42,7 @@ If you want to change the default password policy, follow the steps below.
    | **Expiry Duration (Days)**           | If you have selected **Custom** expiry duration, specify a number of days for password expiry.                                                  |
    | **First Reminder (Days)**            | Specify when to send out a password expiry reminder email to users.                                                                         |
    | **Min Length**                       | Specify the minimum length of the password. The configured value must be between 6 and 128 and should not exceed the **Max Length**.        |
-   | **Max Length**                       | Specify the maximum length of the password. The configured value must be between 6 and 128 and should not be less than then **Min Length**. |
+   | **Max Length**                       | Specify the maximum length of the password. The configured value must be between 6 and 128 and should not be less than the **Min Length**. |
    | **Min Number Of Block Letters**      | Specify the minimum number of uppercase letters in the password. The configured value must be larger than 1.                                |
    | **Min Number Of Digits**             | Specify the minimum number of digits in the password. The configured value must be larger than 1.                                           |
    | **Min Number Of Small Letters**      | Specify the minimum number of lowercase letters in the password. The configured value must be larger than 1.                                |

--- a/docs/docs-content/tenant-settings/password-policy.md
+++ b/docs/docs-content/tenant-settings/password-policy.md
@@ -48,7 +48,7 @@ If you want to change the default password policy, follow the steps below.
    | **Min Number Of Small Letters**      | Specify the minimum number of lowercase letters in the password. The configured value must be larger than 1.                                |
    | **Min Number Of Special Characters** | Specify the minimum number of special characters in the password. The configured value must be larger than 1.                               |
 
-5. Click on **Save** to save the changes.
+5. Click on **Save** to apply the changes.
 
 ## Validate
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR creates a new password policy page and documents the maximum password length enforcement. 

## Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

💻 [Release Notes](https://deploy-preview-8334--docs-spectrocloud.netlify.app/release-notes/)
💻 [Password Policies](https://deploy-preview-8334--docs-spectrocloud.netlify.app/tenant-settings/password-policy/)


## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PEM-8603](https://spectrocloud.atlassian.net/browse/PEM-8603)

## Backports

<!-- Add the relevant backport labels to reflect which versions of the docs your changes will affect. -->

Can this PR be backported?

- [x] No. _Please leave a short comment below about why this PR cannot be backported._
No, release ticket.


[PEM-8603]: https://spectrocloud.atlassian.net/browse/PEM-8603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ