### PR TITLE
docs: add GA of MAAS on LXD PEM-10637

### DIFF
--- a/docs/docs-content/clusters/data-center/maas/create-manage-maas-lxd-clusters.md
+++ b/docs/docs-content/clusters/data-center/maas/create-manage-maas-lxd-clusters.md
@@ -12,9 +12,13 @@ enabled. This feature allows you to spawn multiple control plane nodes as LXD VM
 servers, while your worker nodes run on bare metal. This improves resource utilization by reducing the number of bare
 metal machines needed to run control planes and keeps virtualization overhead low.
 
-:::preview
+## Limitations
 
-:::
+<!-- prettier-ignore-start -->
+
+The deployment of MAAS clusters to LXD VMs is limited to the Kubernetes distribution <VersionedLink text="Palette eXtended Kubernetes (PXK)" url="/integrations/packs/?pack=kubernetes" />.
+
+<!-- prettier-ignore-end -->
 
 ## Prerequisites
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -31,6 +31,12 @@ tags: ["release-notes"]
 
 #### Improvements
 
+<!-- https://spectrocloud.atlassian.net/browse/PEM-9172 -->
+
+- The deployment of
+  [MAAS clusters to LXD Virtual Machines (VMs)](../clusters/data-center/maas/create-manage-maas-lxd-clusters.md) has
+  exited Tech Preview and is now ready for production workloads.
+
 #### Deprecations and Removals
 
 ### Edge


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
- [x] Ensure all **Vale comments** are resolved.
- [x] All **CI jobs** have completed successfully.
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adds the GA of MAAS LXD + limitation to only PXK. 

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Release Notes](https://deploy-preview-10649--docs-spectrocloud.netlify.app/release-notes/)
- [LXD page](https://deploy-preview-10649--docs-spectrocloud.netlify.app/clusters/data-center/maas/create-manage-maas-lxd-clusters/)

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[PEM-10637](https://spectrocloud.atlassian.net/browse/PEM-10637)


[PEM-10637]: https://spectrocloud.atlassian.net/browse/PEM-10637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ