### PR TITLE
docs: use master archiveVersions.json in breaking changes generation

### DIFF
--- a/scripts/index-breaking-changes.sh
+++ b/scripts/index-breaking-changes.sh
@@ -44,7 +44,7 @@ if [ -f "$ALL_VERSIONS_PATH" ] && [ -d "$BREAKING_CHANGES_PARTIALS_PATH" ]; then
   exit 0
 fi
 
-wget -qO "$TEMP_ARCHIVE_FILE" "$ARCHIVE_GH_PATH"
+wget -qO "$TEMP_ARCHIVE_FILE" "$ARCHIVE_GH_PATH" || { echo "❌ Failed to fetch archiveVersions.json from master: $ARCHIVE_GH_PATH"; exit 1; }
 echo "Saved master archiveVersions.json to $TEMP_ARCHIVE_FILE"
 
 # Fetch all branches from the remote

--- a/scripts/index-breaking-changes.sh
+++ b/scripts/index-breaking-changes.sh
@@ -10,7 +10,8 @@ RELEASE_NOTES_PATH="docs/docs-content/release-notes/release-notes.md"
 OLD_RELEASE_NOTES_PATH="docs/docs-content/release-notes.md"
 BREAKING_CHANGES_PARTIALS_PATH="_partials/breaking-changes"
 ALL_VERSIONS_PATH="src/components/ReleaseNotesBreakingChanges/versions.json"
-ARCHIVE_FILE_PATH="$DOCS_ROOT/archiveVersions.json"
+ARCHIVE_GH_PATH="https://raw.githubusercontent.com/spectrocloud/librarium/refs/heads/master/archiveVersions.json"
+TEMP_ARCHIVE_FILE="$DOCS_ROOT/archiveVersions_temp.json"
 
 # Worktree strategy:
 # - Each version branch is processed in an isolated git worktree
@@ -25,6 +26,7 @@ cleanup() {
   echo "🧹 Cleaning up worktrees..."
   git worktree prune || true
   rm -rf "$WORKTREES_DIR" || true
+  rm -f "$TEMP_ARCHIVE_FILE" || true
 }
 trap cleanup EXIT
 
@@ -41,6 +43,9 @@ if [ -f "$ALL_VERSIONS_PATH" ] && [ -d "$BREAKING_CHANGES_PARTIALS_PATH" ]; then
   echo "ℹ️ $ALL_VERSIONS_PATH file and $BREAKING_CHANGES_PARTIALS_PATH directory already exist. Skipping breaking change indexing."
   exit 0
 fi
+
+wget -qO "$TEMP_ARCHIVE_FILE" "$ARCHIVE_GH_PATH"
+echo "Saved master archiveVersions.json to $TEMP_ARCHIVE_FILE"
 
 # Fetch all branches from the remote
 # Pull *only* version-* branches into refs/remotes/origin/, shallow, skip tags,
@@ -210,10 +215,10 @@ for branch in $branches; do
       if [ -z "$line" ]; then
         # Flush the buffer if it has content.
         if [ -n "$buffer" ]; then
-          add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$buffer" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$ARCHIVE_FILE_PATH"
+          add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$buffer" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$TEMP_ARCHIVE_FILE"
           buffer=""
         fi
-        add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$line" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$ARCHIVE_FILE_PATH"
+        add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$line" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$TEMP_ARCHIVE_FILE"
         continue
       fi
 
@@ -222,7 +227,7 @@ for branch in $branches; do
         in_breaking_changes=false
         # Flush the buffer if it has content.
         if [ -n "$buffer" ]; then
-          add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$buffer" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$ARCHIVE_FILE_PATH"
+          add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$buffer" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$TEMP_ARCHIVE_FILE"
           buffer=""
         fi
         continue
@@ -245,13 +250,13 @@ for branch in $branches; do
           in_code_section="true"
         fi
 
-        add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$line" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$ARCHIVE_FILE_PATH"
+        add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$line" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$TEMP_ARCHIVE_FILE"
         continue
       fi
 
       # Don't strip any spacing or collapse lines while we are in the code section.
       if $in_code_section; then
-        add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$line" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$ARCHIVE_FILE_PATH"
+        add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$line" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$TEMP_ARCHIVE_FILE"
         continue
       fi
 
@@ -287,7 +292,7 @@ for branch in $branches; do
         else 
           # Not a VersionedLink line so we need to flush the buffer if it has content.
           if [ -n "$buffer" ]; then
-            add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$buffer" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$ARCHIVE_FILE_PATH"
+            add_breaking_changes_body "$release_number" "$component_updates_identifier" "$component_updates_range" "$buffer" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$TEMP_ARCHIVE_FILE"
             buffer=""
           fi
           # Normal line. Set the line as the buffer so it is ready for the next versioned link.
@@ -301,7 +306,7 @@ for branch in $branches; do
 
   # If we finished the file and have a left over partial, copy it to the current working directory.
   if [ "$partial_created" == "true" ]; then
-    persist_partial_files "$release_number" "$component_updates_identifier" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$DOCS_ROOT"
+    persist_partial_files "$release_number" "$component_updates_identifier" "$wt_path" "$BREAKING_CHANGES_PARTIALS_PATH" "$DOCS_ROOT" "$TEMP_ARCHIVE_FILE"
     partial_created=false
   fi
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR changes the breaking changes script to check out the `archiveVersions.json` file from master, ensuring that it always has a copy of the newest branches. Otherwise, the script breaks in older versions when new branches are created, and the file changes are not backported. This happened now, breaking Netlify builds on version 4.8 when 4.9 was created.
Related PR https://github.com/spectrocloud/librarium/pull/10257

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Breaking Changes](https://deploy-preview-10258--docs-spectrocloud.netlify.app/release-notes/breaking-changes/)

