### PR TITLE
DOC-2737 - Remove specific Kubernetes version references from containerd 2.0 requirements (VMMA)

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -275,9 +275,9 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 - Two new prerequisites have been added to the
   [Create VM Migration Assistant Profile](../vm-management/vm-migration-assistant/create-vm-migration-assistant-profile.md#prerequisites)
-  guide. These prerequisites cover the use of Ubuntu 24.04 and Kubernetes 1.33 (or later) whereby additional parameters
-  must be added to the OS and Kubernetes layers of the cluster profile to ensure the VM Migration Assistant functions
-  properly during disk or image conversions.
+  guide. These prerequisites cover the use of Ubuntu 24.04 and [containerd](https://containerd.io/) v2 whereby
+  additional parameters must be added to the OS and Kubernetes layers of the cluster profile to ensure the VM Migration
+  Assistant functions properly during disk or image conversions.
 
 ### Automation
 

--- a/docs/docs-content/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile.md
+++ b/docs/docs-content/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile.md
@@ -21,13 +21,13 @@ Follow these steps to create a new add-on profile that will be applied to your e
 
 <!-- prettier-ignore-start -->
 
-- If you using an Ubuntu 24.04 pack such as 
-  <VersionedLink text="Ubuntu 24.04 for MaaS" url="/integrations/packs/?pack=ubuntu-maas" /> as your OS layer, you must
-  set `kernel.apparmor_restrict_unprivileged_userns=0` in the
-  `/etc/sysctl.d/10-kubernetes-tuning.conf` file through the OS layer configuration in the cluster profile to ensure that the configuration persists after node restarts.
+- If you using an Ubuntu 24.04 pack as your OS layer, such as
+  <VersionedLink text="Ubuntu 24.04 for MaaS" url="/integrations/packs/?pack=ubuntu-maas" />, you must set
+  `kernel.apparmor_restrict_unprivileged_userns=0` in the `/etc/sysctl.d/10-kubernetes-tuning.conf` file through the OS
+  layer configuration in the cluster profile to ensure that the configuration persists after node restarts.
 
-  This is required to allow the VM Migration Assistant to perform disk or image conversions without running into permission
-  issues related to unprivileged user namespaces. 
+  This is required to allow the VM Migration Assistant to perform disk or image conversions without running into
+  permission issues related to unprivileged user namespaces.
 
   <details>
 
@@ -61,7 +61,8 @@ Follow these steps to create a new add-on profile that will be applied to your e
      ```
 
      If your cluster profile already has a configuration for the `10-kubernetes-tuning.conf` file, add the
-     `kernel.apparmor_restrict_unprivileged_userns=0` line to the existing content while ensuring proper YAML formatting.
+     `kernel.apparmor_restrict_unprivileged_userns=0` line to the existing content while ensuring proper YAML
+     formatting.
 
   8. Click **Confirm Updates** to save the changes to the OS layer configuration.
 
@@ -74,13 +75,13 @@ Follow these steps to create a new add-on profile that will be applied to your e
 
 <!-- prettier-ignore-end -->
 
-- If you using Kubernetes 1.33 or above, you must set the `device_ownership_from_security_context = true` parameter and
-  value in the `/etc/containerd/conf.d/device-ownership.toml` file through the Kubernetes layer configuration in the
-  cluster profile to ensure that the configuration persists after node restarts.
+- If your OS pack/image uses [containerd](https://containerd.io/) v2, you must set the
+  `device_ownership_from_security_context = true` parameter and value in the
+  `/etc/containerd/conf.d/device-ownership.toml` file through the Kubernetes layer configuration in the cluster profile
+  to ensure that the configuration persists after node restarts.
 
   Enable this setting so non-root Container Device Interface (CDI) pods can access block devices during block-volume
-  transfer operations. From Kubernetes 1.33, containerd v2 is used as the container runtime, and this parameter is now
-  opt-in.
+  transfer operations. Since containerd v2, this parameter is opt-in and must be set to true.
 
   <details>
 

--- a/docs/docs-content/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile.md
+++ b/docs/docs-content/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile.md
@@ -76,9 +76,8 @@ Follow these steps to create a new add-on profile that will be applied to your e
 <!-- prettier-ignore-end -->
 
 - If your OS pack or node image uses [containerd](https://containerd.io/) v2, you must set
-  `device_ownership_from_security_context = true` in the
-  `/etc/containerd/conf.d/device-ownership.toml` file using the Kubernetes layer of your cluster profile
-  to ensure that the configuration persists after node restarts.
+  `device_ownership_from_security_context = true` in the `/etc/containerd/conf.d/device-ownership.toml` file using the
+  Kubernetes layer of your cluster profile to ensure that the configuration persists after node restarts.
 
   Enable this setting so non-root Container Device Interface (CDI) pods can access block devices during block-volume
   transfer operations. Since containerd v2, this parameter is opt-in and must be set to true.

--- a/docs/docs-content/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile.md
+++ b/docs/docs-content/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile.md
@@ -75,9 +75,9 @@ Follow these steps to create a new add-on profile that will be applied to your e
 
 <!-- prettier-ignore-end -->
 
-- If your OS pack/image uses [containerd](https://containerd.io/) v2, you must set the
-  `device_ownership_from_security_context = true` parameter and value in the
-  `/etc/containerd/conf.d/device-ownership.toml` file through the Kubernetes layer configuration in the cluster profile
+- If your OS pack or node image uses [containerd](https://containerd.io/) v2, you must set
+  `device_ownership_from_security_context = true` in the
+  `/etc/containerd/conf.d/device-ownership.toml` file using the Kubernetes layer of your cluster profile
   to ensure that the configuration persists after node restarts.
 
   Enable this setting so non-root Container Device Interface (CDI) pods can access block devices during block-volume


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adjusts the wording for the containerd v2 compatibility with the VM Migration Assistant to remove the Kubernetes version reference. It has been clarified that the Kubernetes version is not relevant; only the containerd version in the OS image/pack is.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Create a VM Migration Assistant Profile](https://deploy-preview-10047--docs-spectrocloud.netlify.app/vm-management/vm-migration-assistant/create-vm-migration-assistant-profile/#prerequisites) - clarified the requirements for the containerd v2 support. Also improved the sentence for the first Ubuntu 24.04 prerequisite.
- [Release Notes](https://deploy-preview-10047--docs-spectrocloud.netlify.app/release-notes/#improvements-1) - re-wording of original release note.

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-2737](https://spectrocloud.atlassian.net/browse/DOC-2737)


[DOC-2737]: https://spectrocloud.atlassian.net/browse/DOC-2737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ