### PR TITLE
[version-4-2] DOC-2473 (additional) - Improve persona-check behaviour (#10937)

### DIFF
--- a/.github/persona-check/config.mjs
+++ b/.github/persona-check/config.mjs
@@ -92,7 +92,7 @@ export default {
       "",
       "- `provider=` — `anthropic` (default) or `openai`",
       "- `model=` — a specific model (default: the provider's default); see the [full list of available models](https://github.com/spectrocloud/impersonaid/blob/main/src/models/models.json)",
-      "- `persona=` — pin a persona by name (default: auto-selected per file)",
+      "- `persona=` — pin a persona by name (default: auto-selected per file). Available: `Site Reliability Engineer`, `Product Evaluator`, `Platform Engineer` — see the [full list](https://github.com/spectrocloud/impersonaid/tree/main/personas)",
       "- `question=\"...\"` — free-text question, or `question_key=` a preset; see the [available question keys](https://github.com/spectrocloud/librarium/blob/master/.github/persona-check/config.mjs)",
       "- `files=all` or `files=\"path/a.md,path/b.mdx\"` (default: changed docs above the threshold)",
       `- \`threshold=\` — minimum changed lines to review (default: ${this.threshold})`,

--- a/.github/workflows/persona-check.yaml
+++ b/.github/workflows/persona-check.yaml
@@ -222,10 +222,10 @@ jobs:
             const marker = "<!-- persona-check -->";
             const stamp = new Date().toISOString().replace("T", " ").replace(/:\d\d\.\d+Z$/, " UTC");
             const p = [marker, "## 🤖 Persona check — preview", ""];
-            p.push("The `persona-check` label is applied — **no review has run yet.** Comment `/persona-check` to run it (add overrides such as `files=all` or `provider=openai`).");
+            p.push("The `persona-check` label is applied — **no review has run yet.** Comment `/persona-check` to run it. See the **How to use** dropdown below to add overrides.");
             p.push("");
             if (result.length) {
-              p.push(`**Would review ${result.length} file${result.length === 1 ? "" : "s"}** (threshold ${threshold}, cap ${maxFiles > 0 ? maxFiles : "none"}), largest changes first:`);
+              p.push(`**Persona check would review ${result.length} file${result.length === 1 ? "" : "s"}** (docs with ${threshold}+ changed lines${maxFiles > 0 ? `, capped at ${maxFiles}` : ""}), largest changes first:`);
               p.push("");
               for (const f of selected) p.push(`- \`${f.filename}\` (${f.changes} changed lines)`);
             } else {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-2`:
 - [DOC-2473 (additional) - Improve persona-check behaviour (#10937)](https://github.com/spectrocloud/librarium/pull/10937)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)