### PR TITLE
docs: add timeouts for screenshot-capture and split steps to avoid hanging DOC-2937

### DIFF
--- a/.github/workflows/screenshot_capture.yaml
+++ b/.github/workflows/screenshot_capture.yaml
@@ -36,6 +36,7 @@ jobs:
   create-assets:
     name: asset-builds
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -49,8 +50,16 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      # Split the apt step (--with-deps) from the browser download so a stall is
+      # attributable in the logs. Both are time-boxed so a hung apt/dpkg lock or a
+      # stalled CDN download fails fast instead of running to the 6h job ceiling.
+      - name: Install Playwright system dependencies
+        timeout-minutes: 10
+        run: npx playwright install-deps chromium
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        timeout-minutes: 10
+        run: npx playwright install chromium
 
       - name: Build
         run: |
@@ -85,6 +94,7 @@ jobs:
   visual-snapshots:
     runs-on: ubuntu-latest
     needs: [create-assets]
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -107,8 +117,13 @@ jobs:
             attempt_limit: 3
             attempt_delay: 60000 # 1 minute
 
+      - name: Install Playwright system dependencies
+        timeout-minutes: 10
+        run: npx playwright install-deps chromium
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        timeout-minutes: 10
+        run: npx playwright install chromium
 
       - name: retry action
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3
@@ -137,6 +152,7 @@ jobs:
     name: Merge Screenshots
     runs-on: ubuntu-latest
     needs: [visual-snapshots]
+    timeout-minutes: 30
     steps:
 
     - name: Download blob reports from GitHub Actions Artifacts


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adds timeout minutes and splits out the chromium install 

> The --with-deps flag makes Playwright shell out to sudo apt-get install for OS libraries. On ubuntu-latest runners this commonly blocks indefinitely — either on the dpkg/apt lock (held by the runner's background unattended-upgrades) or on an interactive debconf prompt. Neither has a timeout, so it sits until the 6h ceiling. A stalled Chromium download from the Playwright CDN (no per-download timeout) is the other usual suspect.

---

## 💻 Changed Pages

No user-facing changes.

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-2937](https://spectrocloud.atlassian.net/browse/)


[DOC-2937]: https://spectrocloud.atlassian.net/browse/DOC-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ