### PR TITLE
[version-4-3] docs: trigger version branch deploys on a schedule DOC-2604 (#10848)

### DIFF
--- a/.github/workflows/netlify-version-release.yaml
+++ b/.github/workflows/netlify-version-release.yaml
@@ -1,0 +1,99 @@
+# This workflow triggers Netlify branch-deploy builds for the version-* documentation branches on a schedule.
+# Previously, every push/merge into a version branch (common during backports) triggered a Netlify build, resulting in many unnecessary builds.
+# To reduce builds and speed up backports, the scripts/netlify.sh ignore script now skips push/merge builds on version-* branches, and this workflow rebuilds them twice daily instead - mirroring the cadence of the production release.
+# The workflow lists the remote version-X-Y branches at runtime and POSTs to a Netlify build hook for each one, passing the branch via the trigger_branch query parameter. The build hook sets the INCOMING_HOOK_* environment variables, which scripts/netlify.sh uses to allow the scheduled build.
+# The workflow supports on-demand execution using the workflow_dispatch event.
+#
+# Prerequisite: a repository secret named NETLIFY_BUILD_HOOK_URL must be set to a Netlify build hook URL
+# (Site configuration > Build & deploy > Build hooks), e.g. https://api.netlify.com/build_hooks/<hook-id>.
+
+name: Netlify Version Branch Release
+
+on:
+  schedule:
+    - cron: '0 5 * * *'   # At 9:00 PM PST (5:00 AM UTC next day), every day
+    - cron: '0 21 * * *'  # At 2:00 PM PST (9:00 PM UTC), every day
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Optional single version-X-Y branch to build (e.g. version-4-9). Leave empty to build all version branches.'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: netlify-version-builds
+  cancel-in-progress: false
+
+jobs:
+  trigger-builds:
+    name: Trigger Netlify builds for version branches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Trigger Netlify build hook per version branch
+        env:
+          NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
+          # Optional single branch from a manual workflow_dispatch run; empty for scheduled runs.
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${NETLIFY_BUILD_HOOK_URL:-}" ]; then
+            echo "Error: NETLIFY_BUILD_HOOK_URL secret is not set."
+            exit 1
+          fi
+
+          if [ -n "${INPUT_BRANCH:-}" ]; then
+            # Manual run targeting a single branch. Validate the format before triggering.
+            if ! echo "$INPUT_BRANCH" | grep -qE '^version-[0-9]+-[0-9]+$'; then
+              echo "Error: '$INPUT_BRANCH' is not a valid version-X-Y branch name."
+              exit 1
+            fi
+            branches="$INPUT_BRANCH"
+          else
+            # List remote release branches matching version-X-Y. This intentionally excludes
+            # backport/version-* and other version-suffixed branches.
+            branches=$(git ls-remote --heads origin 'version-*' \
+              | sed 's#.*refs/heads/##' \
+              | grep -E '^version-[0-9]+-[0-9]+$' || true)
+          fi
+
+          if [ -z "$branches" ]; then
+            echo "No version-X-Y branches found; nothing to build."
+            exit 0
+          fi
+
+          echo "Triggering Netlify builds for the following branches:"
+          echo "$branches"
+
+          for branch in $branches; do
+            echo "Triggering build for $branch..."
+            http_code=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              --request POST \
+              --data '{}' \
+              "${NETLIFY_BUILD_HOOK_URL}?trigger_branch=${branch}&trigger_title=scheduled-version-build")
+
+            if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+              echo "  Successfully triggered build for $branch (HTTP $http_code)."
+            else
+              echo "  Failed to trigger build for $branch (HTTP $http_code)."
+              exit 1
+            fi
+          done
+
+      - name: Slack Notification on Failure
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_PRIVATE_TEAM_WEBHOOK }}
+          SLACK_USERNAME: "spectromate"
+          SLACK_ICON_EMOJI: ":robot_panic:"
+          SLACK_COLOR: "danger"
+          SLACKIFY_MARKDOWN: true
+          ENABLE_ESCAPES: true
+          SLACK_MESSAGE: "The scheduled `${{ github.workflow }}` job failed to trigger Netlify version branch builds. [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/docs/contributing/checks-and-ci.md
+++ b/docs/contributing/checks-and-ci.md
@@ -4,15 +4,31 @@
 
 ## Netlify Previews
 
-By default, Netlify previews are enabled for pull requests. However, some branches do not require Netlify previews. In
-the [netlify.toml](../../netlify.toml) file, a custom script is used to determine if a Netlify preview should be
-created. The script is located in the [scripts/netlify.sh](../../scripts/netlify.sh) file. If you need to disable
-Netlify previews for a branch, add the branch name to the `allowed_branches` variable in the
-[scripts/netlify.sh](../../scripts/netlify.sh) file.
+By default, Netlify previews are enabled for pull requests. However, some branches do not require Netlify previews. The
+[netlify.toml](../../netlify.toml) file configures the [scripts/netlify.sh](../../scripts/netlify.sh) script as the
+Netlify `ignore` command, which determines whether a build proceeds based on the deploy context and the branch name.
+
+A separate allowed branches list, stored in the Netlify site build settings, controls which branches may create a
+preview that enables the Netlify Collab drawer. By default, only deploy previews that target the production branch are
+allowed. The [scripts/netlify_add_branch.sh](../../scripts/netlify_add_branch.sh) and
+[scripts/netlify_remove_branch.sh](../../scripts/netlify_remove_branch.sh) scripts manage this list through the Netlify
+API.
 
 If you want to add a branch whereby any pull request to that branch will trigger a Netlify Preview, go to the
 [**Branches and deploy contexts** in Netlify](https://app.netlify.com/projects/docs-spectrocloud/configuration/deploys#branches-and-deploy-contexts)
 and click **Configure**. Add your branch to the **Additional branches** field, and click **Save**.
+
+### Version Branch Builds
+
+Branches that match the `version-X-Y` pattern host the documentation for released Palette versions. To reduce the number
+of redundant builds during backports, Netlify does not build these branches on every push or merge. Instead, the
+[netlify-version-release.yaml](../../.github/workflows/netlify-version-release.yaml) workflow rebuilds them twice daily,
+mirroring the production release cadence. You can also trigger a build on demand from the **Actions** tab in GitHub by
+running the **Netlify Version Branch Release** workflow, optionally specifying a single `version-X-Y` branch.
+
+The [scripts/netlify.sh](../../scripts/netlify.sh) script enforces this behavior. It allows a `version-X-Y`
+branch-deploy build only when the build originates from the scheduled Netlify build hook, and it skips plain push or
+merge builds.
 
 ## Check Writing
 

--- a/scripts/netlify.sh
+++ b/scripts/netlify.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
 ############################################
-# This script checks if a Netlify context is for branch-deploy. 
+# This script checks if a Netlify context is for branch-deploy.
 # Netlify branch-deploy contexts are only allowed for branches that match version-*. This script is used in the Netlify build settings to determine if a preview should be created.
 # This script is created to prevent both a build-preview and a branch-deploy preview from being created for the same branch at the same time.
+
+# DOC-2604: version-* branch-deploy builds are throttled to twice daily instead of running on every push/merge,
+# which previously produced many redundant builds during backports. Scheduled builds are triggered by the
+# netlify-version-release.yaml workflow via a Netlify build hook, which sets the INCOMING_HOOK_* environment
+# variables. A version-* branch-deploy build is therefore only allowed when it originates from that build hook.
+
 # In the CI/CD pipeline, the scripts netlify_add_branch.sh and netlify_remove_branch.sh are used to manage the allowed branches list in the Netlify build settings.
 # The allowed branches list is used to determine which branches are allowed to create a Netlify preview for the purpose on enabling the Netlify Collab drawer.
 # By default, only deploy previews targeting the production branch are allowed, unless manually specified in the Netlify site settings. The scripts netlify_add_branch.sh and netlify_remove_branch.sh handle this responsiblity.
@@ -34,7 +40,16 @@ fi
 # Check if context is branch-deploy and current branch matches version-*
 if [[ "$context" == "branch-deploy" ]]; then
   if [[ "$current_branch" == version-* ]]; then
-    allowed=1
+    # DOC-2604: Only build version-* branches when the build is triggered by the scheduled
+    # Netlify build hook (which sets INCOMING_HOOK_TITLE). Skip plain push/merge builds so
+    # backport merges no longer trigger a build every time.
+    if [[ -n "$INCOMING_HOOK_TITLE" ]]; then
+      echo "Incoming hook detected ($INCOMING_HOOK_TITLE); scheduled version branch build allowed."
+      allowed=1
+    else
+      echo "Push/merge build on version branch; skipping (builds run twice daily via netlify-version-release.yaml)."
+      allowed=0
+    fi
   else
     allowed=0
   fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-3`:
 - [docs: trigger version branch deploys on a schedule DOC-2604 (#10848)](https://github.com/spectrocloud/librarium/pull/10848)
