### PR TITLE
DOC-2871 - 'Where Overrides are Set' section for CAPI Overrides

### DIFF
--- a/docs/docs-content/architecture/override-capi-properties/override-capi-properties.md
+++ b/docs/docs-content/architecture/override-capi-properties/override-capi-properties.md
@@ -76,6 +76,23 @@ process. If there are any conflicts between override and native values, the over
 
 :::
 
+### Where Overrides are Set
+
+The location where you set the override depends on the level of the CAPI object you want to target.
+
+For cluster scoped overrides:
+
+- **New clusters**: Set the override during the **Cluster Config** step.
+- **Existing clusters**: Set the override in the **Settings > Cluster Configuration** drawer for the cluster.
+
+For node pool scoped overrides:
+
+- **New clusters**: Set the override during the **Nodes Config** step.
+- **Existing clusters**: Navigate to the cluster's **Nodes** tab and click the **Edit** option for the relevant node
+  pool to set the override.
+
+You can set cluster and node pool overrides together on the same cluster.
+
 ### Key Format
 
 The top-level key is always the camelCase form of the CAPI Kind. All nested keys are either based on the `json` struct

--- a/docs/docs-content/architecture/override-capi-properties/override-capi-properties.md
+++ b/docs/docs-content/architecture/override-capi-properties/override-capi-properties.md
@@ -82,14 +82,33 @@ The location where you set the override depends on the level of the CAPI object 
 
 For cluster scoped overrides:
 
-- **New clusters**: Set the override during the **Cluster Config** step.
-- **Existing clusters**: Set the override in the **Settings > Cluster Configuration** drawer for the cluster.
+<Tabs groupId="cluster-state">
+<TabItem label="New clusters" value="new">
+
+Set the override during the **Cluster Config** step.
+
+</TabItem>
+<TabItem label="Existing clusters" value="existing">
+
+Set the override in the **Settings > Cluster Configuration** drawer for the cluster.
+
+</TabItem>
+</Tabs>
 
 For node pool scoped overrides:
 
-- **New clusters**: Set the override during the **Nodes Config** step.
-- **Existing clusters**: Navigate to the cluster's **Nodes** tab and click the **Edit** option for the relevant node
-  pool to set the override.
+<Tabs groupId="cluster-state">
+<TabItem label="New clusters" value="new">
+
+Set the override during the **Nodes Config** step.
+
+</TabItem>
+<TabItem label="Existing clusters" value="existing">
+
+Navigate to the cluster's **Nodes** tab and click the **Edit** option for the relevant node pool to set the override.
+
+</TabItem>
+</Tabs>
 
 You can set cluster and node pool overrides together on the same cluster.
 

--- a/docs/docs-content/architecture/override-capi-properties/override-capi-properties.md
+++ b/docs/docs-content/architecture/override-capi-properties/override-capi-properties.md
@@ -226,15 +226,6 @@ construct valid override YAML, use the following steps.
 
    </details>
 
-### Cluster-Level vs. Pool-Level Override
-
-| Level       | Where it is set                   | What it targets                                                           | Top-Level Key Examples                          |
-| ----------- | --------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------- |
-| **Cluster** | Cluster-level cloud configuration | The primary cluster-scoped CAPI control plane or infrastructure resource. | `awsCluster`, `azureManagedControlPlane`        |
-| **Pool**    | Node pool configuration           | The CAPI machine pool or machine template object for that node pool.      | `awsMachineTemplate`, `azureManagedMachinePool` |
-
-Both levels can be used independently or together on the same cluster.
-
 ## Important Behaviors
 
 Before overriding CAPI properties, review the following behaviors that apply when you configure a cluster or node pool.

--- a/docs/docs-content/architecture/override-capi-properties/override-capi-properties.md
+++ b/docs/docs-content/architecture/override-capi-properties/override-capi-properties.md
@@ -80,7 +80,9 @@ process. If there are any conflicts between override and native values, the over
 
 The location where you set the override depends on the level of the CAPI object you want to target.
 
-For cluster scoped overrides:
+You can set cluster and node pool overrides together on the same cluster.
+
+#### Cluster Overrides
 
 <Tabs groupId="cluster-state">
 <TabItem label="New clusters" value="new">
@@ -95,7 +97,7 @@ Set the override in the **Settings > Cluster Configuration** drawer for the clus
 </TabItem>
 </Tabs>
 
-For node pool scoped overrides:
+#### Node Pool Overrides
 
 <Tabs groupId="cluster-state">
 <TabItem label="New clusters" value="new">
@@ -109,8 +111,6 @@ Navigate to the cluster's **Nodes** tab and click the **Edit** option for the re
 
 </TabItem>
 </Tabs>
-
-You can set cluster and node pool overrides together on the same cluster.
 
 ### Key Format
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
- [x] Ensure all **Vale comments** are resolved.
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adds a section to the Override CAPI Properties page that guides users on where to provide CAPI Overrides in Palette. It also removes a redundant section that is better replaced by this new one.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Override Cluster API (CAPI) Properties](https://deploy-preview-10726--docs-spectrocloud.netlify.app/architecture/override-capi-properties/#where-overrides-are-set) - New section named 'Where Overrides are Set'. Removed redundant section.

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-2871](https://spectrocloud.atlassian.net/browse/DOC-2871)


[DOC-2871]: https://spectrocloud.atlassian.net/browse/DOC-2871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ