### PR TITLE
docs: add scaling restrictions for skipped pools

### DIFF
--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -159,10 +159,16 @@ plane, Palette blocks the update.
 
 :::
 
-### Autoscaler Behavior
+### Scaling Behavior
 
-New nodes added by the cluster autoscaler to a skipped worker pool run the pool's current Kubernetes version, not the
-control plane version.
+Scaling behavior for a worker pool with **Skip worker node update** enabled differs by cluster type.
+
+For AWS IaaS, MAAS, and VMware vSphere clusters, scale-up is permitted. New nodes added manually or by the cluster
+autoscaler join at the pool's current Kubernetes version, not the control plane version. Scale-down is not restricted.
+
+For connected Edge Native clusters, scale-up is not permitted while the toggle is enabled. Palette rejects scale-up
+requests on a pool with the toggle enabled, whether initiated manually or by the cluster autoscaler. To expand capacity,
+create a new worker pool and add edge hosts to it instead.
 
 ### Upgrade a Skipped Worker Pool
 

--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -164,7 +164,7 @@ plane, Palette blocks the update.
 Scaling behavior for a worker pool with **Skip worker node update** enabled differs by cluster type.
 
 For AWS IaaS, MAAS, and VMware vSphere clusters, scale-up is permitted. New nodes added manually or by the cluster
-autoscaler join at the pool's current Kubernetes version, not the control plane version. Scale-down is not restricted.
+autoscaler join using the worker pool's current Kubernetes version, not the control plane version. Scale-down is not restricted.
 
 For connected Edge Native clusters, scale-up is not permitted while the toggle is enabled. Palette rejects scale-up
 requests on a pool with the toggle enabled, whether initiated manually or by the cluster autoscaler. To expand capacity,

--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -168,7 +168,7 @@ autoscaler join using the worker pool's current Kubernetes version, not the cont
 
 For connected Edge Native clusters, scale-up is not permitted while the toggle is enabled. Palette rejects scale-up
 requests on a pool with the toggle enabled, whether initiated manually or by the cluster autoscaler. To expand capacity,
-create a new worker pool and add edge hosts to it instead.
+create a new worker pool and add Edge hosts to it instead.
 
 ### Upgrade a Skipped Worker Pool
 

--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -164,7 +164,8 @@ plane, Palette blocks the update.
 Scaling behavior for a worker pool with **Skip worker node update** enabled differs by cluster type.
 
 For AWS IaaS, MAAS, and VMware vSphere clusters, scale-up is permitted. New nodes added manually or by the cluster
-autoscaler join using the worker pool's current Kubernetes version, not the control plane version. Scale-down is not restricted.
+autoscaler join using the worker pool's current Kubernetes version, not the control plane version. Scale-down is not
+restricted.
 
 For connected Edge Native clusters, scale-up is not permitted while the toggle is enabled. Palette rejects scale-up
 requests on a pool with the toggle enabled, whether initiated manually or by the cluster autoscaler. To expand capacity,

--- a/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
@@ -144,8 +144,9 @@ Palette enforces the Kubernetes [N-3 minor version skew](https://kubernetes.io/r
 enabling the toggle would cause a worker pool to fall more than three minor versions behind the control plane, Palette
 blocks the upgrade.
 
-New nodes added by the cluster autoscaler to a skipped worker pool run the pool's current Kubernetes version, not the
-control plane version.
+Scale-up is not permitted while the toggle is enabled. Palette rejects scale-up requests on a pool with the toggle
+enabled, whether initiated manually or by the cluster autoscaler. To expand capacity, create a new worker pool and add
+edge hosts to it instead.
 
 ### Upgrade a Skipped Worker Pool
 

--- a/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
@@ -146,7 +146,7 @@ blocks the upgrade.
 
 Scale-up is not permitted while the toggle is enabled. Palette rejects scale-up requests on a pool with the toggle
 enabled, whether initiated manually or by the cluster autoscaler. To expand capacity, create a new worker pool and add
-edge hosts to it instead.
+Edge hosts to it instead.
 
 ### Upgrade a Skipped Worker Pool
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [ ] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

docs: add scaling restrictions for skipped pools

Document platform-specific scaling restrictions for pools with
Skip worker node update enabled. AWS IaaS, MAAS, and VMware vSphere
permit scale-up. Edge Native does not.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Scaling Behavior](https://deploy-preview-10763--docs-spectrocloud.netlify.app/clusters/cluster-management/node-pool/#scaling-behavior)
- [Decoupled Control Plane and Worker Node Upgrades](https://deploy-preview-10763--docs-spectrocloud.netlify.app/clusters/edge/cluster-management/upgrade-behavior/#decoupled-control-plane-and-worker-node-upgrades)

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[Note on scaling restrictions when skip worker updates is enabled for a pool](https://spectrocloud.atlassian.net/browse/PE-8625)
