### PR TITLE
docs: generate empty cve map when integrations are disabled DOC-2827

### DIFF
--- a/.github/actions/build-cached-cves/action.yaml
+++ b/.github/actions/build-cached-cves/action.yaml
@@ -31,14 +31,25 @@ runs:
 
     - name: Download CVE Data
       run: |
-        # Find the latest CVE upload workflow.
-        run_id=$(gh run list --workflow="post_release.yaml" --limit 1 --status=success --json databaseId | jq -r '.[0].databaseId')
-        echo 'Fetching artifacts from run $run_id'
+        # Find the most recent runs that still have non-expired CVE artifacts.
+        # post_release.yaml runs as a reusable workflow, so its artifacts are filed under the
+        # caller (release.yaml), not under "post_release.yaml". Look each artifact up by name
+        # across all workflows rather than by workflow name, and skip expired ones so we never
+        # resolve a run whose artifacts have already passed their retention window.
+        sb_run=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=security-bulletins&per_page=100" \
+          --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .workflow_run.id')
+        pc_run=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=pack-cves&per_page=100" \
+          --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .workflow_run.id')
+        if [ -z "$sb_run" ] || [ "$sb_run" = "null" ] || [ -z "$pc_run" ] || [ "$pc_run" = "null" ]; then
+          echo "::error::No non-expired security-bulletins or pack-cves artifact found to fall back to."
+          exit 1
+        fi
+        echo "Fetching security-bulletins from run $sb_run and pack-cves from run $pc_run"
         # Remove any downloaded artifacts, should they exist.
         rm -rf ./downloaded_artifacts
-        # Download the latest artifact to a new dir.
-        gh run download ${run_id} --name security-bulletins --dir ./downloaded_artifacts/security-bulletins
-        gh run download ${run_id} --name pack-cves --dir ./downloaded_artifacts/pack-cves
+        # Download the latest artifacts to a new dir.
+        gh run download ${sb_run} --name security-bulletins --dir ./downloaded_artifacts/security-bulletins
+        gh run download ${pc_run} --name pack-cves --dir ./downloaded_artifacts/pack-cves
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.gh-token }}

--- a/.github/actions/build-cached-packs/action.yaml
+++ b/.github/actions/build-cached-packs/action.yaml
@@ -31,8 +31,18 @@ runs:
 
     - name: Download Packs Data
       run: |
-        # Find the latest packs upload workflow.
-        run_id=$(gh run list --workflow="post_release.yaml" --limit 1 --status=success --json databaseId | jq -r '.[0].databaseId')
+        # Find the most recent run that still has a non-expired "build-packs" artifact.
+        # post_release.yaml runs as a reusable workflow, so its artifacts are filed under the
+        # caller (release.yaml), not under "post_release.yaml". Look the artifact up by name
+        # across all workflows rather than by workflow name, and skip expired ones so we never
+        # resolve a run whose artifacts have already passed their retention window.
+        run_id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=build-packs&per_page=100" \
+          --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .workflow_run.id')
+        if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+          echo "::error::No non-expired build-packs artifact found to fall back to."
+          exit 1
+        fi
+        echo "Fetching build-packs artifact from run $run_id"
         # Remove any downloaded artifacts, should they exist.
         rm -rf ./downloaded_artifacts
         # Download the latest artifact to a new dir.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -267,20 +267,20 @@ jobs:
   post-release-processing:
     name: "Post Release Processing"
     needs: [release]
-    if: ${{ needs.release.result == 'success' }}
+    if: ${{ always() && needs.release.result == 'success' }}
     uses: ./.github/workflows/post_release.yaml
     secrets: inherit
 
   screenshot-capture:
     name: "Screenshot Capture"
     needs: [release]
-    if: ${{ needs.release.result == 'success' }}
+    if: ${{ always() && needs.release.result == 'success' }}
     uses: ./.github/workflows/screenshot_capture.yaml
     secrets: inherit
 
   algolia-crawler:
     name: "Algolia Crawler"
     needs: [release]
-    if: ${{ needs.release.result == 'success' }}
+    if: ${{ always() && needs.release.result == 'success' }}
     uses: ./.github/workflows/aloglia_crawler.yaml
     secrets: inherit

--- a/utils/pack-cves/index.js
+++ b/utils/pack-cves/index.js
@@ -116,6 +116,9 @@ async function generateCVEs() {
       await fs.writeFile(filename, JSON.stringify({}, null, 2));
     }
 
+    // Still emit an (empty) import map so the static import in PacksReadme.tsx resolves.
+    await generatePackCVEImportMap();
+
     return;
   }
 
@@ -289,6 +292,7 @@ async function generatePackCVEImportMap() {
   const outputFile = "src/generated/packCveImports.ts";
 
   mkdirSync(path.dirname(outputFile), { recursive: true });
+  mkdirSync(packsDir, { recursive: true });
 
   const files = await fs.readdir(packsDir);
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR generates an empty pack cve map when security integrations are disabled.  

It also fixes post-release.yaml processing which has been changed to a workflow run and has been silently skipped since. We have no unexpired pack, security bulletins or pack-cve bundles cached as a result. 

---

## 💻 Changed Pages

No user-facing changes.

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-2827](https://spectrocloud.atlassian.net/browse/DOC-2827)


[DOC-2827]: https://spectrocloud.atlassian.net/browse/DOC-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ