### PR TITLE
docs: DOC-2721: Correcting airgap binary URLs

### DIFF
--- a/_partials/self-hosted/_setup-steps.mdx
+++ b/_partials/self-hosted/_setup-steps.mdx
@@ -270,7 +270,7 @@ partial_name: setup-steps
 
     <Tabs>
 
-    <TabItem value="palette" label="Palette"
+    <TabItem value="palette" label="Palette">
 
     ```shell
     chmod +x airgap-<version>.bin && ./airgap-<version>.bin

--- a/_partials/self-hosted/_setup-steps.mdx
+++ b/_partials/self-hosted/_setup-steps.mdx
@@ -268,6 +268,10 @@ partial_name: setup-steps
 
 18. Start the {props.edition} installation binary, which uploads release-specific {props.edition} images and packs to the Harbor registry. Replace `<version>` with the version of the binary received from the support team.
 
+    <Tabs>
+
+    <TabItem value="palette" label="Palette"
+
     ```shell
     chmod +x airgap-<version>.bin && ./airgap-<version>.bin
     ```
@@ -275,8 +279,26 @@ partial_name: setup-steps
     Consider the following example for reference.
 
     ```shell
-    chmod +x airgap-4-4-14.bin && ./airgap-4-4-14.bin
+    chmod +x airgap-v4.4.14.bin && ./airgap-v4.4.14.bin
     ```
+
+    </TabItem>
+
+    <TabItem value="vertex" label="Palette VerteX">
+
+    ```shell
+    chmod +x airgap-vertex-<version>.bin && ./airgap-vertex-<version>.bin
+    ```
+    
+    Consider the following example for reference.
+
+    ```shell
+    chmod +x airgap-vertex-v4.4.14.bin && ./airgap-vertex-v4.4.14.bin
+    ```
+
+    </TabItem>
+
+    </Tabs>
 
     This step may take some time to complete. A `Setup Completed` message confirms it is finished.
 

--- a/docs/docs-content/downloads/palette-vertex/additional-packs.md
+++ b/docs/docs-content/downloads/palette-vertex/additional-packs.md
@@ -24,8 +24,8 @@ You must SSH into your Palette VerteX airgap support VM to download and install 
 username and password for the support team's private repository. Reach out to our support team to
 [obtain the credentials](../../vertex/vertex.md#access-palette-vertex).
 
-The following example shows how to download the `airgap-vertex-pack-cni-calico-3.25.1.bin` binary. Replace `XXXX` with
-your username and `YYYY` with your password.
+The following example shows how to download the `airgap-vertex-pack-cni-calico-3.30.2.bin` binary. Replace `<username>`
+with your username and `<password>` with your password.
 
 1. In your terminal, use the following command template to SSH into the Palette airgap support VM. Enter the path to
    your private SSH key, username, and the IP or domain of the airgap support VM. The default username is `ubuntu`.
@@ -34,9 +34,7 @@ your username and `YYYY` with your password.
    ssh -i </path/to/private/key> <username>@<vm-ip-or-domain>
    ```
 
-   Consider the following command example for reference.
-
-   ```shell
+   ```shell title="Example command" hideClipboard
    ssh -i /docs/ssh-private-key.pem ubuntu@palette.example.com
    ```
 
@@ -53,9 +51,13 @@ your username and `YYYY` with your password.
    <TabItem label="curl" value="curl">
 
    ```bash
-   curl --user 'XXXX:YYYY' \
-   https://software-private.spectrocloud.com/airgap-fips/packs/airgap-vertex-pack-cni-calico-3.25.1.bin \
-   --output airgap-vertex-pack-cni-calico-3.25.1.bin
+   curl --user '<username>:<password>' <download-link> \
+   --output <filename>
+   ```
+
+   ```bash title="Example command" hideClipboard
+   curl --user username:password https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-3.30.2.bin  \
+   --output airgap-vertex-pack-cni-calico-3.30.2.bin
    ```
 
    </TabItem>
@@ -63,9 +65,15 @@ your username and `YYYY` with your password.
    <TabItem label="wget" value="wget">
 
    ```shell
-   wget --user='XXXX' --password='YYYY' \
-   --output-document=airgap-vertex-pack-cni-calico-3.25.1.bin \
-   https://software-private.spectrocloud.com/airgap-fips/packs/airgap-vertex-pack-cni-calico-3.25.1.bin
+   wget --user='<username>' --password='<password>' \
+   --output-document=<filename> \
+   <download-link>
+   ```
+
+   ```shell title="Example command" hideClipboard
+   wget --user='username' --password='password' \
+   --output-document airgap-vertex-pack-cni-calico-3.30.2.bin \
+   https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-3.30.2.bin
    ```
 
    </TabItem>
@@ -76,8 +84,11 @@ your username and `YYYY` with your password.
    binary name with the one you downloaded.
 
    ```bash
-   chmod +x airgap-vertex-pack-cni-calico-3.25.1.bin && \
-   ./airgap-vertex-pack-cni-calico-3.25.1.bin
+   chmod +x <filename> && ./<filename>
+   ```
+
+   ```bash title="Example command" hideClipboard
+   chmod +x airgap-vertex-pack-cni-calico-3.30.2.bin && ./airgap-vertex-pack-cni-calico-3.30.2.bin
    ```
 
 :::info

--- a/docs/docs-content/downloads/palette-vertex/additional-packs.md
+++ b/docs/docs-content/downloads/palette-vertex/additional-packs.md
@@ -56,7 +56,7 @@ with your username and `<password>` with your password.
    ```
 
    ```bash title="Example command" hideClipboard
-   curl --user username:password https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-3.30.2.bin  \
+   curl --user 'username:password' https://software-private.spectrocloud.com/airgap-vertex/packs/airgap-vertex-pack-cni-calico-3.30.2.bin  \
    --output airgap-vertex-pack-cni-calico-3.30.2.bin
    ```
 

--- a/docs/docs-content/downloads/self-hosted-palette/additional-packs.md
+++ b/docs/docs-content/downloads/self-hosted-palette/additional-packs.md
@@ -56,7 +56,7 @@ The following example shows how to download the `argo-cd-8.3.0.bin` binary. Repl
    ```
 
    ```bash title="Example command" hideClipboard
-   curl --user username:password https://software-private.spectrocloud.com/airgap/packs/argo-cd-8.3.0.bin  \
+   curl --user 'username:password' https://software-private.spectrocloud.com/airgap/packs/argo-cd-8.3.0.bin  \
    --output argo-cd-8.3.0.bin
    ```
 

--- a/docs/docs-content/downloads/self-hosted-palette/additional-packs.md
+++ b/docs/docs-content/downloads/self-hosted-palette/additional-packs.md
@@ -24,8 +24,8 @@ You must SSH into your Palette airgap support VM to download and install the bin
 and password for the support team's private repository. Reach out to our support team to
 [obtain the credentials](../../enterprise-version/enterprise-version.md#access-palette).
 
-The following example shows how to download the `airgap-pack-aws-alb-2.5.1.bin` binary. Replace `XXXX` with your
-username and `YYYY` with your password.
+The following example shows how to download the `argo-cd-8.3.0.bin` binary. Replace `<username>` with your username and
+`<password>` with your password.
 
 1. In your terminal, use the following command template to SSH into the Palette airgap support VM. Enter the path to
    your private SSH key, username, and the IP or domain of the airgap support VM. The default username is `ubuntu`.
@@ -34,9 +34,7 @@ username and `YYYY` with your password.
    ssh -i </path/to/private/key> <username>@<vm-ip-or-domain>
    ```
 
-   Consider the following command example for reference.
-
-   ```shell
+   ```shell title="Example command" hideClipboard
    ssh -i /docs/ssh-private-key.pem ubuntu@palette.example.com
    ```
 
@@ -53,9 +51,13 @@ username and `YYYY` with your password.
    <TabItem label="curl" value="curl">
 
    ```bash
-   curl --user 'XXXX:YYYY' \
-   https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-aws-ebs-1.26.1.bin \
-   --output airgap-pack-csi-aws-ebs-1.26.1.bin
+   curl --user '<username>:<password>' <download-link> \
+   --output <filename>
+   ```
+
+   ```bash title="Example command" hideClipboard
+   curl --user username:password https://software-private.spectrocloud.com/airgap/packs/argo-cd-8.3.0.bin  \
+   --output argo-cd-8.3.0.bin
    ```
 
    </TabItem>
@@ -63,9 +65,15 @@ username and `YYYY` with your password.
    <TabItem label="wget" value="wget">
 
    ```shell
-   wget --user='XXXX' --password='YYYY' \
-   --output-document=airgap-pack-csi-aws-ebs-1.26.1.bin \
-   https://software-private.spectrocloud.com/airgap/packs/airgap-pack-csi-aws-ebs-1.26.1.bin
+   wget --user='<username>' --password='<password>' \
+   --output-document=<filename> \
+   <download-link>
+   ```
+
+   ```shell title="Example command" hideClipboard
+   wget --user='username' --password='password' \
+   --output-document argo-cd-8.3.0.bin \
+   https://software-private.spectrocloud.com/airgap/packs/argo-cd-8.3.0.bin
    ```
 
    </TabItem>
@@ -76,8 +84,11 @@ username and `YYYY` with your password.
    binary name with the one you downloaded.
 
    ```bash
-   chmod +x airgap-pack-csi-aws-ebs-1.26.1.bin && \
-   ./airgap-pack-csi-aws-ebs-1.26.1.bin
+   chmod +x <filename> && ./<filename>
+   ```
+
+   ```bash title="Example command" hideClipboard
+   chmod +x argo-cd-8.3.0.bin && ./argo-cd-8.3.0.bin
    ```
 
 :::info

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/kubernetes-airgap-instructions.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/kubernetes-airgap-instructions.md
@@ -89,15 +89,15 @@ Complete the following steps before deploying the airgap VerteX installation.
    ```
 
    ```shell
-   curl --user XXXXX:YYYYYYY https://software-private.spectrocloud.com/airgap-fips/$VERSION/airgap-fips-v$VERSION.bin  \
-   --output airgap-fips-v$VERSION.bin
+   curl --user XXXXX:YYYYYYY https://software-private.spectrocloud.com/airgap-vertex/$VERSION/airgap-vertex-v$VERSION.bin  \
+   --output airgap-vertex-v$VERSION.bin
    ```
 
 7. Update the airgap setup binary permissions to allow execution. Replace the file name below with the name of the
    airgap setup binary you downloaded.
 
    ```shell
-   chmod +x airgap-fips-v$VERSION.bin
+   chmod +x airgap-vertex-v$VERSION.bin
    ```
 
 8. Copy or move the airgap binary to another Linux environment inside your airgap environment. Use any approved method
@@ -229,7 +229,7 @@ Complete the following steps before deploying the airgap VerteX installation.
 12. Start the airgap setup binary. Replace the file name below with the name of the airgap setup binary you downloaded.
 
     ```shell
-    ./airgap-fips-v$VERSION.bin
+    ./airgap-vertex-v$VERSION.bin
     ```
 
     Upon completion, a success message will be displayed. The output is condensed for brevity.
@@ -252,19 +252,19 @@ Complete the following steps before deploying the airgap VerteX installation.
     upload process. This step requires internet access, so you may have to download the binaries on a separate machine
     outside the airgap environment and transfer them to the airgap environment using an approved method.
 
-    In the example below, the `airgap-fips-pack-amazon-linux-eks-1.0.0.bin` binary permissions are updated to allow
+    In the example below, the `airgap-vertex-pack-cni-calico-3.25.1.bin` binary permissions are updated to allow
     execution and the binary is started.
 
-    ```shell
-    chmod +x airgap-fips-pack-amazon-linux-eks-1.0.0.bin && \
-    ./airgap-fips-pack-amazon-linux-eks-1.0.0.bin
+    ```shell title="Example command" hideClipboard
+    chmod +x airgap-vertex-pack-cni-calico-3.25.1.bin && \
+    ./airgap-vertex-pack-cni-calico-3.25.1.bin
     ```
 
-    ```shell hideClipboard
+    ```shell title="Example output" hideClipboard
       Verifying archive integrity...  100%   MD5 checksums are OK. All good.
-      Uncompressing Airgap Pack - amazon-linux-eks Version 4.0.17  100%
+      Uncompressing Airgap Pack - cni-calico Version 3.25.1  100%
       Setting up Packs
-      - Pushing Pack amazon-linux-eks:1.0.0
+      - Pushing Pack cni-calico:3.25.1
       Setup Completed
     ```
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR corrects incorrect airgap binary links for the VerteX installation and standardizes several commands for additional pack downloads, which can vary based on the pack location.

**NOTE:** While NOT ideal, to avoid conflicts with the self-hosted refactor as much as possible, I introduced a Palette/VerteX tab in an existing partial, where the command differs. Otherwise, we would have had to split the page into multiple partials or remove it altogether. 

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Environment Setup with an Existing RHEL VM - Palette](https://deploy-preview-9978--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/airgap-install/environment-setup/env-setup-vm/) - Updated partial with tabs
- [Environment Setup with an Existing RHEL VM - VerteX](https://deploy-preview-9978--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/airgap-install/environment-setup/env-setup-vm-vertex/) - Updated partial with tabs
- [Additional Packs - Palette](https://deploy-preview-9978--docs-spectrocloud.netlify.app/downloads/self-hosted-palette/additional-packs/#usage-instructions) - Updated Usage Instructions section
- [Additional Packs - VerteX](https://deploy-preview-9978--docs-spectrocloud.netlify.app/downloads/palette-vertex/additional-packs/#usage-instructions) - Updated Usage Instructions section
- [Environment Setup - VerteX](https://deploy-preview-9978--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/kubernetes-airgap-instructions/) - Changed `airgap-fips` > `airgap-vertex`

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-2721](https://spectrocloud.atlassian.net/browse/DOC-2721)


[DOC-2721]: https://spectrocloud.atlassian.net/browse/DOC-2721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ