### PR TITLE
docs: add cleanup to cluster templates tutorial

### DIFF
--- a/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
+++ b/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
@@ -967,10 +967,11 @@ Cluster deletion may take 15 to 30 minutes.
 
 :::info
 
-If a cluster is still deleting after 30 minutes, set `force_delete = true` on the stuck cluster resource in
-`clusters.tf` and run `terraform apply -auto-approve`. Terraform waits 20 minutes for the cluster to delete naturally.
-If it does not, Terraform force-deletes the cluster from Palette. Note that in this case Palette does not clean up the
-underlying cloud resources, and you must remove any remaining infrastructure manually.
+If a cluster is still deleting after 30 minutes, set `force_delete = true` on the affected cluster resource in `clusters.tf` and run `terraform apply -auto-approve`. 
+
+Terraform waits 20 minutes for the cluster to delete naturally. If the deletion does not complete within that time, Terraform force-deletes the cluster from Palette. 
+
+When a cluster is force-deleted, Palette does not clean up the underlying cloud resources. You must manually remove any remaining infrastructure.
 
 ```hcl
 resource "spectrocloud_cluster_aws" "dev_cluster" {

--- a/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
+++ b/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
@@ -982,7 +982,7 @@ resource "spectrocloud_cluster_aws" "dev_cluster" {
 
 :::
 
-Once the destroy completes, confirm in Palette that all resources are removed.
+Once `terraform destroy` completes, confirm in Palette that all resources are removed.
 
 From the left main menu, select **Clusters** and confirm that `tf-dev-cluster` and `tf-prod-cluster` no longer appear.
 

--- a/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
+++ b/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
@@ -927,4 +927,69 @@ Repeat the same Kubecost and cluster profile version checks for `tf-prod-cluster
 
 ## Cleanup
 
+Run `terraform destroy` to remove all resources created during this tutorial. Terraform destroys them in the correct
+dependency order: clusters, the cluster template, profiles, and finally the maintenance policy.
+
+Issue `terraform plan -destroy` to preview the resources that Terraform removes.
+
+```shell
+terraform plan -destroy
+```
+
+```text hideClipboard title="Expected output"
+Plan: 0 to add, 0 to change, 6 to destroy.
+```
+
+Apply the destroy to remove all resources.
+
+```shell
+terraform destroy -auto-approve
+```
+
+```bash hideClipboard title="Expected output"
+spectrocloud_cluster_aws.dev_cluster[0]: Destroying...
+spectrocloud_cluster_aws.prod_cluster[0]: Destroying...
+spectrocloud_cluster_aws.dev_cluster[0]: Destruction complete after 20m0s
+spectrocloud_cluster_aws.prod_cluster[0]: Destruction complete after 22m0s
+spectrocloud_cluster_config_template.aws_template[0]: Destroying...
+spectrocloud_cluster_config_template.aws_template[0]: Destruction complete after 1s
+spectrocloud_cluster_profile.aws_profile_v110[0]: Destroying...
+spectrocloud_cluster_profile.aws_profile[0]: Destroying...
+spectrocloud_cluster_profile.aws_profile_v110[0]: Destruction complete after 1s
+spectrocloud_cluster_profile.aws_profile[0]: Destruction complete after 1s
+spectrocloud_cluster_config_policy.maintenance: Destroying...
+spectrocloud_cluster_config_policy.maintenance: Destruction complete after 1s
+
+Destroy complete! Resources: 6 destroyed.
+```
+
+Cluster deletion may take 15 to 30 minutes.
+
+:::info
+
+If a cluster is still deleting after 30 minutes, set `force_delete = true` on the stuck cluster resource in
+`clusters.tf` and run `terraform apply -auto-approve`. Terraform waits 20 minutes to see if the cluster deletes
+naturally. If it does not, Terraform force-deletes the cluster from Palette. Note that in this case Palette does not
+clean up the underlying cloud resources, and you must remove any remaining infrastructure manually.
+
+```hcl
+resource "spectrocloud_cluster_aws" "dev_cluster" {
+  count = var.deploy-aws ? 1 : 0
+  ...
+  force_delete = true
+}
+```
+
+:::
+
+Once the destroy completes, confirm in Palette that all resources are removed.
+
+From the left main menu, select **Clusters** and confirm that `tf-dev-cluster` and `tf-prod-cluster` no longer appear.
+
+From the left main menu, select **Cluster Configurations**. Select the **Templates** tab and confirm
+`tf-cluster-template-aws` no longer appears. Select the **Policies** tab and confirm `tf-maintenance-policy` no longer
+appears.
+
+From the left main menu, select **Profiles** and confirm `tf-cluster-template-profile-aws` no longer appears.
+
 ## Wrap-Up

--- a/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
+++ b/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
@@ -927,7 +927,8 @@ Repeat the same Kubecost and cluster profile version checks for `tf-prod-cluster
 
 ## Cleanup
 
-Run `terraform destroy` to remove all resources created during this tutorial. Terraform deletes resources in dependency order: clusters first, followed by the cluster template, profiles, and finally the maintenance policy.
+Run `terraform destroy` to remove all resources created during this tutorial. Terraform deletes resources in dependency
+order: clusters first, followed by the cluster template, profiles, and finally the maintenance policy.
 
 Issue `terraform plan -destroy` to preview the resources that Terraform removes.
 
@@ -966,11 +967,14 @@ Cluster deletion may take 15 to 30 minutes.
 
 :::info
 
-If a cluster is still deleting after 30 minutes, set `force_delete = true` on the affected cluster resource in `clusters.tf` and run `terraform apply -auto-approve`. 
+If a cluster is still deleting after 30 minutes, set `force_delete = true` on the affected cluster resource in
+`clusters.tf` and run `terraform apply -auto-approve`.
 
-Terraform waits 20 minutes for the cluster to delete naturally. If the deletion does not complete within that time, Terraform force-deletes the cluster from Palette. 
+Terraform waits 20 minutes for the cluster to delete naturally. If the deletion does not complete within that time,
+Terraform force-deletes the cluster from Palette.
 
-When a cluster is force-deleted, Palette does not clean up the underlying cloud resources. You must manually remove any remaining infrastructure.
+When a cluster is force-deleted, Palette does not clean up the underlying cloud resources. You must manually remove any
+remaining infrastructure.
 
 ```hcl
 resource "spectrocloud_cluster_aws" "dev_cluster" {

--- a/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
+++ b/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
@@ -927,8 +927,7 @@ Repeat the same Kubecost and cluster profile version checks for `tf-prod-cluster
 
 ## Cleanup
 
-Run `terraform destroy` to remove all resources created during this tutorial. Terraform destroys them in the correct
-dependency order: clusters, the cluster template, profiles, and finally the maintenance policy.
+Run `terraform destroy` to remove all resources created during this tutorial. Terraform deletes resources in dependency order: clusters first, followed by the cluster template, profiles, and finally the maintenance policy.
 
 Issue `terraform plan -destroy` to preview the resources that Terraform removes.
 

--- a/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
+++ b/docs/docs-content/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform.md
@@ -968,9 +968,9 @@ Cluster deletion may take 15 to 30 minutes.
 :::info
 
 If a cluster is still deleting after 30 minutes, set `force_delete = true` on the stuck cluster resource in
-`clusters.tf` and run `terraform apply -auto-approve`. Terraform waits 20 minutes to see if the cluster deletes
-naturally. If it does not, Terraform force-deletes the cluster from Palette. Note that in this case Palette does not
-clean up the underlying cloud resources, and you must remove any remaining infrastructure manually.
+`clusters.tf` and run `terraform apply -auto-approve`. Terraform waits 20 minutes for the cluster to delete naturally.
+If it does not, Terraform force-deletes the cluster from Palette. Note that in this case Palette does not clean up the
+underlying cloud resources, and you must remove any remaining infrastructure manually.
 
 ```hcl
 resource "spectrocloud_cluster_aws" "dev_cluster" {


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

docs: add cleanup to cluster templates tutorial

Teach users to destroy all tutorial resources with a single `terraform destroy` command.

Show that Terraform handles dependency ordering automatically, removing clusters before the template, profiles, and policy.

Add Terraform force-delete note for clusters stuck deleting.

Guide users through verifying all resources are removed in Palette after the destroy completes.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Cleanup](https://deploy-preview-10487--docs-spectrocloud.netlify.app/tutorials/clusters/cluster-templates/standardize-clusters-with-cluster-templates-terraform/#cleanup)

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[Terraform – Clean up Terraform-managed resources](https://spectrocloud.atlassian.net/browse/DOC-2662)