### PR TITLE
DOC-2822 - Pre-built Docker Image option for OpenShift clusters

### DIFF
--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/create-manage-maas-openshift-clusters-hypershift.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/create-manage-maas-openshift-clusters-hypershift.md
@@ -16,14 +16,14 @@ Palette supports creating and managing OpenShift clusters on MAAS bare-metal ser
 plane components as pods. OpenShift workload clusters are then provisioned with their worker nodes on bare-metal MAAS
 hosts, while their control planes are hosted on the HyperShift host cluster.
 
-Prior to creating OpenShift workload clusters, you must build a custom
+Prior to creating OpenShift workload clusters, you must prepare and import a MAAS-compatible
 [Red Hat Enterprise Linux CoreOS (RHCOS)](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/architecture/architecture-rhcos)
-image that is compatible with MAAS deployment.
+or [CentOS Stream CoreOS (SCOS)](https://cloud.centos.org/centos/scos/) image.
 
 This section covers three sequential tasks that enable you to create and manage OpenShift clusters on MAAS using
 HyperShift:
 
-1. [Build and import a MAAS-compatible RHCOS image.](./build-import-rhcos-image.md)
+1. [Prepare a CoreOS image.](./prepare-coreos-image.md)
 2. [Create a HyperShift cluster to host the OpenShift control plane pods.](./create-hypershift-host-cluster.md)
 3. [Create OpenShift workload clusters that use the HyperShift hosted control plane.](./create-openshift-workload-cluster.md)
 

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/create-openshift-workload-cluster.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/create-openshift-workload-cluster.md
@@ -22,9 +22,9 @@ in the HyperShift host cluster. Worker nodes are then provisioned as bare-metal 
   OperatorHub is accessed through the OpenShift console of your workload cluster. Add-ons installed through the
   OperatorHub are managed directly through the OpenShift console and are not visible in Palette.
 
-- Only the Bring Your Own OS (BYOOS) pack is supported for the OS layer. The RHCOS image must be built specifically for
-  MAAS using the process described in [Build and Import MAAS-Compatible RHCOS Image](./build-import-rhcos-image.md).
-  Standard MAAS OS images are not compatible with OpenShift.
+- Only the Bring Your Own OS (BYOOS) pack is supported for the OS layer. The CoreOS image must be prepared specifically
+  for MAAS using the process described in [Prepare CoreOS image](./prepare-coreos-image.md). Standard MAAS OS images are
+  not compatible with OpenShift.
 
 - Open Virtual Networking (OVN)-Kubernetes is configured automatically by the OpenShift pack. A dedicated OVN-Kubernetes
   Container Network Interface (CNI) pack is not supported. The CNI layer of the workload cluster profile must use the
@@ -39,9 +39,8 @@ in the HyperShift host cluster. Worker nodes are then provisioned as bare-metal 
 
 ## Prerequisites
 
-- The MAAS-compatible RHCOS image imported in
-  [Build and Import MAAS-Compatible RHCOS Image](./build-import-rhcos-image.md) must be available in your MAAS
-  environment.
+- The MAAS-compatible CoreOS image imported in [Prepare CoreOS image](./prepare-coreos-image.md) must be available in
+  your MAAS environment.
 
 - The HyperShift host cluster created in [Create HyperShift Host Cluster](./create-hypershift-host-cluster.md) must be
   in the **Running** state with the HyperShift Operator healthy.
@@ -58,11 +57,11 @@ in the HyperShift host cluster. Worker nodes are then provisioned as bare-metal 
   - <VersionedLink text="Bring Your Own OS (BYOOS)" url="/integrations/packs/?pack=generic-byoi" /> pack for the OS
     layer. Set the following parameters in the pack values.
 
-    | Parameter              | Description                                                                                                                                                                                                                                | Example value               |
-    | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
-    | `pack.osImageOverride` | The name of the MAAS image imported when following the [Build and Import MAAS-Compatible RHCOS Image](./build-import-rhcos-image.md) guide. This should match the `<image-name>` parameter specified in the `import-maas-image.sh` script. | `rhcos-4.20.13-with-ubuntu` |
-    | `pack.osName`          | The value of the `<operating-system>` parameter specified during import.                                                                                                                                                                   | `openshift`                 |
-    | `pack.osVersion`       | The value of the `<release-version>` parameter specified during import.                                                                                                                                                                    | `4.20.13`                   |
+    | Parameter              | Description                                                                                                                                                                             | Example values                                 |
+    | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+    | `pack.osImageOverride` | The name of the MAAS image imported when following the [Prepare CoreOS image](./prepare-coreos-image.md) guide. This should match the `<image-name>` parameter specified during import. | `rhcos-4.20.13-with-ubuntu` <br /> `scos-10.0` |
+    | `pack.osName`          | The value of the `<operating-system>` parameter specified during import.                                                                                                                | `openshift` <br /> `scos`                      |
+    | `pack.osVersion`       | The value of the `<release-version>` parameter specified during import.                                                                                                                 | `4.20.13` <br /> `10.0.20250628-0`             |
 
   - <VersionedLink text="OpenShift" url="/integrations/packs/?pack=openshift&tab=main" /> pack for the Kubernetes layer.
     Ensure the OpenShift version is compatible with the HyperShift Operator version installed on the host cluster. Refer

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image.md
@@ -1,8 +1,9 @@
 ---
-sidebar_label: "Build and Import RHCOS Image"
-title: "Build and Import MAAS-Compatible RHCOS Image"
+sidebar_label: "Prepare CoreOS Image"
+title: "Prepare a MAAS-Compatible CoreOS Image"
 description:
-  "Learn how to build and import a MAAS-compatible RHCOS image for use with OpenShift workload clusters on MAAS."
+  "Learn how to prepare and import a MAAS-compatible CoreOS (RHCOS or SCOS) image for use with OpenShift workload
+  clusters on MAAS."
 hide_table_of_contents: false
 tags: ["data center", "maas", "openshift", "hypershift"]
 sidebar_position: 10
@@ -12,7 +13,7 @@ sidebar_position: 10
 
 :::
 
-Red Hat Enterprise Linux CoreOS (RHCOS) is incompatible with the standard
+Red Hat Enterprise Linux CoreOS (RHCOS) and the related CentOS Stream CoreOS (SCOS) are incompatible with the standard
 MAAS/[Curtin](https://canonical.com/blog/customising-maas-installs) deployment process out of the box. MAAS deploys
 machines using a two-stage boot process in which Curtin writes and validates the target OS disk image. Curtin expects a
 traditional Linux root filesystem layout, including:
@@ -21,18 +22,126 @@ traditional Linux root filesystem layout, including:
 - `cloud-init` as the machine configuration tool
 - a standard filesystem structure
 
-None of these are provided natively by RHCOS. In addition, RHCOS uses
+None of these are provided natively by RHCOS or SCOS, as both are immutable OSTree-based operating systems. In addition,
+they use
 [Ignition](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/assembly_using-the-ignition-tool-for-the-rhel-for-edge-simplified-installer-images_composing-installing-managing-rhel-for-edge-images)
 for machine configuration rather than cloud-init.
 
-To work around this, the RHCOS MAAS image build process appends a minimal Ubuntu root filesystem as an extra partition
-to the official RHCOS raw image. This allows Curtin validation to pass, while Curtin hooks persist the real Ignition
-configuration for RHCOS, which is applied on first boot.
+To work around this, the MAAS-compatible CoreOS image build process appends a minimal Ubuntu root filesystem as an extra
+partition to the official CoreOS raw image. This allows Curtin validation to pass, while Curtin hooks persist the real
+Ignition configuration for the CoreOS variant, which is applied on first boot.
 
-This guide walks you through building the MAAS-compatible RHCOS image and importing it into your MAAS environment. This
-image is required before you can deploy OpenShift workload clusters on MAAS using HyperShift.
+This guide walks you through importing a MAAS-compatible CoreOS image into your MAAS environment. This image is required
+before you can deploy OpenShift workload clusters on MAAS using HyperShift. You can choose between the two options
+described in the following table.
 
-## Prerequisites
+| Option                                                                                  | Requirements                         | Usage                                                             |
+| --------------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------- |
+| [Option 1 - Use the Pre-Built Docker Image](#option-1---use-the-pre-built-docker-image) | Docker, MAAS credentials             | You want to use the published SCOS version with minimal effort.   |
+| [Option 2 - Build Your Own Image](#option-2---build-your-own-image)                     | Linux build host with root, MAAS CLI | You need a specific RHCOS version or want to customize the image. |
+
+## Option 1 - Use the Pre-Built Docker Image
+
+The pre-built Docker image bundles a MAAS-ready SCOS image and the MAAS CLI. Use this option to import the published
+SCOS version with minimal effort.
+
+### Prerequisites
+
+- A host with [Docker](https://docs.docker.com/engine/install/) installed.
+
+  - The host must have network access to your MAAS server endpoint to import the image successfully.
+
+- A MAAS server endpoint and API key. Refer to the
+  [MAAS API Keys](https://canonical.com/maas/docs/how-to-find-and-use-api-keys) documentation for guidance on obtaining
+  your API key.
+
+### Enablement
+
+1. Log in to the host where Docker is installed and has access to your MAAS server endpoint.
+
+2. Use the following command to pull the pre-built Docker image.
+
+   **Last update**: May 31, 2026
+
+   ```bash title="Export image variable"
+   export IMAGE=us-docker.pkg.dev/palette-images/third-party/scos-maas:v10.0.20250628-0
+   ```
+
+   ```bash title="Pull the Docker image"
+   docker pull $IMAGE
+   ```
+
+3. Set your MAAS credentials as environment variables. Replace `<https://your-maas-server/MAAS>` and `<maas-api-key>`
+   with your MAAS server endpoint and API key, respectively.
+
+   ```bash title="Set MAAS credentials"
+   export MAAS_ENDPOINT="<https://your-maas-server/MAAS>"
+   export MAAS_API_KEY="<maas-api-key>"
+   ```
+
+4. Use the following command to import the SCOS image into MAAS.
+
+   - Replace `<image-name>` with a descriptive name for the image as it will appear in the MAAS boot resources list.
+   - Replace `<operating-system>` with the OS name to associate with the image in MAAS.
+   - Replace `<release-version>` with the OS version to associate with the image in MAAS.
+
+   ```bash title="Template"
+   docker run --rm \
+     --env MAAS_ENDPOINT="$MAAS_ENDPOINT" \
+     --env MAAS_API_KEY="$MAAS_API_KEY" \
+     $IMAGE \
+     /image.raw.gz <image-name> <operating-system> <release-version>
+   ```
+
+   The `/image.raw.gz` argument refers to the SCOS image path inside the container and should not be changed.
+
+   ```bash hideClipboard title="Example"
+   docker run --rm \
+     --env MAAS_ENDPOINT="$MAAS_ENDPOINT" \
+     --env MAAS_API_KEY="$MAAS_API_KEY" \
+     $IMAGE \
+     /image.raw.gz scos-10.0 scos 10.0.20250628-0
+   ```
+
+   Once the command completes, the image will appear in the MAAS boot resources list under the **Custom** or **Other**
+   category. Partition cleanup is handled automatically during deployment, no manual disk management is required.
+
+### Validate
+
+<Tabs groupId="validate-image">
+
+<TabItem label="MAAS UI" value="maas-ui">
+
+1. Log in to your MAAS server web interface.
+
+2. From the left sidebar, navigate to **Images**.
+
+3. Locate the image under the **Custom** or **Other** category and verify it appears with the name you specified during
+   import. The name appears under the **Release Title** column. For example, `scos-10.0`.
+
+4. Confirm the image status is **Synced**.
+
+</TabItem>
+
+<TabItem label="MAAS CLI" value="maas-cli">
+
+Use the following command to list all boot resources and confirm your image is present. Replace `<image-name>` with the
+name of the image you specified during import. For example, `scos-10.0`.
+
+```bash
+maas default boot-resources read | grep "<image-name>"
+```
+
+If the image was imported successfully, the command returns a JSON entry containing the image name. No output indicates
+the image was not found.
+
+</TabItem>
+
+</Tabs>
+
+## Option 2 - Build Your Own Image
+
+### Prerequisites
 
 - A Linux build host with the following tools installed:
 
@@ -56,7 +165,7 @@ image is required before you can deploy OpenShift workload clusters on MAAS usin
 
 - The RHCOS image build scripts, available at the following URL.
 
-  **Last updated**: June 3, 2026
+  **Last update**: May 3, 2026
 
   ```text
   http://software.spectrocloud.com/rhcos-maas-image-builder/v4.8.c-v2/rhcos-maas-image.tgz
@@ -85,7 +194,7 @@ image is required before you can deploy OpenShift workload clusters on MAAS usin
   ~/images/rhcos-4.20.13-x86_64-metal.x86_64.raw.gz
   ```
 
-## Enablement
+### Enablement
 
 1. Log in to your MAAS build host and navigate to the directory where you extracted the RHCOS image build scripts.
 
@@ -189,7 +298,7 @@ image is required before you can deploy OpenShift workload clusters on MAAS usin
    boot-resources import. The image will then appear in the MAAS boot resources list. Partition cleanup is handled
    automatically during deployment, no manual disk management is required.
 
-## Validate
+### Validate
 
 <Tabs groupId="validate-image">
 
@@ -226,6 +335,6 @@ the image was not found.
 
 ## Next Steps
 
-Now that the MAAS-compatible RHCOS image is imported, you can proceed to
+Now that the MAAS-compatible CoreOS image is imported, you can proceed to
 [create the HyperShift host cluster](./create-hypershift-host-cluster.md) that will run the OpenShift control plane
 components.

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image.md
@@ -205,7 +205,7 @@ the image was not found.
    sudo ./build-rootfs.sh ./ubuntu2404-rootfs
    ```
 
-   The script runs `debootstrap` for Ubuntu 24.04 (Noble), installs `cloud-init`, `netplan.io`, `python3-cffi`, and
+   The script executes `debootstrap` for Ubuntu 24.04 (Noble), installs `cloud-init`, `netplan.io`, `python3-cffi`, and
    `python3-ply`, cleans apt caches, and outputs the root filesystem directory to `./ubuntu2404-rootfs/`. This directory
    is copied into the extra partition in the next step.
 

--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image.md
@@ -104,7 +104,7 @@ SCOS version with minimal effort.
    ```
 
    Once the command completes, the image will appear in the MAAS boot resources list under the **Custom** or **Other**
-   category. Partition cleanup is handled automatically during deployment, no manual disk management is required.
+   category. Partition cleanup is handled automatically during deployment; no manual disk management is required.
 
 ### Validate
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -25,6 +25,14 @@ tags: ["release-notes"]
 
 #### Improvements
 
+<!-- https://spectrocloud.atlassian.net/browse/DOC-2822 -->
+
+- <TpBadge /> You can now use a pre-built Docker image to import a MAAS-compatible CentOS Stream CoreOS (SCOS) image
+  when [preparing the CoreOS
+  image](../clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image.md) required
+  for OpenShift workload clusters on MAAS using HyperShift. This provides a faster alternative to building a custom
+  RHCOS image from source.
+
 <!-- https://spectrocloud.atlassian.net/browse/DOC-2788 -->
 
 - The metrics server commands for

--- a/redirects.js
+++ b/redirects.js
@@ -993,6 +993,10 @@ let redirects = [
     from: `/clusters/cluster-groups/vcluster-upgrade/`,
     to: `/clusters/cluster-groups/vcluster-upgrades/`,
   },
+  {
+    from: "/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/build-import-rhcos-image/",
+    to: "/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image/",
+  },
 ];
 
 if (packRedirects.length > 0) {


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR documents a new method for preparing a CoreOS image for OpenShift clusters on MAAS. It also changes the filename and adds a related redirect. This is required to better align the new context for both the build and pre-built image options.

---

## 💻 Renamed Pages

- [Prepare a MAAS-Compatible CoreOS Image](https://deploy-preview-10483--docs-spectrocloud.netlify.app/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image/) - Option 1 added. Option 2 remains mostly the same.

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Create and Manage MAAS OpenShift Clusters with HyperShift](https://deploy-preview-10483--docs-spectrocloud.netlify.app/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/) - Minor wording adjustments and hyperlink to CentOS CoreOS Stream page.
- [Create OpenShift Workload Cluster with HyperShift Control Plane](https://deploy-preview-10483--docs-spectrocloud.netlify.app/clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/create-openshift-workload-cluster/) - Minor wording updates and examples for CentOS.
- [Release Notes](https://deploy-preview-10483--docs-spectrocloud.netlify.app/release-notes/#improvements) - added release note under improvement.
- Added redirect to `redirect.js` due to filename change.

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-2822](https://spectrocloud.atlassian.net/browse/DOC-2822)


[DOC-2822]: https://spectrocloud.atlassian.net/browse/DOC-2822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ