### PR TITLE
docs: Troubleshooting - AL2 Traefik Capability on Self-Hosted

### DIFF
--- a/_partials/self-hosted/_install-on-kubernetes-al2.mdx
+++ b/_partials/self-hosted/_install-on-kubernetes-al2.mdx
@@ -1,0 +1,16 @@
+---
+partial_category: self-hosted
+partial_name: install-on-kubernetes-al2
+---
+
+:::warning
+
+The Traefik ingress controller, which is installed by default beginning with {props.edition} version 4.8.47,
+configures the non-root security context `NET_BIND_SERVICE` Linux capability in the Traefik DaemonSet. This
+capability is not supported on deprecated Amazon Linux 2 (AL2) nodes, resulting in a `CrashLoopBackOff` state on
+`traefik-ingress-controller` pods. Refer to our
+[Troubleshooting - Traefik Ingress Controller Pods Crash on Amazon Linux 2 EKS Nodes](/troubleshooting/enterprise-install/#scenario---traefik-ingress-controller-pods-crash-on-amazon-linux-2-eks-nodes)
+guide for the workaround.
+
+:::
+

--- a/_partials/self-hosted/_install-on-kubernetes-al2.mdx
+++ b/_partials/self-hosted/_install-on-kubernetes-al2.mdx
@@ -9,7 +9,7 @@ The Traefik ingress controller, which is installed by default beginning with {pr
 configures the non-root security context `NET_BIND_SERVICE` Linux capability in the Traefik DaemonSet. This
 capability is not supported on deprecated Amazon Linux 2 (AL2) nodes, resulting in a `CrashLoopBackOff` state on
 `traefik-ingress-controller` pods. Refer to our
-[Troubleshooting - Traefik Ingress Controller Pods Crash on Amazon Linux 2 EKS Nodes](/troubleshooting/enterprise-install/#scenario---traefik-ingress-controller-pods-crash-on-amazon-linux-2-eks-nodes)
+[Troubleshooting - Traefik Ingress Controller Pods Crash on Amazon Linux 2 Nodes](/troubleshooting/enterprise-install/#scenario---traefik-ingress-controller-pods-crash-on-amazon-linux-2-nodes)
 guide for the workaround.
 
 :::

--- a/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/airgap-install/eks-ecr-airgap-install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/airgap-install/eks-ecr-airgap-install.md
@@ -823,6 +823,8 @@ Finally, install Palette. Image Swap handles all image rewriting automatically, 
     `ingress-nginx`, `ingress-traefik`, `jet-system`, and `ui-system` namespaces are in a `Running` or `Completed`
     state.
 
+    <PartialsComponent category="self-hosted" name="install-on-kubernetes-al2" edition="Palette" />
+
     ```shell
     kubectl get pods --all-namespaces | grep --extended-regexp '(cp-system|hubble-system|ingress-nginx|ingress-traefik|jet-system|ui-system)'
     ```

--- a/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/airgap-install/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/airgap-install/install.md
@@ -766,6 +766,8 @@ environment. Reach out to our support team if you need assistance.
     `cp-system`, `hubble-system`, `ingress-traefik`, `ingress-nginx`, `jet-system`, and `ui-system` reach the _Ready_
     state. The installation takes two to three minutes to complete.
 
+    <PartialsComponent category="self-hosted" name="install-on-kubernetes-al2" edition="Palette" />
+
     ```shell
     kubectl get pods --all-namespaces --watch
     ```

--- a/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/install.md
+++ b/docs/docs-content/enterprise-version/install-palette/install-on-kubernetes/install.md
@@ -689,6 +689,8 @@ your environment. Reach out to our support team if you need assistance.
     `cp-system`, `hubble-system`, `ingress-traefik`, `ingress-nginx`, `jet-system` , and `ui-system` reach the _Ready_
     state. The installation takes between two to three minutes to complete.
 
+    <PartialsComponent category="self-hosted" name="install-on-kubernetes-al2" edition="Palette" />
+
     ```shell
     kubectl get pods --all-namespaces --watch
     ```

--- a/docs/docs-content/troubleshooting/enterprise-install.md
+++ b/docs/docs-content/troubleshooting/enterprise-install.md
@@ -10,6 +10,128 @@ tags: ["troubleshooting", "self-hosted", "palette", "vertex"]
 
 Refer to the following sections to troubleshoot errors encountered when installing an Enterprise Cluster.
 
+## Scenario - Traefik Ingress Controller Pods Crash on Amazon Linux 2 EKS Nodes
+
+Traefik ingress controller DaemonSet pods may enter a `CrashLoopBackOff` state on deprecated Amazon Linux 2 (AL2) EKS
+nodes in [self-hosted Palette](../enterprise-version/install-palette/install-on-kubernetes/install-on-kubernetes.md) and
+[Palette VerteX](../vertex/install-palette-vertex/install-on-kubernetes/install-on-kubernetes.md) Helm-based
+installations. This is caused by the non-root security context `NET_BIND_SERVICE` Linux capability configured in the
+Traefik DaemonSet, which allows non-root processes to bind to privileged ports. The `NET_BIND_SERVICE` capability is
+incompatible with the older kernel and `containerd` versions included with AL2.
+
+To fix this issue, modify the Traefik ingress controller DaemonSet to run as the root user. This allows Traefik
+processes to bind to privileged ports without needing the `NET_BIND_SERVICE` capability.
+
+:::warning
+
+This workaround changes the Traefik ingress controller to run as the root user. We recommend upgrading AL2 nodes to
+Amazon Linux 2023 (AL2023) as soon as possible and reverting this change afterward. For more information, refer to
+[Upgrade from Amazon Linux 2 to Amazon Linux 2023](https://docs.aws.amazon.com/eks/latest/userguide/al2023.html).
+
+:::
+
+### Debug Steps
+
+1. Log in to your
+   [self-hosted Palette](../enterprise-version/system-management/system-management.md#access-the-system-console) or
+   [Palette VerteX](../vertex/system-management/system-management.md#access-the-system-console) system console.
+
+2. From the left main menu, select **Enterprise Cluster**.
+
+3. On the **Overview** tab, download the **Kubernetes Config File**.
+
+4. Open a terminal session in an environment that has network access to the affected EKS cluster. From your terminal,
+   set the `KUBECONFIG` variable to the file path of the kubeconfig.
+
+   ```shell
+   export KUBECONFIG=<path-to-kubeconfig>
+   ```
+
+5. Verify that the Traefik DaemonSet pods are in a `CrashLoopBackOff` state on AL2 nodes.
+
+   ```bash
+   kubectl get pods --namespace ingress-traefik
+   ```
+
+   ```bash title="Example output" hideClipboard
+   NAME                               READY   STATUS             RESTARTS         AGE
+   traefik-ingress-controller-dkjs5   0/1     CrashLoopBackOff   25 (4m43s ago)   107m
+   traefik-ingress-controller-nltlh   0/1     CrashLoopBackOff   25 (5m2s ago)    107m
+   traefik-ingress-controller-vctdm   0/1     CrashLoopBackOff   25 (4m40s ago)   107m
+   ```
+
+6. Confirm the error by checking the logs of a crashing pod. Replace `<pod-name>` with the name of the affected pod. If
+   the output contains `listen tcp :80: bind: permission denied`, the issue is caused by the non-root security context.
+
+   ```bash
+   kubectl logs <pod-name> --namespace ingress-traefik
+   ```
+
+   ```bash title="Example output" hideClipboard {3}
+   ... # additional output omitted for readability
+
+   2026-04-13T14:41:51Z ERR Command error error="command traefik error: error while building entryPoint web: building listener: error opening listener: listen tcp :80: bind: permission denied"
+   ```
+
+7. Edit the Traefik DaemonSet.
+
+   ```bash
+   kubectl edit daemonset traefik-ingress-controller --namespace ingress-traefik
+   ```
+
+8. Locate the pod-level `securityContext` section under `spec.template.spec`. Set `runAsNonRoot: false` and change the
+   user and group process IDs from `65532` to `0`.
+
+   ```yaml hideClipboard
+   spec:
+     template:
+       spec:
+         securityContext:
+           fsGroup: 0
+           runAsGroup: 0
+           runAsNonRoot: false
+           runAsUser: 0
+   ```
+
+9. Locate the container-level `securityContext` section under `spec.template.spec.containers` for the `controller`
+   container. Set `securityContext.runAsUser: 0` and `allowPrivilegeEscalation: false`.
+
+   ```yaml hideClipboard {4,11}
+   containers:
+     - name: controller
+       securityContext:
+         allowPrivilegeEscalation: true
+         capabilities:
+           add:
+             - NET_BIND_SERVICE
+           drop:
+             - ALL
+         readOnlyRootFilesystem: true
+         runAsUser: 0
+   ```
+
+10. Save and close the editor. Kubernetes performs a rolling update of the DaemonSet.
+
+11. Verify that all Traefik pods are running.
+
+    ```bash
+    kubectl get pods --namespace ingress-traefik --output wide
+    ```
+
+    ```bash title="Example output" hideClipboard
+    NAME                               READY   STATUS    RESTARTS   AGE
+    traefik-ingress-controller-pfktw   1/1     Running   0          14s
+    traefik-ingress-controller-w4nkq   1/1     Running   0          14s
+    traefik-ingress-controller-w9k8l   1/1     Running   0          14s
+    ```
+
+12. Confirm that Traefik is serving traffic by checking the logs of a pod on an AL2 node. Replace `<pod-name>` with the
+    name of the pod running on an AL2 node. The logs should no longer contain `permission denied` errors.
+
+    ```bash
+    kubectl logs <pod-name> --namespace ingress-traefik
+    ```
+
 ## Scenario - MongoDB Replica Pods Crash during Palette Upgrade
 
 When upgrading a self-hosted Palette instance from 4.8.35 to 4.8.37, MongoDB replica pods may crash with a

--- a/docs/docs-content/troubleshooting/enterprise-install.md
+++ b/docs/docs-content/troubleshooting/enterprise-install.md
@@ -10,9 +10,9 @@ tags: ["troubleshooting", "self-hosted", "palette", "vertex"]
 
 Refer to the following sections to troubleshoot errors encountered when installing an Enterprise Cluster.
 
-## Scenario - Traefik Ingress Controller Pods Crash on Amazon Linux 2 EKS Nodes
+## Scenario - Traefik Ingress Controller Pods Crash on Amazon Linux 2 Nodes
 
-Traefik ingress controller DaemonSet pods may enter a `CrashLoopBackOff` state on deprecated Amazon Linux 2 (AL2) EKS
+Traefik ingress controller DaemonSet pods may enter a `CrashLoopBackOff` state on deprecated Amazon Linux 2 (AL2)
 nodes in [self-hosted Palette](../enterprise-version/install-palette/install-on-kubernetes/install-on-kubernetes.md) and
 [Palette VerteX](../vertex/install-palette-vertex/install-on-kubernetes/install-on-kubernetes.md) Helm-based
 installations. This is caused by the non-root security context `NET_BIND_SERVICE` Linux capability configured in the
@@ -40,7 +40,7 @@ Amazon Linux 2023 (AL2023) as soon as possible and reverting this change afterwa
 
 3. On the **Overview** tab, download the **Kubernetes Config File**.
 
-4. Open a terminal session in an environment that has network access to the affected EKS cluster. From your terminal,
+4. Open a terminal session in an environment that has network access to the affected self-hosted management cluster. From your terminal,
    set the `KUBECONFIG` variable to the file path of the kubeconfig.
 
    ```shell
@@ -94,7 +94,7 @@ Amazon Linux 2023 (AL2023) as soon as possible and reverting this change afterwa
    ```
 
 9. Locate the container-level `securityContext` section under `spec.template.spec.containers` for the `controller`
-   container. Set `securityContext.runAsUser: 0` and `allowPrivilegeEscalation: false`.
+   container. Set `securityContext.runAsUser: 0` and `allowPrivilegeEscalation: true`.
 
    ```yaml hideClipboard {4,11}
    containers:

--- a/docs/docs-content/troubleshooting/enterprise-install.md
+++ b/docs/docs-content/troubleshooting/enterprise-install.md
@@ -12,8 +12,8 @@ Refer to the following sections to troubleshoot errors encountered when installi
 
 ## Scenario - Traefik Ingress Controller Pods Crash on Amazon Linux 2 Nodes
 
-Traefik ingress controller DaemonSet pods may enter a `CrashLoopBackOff` state on deprecated Amazon Linux 2 (AL2)
-nodes in [self-hosted Palette](../enterprise-version/install-palette/install-on-kubernetes/install-on-kubernetes.md) and
+Traefik ingress controller DaemonSet pods may enter a `CrashLoopBackOff` state on deprecated Amazon Linux 2 (AL2) nodes
+in [self-hosted Palette](../enterprise-version/install-palette/install-on-kubernetes/install-on-kubernetes.md) and
 [Palette VerteX](../vertex/install-palette-vertex/install-on-kubernetes/install-on-kubernetes.md) Helm-based
 installations. This is caused by the non-root security context `NET_BIND_SERVICE` Linux capability configured in the
 Traefik DaemonSet, which allows non-root processes to bind to privileged ports. The `NET_BIND_SERVICE` capability is
@@ -40,8 +40,8 @@ Amazon Linux 2023 (AL2023) as soon as possible and reverting this change afterwa
 
 3. On the **Overview** tab, download the **Kubernetes Config File**.
 
-4. Open a terminal session in an environment that has network access to the affected self-hosted management cluster. From your terminal,
-   set the `KUBECONFIG` variable to the file path of the kubeconfig.
+4. Open a terminal session in an environment that has network access to the affected self-hosted management cluster.
+   From your terminal, set the `KUBECONFIG` variable to the file path of the kubeconfig.
 
    ```shell
    export KUBECONFIG=<path-to-kubeconfig>

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/install.md
@@ -778,6 +778,8 @@ environment. Reach out to our support team if you need assistance.
     `cp-system`, `hubble-system`, `ingress-traefik`, `ingress-nginx`, `jet-system`, and `ui-system` reach the _Ready_
     state. The installation takes between two to three minutes to complete.
 
+    <PartialsComponent category="self-hosted" name="install-on-kubernetes-al2" edition="Palette VerteX" />
+
     ```shell
     kubectl get pods --all-namespaces --watch
     ```

--- a/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/install.md
+++ b/docs/docs-content/vertex/install-palette-vertex/install-on-kubernetes/install.md
@@ -684,6 +684,8 @@ your environment. Reach out to our support team if you need assistance.
     `cp-system`, `hubble-system`, `ingress-traefik`, `ingress-nginx`, `jet-system`, and `ui-system` reach the _Ready_
     state. The installation takes between two to three minutes to complete.
 
+    <PartialsComponent category="self-hosted" name="install-on-kubernetes-al2" edition="Palette VerteX" />
+
     ```shell
     kubectl get pods --all-namespaces --watch
     ```


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adds a troubleshooting guide for installing self-hosted Palette on EKS clusters with AL2 nodes. Since AL2 nodes are deprecated, this issue will not be fixed; therefore, no known issue has been added.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Troubleshooting - Enterprise Install](https://deploy-preview-10099--docs-spectrocloud.netlify.app/troubleshooting/enterprise-install/) - New section
- [Install Palette - K8s Non-Airgap](https://deploy-preview-10099--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-kubernetes/install/#:~:text=The%20Traefik%20ingress%20controller) - Added partial admonition
- [Install Palette - K8s Airgap](https://deploy-preview-10099--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-kubernetes/airgap-install/install/#:~:text=The%20Traefik%20ingress%20controller) - Added partial admonition
- [Install Palette - EKS with ECR Mirroring](https://deploy-preview-10099--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-kubernetes/airgap-install/eks-ecr-airgap-install/#install-custom-resource-definitions/#:~:text=The%20Traefik%20ingress%20controller) - Added partial admonition
- [Install VerteX - K8s Non-Airgap](https://deploy-preview-10099--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-kubernetes/install/#:~:text=The%20Traefik%20ingress%20controller) - Added partial admonition
- [Install VerteX - K8s Airgap](https://deploy-preview-10099--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-kubernetes/airgap-install/install/#:~:text=The%20Traefik%20ingress%20controller) - Added partial admonition

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[PEM-10532](https://spectrocloud.atlassian.net/browse/PEM-10532)


[PEM-10532]: https://spectrocloud.atlassian.net/browse/PEM-10532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ