### PR TITLE
[version-4-6] chore: Add .claude and .cursor to gitignore (#10529)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,12 @@ vale/styles/config/vocabularies/spectrocloud-vocab
 unused_images.json
 
 .secrets
+
+# Local MCP Config
+.mcp.json
+
+# Claude Code
+.claude/
+
+# Cursor
+.cursor/


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-6`:
 - [chore: Add .claude and .cursor to gitignore (#10529)](https://github.com/spectrocloud/librarium/pull/10529)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)