### PR TITLE
docs: add the Docs navbar entry again DOC-2764

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -381,6 +381,14 @@ const config = {
         },
         items: [
           {
+            to: "/",
+            type: "docSidebar",
+            sidebarId: "docSidebar",
+            label: "Docs",
+            position: "left",
+            activeBaseRegex: "^(?!/api/).*$",
+          },
+          {
             to: "/tutorials",
             type: "docSidebar",
             sidebarId: "tutorialSidebar",


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels.
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adds back the Docs navbar item that was removed as part of https://github.com/spectrocloud/librarium/pull/8696. 
It navigates to `/release-notes` because it is the first doc defined in the linked docSidebar. 
Restoring original behaviour, so leaving it as is. 

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Preview site](https://deploy-preview-10148--docs-spectrocloud.netlify.app/)

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-2764](https://spectrocloud.atlassian.net/browse/DOC-2764)


[DOC-2764]: https://spectrocloud.atlassian.net/browse/DOC-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ