### PR TITLE
[version-4-8] docs: change generate component updates to fetch Platone tickets from Pack Updates task as well DOC-2814 (#10873)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,30 +389,28 @@ generate-release: ## Generate all release files except release notes
 	make -s format > /dev/null 2>&1
 
 init-release:
-	grep -q "^# RELEASE NOTES" .env || echo "\n# RELEASE NOTES" >> .env
-	grep -q "^export RELEASE_NAME=" .env || echo "export RELEASE_NAME=" >> .env
-	grep -q "^export RELEASE_VERSION=" .env || echo "export RELEASE_VERSION=" >> .env
-	grep -q "^export RELEASE_DATE=" .env || echo "export RELEASE_DATE=" >> .env
-	grep -q "^export RELEASE_CANVOS=" .env || echo "export RELEASE_CANVOS=" >> .env
-	grep -q "^export RELEASE_EDGE_CLI_VERSION=" .env || echo "export RELEASE_EDGE_CLI_VERSION=" >> .env
-	grep -q "^export RELEASE_EDGE_CLI_DEPRECATED=" .env || echo "export RELEASE_EDGE_CLI_DEPRECATED=false" >> .env
-	grep -q "^export RELEASE_TERRAFORM_VERSION=" .env || echo "export RELEASE_TERRAFORM_VERSION=" >> .env
-	grep -q "^# COMPONENT UPDATES" .env || echo "\n# COMPONENT UPDATES" >> .env
-	grep -q "^export RELEASE_PALETTE_CLI_VERSION=" .env || echo "export RELEASE_PALETTE_CLI_VERSION=" >> .env
-	grep -q "^export RELEASE_PALETTE_CLI_SHA=" .env || echo "export RELEASE_PALETTE_CLI_SHA=" >> .env
-	grep -q "^export RELEASE_EDGE_CLI_VERSION=" .env || echo "export RELEASE_EDGE_CLI_VERSION=" >> .env
-	grep -q "^export RELEASE_EDGE_CLI_SHA=" .env || echo "export RELEASE_EDGE_CLI_SHA=" >> .env
-	grep -q "^export RELEASE_REGISTRY_VERSION=" .env || echo "export RELEASE_REGISTRY_VERSION=" >> .env
-	grep -q "^export RELEASE_SPECTRO_CLI_VERSION=" .env || echo "export RELEASE_SPECTRO_CLI_VERSION=" >> .env
-	grep -q "^export RELEASE_VMWARE_KUBERNETES_VERSION=" .env || echo "export RELEASE_VMWARE_KUBERNETES_VERSION=" >> .env
-	grep -q "^export RELEASE_VMWARE_OVA_URL=" .env || echo "export RELEASE_VMWARE_OVA_URL=" >> .env
-	grep -q "^export RELEASE_VMWARE_FIPS_OVA_URL=" .env || echo "export RELEASE_VMWARE_FIPS_OVA_URL=" >> .env
-	grep -q "^export RELEASE_HIGHEST_KUBERNETES_VERSION=" .env || echo "export RELEASE_HIGHEST_KUBERNETES_VERSION=" >> .env
-	grep -q "^export RELEASE_PCG_KUBERNETES_VERSION=" .env || echo "export RELEASE_PCG_KUBERNETES_VERSION=" >> .env
-	grep -q "^export JIRA_EMAIL=" .env || echo "export JIRA_EMAIL=" >> .env
-	grep -q "^export JIRA_API_TOKEN=" .env || echo "export JIRA_API_TOKEN=" >> .env
-	grep -q "^export SUPER_API_TOKEN=" .env || echo "export SUPER_API_TOKEN=" >> .env
-	grep -q "^export GITHUB_TOKEN=" .env || echo "export GITHUB_TOKEN=" >> .env
+	grep -q "^# RELEASE NOTES" .env || printf "\n# RELEASE NOTES\n" >> .env
+	grep -q "^export RELEASE_NAME=" .env || printf "export RELEASE_NAME=\n" >> .env
+	grep -q "^export RELEASE_VERSION=" .env || printf "export RELEASE_VERSION=\n" >> .env
+	grep -q "^export RELEASE_DATE=" .env || printf "export RELEASE_DATE=\n" >> .env
+	grep -q "^export RELEASE_CANVOS=" .env || printf "export RELEASE_CANVOS=\n" >> .env
+	grep -q "^export RELEASE_EDGE_CLI_VERSION=" .env || printf "export RELEASE_EDGE_CLI_VERSION=\n" >> .env
+	grep -q "^export RELEASE_EDGE_CLI_DEPRECATED=" .env || printf "export RELEASE_EDGE_CLI_DEPRECATED=false\n" >> .env
+	grep -q "^export RELEASE_TERRAFORM_VERSION=" .env || printf "export RELEASE_TERRAFORM_VERSION=\n" >> .env
+	grep -q "^# COMPONENT UPDATES" .env || printf "\n# COMPONENT UPDATES\n" >> .env
+	grep -q "^export RELEASE_PALETTE_CLI_VERSION=" .env || printf "export RELEASE_PALETTE_CLI_VERSION=\n" >> .env
+	grep -q "^export RELEASE_PALETTE_CLI_SHA=" .env || printf "export RELEASE_PALETTE_CLI_SHA=\n" >> .env
+	grep -q "^export RELEASE_REGISTRY_VERSION=" .env || printf "export RELEASE_REGISTRY_VERSION=\n" >> .env
+	grep -q "^export RELEASE_SPECTRO_CLI_VERSION=" .env || printf "export RELEASE_SPECTRO_CLI_VERSION=\n" >> .env
+	grep -q "^export RELEASE_VMWARE_KUBERNETES_VERSION=" .env || printf "export RELEASE_VMWARE_KUBERNETES_VERSION=\n" >> .env
+	grep -q "^export RELEASE_VMWARE_OVA_URL=" .env || printf "export RELEASE_VMWARE_OVA_URL=\n" >> .env
+	grep -q "^export RELEASE_VMWARE_FIPS_OVA_URL=" .env || printf "export RELEASE_VMWARE_FIPS_OVA_URL=\n" >> .env
+	grep -q "^export RELEASE_HIGHEST_KUBERNETES_VERSION=" .env || printf "export RELEASE_HIGHEST_KUBERNETES_VERSION=\n" >> .env
+	grep -q "^export RELEASE_PCG_KUBERNETES_VERSION=" .env || printf "export RELEASE_PCG_KUBERNETES_VERSION=\n" >> .env
+	grep -q "^export JIRA_EMAIL=" .env || printf "export JIRA_EMAIL=\n" >> .env
+	grep -q "^export JIRA_API_TOKEN=" .env || printf "export JIRA_API_TOKEN=\n" >> .env
+	grep -q "^export SUPER_API_TOKEN=" .env || printf "export SUPER_API_TOKEN=\n" >> .env
+	grep -q "^export GITHUB_TOKEN=" .env || printf "export GITHUB_TOKEN=\n" >> .env
 
 ###@ Aloglia Indexing
 

--- a/scripts/release/generate-component-updates-ai.sh
+++ b/scripts/release/generate-component-updates-ai.sh
@@ -111,6 +111,13 @@ done < <(
     '
 )
 
+if (( ${#LINKED_ISSUES[@]} == 0 )); then
+  echo "❌  No linked issues found for ticket: $JIRA_TICKET" >&2
+  exit 1
+fi
+
+echo "ℹ️  Linked issues retrieved: ${LINKED_ISSUES[*]}"
+
 # Fetch only Platone tickets to create the packs list in the release notes
 PLATONE_ISSUES=()
 while IFS= read -r issue; do
@@ -128,13 +135,56 @@ done < <(
     '
 )
 
-if (( ${#LINKED_ISSUES[@]} == 0 )); then
-  echo "❌  No linked issues found for ticket: $JIRA_TICKET" >&2
-  exit 1
+# Find the "Pack Updates" ticket linked to the component update ticket.
+PACK_UPDATES_TICKET=$(
+  curl --fail-with-body \
+    --url "${JIRA_DOMAIN}/rest/api/3/issue/${JIRA_TICKET}?fields=issuelinks" \
+    --user "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+    --header "Accept: application/json" \
+  | jq -r '
+      [ .fields.issuelinks[]
+        | (.outwardIssue // .inwardIssue)
+        | select(.fields.summary | contains("Pack Updates"))
+        | .key
+      ] | first // empty
+    '
+)
+
+# Fetch the child tickets of the Pack Updates ticket whose summary contains
+# "[Platone]" and add them to the Platone issues list, then dedupe.
+if [[ -n "$PACK_UPDATES_TICKET" ]]; then
+  echo "ℹ️ Pack Updates ticket linked to $JIRA_TICKET: $PACK_UPDATES_TICKET"
+  while IFS= read -r issue; do
+    [[ -n "$issue" ]] && PLATONE_ISSUES+=("$issue")
+  done < <(
+    curl --fail-with-body \
+      --get \
+      --url "${JIRA_DOMAIN}/rest/api/3/search/jql" \
+      --user "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+      --header "Accept: application/json" \
+      --data-urlencode "jql=parent = ${PACK_UPDATES_TICKET}" \
+      --data-urlencode "fields=summary" \
+      --data-urlencode "maxResults=100" \
+    | jq -r '
+        .issues[]
+        | select(.fields.summary | contains("[Platone]"))
+        | .key
+      '
+  )
+else
+  echo "⚠️ No Pack Updates ticket linked to $JIRA_TICKET." >&2
 fi
 
-echo "ℹ️  Linked issues retrieved: ${LINKED_ISSUES[*]}"
-echo "ℹ️  Platone issues retrieved: ${PLATONE_ISSUES[*]}"
+# Dedupe the combined Platone issues list.
+if (( ${#PLATONE_ISSUES[@]} > 0 )); then
+  DEDUPED_ISSUES=()
+  while IFS= read -r issue; do
+    [[ -n "$issue" ]] && DEDUPED_ISSUES+=("$issue")
+  done < <(printf '%s\n' "${PLATONE_ISSUES[@]}" | sort -u)
+  PLATONE_ISSUES=("${DEDUPED_ISSUES[@]}")
+fi
+
+echo "ℹ️ Platone issues retrieved: ${PLATONE_ISSUES[*]}"
 
 # Check if release notes section for this component update ticket already exists in the release notes file
 COMPONENT_UPDATES_EXISTING_BODY=""


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-8`:
 - [docs: change generate component updates to fetch Platone tickets from Pack Updates task as well DOC-2814 (#10873)](https://github.com/spectrocloud/librarium/pull/10873)