### PR TITLE
pe-8655 addendum: updating multi-nic routing info to edge and launchpad for VMs

### DIFF
--- a/docs/docs-content/clusters/edge/local-ui/host-management/configure-network-interfaces.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/configure-network-interfaces.md
@@ -36,6 +36,31 @@ irrecoverable failures.
 
 - Credentials to log in to Local UI. You can log in with any OS user's credentials.
 
+## Configure the Management Interface
+
+The management interface handles Edge host management traffic, including Local UI access, communication between Edge
+hosts, and content synchronization. If no management interface is selected, the Edge host uses the network interface
+associated with the default route.
+
+You can configure the management interface in the Edge Installer `user-data` file. A selection made in the TUI overrides
+the value from `user-data`. After initial setup, a selection made in Local UI overrides the value from the TUI.
+
+1. Log in to Local UI.
+
+2. From the **Edge Host** page, locate the **Management Interface** field.
+
+3. Select the interface to use for management traffic.
+
+4. Click **Confirm** to save the change.
+
+:::warning
+
+Selecting a management interface does not change how the host routes network traffic. If multiple adapters use the same
+subnet and each adapter has a default route, traffic may leave through a different adapter than expected. For best
+results, place management and cluster traffic on separate subnets.
+
+:::
+
 ## Configure NICs
 
 1. Log in to Local UI.
@@ -47,9 +72,9 @@ irrecoverable failures.
 
    :::info
 
-   The NIC currently used for Edge host management (Local UI access and registration) is not editable. This management
-   NIC is locked by design to avoid breaking connectivity. You can identify it by the IP address used to access the
-   Local UI. The management NIC is selected during TUI initial setup. For more information, refer to
+   The interface currently used for Edge host management is not editable. This interface is locked by design to avoid
+   breaking connectivity. The active management interface can be configured through `user-data`, the TUI, or Local UI.
+   For more information, refer to
    [Initial Edge Host Configuration with Palette TUI](../../site-deployment/site-installation/initial-setup.md).
 
    :::

--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/initial-setup.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/initial-setup.md
@@ -126,16 +126,29 @@ more information about EdgeForge and site user data, refer to
    Check the existing hostname and, optionally, change it to a new one. Use the **TAB** key or the up and down arrow
    keys to switch between fields. When you make a change, press **ENTER** to apply the change.
 
-6. In **Network Adapter**, choose the interface that the Edge host uses for management traffic. From the **Management
-   Interface** drop-down menu, select **None**, a network interface, or a VLAN sub-interface. The selected interface
-   handles Local UI access and host-to-host traffic. If you select **None**, the Edge host uses the network interface
-   associated with the default route.
+6. In **Network Adapter**, choose the interface that the Edge host uses for management traffic. Management traffic
+   includes Local UI access, communication between Edge hosts, and content synchronization.
+
+   From the **Management Interface** drop-down menu, select **None**, a network interface, or a VLAN sub-interface. If
+   you select **None**, the Edge host uses the network interface associated with the default route.
+
+   You can configure the management interface in the Edge Installer `user-data` file. A selection made in the TUI
+   overrides the value from `user-data`. After initial setup, a selection made in Local UI overrides the value from the
+   TUI.
 
    Use the **TAB** key to switch between the **Management Interface** drop-down menu and the network adapter table. The
    selected management interface persists after the Edge host reboots. After you complete the initial setup, the
    selected interface is displayed as **Mgmt interface** on the Palette TUI landing page.
 
    ![updated screenshot of management interface](/clusters_site-installation_initial-setup_tui-management-interface_4.8.webp)
+
+   :::info
+
+   The management interface controls Edge host management traffic only. To control Kubernetes cluster traffic, specify
+   `host.nicName` in the machine pool configuration. This interface is used for node IP selection, the Kubernetes
+   control plane API, etcd, and the cluster virtual IP address (VIP).
+
+   :::
 
 7. From the network adapter table, select an adapter to configure its network settings. By default, network adapters
    request an IP automatically from the Dynamic Host Configuration Protocol (DHCP) server. The Classless Inter-Domain

--- a/docs/docs-content/vm-management/launchpad-for-vms/install-vmla-iso.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/install-vmla-iso.md
@@ -99,27 +99,37 @@ Each device where you install the Launchpad for VMs Appliance ISO must meet the 
 
 12. In **Hostname**, check the existing hostname and, optionally, change it to a new one.
 
-13. In **Network Adapter**, select a network adapter to configure. By default, network adapters request an IP address
-    automatically from the Dynamic Host Configuration Protocol (DHCP) server. The Classless Inter-Domain Routing (CIDR)
-    block of each adapter's possible IP address appears on the **Network Adapter** screen.
+13. In **Network Adapter**, choose the interface that the Launchpad host uses for management traffic. Management traffic
+    includes Local UI access, communication between hosts, and content synchronization.
+
+    From the **Management Interface** drop-down menu, select **None**, a network interface, or a VLAN sub-interface. If
+    you select **None**, the Launchpad host uses the network interface associated with the default route.
+
+    You can configure the management interface in the Edge Installer `user-data` file. A selection made in the TUI
+    overrides the value from `user-data`. After initial setup, a selection made in Local UI overrides the value from the
+    TUI.
+
+14. From the network adapter table, select a network adapter to configure. By default, network adapters request an IP
+    address automatically from the Dynamic Host Configuration Protocol (DHCP) server. The Classless Inter-Domain Routing
+    (CIDR) block of each adapter's possible IP address appears on the **Network Adapter** screen.
 
     On the configuration page for each adapter, you can switch the IP addressing scheme from DHCP to static IP. In
     static IP mode, provide a static external IP address, subnet mask, and the default gateway address. A static
     external IP address removes the existing DHCP settings.
 
-14. (Optional) Specify a Virtual Local Area Network (VLAN) ID on the configuration page of each network adapter. A VLAN
+15. (Optional) Specify a Virtual Local Area Network (VLAN) ID on the configuration page of each network adapter. A VLAN
     ID segments network traffic on the same physical network interface for network isolation. If you assign a VLAN ID,
     the Launchpad host tags all outgoing packets from that adapter with the specified VLAN identifier.
 
-15. (Optional) Specify the MTU for your network adapter. The MTU defines the largest packet size, in bytes, that the
+16. (Optional) Specify the MTU for your network adapter. The MTU defines the largest packet size, in bytes, that the
     interface can send without fragmentation. Press **ENTER** to apply the change.
 
-16. In **DNS Configuration**, specify the IP addresses of the primary and secondary name servers. Optionally, specify a
+17. In **DNS Configuration**, specify the IP addresses of the primary and secondary name servers. Optionally, specify a
     search domain. Press **ENTER** to apply the change.
 
-17. In **NTP Configuration**, specify one or more NTP servers. For example, `0.pool.ntp.org` and `1.pool.ntp.org`.
+18. In **NTP Configuration**, specify one or more NTP servers. For example, `0.pool.ntp.org` and `1.pool.ntp.org`.
 
-18. After you confirm the configurations, navigate to **Logout** and press **ENTER** to complete the configuration. The
+19. After you confirm the configurations, navigate to **Logout** and press **ENTER** to complete the configuration. The
     terminal screen displays the hostname and network information of your Launchpad host. Verify that all displayed
     information is consistent with your configurations.
 
@@ -131,9 +141,18 @@ Each device where you install the Launchpad for VMs Appliance ISO must meet the 
 
 2. Log in with the username and password you created during installation.
 
-3. In the **Network interfaces** section, beside **Bonds**, select **Create**.
+3. If you need to change the interface used for management traffic, locate the **Management Interface** field and select
+   the interface to use. Local UI can override the management interface selected during TUI configuration.
 
-4. Complete the fields on the **Create Bond** screen and select **Confirm**.
+   :::warning
+
+   Changing the management interface may cause Local UI connectivity loss.
+
+   :::
+
+4. In the **Network interfaces** section, beside **Bonds**, select **Create**.
+
+5. Complete the fields on the **Create Bond** screen and select **Confirm**.
 
    | **Parameter**                | **Description**                                                                                |
    | ---------------------------- | ---------------------------------------------------------------------------------------------- |
@@ -154,9 +173,9 @@ Each device where you install the Launchpad for VMs Appliance ISO must meet the 
 
    :::
 
-5. In the **Network interfaces** section, beside **Bridges**, select **Create**.
+6. In the **Network interfaces** section, beside **Bridges**, select **Create**.
 
-6. Complete the fields on the **Create Bridge** screen and select **Confirm**.
+7. Complete the fields on the **Create Bridge** screen and select **Confirm**.
 
    | **Parameter**         | **Description**                                                                                                                                       |
    | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -231,17 +250,26 @@ Each device where you install the Launchpad for VMs Appliance ISO must meet the 
 
    ### Network Settings
 
-   | **Parameter**                        | **Description**                                                                                                                           |
-   | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-   | **Pod CIDR**                         | IP address range assigned to internal Kubernetes pod networking. Change only if this conflicts with your existing network.                |
-   | **Service CIDR**                     | IP address range reserved for Kubernetes services, such as internal load balancers and DNS. Must not overlap with Pod Network Range.      |
-   | **MetalLB IP Address**               | A single unused IP address on your network that exposes cluster services externally.                                                      |
-   | **Cilium and MetalLB interface**     | The physical network interface, bond, or bridge on each node used for cluster traffic and external service announcements.                 |
-   | **Enable VLAN Filtering (Optional)** | When enabled, the bridge interface permits only VLANs listed in **VLAN range for VMs**. Disable unless you need strict VLAN isolation.    |
-   | **VLAN range for VMs**               | VLAN IDs that tenant VMs can use. Accepts individual IDs, such as `12` and `13`, or ranges, such as `15-20`.                              |
-   | **Bridge Interface**                 | The Linux bridge interface on cluster nodes that connects tenant VMs to the physical network. Leave blank to auto-detect.                 |
-   | **Cluster runs on br0**              | Enable if your Kubernetes cluster nodes communicate via the `br0` bridge interface or a VLAN sub-interface of br0.                        |
-   | **VLANs on top of br0**              | List all VLAN IDs configured as sub-interfaces or dynamically attached on `br0`. Include VLAN 1 and all VM VLANs. For example, `1,10,20`. |
+   | **Parameter**                        | **Description**                                                                                                                                                                                                       |
+   | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Pod CIDR**                         | IP address range assigned to internal Kubernetes pod networking. Change only if this conflicts with your existing network.                                                                                            |
+   | **Service CIDR**                     | IP address range reserved for Kubernetes services, such as internal load balancers and DNS. Must not overlap with Pod Network Range.                                                                                  |
+   | **MetalLB IP Address**               | A single unused IP address on your network that exposes cluster services externally.                                                                                                                                  |
+   | **Cilium and MetalLB interface**     | The physical network interface, bond, or bridge on each node used for Kubernetes cluster traffic and external service announcements. This setting does not control the management interface used for Local UI access. |
+   | **Enable VLAN Filtering (Optional)** | When enabled, the bridge interface permits only VLANs listed in **VLAN range for VMs**. Disable unless you need strict VLAN isolation.                                                                                |
+   | **VLAN range for VMs**               | VLAN IDs that tenant VMs can use. Accepts individual IDs, such as `12` and `13`, or ranges, such as `15-20`.                                                                                                          |
+   | **Bridge Interface**                 | The Linux bridge interface on cluster nodes that connects tenant VMs to the physical network. Leave blank to auto-detect.                                                                                             |
+   | **Cluster runs on br0**              | Enable if your Kubernetes cluster nodes communicate via the `br0` bridge interface or a VLAN sub-interface of br0.                                                                                                    |
+   | **VLANs on top of br0**              | List all VLAN IDs configured as sub-interfaces or dynamically attached on `br0`. Include VLAN 1 and all VM VLANs. For example, `1,10,20`.                                                                             |
+
+   :::warning
+
+   Selecting a management interface or a Cilium and MetalLB interface does not change how the host routes network
+   traffic. If multiple adapters use the same subnet and each adapter has a default route, traffic may leave through a
+   different adapter than expected. For best results, place management and cluster traffic on separate subnets and
+   configure both interfaces explicitly.
+
+   :::
 
    ### OS and Metrics
 

--- a/docs/docs-content/vm-management/launchpad-for-vms/vmo-networking.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/vmo-networking.md
@@ -40,7 +40,7 @@ VMs, this is the interface selected in the **Cilium and MetalLB interface** fiel
 
 Selecting a management interface or a cluster traffic interface does not change how the host routes network traffic. If
 multiple adapters use the same subnet and each adapter has a default route, traffic may leave through a different
-adapter than expected. This can cause control plane nodes to fail joining the cluster.
+adapter than expected. This may prevent control plane nodes from successfully joining the cluster.
 
 For best results, place management and cluster traffic on separate subnets and configure both interfaces explicitly.
 

--- a/docs/docs-content/vm-management/launchpad-for-vms/vmo-networking.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/vmo-networking.md
@@ -20,13 +20,37 @@ For the VM Appliance, Cilium is used to provide a way to achieve that goal. It d
 requirements for the host network configuration and for the Kubernetes worker nodes in order to have valid network
 targets to bridge the VMs onto.
 
-This page examines either a two-NIC, one-bond network configuration deployment or a four-NIC, two-bond network
-configuration deployment. You can do alternative configurations but they must have a bridge of `br0` as a prerequisite.
+This page examines a two-NIC, one-bond network configuration and a four-NIC, two-bond network configuration. You can use
+alternative configurations, but they must include a `br0` bridge.
+
+## Management and Cluster Traffic
+
+Launchpad for VMs hosts can use separate network interfaces for management traffic and Kubernetes cluster traffic.
+Management traffic includes Local UI access, communication between hosts, and content synchronization.
+
+You can configure the management interface in the Edge Installer `user-data` file. A selection made in the TUI overrides
+the value from `user-data`. After initial setup, a selection made in Local UI overrides the value from the TUI. If no
+management interface is selected, the host uses the network interface associated with the default route.
+
+Kubernetes cluster traffic uses the interface selected during cluster creation. This includes node IP selection,
+Kubernetes control plane traffic, etcd traffic, and traffic for the cluster virtual IP address (VIP). For Launchpad for
+VMs, this is the interface selected in the **Cilium and MetalLB interface** field.
+
+:::warning
+
+Selecting a management interface or a cluster traffic interface does not change how the host routes network traffic. If
+multiple adapters use the same subnet and each adapter has a default route, traffic may leave through a different
+adapter than expected. This can cause control plane nodes to fail joining the cluster.
+
+For best results, place management and cluster traffic on separate subnets and configure both interfaces explicitly.
+
+:::
 
 ## Two NICs, One Bond Configuration
 
 When network interfaces are limited, NICs can be configured with a single bond (`bond0`) and bridge (`br0`) that carry
-multiple VLANs. The following table and image present one possible example.
+multiple VLANs. This configuration assumes that you use two Fiber Channel adapters for storage. The following table and
+image present one possible example.
 
 | Interface  | Type           | Consisting of     | VLAN   | CIDR           | Gateway    |
 | ---------- | -------------- | ----------------- | ------ | -------------- | ---------- |


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adds info about upcoming changes to TUI and local UI networking. This adds addition info that were added in PR#10617. (additional info was added after that PR was merged)

- Added guidance for selecting the management interface on Edge and Launchpad for VMs hosts.
- Documented the management interface override order: `user-data`, TUI, then Local UI.
- Clarified the difference between management traffic and Kubernetes cluster traffic.
- Added multi-NIC routing guidance for cases where multiple adapters share a subnet or default route.
- Updated VMO networking guidance to explain management and cluster traffic interface selection.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Launchpad for VMs: Install page](https://deploy-preview-10740--docs-spectrocloud.netlify.app/vm-management/launchpad-for-vms/install-vmla-iso/#network-settings)
- [Launchpad for VMs: Network Configurations page](https://deploy-preview-10740--docs-spectrocloud.netlify.app/vm-management/launchpad-for-vms/vmo-networking/)
- [Edge: Initial Setup](https://deploy-preview-10740--docs-spectrocloud.netlify.app/clusters/edge/site-deployment/site-installation/initial-setup/)
- [Edge: Configure Network Interfaces](https://deploy-preview-10740--docs-spectrocloud.netlify.app/clusters/edge/local-ui/host-management/configure-network-interfaces/)

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[Jira Ticket](https://spectrocloud.atlassian.net/browse/PE-8655)
