### PR TITLE
DOC-2825 / DOC-2836 - Improvements to EKS Pod Identity and ECR documentation

### DIFF
--- a/_partials/clusters/aws/eks-pod-identity/_eks-pod-identity-prerequisites.mdx
+++ b/_partials/clusters/aws/eks-pod-identity/_eks-pod-identity-prerequisites.mdx
@@ -66,11 +66,11 @@ partial_name: eks-pod-identity-prerequisites
   
   The following table lists the IAM roles that must be created. Create them in the order shown as some roles are referenced by others.
 
-  | Service                  | IAM Role Name Example      |
-  | ------------------------ | -------------------------- |
-  | Palette                  | `SpectroCloudPaletteRole`         |
-  | Hubble service           | `SpectroCloudHubbleRole`   |
-  | Identity service         | `SpectroCloudIdentityRole` |
+  | Service                  | IAM Role Name Example      | Create Order |
+  | ------------------------ | -------------------------- | ------------- |
+  | Palette                  | `SpectroCloudPaletteRole`  | 1             |
+  | Hubble service           | `SpectroCloudHubbleRole`   | 2             |
+  | Identity service         | `SpectroCloudIdentityRole` | 3             |
 
   The following tabs provide guidance on the trust policies and permissions policies that must be assigned to each IAM role. Create these IAM roles in the same AWS account as the EKS management cluster that hosts Palette or Palette VerteX.
 
@@ -101,6 +101,13 @@ partial_name: eks-pod-identity-prerequisites
   - The [required IAM policies](/clusters/public-cloud/aws/required-iam-policies/) must be assigned to the IAM role created for Palette.
 
   - In addition to the required IAM policies, the following permissions policy must also be assigned to the IAM role created for Palette.
+  
+    If you are using [Core IAM Policies](/clusters/public-cloud/aws/required-iam-policies/core-iam-policies/), add the additional permissions policy in the Core IAM Policies tab. If you are using [Minimum IAM
+    Policies](/clusters/public-cloud/aws/required-iam-policies/minimum-permissions-policies/), add the additional permissions policy in the Minimum IAM Policies tab.
+
+    <Tabs groupId="core-or-minimum-iam-policies">
+
+    <TabItem label="Core IAM Policies" value="core-iam-policies">
 
     ```json
     {
@@ -111,9 +118,7 @@ partial_name: eks-pod-identity-prerequisites
           "Action": [
             "eks:ListPodIdentityAssociations",
             "eks:CreatePodIdentityAssociation",
-            "eks:DeletePodIdentityAssociation",
-            "eks:DescribeAddonVersions",
-            "eks:CreateAddon"
+            "eks:DeletePodIdentityAssociation"
 
           ],
           "Resource": "*"
@@ -126,6 +131,39 @@ partial_name: eks-pod-identity-prerequisites
       ]
     }
     ```
+
+    </TabItem>
+
+    <TabItem label="Minimum IAM Policies" value="minimum-iam-policies">
+
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "eks:ListPodIdentityAssociations",
+            "eks:CreatePodIdentityAssociation",
+            "eks:DeletePodIdentityAssociation",
+            "eks:DescribeAddonVersions",
+            "eks:CreateAddon",
+            "eks:UpdateAddon"
+          ],
+          "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": ["iam:PassRole"],
+          "Resource": "*"
+        }
+      ]
+    }
+    ```
+
+    </TabItem>
+
+    </Tabs>
 
   </TabItem>
 
@@ -237,7 +275,10 @@ partial_name: eks-pod-identity-prerequisites
     ```
 
   - The following permissions policy must be assigned to the IAM role created for the identity service.
+  
+    You must use the ARN of the Palette IAM role in the `Resource` field of the `iam:GetRole` and `iam:PassRole` actions.
 
+    - Replace the `<partition>` placeholder with the appropriate AWS partition (for example, `aws` or `aws-us-gov`).
     - Replace `<aws-account-id>` with your AWS account ID.
     - Replace `<role-name-for-palette-iam-role>` with the name of the IAM role created for Palette (for example, `SpectroCloudPaletteRole`).
 
@@ -253,9 +294,7 @@ partial_name: eks-pod-identity-prerequisites
           "Action": [
             "eks:ListPodIdentityAssociations",
             "eks:CreatePodIdentityAssociation",
-            "eks:DeletePodIdentityAssociation",
-            "eks:DescribeAddonVersions",
-            "eks:CreateAddon"
+            "eks:DeletePodIdentityAssociation"
           ],
           "Resource": [
             "*"
@@ -278,7 +317,7 @@ partial_name: eks-pod-identity-prerequisites
             "iam:GetRole"
           ],
           "Resource": [
-            "arn:aws:iam::<aws-account-id>:role/<role-name-for-palette-iam-role>"
+            "arn:<partition>:iam::<aws-account-id>:role/<role-name-for-palette-iam-role>"
           ]
         },
         {
@@ -288,7 +327,7 @@ partial_name: eks-pod-identity-prerequisites
             "iam:PassRole"
           ],
           "Resource": [
-            "arn:aws:iam::<aws-account-id>:role/<role-name-for-palette-iam-role>"
+            "arn:<partition>:iam::<aws-account-id>:role/<role-name-for-palette-iam-role>"
           ]
         }
       ]
@@ -304,12 +343,12 @@ partial_name: eks-pod-identity-prerequisites
 
   The following table lists the IAM roles that must be created. Create them in the order shown as some roles are referenced by others.
 
-  | Service                     | IAM Role Name Example       | Where to Create Role                       |
-  | --------------------------- | --------------------------- | ------------------------------------------ |
-  | Identity service            | `SpectroCloudIdentityLocalRole`  | Same AWS account as EKS management cluster |
-  | Palette                     | `SpectroCloudPaletteTargetRole`          | Target AWS account for workload cluster resources |
-  | Hubble service              | `SpectroCloudHubbleTargetRole`    | Target AWS account for workload cluster resources |
-  | Hubble service | `SpectroCloudHubbleLocalRole` | Same AWS account as EKS management cluster |
+  | Service                     | IAM Role Name Example           | Where to Create Role                              | Create Order |
+  | --------------------------- | ------------------------------- | ------------------------------------------------- | ------------ |
+  | Identity service            | `SpectroCloudIdentityLocalRole` | Same AWS account as EKS management cluster        | 1            |
+  | Palette                     | `SpectroCloudPaletteTargetRole` | Target AWS account for workload cluster resources | 2            |
+  | Hubble service              | `SpectroCloudHubbleTargetRole`  | Target AWS account for workload cluster resources | 3            |
+  | Hubble service              | `SpectroCloudHubbleLocalRole`   | Same AWS account as EKS management cluster        | 4            |
 
 
   The following tabs provide guidance on the trust policies and permissions policies that must be assigned to each IAM role.
@@ -353,8 +392,9 @@ partial_name: eks-pod-identity-prerequisites
 
   - The following permissions policy must be assigned to the IAM local role created for the identity service.
 
+    - Replace the `<partition>` placeholder with the appropriate AWS partition (for example, `aws` or `aws-us-gov`).
     - Replace `<target-aws-account-id>` with the AWS account ID where the workload cluster resources are located.
-    - Replace `<role-name-for-palette-iam-local-role>` with the name of the IAM role created for Palette in the target AWS account (for example, `SpectroCloudPaletteTargetRole`).
+    - Replace `<role-name-for-palette-iam-target-role>` with the name of the IAM role created for Palette in the target AWS account (for example, `SpectroCloudPaletteTargetRole`).
     - Replace `<aws-management-cluster-account-id>` with the AWS account ID where the EKS management cluster is deployed.
     - Replace `<role-name-for-identity-service-iam-local-role>` with the name of this IAM role created for the identity service (for example, `SpectroCloudIdentityLocalRole`).
 
@@ -370,9 +410,7 @@ partial_name: eks-pod-identity-prerequisites
           "Action": [
             "eks:ListPodIdentityAssociations",
             "eks:CreatePodIdentityAssociation",
-            "eks:DeletePodIdentityAssociation",
-            "eks:DescribeAddonVersions",
-            "eks:CreateAddon"
+            "eks:DeletePodIdentityAssociation"
           ],
           "Resource": [
             "*"
@@ -398,8 +436,8 @@ partial_name: eks-pod-identity-prerequisites
             "sts:TagSession"
           ],
           "Resource": [
-            "arn:aws:iam::<target-aws-account-id>:role/<role-name-for-palette-iam-local-role>",
-            "arn:aws:iam::<aws-management-cluster-account-id>:role/<role-name-for-identity-service-iam-local-role>"
+            "arn:<partition>:iam::<target-aws-account-id>:role/<role-name-for-palette-iam-target-role>",
+            "arn:<partition>:iam::<aws-management-cluster-account-id>:role/<role-name-for-identity-service-iam-local-role>"
           ]
         }
       ]
@@ -414,6 +452,7 @@ partial_name: eks-pod-identity-prerequisites
     trust policy is the same as outlined in the
     [Amazon EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-association.html#pod-id-association-create).
 
+    - Replace the `<partition>` placeholder with the appropriate AWS partition (for example, `aws` or `aws-us-gov`).
     - Replace `<aws-management-cluster-account-id>` with the AWS account ID where the EKS management cluster is deployed.
     - Replace `<aws-management-cluster-region>` with the AWS region where the EKS management cluster is deployed.
     - Replace `<management-cluster-name>` with the name of the EKS management cluster.
@@ -428,7 +467,7 @@ partial_name: eks-pod-identity-prerequisites
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::<aws-management-cluster-account-id>:role/<role-name-for-identity-service-iam-local-role>"
+            "AWS": "arn:<partition>:iam::<aws-management-cluster-account-id>:role/<role-name-for-identity-service-iam-local-role>"
           },
           "Action": "sts:AssumeRole",
           "Condition": {
@@ -440,7 +479,7 @@ partial_name: eks-pod-identity-prerequisites
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::<aws-management-cluster-account-id>:role/<role-name-for-identity-service-iam-local-role>"
+            "AWS": "arn:<partition>:iam::<aws-management-cluster-account-id>:role/<role-name-for-identity-service-iam-local-role>"
           },
           "Action": "sts:AssumeRole",
           "Condition": {
@@ -452,7 +491,7 @@ partial_name: eks-pod-identity-prerequisites
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::<aws-management-cluster-account-id>:role/<role-name-for-identity-service-iam-local-role>"
+            "AWS": "arn:<partition>:iam::<aws-management-cluster-account-id>:role/<role-name-for-identity-service-iam-local-role>"
           },
           "Action": "sts:TagSession"
         },
@@ -471,6 +510,13 @@ partial_name: eks-pod-identity-prerequisites
   - The [required IAM policies](/clusters/public-cloud/aws/required-iam-policies/) must be assigned to the IAM target role created for Palette.
 
   - In addition to the required IAM policies, the following permissions policy must also be assigned to the IAM target role created for Palette.
+  
+    If you are using [Core IAM Policies](/clusters/public-cloud/aws/required-iam-policies/core-iam-policies/), add the additional permissions policy in the Core IAM Policies tab. If you are using [Minimum IAM
+    Policies](/clusters/public-cloud/aws/required-iam-policies/minimum-permissions-policies/), add the additional permissions policy in the Minimum IAM Policies tab.
+
+    <Tabs groupId="core-or-minimum-iam-policies">
+
+    <TabItem label="Core IAM Policies" value="core-iam-policies">
 
     ```json
     {
@@ -481,9 +527,8 @@ partial_name: eks-pod-identity-prerequisites
           "Action": [
             "eks:ListPodIdentityAssociations",
             "eks:CreatePodIdentityAssociation",
-            "eks:DeletePodIdentityAssociation",
-            "eks:DescribeAddonVersions",
-            "eks:CreateAddon"
+            "eks:DeletePodIdentityAssociation"
+
           ],
           "Resource": "*"
         },
@@ -496,12 +541,46 @@ partial_name: eks-pod-identity-prerequisites
     }
     ```
 
+    </TabItem>
+
+    <TabItem label="Minimum IAM Policies" value="minimum-iam-policies">
+
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "eks:ListPodIdentityAssociations",
+            "eks:CreatePodIdentityAssociation",
+            "eks:DeletePodIdentityAssociation",
+            "eks:DescribeAddonVersions",
+            "eks:CreateAddon",
+            "eks:UpdateAddon"
+          ],
+          "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": ["iam:PassRole"],
+          "Resource": "*"
+        }
+      ]
+    }
+    ```
+
+    </TabItem>
+
+    </Tabs>
+
   </TabItem>
 
   <TabItem label="Hubble service IAM target role" value="hubble-service-iam-target-role">
 
   - The following trust policy must be assigned to the IAM target role created for the Hubble service. Replace the following templated values with your own values.
 
+    - `<partition>`: The appropriate AWS partition (for example, `aws` or `aws-us-gov`).
     - `<aws-management-cluster-account-id>`: The AWS account ID where the EKS management cluster is deployed.
     - `<aws-management-cluster-region>`: The AWS region where the EKS management cluster is deployed.
     - `<management-cluster-name>`: The name of the EKS management cluster.
@@ -515,7 +594,7 @@ partial_name: eks-pod-identity-prerequisites
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::<aws-management-cluster-account-id>:role/spectro-hubble-identity"
+            "AWS": "arn:<partition>:iam::<aws-management-cluster-account-id>:role/spectro-hubble-identity"
           },
           "Action": "sts:AssumeRole",
           "Condition": {
@@ -527,7 +606,7 @@ partial_name: eks-pod-identity-prerequisites
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::<aws-management-cluster-account-id>:role/spectro-hubble-identity"
+            "AWS": "arn:<partition>:iam::<aws-management-cluster-account-id>:role/spectro-hubble-identity"
           },
           "Action": "sts:TagSession"
         }
@@ -622,6 +701,7 @@ partial_name: eks-pod-identity-prerequisites
 
   - The following permissions policy must be assigned to the IAM local role created for Hubble service.
   
+    - Replace the `<partition>` placeholder with the appropriate AWS partition (for example, `aws` or `aws-us-gov`).
     - Replace the `<target-aws-account-id>` placeholder with the AWS account ID where the workload cluster resources are located.
     - Replace the `<hubble-service-iam-target-role>` placeholder with the name of the IAM role created for the Hubble service in the target AWS account (for example, `SpectroCloudHubbleTargetRole`).
 
@@ -637,7 +717,7 @@ partial_name: eks-pod-identity-prerequisites
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:iam::<target-aws-account-id>:role/<hubble-service-iam-target-role>"
+        "arn:<partition>:iam::<target-aws-account-id>:role/<hubble-service-iam-target-role>"
       ],
       "Sid": "IAM"
     }
@@ -667,8 +747,8 @@ partial_name: eks-pod-identity-prerequisites
 
   Use the following AWS CLI command to create a pod identity association for the Palette Hubble service in the same AWS account as the EKS management cluster.
   
-  - Replace
-  `<eks-cluster-name>` with the name of your Amazon EKS cluster.
+  - Replace `<eks-cluster-name>` with the name of your Amazon EKS cluster.
+  - Replace the `<partition>` placeholder with the appropriate AWS partition (for example, `aws` or `aws-us-gov`).
   - Replace `<aws-account-id>` with your AWS account ID.
   - Replace `<hubble-service-iam-role-name>` with the name of the IAM role created for the Palette Hubble service (for example, `SpectroCloudHubbleRole`).
 
@@ -679,12 +759,13 @@ partial_name: eks-pod-identity-prerequisites
   --cluster-name <eks-cluster-name> \
   --namespace hubble-system \
   --service-account spectro-hubble \
-  --role-arn arn:aws:iam::<aws-account-id>:role/<hubble-service-iam-role-name>
+  --role-arn arn:<partition>:iam::<aws-account-id>:role/<hubble-service-iam-role-name>
   ```
 
   Similarly, use the following AWS CLI command to create a pod identity association for the Palette identity service in the same AWS account as the EKS management cluster.
   
   - Replace `<eks-cluster-name>` with the name of your Amazon EKS Cluster.
+  - Replace the `<partition>` placeholder with the appropriate AWS partition (for example, `aws` or `aws-us-gov`).
   - Replace `<aws-account-id>` with your AWS account ID.
   - Replace `<identity-service-iam-role-name>` with the name of the IAM role created for the Palette identity service (for example, `SpectroCloudIdentityRole`).
 
@@ -695,7 +776,7 @@ partial_name: eks-pod-identity-prerequisites
   --cluster-name <eks-cluster-name> \
   --namespace palette-identity \
   --service-account palette-identity \
-  --role-arn arn:aws:iam::<aws-account-id>:role/<identity-service-iam-role-name>
+  --role-arn arn:<partition>:iam::<aws-account-id>:role/<identity-service-iam-role-name>
   ```
 
   </TabItem>
@@ -705,6 +786,7 @@ partial_name: eks-pod-identity-prerequisites
   Use the following AWS CLI command to create a pod identity association for the Palette Hubble service that needs to access AWS resources in a different AWS account to the EKS management cluster.
   
   - Replace `<eks-cluster-name>` with the name of your Amazon EKS cluster.
+  - Replace the `<partition>` placeholder with the appropriate AWS partition (for example, `aws` or `aws-us-gov`).
   - Replace `<aws-management-cluster-account-id>` with the AWS account ID where your EKS management cluster is located.
   - Replace `<hubble-service-iam-local-role-name>` with the name of the IAM role created for the Palette Hubble service (for example, `SpectroCloudHubbleLocalRole`).
   - Replace `<target-aws-account-id>` with the AWS account ID where the workload cluster resources are located.
@@ -717,13 +799,14 @@ partial_name: eks-pod-identity-prerequisites
   --cluster-name <eks-cluster-name> \
   --namespace hubble-system \
   --service-account spectro-hubble \
-  --role-arn arn:aws:iam::<aws-management-cluster-account-id>:role/<hubble-service-iam-local-role-name>
-  --target-role-arn arn:aws:iam::<target-aws-account-id>:role/<hubble-service-iam-target-role-name>
+  --role-arn arn:<partition>:iam::<aws-management-cluster-account-id>:role/<hubble-service-iam-local-role-name>
+  --target-role-arn arn:<partition>:iam::<target-aws-account-id>:role/<hubble-service-iam-target-role-name>
   ```
 
   Similarly, use the following AWS CLI command to create a pod identity association for the Palette identity service that needs to access AWS resources in a different AWS account to the EKS management cluster.
 
   - Replace `<eks-cluster-name>` with the name of your Amazon EKS Cluster.
+  - Replace the `<partition>` placeholder with the appropriate AWS partition (for example, `aws` or `aws-us-gov`).
   - Replace `<aws-management-cluster-account-id>` with the AWS account ID where your EKS management cluster is located.
   - Replace `<identity-service-iam-local-role-name>` with the name of the IAM role created for the Palette identity service (for example, `SpectroCloudIdentityLocalRole`).
 
@@ -734,7 +817,7 @@ partial_name: eks-pod-identity-prerequisites
   --cluster-name <eks-cluster-name> \
   --namespace palette-identity \
   --service-account palette-identity \
-  --role-arn arn:aws:iam::<aws-management-cluster-account-id>:role/<identity-service-iam-local-role-name>
+  --role-arn arn:<partition>:iam::<aws-management-cluster-account-id>:role/<identity-service-iam-local-role-name>
   ```
 
   </TabItem>

--- a/_partials/clusters/aws/eks-pod-identity/_eks-pod-identity-validate.mdx
+++ b/_partials/clusters/aws/eks-pod-identity/_eks-pod-identity-validate.mdx
@@ -38,6 +38,9 @@ partial_name: eks-pod-identity-validate
    ```
 
    :::info
+
    Palette supports [EKS Pod Identity](https://aws.amazon.com/blogs/containers/amazon-eks-pod-identity-a-new-way-for-applications-on-eks-to-obtain-iam-credentials/) 
-   for [Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/) authentication. Refer to the [Configure EKS Pod Identity for ECR Registries](/clusters/public-cloud/aws/enable-pod-identity-ecr) guide for more information.
+   for [Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/) authentication.
+   Refer to the [Configure EKS Pod Identity for ECR Registries](/clusters/public-cloud/aws/enable-pod-identity-ecr) guide for more information.
+
    :::

--- a/docs/docs-content/clusters/public-cloud/aws/add-aws-accounts.md
+++ b/docs/docs-content/clusters/public-cloud/aws/add-aws-accounts.md
@@ -231,7 +231,7 @@ Use the steps below to add an AWS GovCloud account using dynamic STS credentials
 
 #### Limitations
 
-<PartialsComponent category="eks-pod-identity" name="eks-pod-identity-limitations" partition="AWS" />
+<PartialsComponent category="eks-pod-identity" name="eks-pod-identity-limitations" partition="AWS US Gov" />
 
 #### Prerequisites
 

--- a/docs/docs-content/clusters/public-cloud/aws/enable-pod-identity-ecr.md
+++ b/docs/docs-content/clusters/public-cloud/aws/enable-pod-identity-ecr.md
@@ -30,7 +30,7 @@ management cluster. Use static or dynamic access credentials for registries in d
 - Access to the Amazon EKS cluster's kubeconfig file. You must be able to use `kubectl` to perform validation steps on
   the cluster.
 
-- A Palette account with [tenant admin](/tenant-settings/) access.
+- A Palette account with [tenant admin](../../../tenant-settings/tenant-settings.md) access.
 
 - AWS CLI must be installed and configured with the necessary permissions to access and update pod identity associations
   for your EKS cluster.
@@ -40,14 +40,16 @@ management cluster. Use static or dynamic access credentials for registries in d
 1.  Execute the following command to list the pod identity associations in your EKS cluster. Replace the
     `<eks-cluster-name>` with your cluster name and `<region>` with your AWS region.
 
-    Make a note of the ARN corresponding to `spectro-hubble`.
-
     ```shell
     aws eks list-pod-identity-associations \
     --cluster-name <eks-cluster-name> \
     --region <region> \
     --output table
     ```
+
+    Make a note of the `RoleArn` corresponding to the `spectro-hubble` service account. You only need the name of the
+    IAM role, which is the last part of the ARN after the final slash (`/`). For example, if your `RoleArn` is
+    `arn:aws:iam::123456789012:role/SpectroCloudHubbleRole`, the role name is `SpectroCloudHubbleRole`.
 
     ```shell hideClipboard title="Example Output"
     ----------------------------------------------------------------------------------------------------------------------------------
@@ -56,7 +58,7 @@ management cluster. Use static or dynamic access credentials for registries in d
     | AssociationId                 | Namespace               | ServiceAccount                |  RoleArn                             |
     +-------------------------------+-------------------------+------------------------------- +--------------------------------------+
     | a1b2c3d4-5678-90ab-cdef-11111 | kube-system             | aws-node                      |  arn:aws:iam::123456789012:role/AmazonEKS_CNI_Role |
-    | b2c3d4e5-6789-01bc-def0-22222 | hubble-system           | spectro-hubble                |  arn:aws:iam::123456789012:role/spectro-hubble-role |
+    | b2c3d4e5-6789-01bc-def0-22222 | hubble-system           | spectro-hubble                |  arn:aws:iam::123456789012:role/SpectroCloudHubbleRole |
     +-------------------------------+-------------------------+------------------------------- +--------------------------------------+
     ```
 
@@ -92,8 +94,8 @@ management cluster. Use static or dynamic access credentials for registries in d
     ```
 
 3.  Execute the following command to add the permissions defined in the `ecr-permissions-policy.json` file to your
-    `spectro-hubble` EKS Pod Identity association. Replace `<hubble-role-name>` with the ARN of your pod identity
-    association from **Step 1**.
+    `spectro-hubble` EKS Pod Identity association. Replace `<hubble-role-name>` with the role name identified in **Step
+    1** (for example, `SpectroCloudHubbleRole`).
 
     ```shell
     aws iam put-role-policy \
@@ -108,15 +110,15 @@ management cluster. Use static or dynamic access credentials for registries in d
 
     - Replace `<eks-cluster-name>` with the name of your Amazon EKS Cluster.
     - Replace `<aws-account-id>` with your AWS account ID.
-    - Replace `<identity-service-iam-role-name>` with the name of the IAM role created for the Palette identity service
-      . For example, `SpectroCloudIdentityRole`.
+    - Replace `<hubble-role-name>` with the role name identified in **Step 1** (for example, `SpectroCloudHubbleRole`).
+    - Replace `<region>` with your AWS region.
 
     ```shell
     aws eks create-pod-identity-association \
     --cluster-name <eks-cluster-name> \
     --namespace hubble-system \
     --service-account spectro-specman \
-    --role-arn arn:aws:iam::<aws-account-id>:role/<identity-service-iam-role-name> \
+    --role-arn arn:aws:iam::<aws-account-id>:role/<hubble-role-name> \
     --region <region>
     ```
 
@@ -140,7 +142,24 @@ management cluster. Use static or dynamic access credentials for registries in d
     partitioned roll out complete: 3 new pods have been updated...
     ```
 
-7.  Edit the `values.yaml` file for your
+7.  Issue the following commands to verify that EKS Pod Identity has set the required environment variables for the
+    Hubble and Specman services.
+
+    ```bash
+    kubectl get pods --namespace hubble-system -l component=cloud \
+    --output jsonpath='{.items[0].spec.containers[0].env[*].name}' | tr ' ' '\n' | grep AWS_CONTAINER
+    ```
+
+    ```bash
+    kubectl get pod specman-0 --namespace hubble-system \
+    --output jsonpath='{.spec.containers[0].env[*].name}' | tr ' ' '\n' | grep AWS_CONTAINER
+    ```
+
+    Both the `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` environment variables
+    should be present in the output of both commands, indicating that Amazon EKS has injected the
+    [necessary configuration for EKS Pod Identity](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html).
+
+8.  Edit the `values.yaml` file for your
     [self-hosted Palette](../../../enterprise-version/install-palette/install-on-kubernetes/install.md) or
     [VerteX](../../../vertex/install-palette-vertex/install-on-kubernetes/install.md) installation. Set the following
     fields and values.
@@ -153,16 +172,13 @@ management cluster. Use static or dynamic access credentials for registries in d
               credentialType: "pod-identity"
          ```
 
-8.  Issue the following command to apply changes. Replace the `<version>` with the Palette release version installed on
+9.  Issue the following command to apply changes. Replace the `<version>` with the Palette release version installed on
     your Palette or VerteX environment. If you are unsure, you can retrieve the version using the
     `helm list --namespace hubble-system` command.
 
     ```shell
-     helm upgrade palette spectro-mgmt-plane-<version>.tgz \
-      -f values.yaml --namespace hubble-system
-
-     kubectl rollout restart deployment cloud --namespace hubble-system
-     kubectl rollout restart statefulset specman --namespace hubble-system
+    helm upgrade palette spectro-mgmt-plane-<version>.tgz \
+    --values values.yaml --namespace hubble-system
     ```
 
     ```shell hideClipboard title="Example Output"
@@ -173,13 +189,23 @@ management cluster. Use static or dynamic access credentials for registries in d
     STATUS: deployed
     REVISION: 5
     TEST SUITE: None
+    ```
+
+10. Issue the following command to restart the `cloud` and `specman` services in order to apply all updates.
+
+    ```shell
+    kubectl rollout restart deployment cloud --namespace hubble-system
+    kubectl rollout restart statefulset specman --namespace hubble-system
+    ```
+
+    ```shell hideClipboard title="Example Output"
     deployment.apps/cloud restarted
     statefulset.apps/specman restarted
     ```
 
 ## Validation
 
-1. Log in to Palette as a [tenant admin](/tenant-settings/).
+1. Log in to Palette as a [tenant admin](../../../tenant-settings/tenant-settings.md).
 
 2. Navigate to **Tenant Settings** > **Registries**. The system ECR registry should show a valid timestamp in the **Last
    Synced** column. Registry packs are available for

--- a/docs/docs-content/clusters/public-cloud/aws/enable-pod-identity-ecr.md
+++ b/docs/docs-content/clusters/public-cloud/aws/enable-pod-identity-ecr.md
@@ -146,7 +146,7 @@ management cluster. Use static or dynamic access credentials for registries in d
     Hubble and Specman services.
 
     ```bash
-    kubectl get pods --namespace hubble-system -l component=cloud \
+    kubectl get pods --namespace hubble-system --selector component=cloud \
     --output jsonpath='{.items[0].spec.containers[0].env[*].name}' | tr ' ' '\n' | grep AWS_CONTAINER
     ```
 

--- a/docs/docs-content/clusters/public-cloud/aws/required-iam-policies/additional-iam-policies-specific-use-cases.md
+++ b/docs/docs-content/clusters/public-cloud/aws/required-iam-policies/additional-iam-policies-specific-use-cases.md
@@ -49,3 +49,42 @@ you must attach the **PaletteHostResourceGroupsPolicy** on top of the [Core IAM 
 [Minimum Permissions Policies](./minimum-permissions-policies.md).
 
 <PartialsComponent category="permissions" name="aws-host-resource-groups-policy" />
+
+## EKS Pod Identity with Minimum Permissions Policies
+
+:::info
+
+These permissions have been included in the prerequisites steps for enabling EKS Pod Identity in the
+[Add AWS Accounts](../add-aws-accounts.md) guide and are mentioned here for posterity and reference.
+
+:::
+
+If you are using [Minimum Permissions Policies](./minimum-permissions-policies.md) for EKS (static or dynamic) and you
+want to enable EKS Pod Identity, the following permissions policy must also be assigned to the IAM role or IAM target
+role created for Palette (for example, `SpectroCloudPaletteRole` or `SpectroCloudPaletteTargetRole`).
+
+<!-- prettier-ignore-start -->
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeAddonVersions",
+        "eks:CreateAddon",
+        "eks:UpdateAddon"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["iam:PassRole"],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+<!-- prettier-ignore-end -->

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -140,6 +140,13 @@ Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible ver
 
 ### Docs and Education
 
+- Documentation improvements have been made for EKS Pod Identity on the
+  [Register and Manage AWS Accounts](../clusters/public-cloud/aws/add-aws-accounts.md) and
+  [Enable Pod Identity for ECR Authentication](../clusters/public-cloud/aws/enable-pod-identity-ecr.md) pages. This
+  includes clarifying the required permissions for the Palette IAM role when using
+  [Minimum Permissions Policies](../clusters/public-cloud/aws/required-iam-policies/minimum-permissions-policies.md) and
+  providing more detailed instructions for identifying the IAM role for ECR authentication.
+
 ### Packs
 
 #### Pack Notes

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -55,8 +55,8 @@ tags: ["release-notes"]
 - <TpBadge /> You can now use a pre-built Docker image to import a MAAS-compatible CentOS Stream CoreOS (SCOS) image
   when [preparing the CoreOS
   image](../clusters/data-center/maas/create-manage-maas-openshift-clusters-hypershift/prepare-coreos-image.md) required
-  for OpenShift workload clusters on MAAS using HyperShift. This provides a faster alternative to building a custom
-  RHCOS image from source.
+  for OpenShift workload clusters on MAAS using HyperShift. This provides a faster alternative to building a custom Red
+  Hat Enterprise Linux CoreOS (RHCOS) image from source.
 
 <!-- https://spectrocloud.atlassian.net/browse/DOC-2788 -->
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR covers a number of updates to the EKS Pod Identity documentation, including:

- Clarity on what additional permissions are required when using Minimum Permissions Policies vs Core IAM Policies.
- Additional table column (where applicable) to show the order in which to create IAM roles for EKS Pod Identity.
- Missing partition variable to account for AWS US Gov partitions.
- More accurate description of how to locate the Hubble service IAM role for ECR integration.
- Additional validation step after services are restarted in step 6 of the ECR + EKS Pod Identity integration guide.
- Splitting of the last enablement step in the ECR + EKS Pod Identity integration guide (as per CS request).

The Jira tickets explain the rationale for the changes, and I've also included additional improvements I identified.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Add an AWS Account to Palette (Prerequisites)](https://deploy-preview-10514--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/add-aws-accounts/#prerequisites-2)
- [Add an AWS Account to Palette (Validate)](https://deploy-preview-10514--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/add-aws-accounts/#validate-2) - Just an extra line added.
- [Additional IAM Policies for Specific Use Cases](https://deploy-preview-10514--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/required-iam-policies/additional-iam-policies-specific-use-cases/#eks-pod-identity-with-minimum-permissions-policies) - new section for the minimum permissions with Pod Identity.
- [Configure EKS Pod Identity for ECR Registries](https://deploy-preview-10514--docs-spectrocloud.netlify.app/clusters/public-cloud/aws/enable-pod-identity-ecr/) - multiple updates.
- [Release Notes](https://deploy-preview-10514--docs-spectrocloud.netlify.app/release-notes/#docs-and-education) - I felt this was worthy of a release note.

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

- [DOC-2825](https://spectrocloud.atlassian.net/browse/DOC-2825)
- [DOC-2836](https://spectrocloud.atlassian.net/browse/DOC-2836)

[DOC-2825]: https://spectrocloud.atlassian.net/browse/DOC-2825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ