### PR TITLE
fixing multi-linked lines in breaking changes

### DIFF
--- a/scripts/index-breaking-changes-utils.sh
+++ b/scripts/index-breaking-changes-utils.sh
@@ -115,10 +115,23 @@ persist_partial_files () {
 }
 
 # Function to find legacy domain from archiveVersions.json
-# Outputs: a single matching legacy domain
-# $1 - release version, example: v4.5.3
-# $2 - worktree path
-# $3 - archiveVersions.json path
+#
+# Purpose:
+# - Map a release version to the correct legacy documentation domain
+#
+# What this does:
+# - Extracts major and minor version from the release (e.g. 4.7.10 → 4.7)
+# - Matches against archiveVersions.json entries like "v4.7.x"
+# - Ignores patch version intentionally
+# - Returns the first matching legacy domain URL
+#
+# Notes:
+# - If no match is found, function returns non-zero
+# - Used to rewrite links to legacy documentation paths
+#
+# Params:
+# $1 - release version, example: 4.7.10
+# $2 - archiveVersions.json path
 find_legacy_domain() {
   local release_version=$1
   local archive_versions_path=$2
@@ -146,12 +159,37 @@ find_legacy_domain() {
 }
 
 # Function to add breaking changes body to the partials file
+#
+# Purpose:
+# - Append processed breaking change content to the correct partial file
+#
+# What this does:
+# - Determines which partial file to write to (release or component updates)
+# - Resolves the appropriate legacy domain for link rewriting
+# - Preserves empty lines as-is
+
+# Process each markdown link on the line independently
+#
+#   What this does:
+    # - Extracts link text and target from markdown links
+    # - Removes optional titles and surrounding angle brackets
+    # - Skips external URLs and image assets
+    # - Normalizes internal links for legacy documentation:
+    #   • strips leading ./, ../, or /
+    #   • removes fragments (#...) and file extensions (.md/.mdx)
+    #   • removes duplicate trailing path segments (e.g. foo/foo.md)
+# - Rewrites internal links to use legacy documentation paths
+#
+# Notes:
+# - External URLs and image assets are not modified
+# - Link normalization is required to match legacy doc structure
+#
 # Params:
 # $1 - release number, example: 4.0.0
-# $2 - component updates identifier, example: component-updates-october-2025-41
-# $3 - component updates range, example: 4.7.21 - 4.7.23
-# $4 - body text of the breaking change
-# $5 - worktree path
+# $2 - component updates identifier
+# $3 - component updates range
+# $4 - body text line
+# $5 - worktree path
 # $6 - breaking changes partials path
 # $7 - archiveVersions.json path
 add_breaking_changes_body() {

--- a/scripts/index-breaking-changes-utils.sh
+++ b/scripts/index-breaking-changes-utils.sh
@@ -120,29 +120,29 @@ persist_partial_files () {
 # $2 - worktree path
 # $3 - archiveVersions.json path
 find_legacy_domain() {
-  release_version=$1
-  wt_path=$2
-  archive_versions_path=$3
-  popd >/dev/null  # leave the worktree to look up file
+  local release_version=$1
+  local archive_versions_path=$2
 
   # release_version like "4.7.10"
-  local release_maj; release_maj=$(echo "$release_version" | cut -d . -f1)
-  local release_min; release_min=$(echo "$release_version" | cut -d . -f2)
+  local release_maj
+  local release_min
+  release_maj=$(echo "$release_version" | cut -d . -f1)
+  release_min=$(echo "$release_version" | cut -d . -f2)
 
-  # Read key/value as TSV (array) and keep the loop in the current shell
+  # name like "v4.7.x" or "v3.4.x and prior"
   while IFS=$'\t' read -r name url; do
-    # name like "v4.7.x" or "v3.4.x and prior"
-    local entry_maj; entry_maj=$(echo "$name" | cut -d . -f1 | sed 's/^v//')
-    local entry_min; entry_min=$(echo "$name" | cut -d . -f2)
+    local entry_maj
+    local entry_min
+    entry_maj=$(echo "$name" | cut -d . -f1 | sed 's/^v//')
+    entry_min=$(echo "$name" | cut -d . -f2)
 
     if [[ "$release_maj" == "$entry_maj" && "$release_min" == "$entry_min" ]]; then
-      echo "$url"
-      return 0   # exits the surrounding function as intended
+      printf '%s\n' "$url"
+      return 0
     fi
   done < <(jq -r 'to_entries[] | [.key, .value] | @tsv' "$archive_versions_path")
 
-  pushd "$wt_path" >/dev/null # re-enter the worktree
-
+  return 1
 }
 
 # Function to add breaking changes body to the partials file
@@ -164,81 +164,85 @@ add_breaking_changes_body() {
   archive_file_path=$7
   filename=""
   legacy_domain=""
+
   if [ -n "$release_number" ]; then
     replaced=$(echo "$release_number" | tr '.' '_')
     filename="$breaking_changes_partials_path/br_$replaced.mdx"
-    legacy_domain=$(find_legacy_domain "$release_number" "$wt_path" "$archive_file_path")
+    legacy_domain=$(find_legacy_domain "$release_number" "$archive_file_path")
   fi
+
   if [ -n "$component_updates_identifier" ]; then
     filename="$breaking_changes_partials_path/br_component_updates_$component_updates_identifier.mdx"
-    first_version=$(echo "$component_updates_range" | grep -Eo '^[0-9]+(\.[0-9]+){2}')
-    legacy_domain=$(find_legacy_domain "$first_version" "$wt_path" "$archive_file_path")
+
+    if [ -n "$component_updates_range" ]; then
+      first_version=$(echo "$component_updates_range" | grep -Eo '^[0-9]+(\.[0-9]+){2}')
+      if [ -n "$first_version" ]; then
+        legacy_domain=$(find_legacy_domain "$first_version" "$archive_file_path" || true)
+      fi
+    fi
   fi
 
   # If line is empty just append it and return
   if [ -z "$new_line" ]; then
-    echo >> "$filename"   # ensures file ends with a newline
+    echo >> "$filename"
     return
   fi
 
-  # Extract link text: [text](...)
-  link_text=$(
-    printf '%s\n' "$new_line" \
-    | grep -E '\[[^]]+\]\([^)]*\)' \
-    | sed -n -E 's/.*\[([^]]*)\]\(((<[^>]+>)|([^ )][^)]*))( "([^"]*)")?\).*/\1/p'
-  )
+  # Process each markdown link on the line independently
+  while IFS= read -r match; do
+    [ -z "$match" ] && continue
 
-  # Extract URL (supports <angle-bracket URLs> and optional "title")
-  link_url=$(
-    printf '%s\n' "$new_line" \
-    | grep -E '\[[^]]+\]\([^)]*\)' \
-    | sed -n -E 's/.*\[[^]]*\]\(((<[^>]+>)|([^ )][^)]*))( "([^"]*)")?\).*/\1/p' \
-    | sed -E 's/^<([^>]+)>$/\1/'   # drop angle brackets if present
-  )
+    link_text=$(
+      printf '%s\n' "$match" \
+      | sed -n -E 's/^\[([^]]+)\]\(.*\)$/\1/p'
+    )
 
-  if [ -z "$link_text" ] || [ -z "$link_url" ]; then
-    # No links found, just append the line as is
-    echo "$new_line" >> "$filename"
-    return
-  fi
+    raw_target=$(
+      printf '%s\n' "$match" \
+      | sed -n -E 's/^\[[^]]+\]\((.*)\)$/\1/p'
+    )
 
-  if [[ $link_url == http* || $link_url == *.webp ]]; then
-    # It's an external image link, just append the line as is
-    echo "$new_line" >> "$filename"
-    return
-  fi
+    [ -z "$link_text" ] && continue
+    [ -z "$raw_target" ] && continue
 
-  # Start the link replacement process
-  # prefix: everything before the first occurrence of "[$link_text]"
-  prefix="${new_line%%[[]"$link_text"[]]*}"
-  # suffix: everything after the first occurrence of "$link_url)"
-  suffix="${new_line#*"$link_url")}"
-  clean_link="$link_url"
+    # Remove optional title at the end:  path "title"   or   <path> "title"
+    link_url=$(printf '%s\n' "$raw_target" | sed -E 's/[[:space:]]+"[^"]*"$//')
 
-  # Strip leading ./, ../ or /
-  [[ $clean_link == ../* ]] && clean_link="${clean_link:3}"
-  [[ $clean_link == /*  ]] && clean_link="${clean_link:1}"
-  # append /release-notes to link in this case since it is relative to release notes folder
-  [[ $clean_link == ./* ]] && clean_link="release-notes/${clean_link:2}"
+    # Remove surrounding angle brackets if present
+    link_url=$(printf '%s\n' "$link_url" | sed -E 's/^<([^>]+)>$/\1/')
 
-  # Drop #fragment
-  clean_link="${clean_link%%#*}"
+    [ -z "$link_url" ] && continue
 
-  # Drop .md / .mdx extensions
-  clean_link="${clean_link%.md}"
-  clean_link="${clean_link%.mdx}"
+    # Leave external URLs and image assets unchanged
+    if [[ $link_url == http* || $link_url == *.webp ]]; then
+      continue
+    fi
 
-  # Remove duplicate last segment if it equals previous (e.g., foo/foo.md)
-  IFS='/' read -r -a segments <<< "$clean_link"
-  len=${#segments[@]}
-  if (( len >= 2 )) && [[ "${segments[len-1]}" == "${segments[len-2]}" ]]; then
-    unset 'segments[len-1]'
-    clean_link=$(IFS='/'; echo "${segments[*]}")
-  fi
+    clean_link="$link_url"
 
-  replacement="[$link_text]($legacy_domain/$clean_link)"
-  # Rebuild the line
-  new_line="${prefix}${replacement}${suffix}"
+    # Strip leading ./, ../ or /
+    [[ $clean_link == ../* ]] && clean_link="${clean_link#../}"
+    [[ $clean_link == /*  ]] && clean_link="${clean_link#/}"
+    [[ $clean_link == ./* ]] && clean_link="release-notes/${clean_link#./}"
+
+    # Drop #fragment
+    clean_link="${clean_link%%#*}"
+
+    # Drop .md / .mdx extensions
+    clean_link="${clean_link%.md}"
+    clean_link="${clean_link%.mdx}"
+
+    # Remove duplicate last segment if it equals previous (e.g. foo/foo.md)
+    IFS='/' read -r -a segments <<< "$clean_link"
+    len=${#segments[@]}
+    if (( len >= 2 )) && [[ "${segments[$((len-1))]}" == "${segments[$((len-2))]}" ]]; then
+      unset 'segments[$((len-1))]'
+      clean_link=$(IFS='/'; echo "${segments[*]}")
+    fi
+
+    replacement="[$link_text]($legacy_domain/$clean_link)"
+    new_line="${new_line//"$match"/$replacement}"
+  done < <(printf '%s\n' "$new_line" | grep -oE '\[[^]]+\]\([^)]*\)')
 
   echo "$new_line" >> "$filename"
 }

--- a/scripts/index-breaking-changes.sh
+++ b/scripts/index-breaking-changes.sh
@@ -10,7 +10,7 @@ RELEASE_NOTES_PATH="docs/docs-content/release-notes/release-notes.md"
 OLD_RELEASE_NOTES_PATH="docs/docs-content/release-notes.md"
 BREAKING_CHANGES_PARTIALS_PATH="_partials/breaking-changes"
 ALL_VERSIONS_PATH="src/components/ReleaseNotesBreakingChanges/versions.json"
-ARCHIVE_FILE_PATH="archiveVersions.json"
+ARCHIVE_FILE_PATH="$DOCS_ROOT/archiveVersions.json"
 
 # Where to place worktrees (unique per run)
 WORKTREES_DIR="$(mktemp -d -t librarium-worktrees-XXXXXX)"
@@ -37,10 +37,13 @@ git fetch --prune --no-tags --depth=1 origin \
   '+refs/heads/version-*:refs/remotes/origin/version-*'
 
 # Get remote version branches (no locals, no HEAD), exclude version-3-4
-branches="$(git for-each-ref --format='%(refname:strip=3)' 'refs/remotes/origin/version-*' \
-  | grep -v '^HEAD$' \
-  | grep -v '^version-3-4$' \
-  | sort -u)"
+ branches="$(git for-each-ref --format='%(refname:strip=3)' 'refs/remotes/origin/version-*' \
+   | grep -v '^HEAD$' \
+   | grep -v '^version-3-4$' \
+   | sort -u)"
+
+# Leave this commented. To be used when doing local testing. 
+# branches="version-4-7 version-4-8"
 
 # Remove files for repeatable runs.
 rm -rf $BREAKING_CHANGES_PARTIALS_PATH

--- a/scripts/index-breaking-changes.sh
+++ b/scripts/index-breaking-changes.sh
@@ -45,13 +45,13 @@ git fetch --prune --no-tags --depth=1 origin \
 # Leave this commented. To be used when doing local testing. 
 # branches="version-4-7 version-4-8"
 
-# Remove files for repeatable runs.
-rm -rf $BREAKING_CHANGES_PARTIALS_PATH
-rm -f $ALL_VERSIONS_PATH
-touch $ALL_VERSIONS_PATH
-echo "[" >> $ALL_VERSIONS_PATH
+# Remove files for repeatable runs. Linus added quotes to avoid issues with blank spaces
+rm -rf "$BREAKING_CHANGES_PARTIALS_PATH"
+rm -f "$ALL_VERSIONS_PATH"
+touch "$ALL_VERSIONS_PATH"
+echo "[" >> "$ALL_VERSIONS_PATH"
 # Create the directory in the main repo if it doesn't exist
-mkdir -p $BREAKING_CHANGES_PARTIALS_PATH
+mkdir -p "$BREAKING_CHANGES_PARTIALS_PATH"
 
 for branch in $branches; do
   echo "ℹ️ Checking branch: $branch"
@@ -247,10 +247,10 @@ for branch in $branches; do
   git worktree remove --force "$wt_path"
 done
 
-clean_files $BREAKING_CHANGES_PARTIALS_PATH
+clean_files "$BREAKING_CHANGES_PARTIALS_PATH"
 
 # Remove the last comma from the ALL_VERSIONS_PATH file
-sed '$s/,\s*$//' $ALL_VERSIONS_PATH > temp && mv temp $ALL_VERSIONS_PATH
-echo "]" >> $ALL_VERSIONS_PATH
+sed '$s/,\s*$//' "$ALL_VERSIONS_PATH" > temp && mv temp $ALL_VERSIONS_PATH
+echo "]" >> "$ALL_VERSIONS_PATH"
 git worktree prune
 echo "✅ All branches checked."

--- a/scripts/index-breaking-changes.sh
+++ b/scripts/index-breaking-changes.sh
@@ -12,6 +12,11 @@ BREAKING_CHANGES_PARTIALS_PATH="_partials/breaking-changes"
 ALL_VERSIONS_PATH="src/components/ReleaseNotesBreakingChanges/versions.json"
 ARCHIVE_FILE_PATH="$DOCS_ROOT/archiveVersions.json"
 
+# Worktree strategy:
+# - Each version branch is processed in an isolated git worktree
+# - All file reads and transformations happen inside that worktree
+# - Generated files must be copied back to the main repo explicitly
+# - Worktrees are cleaned up after execution
 # Where to place worktrees (unique per run)
 WORKTREES_DIR="$(mktemp -d -t librarium-worktrees-XXXXXX)"
 echo "ℹ️ Using worktrees dir: $WORKTREES_DIR"
@@ -23,8 +28,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# If ALL_VERSIONS_PATH file and BREAKING_CHANGES_PARTIALS_PATH directory already exist, skip the entire script.
-# This is to speed up local development where we don't need to re-index every time.
+# If ALL_VERSIONS_PATH file and BREAKING_CHANGES_PARTIALS_PATH directory already exist,
+# skip the entire script.
+#
+# Purpose:
+# - Speed up local development by avoiding reprocessing all branches
+#
+# Notes:
+# - This may hide changes if stale output already exists
+# - Delete these artifacts to force a full re-run
 if [ -f "$ALL_VERSIONS_PATH" ] && [ -d "$BREAKING_CHANGES_PARTIALS_PATH" ]; then
   echo "ℹ️ $ALL_VERSIONS_PATH file and $BREAKING_CHANGES_PARTIALS_PATH directory already exist. Skipping breaking change indexing."
   exit 0
@@ -72,13 +84,35 @@ for branch in $branches; do
   component_updates_identifier=""
   component_updates_title=""
   release_number=""
+    # Buffer handling for VersionedLink processing
+  #
+  # Purpose:
+  # - Collapse adjacent <VersionedLink> lines into a single logical line
+  #
+  # What this does:
+  # - Accumulates VersionedLink lines into a buffer
+  # - Flushes the buffer when encountering:
+  #   • normal text lines
+  #   • blank lines
+  #   • section boundaries
+  #
+  # Notes:
+  # - Required to preserve correct formatting in generated partials
   # Variable to hold the current buffer text so that we can collapse versioned links on same line.
   buffer=""
   in_code_section=false
   partial_created=false
   # Read the release notes file line by line.
   while IFS= read -r line; do
-    # If the line is an H2 that contains "Release", we extract the number and begin processing.
+    # Detect release heading and extract version
+    #
+    # What this does:
+    # - Removes markdown anchor fragments (e.g. {#...})
+    # - Extracts the version from headings like:
+    #   • "## Release 4.7.10"
+    #   • "## Release 4.7.8 - 4.7.10"
+    # - Always selects the final version in a range
+    # - Resets component updates tracking for the new release
     if echo "$line" | grep -q "##.*Release"; then
       # If we were already processing a file, copy it to the current working directory.
       if [ "$partial_created" == "true" ]; then
@@ -126,6 +160,17 @@ for branch in $branches; do
       continue
     fi
 
+    # Detect component updates version range
+    #
+    # What this does:
+    # - Matches the exact sentence describing component update versions
+    # - Extracts a single version or version range (e.g. 4.7.21 - 4.7.23)
+    #
+    # Notes:
+    # - This match is intentionally strict
+    # - The phrasing must remain unchanged or this will fail
+    # - No alternative reliable identifier exists for this line
+
     # THIS PHRASING MUST MATCH EXACTLY TO CATCH THE COMPONENT UPDATES RANGE.
     # I HAVE NO OTHER WAY TO UNIQUELY IDENTIFY THIS LINE.
     if [ -n "$component_updates_identifier" ] && echo "$line" | grep -qE '^The following components have been updated for Palette version [0-9]+(\.[0-9]+){2}([[:space:]]*[-–—][[:space:]]*[0-9]+(\.[0-9]+){2})?\.$'; then
@@ -136,6 +181,13 @@ for branch in $branches; do
       continue 
     fi
 
+    # Enter breaking changes section for a release
+    #
+    # What this does:
+    # - Activates breaking changes processing mode
+    # - Creates the corresponding partial file
+    # - All subsequent lines are processed until another heading is encountered
+    #
     # Find any breaking changes headings if we have detected the version heading.
     # Breaking changes MUST be H3 or more.
     if [ -n "$release_number" ] && echo "$line" | grep -iq '^###\+#*[[:space:]]*Breaking Changes'; then
@@ -176,6 +228,14 @@ for branch in $branches; do
         continue
       fi
 
+      # Handle code block boundaries
+      #
+      # What this does:
+      # - Toggles code section mode on/off
+      # - Prevents line collapsing and whitespace normalization inside code blocks
+      #
+      # Notes:
+      # - Code blocks must be preserved exactly as written
       # If we are in breaking changes and the line starts a code block don't collapse or strip spaces.
       if echo "$line" | grep -q '^[[:space:]]*```'; then
         # Toggle in_code_section
@@ -195,6 +255,10 @@ for branch in $branches; do
         continue
       fi
 
+      # Skip prettier ignore markers
+      #
+      # Purpose:
+      # - These are formatting directives and should not appear in generated output
       # If the line is prettier-ignore-start or prettier-ignore-end skip it.
       if echo "$line" | grep -q '^[[:space:]]*<!-- prettier-ignore-start -->'; then
         continue
@@ -246,6 +310,13 @@ for branch in $branches; do
   # Remove the worktree to keep the workspace small
   git worktree remove --force "$wt_path"
 done
+
+# Final output cleanup
+#
+# What this does:
+# - Normalizes spacing in generated partials
+# - Removes trailing comma from versions.json
+# - Finalizes JSON array structure
 
 clean_files "$BREAKING_CHANGES_PARTIALS_PATH"
 


### PR DESCRIPTION
# ✅ Pull Request Checklist



---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR addresses the following:

* addressed issue where multiple markdown links on a line were not being interpreted correctly
* refactored `find_legacy_domain()` to remove `pushd/popd` and use explicit file path
* use absolute path for `archiveVersions.json` to avoid worktree issues
* added in protection against empty component update ranges
*  prevented non-critical lookup failures from exiting the script
* updated some comments to provide more details in case of future troubleshooting


