### PR TITLE
Launchpad for VMs Infrastructure section: storage page

### DIFF
--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/infrastructure.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/infrastructure.md
@@ -18,9 +18,10 @@ and Network Attachment Definitions (NADs) you define here.
 
 ## Infrastructure Resources
 
-| **Resource**                  | **Description**                                                                         |
-| ----------------------------- | --------------------------------------------------------------------------------------- |
-| [Namespaces](./namespaces.md) | Create, adopt, and edit managed namespaces, and apply resource quotas and limit ranges. |
+| **Resource**                  | **Description**                                                                                   |
+| ----------------------------- | ------------------------------------------------------------------------------------------------- |
+| [Namespaces](./namespaces.md) | Create, adopt, and edit managed namespaces, and apply resource quotas and limit ranges.           |
+| [Storage](./storage.md)       | Manage StorageClasses, storage pools, PersistentVolumeClaims, and DataVolumes that back VM disks. |
 
 ## Related Workflows
 

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -293,7 +293,7 @@ VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create,
 
    :::info
 
-   VMO doesn't yet support private registries that require authentication.
+   The VMO UI does not include an option to add private registries that require authentication. Contact [Spectro Cloud Support](mailto:support@spectrocloud.com) for manual configuration steps.
 
    :::
 

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -42,6 +42,58 @@ StorageClass operations.
 | **Delete**      | Remove a StorageClass. If any PVCs or DataVolumes use the StorageClass, VMO blocks the deletion and lists the dependent volumes. |
 | **Set default** | Mark one StorageClass as the cluster default. New PVCs that do not specify a StorageClass use the default.                       |
 
+### Create a StorageClass
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Classes**.
+
+2. Select **Create Storage Class**.
+
+3. Configure the following fields.
+
+   | **Field**                                          | **Description**                                                                                                      |
+   | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+   | **Class Name**                                     | The StorageClass name. Follow Kubernetes naming rules (lowercase, alphanumeric, hyphens); up to 128 characters.      |
+   | **Default Class**                                  | Select to mark this StorageClass as the cluster default. New PVCs that don't specify a StorageClass use the default. |
+   | **Allow Expansion**                                | Select to let PVCs expand. The underlying provider must support volume expansion.                                    |
+   | **Allow for VMs**                                  | Select to make this StorageClass available for VM workloads.                                                         |
+   | **Create StorageProfile for CSI-assisted cloning** | Select to enable offloaded (`csi-clone`) DataVolume clones on Block volumes for this StorageClass.                   |
+   | **Reclaim Policy**                                 | The Kubernetes reclaim policy: `Delete` or `Retain`. Controls what happens to a PV when its PVC is released.         |
+   | **Binding Mode**                                   | `Immediate` or `WaitForFirstConsumer`. Controls when volume binding and dynamic provisioning happen.                 |
+
+4. Under **Parameters**, configure how VMO provisions volumes. The available parameters depend on the storage provider.
+   The following parameters apply to Piraeus/LINSTOR.
+
+   | **Field**                            | **Description**                                                                                                              |
+   | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+   | **Select a Policy**                  | Select a Storage Policy to fill in the parameters below, or choose **No Policy (manual parameters)** to enter them manually. |
+   | **Storage Pool**                     | The name of the LINSTOR storage pool to provision from.                                                                      |
+   | **Placement Count**                  | The number of replicas for each volume.                                                                                      |
+   | **Resource Group**                   | The LINSTOR resource group name.                                                                                             |
+   | **Advanced Parameters** _(Optional)_ | Expand to configure other provider-specific parameters as key-value pairs.                                                   |
+
+5. Select **Create Storage Class**.
+
+## Storage Profiles
+
+Storage Profiles are CDI resources that define how VMO provisions DataVolumes for each StorageClass. VMO auto-creates a
+StorageProfile for a StorageClass when the **Create StorageProfile for CSI-assisted cloning** option is selected during
+StorageClass creation.
+
+### Edit a Storage Profile
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Profiles**.
+
+2. Select the StorageProfile you want to edit.
+
+3. Configure the following fields.
+
+   | **Field**          | **Description**                                                                                                                                                     |
+   | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Volume Mode**    | `Block` or `Filesystem`. `Block` with `csi-clone` is recommended for Piraeus/LINSTOR. Choose `Filesystem` only when the storage backend lacks Block volume support. |
+   | **Clone Strategy** | `csi-clone`, `copy`, or `snapshot`. Controls how VMO clones DataVolumes backed by this StorageClass.                                                                |
+
+4. Select **Save**.
+
 ## Storage Pools
 
 Storage pools are provider-specific. For Piraeus/LINSTOR, VMO supports the following storage pool operations.
@@ -59,6 +111,67 @@ may expose different APIs or require configuration outside VMO.
 
 :::
 
+### Create a Storage Pool
+
+Storage Pool creation is provider-specific. The following steps apply to Piraeus/LINSTOR.
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Pools**.
+
+2. Select **Create Storage Pool**.
+
+3. Configure the common fields.
+
+   | **Field**        | **Description**                                                                                                                   |
+   | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+   | **Pool Name**    | The storage pool name. Up to 128 characters.                                                                                      |
+   | **Pool Type**    | The backing storage type: **LVM Thin**, **LVM**, **ZFS**, **ZFS Thin**, **File**, or **File Thin**.                               |
+   | **Host Devices** | Block devices from cluster nodes to include in the pool. If no devices appear, enter a device path (for example, `/dev/nvme0n1`). |
+
+4. Configure the fields for the selected **Pool Type**.
+
+   <Tabs groupId="storage-pool-type">
+
+   <TabItem value="lvm-thin" label="LVM Thin">
+
+   | **Field**        | **Description**                                     |
+   | ---------------- | --------------------------------------------------- |
+   | **Volume Group** | The LVM volume group name (for example, `drbd-vg`). |
+   | **Thin Pool**    | The LVM thin pool name (for example, `thinpool`).   |
+
+   </TabItem>
+
+   <TabItem value="lvm" label="LVM">
+
+   | **Field**        | **Description**                                     |
+   | ---------------- | --------------------------------------------------- |
+   | **Volume Group** | The LVM volume group name (for example, `drbd-vg`). |
+
+   </TabItem>
+
+   <TabItem value="zfs" label="ZFS / ZFS Thin">
+
+   | **Field**    | **Description**                  |
+   | ------------ | -------------------------------- |
+   | **ZFS Pool** | The name of the ZFS pool to use. |
+
+   Select **ZFS Thin** for thin-provisioned ZFS volumes. Both pool types share the same configuration fields.
+
+   </TabItem>
+
+   <TabItem value="file" label="File / File Thin">
+
+   | **Field**     | **Description**                                                                    |
+   | ------------- | ---------------------------------------------------------------------------------- |
+   | **Directory** | The host directory that stores pool files (for example, `/var/lib/linstor-pools`). |
+
+   Select **File Thin** for thin-provisioned file-backed volumes. Both pool types share the same configuration fields.
+
+   </TabItem>
+
+   </Tabs>
+
+5. Select **Create Storage Pool**.
+
 ### OS Disk Exclusion
 
 VMO automatically excludes disks that back critical OS mount points (`/`, `/boot`, `/boot/efi`, `/efi`, and `/usr`) from
@@ -67,6 +180,31 @@ a storage pool.
 
 The exclusion covers the full parent disk, not just the mounted partition. For example, if `/dev/sda1` is mounted at
 `/`, VMO hides the entire `sda` disk from the device list.
+
+## Storage Policies
+
+Storage Policies are reusable parameter presets for StorageClass creation. When creating a StorageClass, select a policy
+from the **Select a Policy** dropdown to fill in provider-specific parameters instead of entering them manually.
+
+### Create a Storage Policy
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Policies**.
+
+2. Select **Create Policy**.
+
+3. Configure the following fields.
+
+   | **Field**                    | **Description**                                                                                                                 |
+   | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+   | **Policy Name**              | The policy name. Follow Kubernetes naming rules (lowercase, alphanumeric, hyphens); up to 128 characters.                       |
+   | **Display Name**             | A human-readable name for the policy. Shown in the Storage Policies list and in the Storage Class **Select a Policy** dropdown. |
+   | **Description** _(Optional)_ | A short description of the policy.                                                                                              |
+   | **Provider**                 | The storage provider the policy applies to (for example, `piraeus`).                                                            |
+
+4. Use **Add Group** and **Add Parameter** to define the parameters the policy sets. VMO applies these parameters when
+   the policy is selected during StorageClass creation.
+
+5. Select **Save**.
 
 ## DataVolumes
 
@@ -84,11 +222,101 @@ disks. VMO supports the following DataVolume sources.
 
 VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create, resize, and delete them.
 
-When creating a DataVolume from **Upload**, **URL**, or **Registry**, use the **Image** checkbox to control how VMO
-treats the volume during VM creation.
+### Create a DataVolume
 
-- **Cleared**: VMO treats the DataVolume as an ISO for a CD-ROM installer.
-- **Selected**: VMO treats the DataVolume as a disk image for a boot disk or template source.
+1. From the VMO left main menu, select **Infrastructure** > **Storage**.
+
+2. Select **Create DataVolume**.
+
+3. Configure the common fields.
+
+   | **Field**         | **Description**                                                                                               |
+   | ----------------- | ------------------------------------------------------------------------------------------------------------- |
+   | **Name**          | The DataVolume name. Follow Kubernetes naming rules (lowercase, alphanumeric, hyphens); up to 128 characters. |
+   | **Namespace**     | The namespace in which the appliance creates the DataVolume.                                                  |
+   | **Storage Class** | The StorageClass that backs the DataVolume. Defaults to the cluster default (for example, `vmo-default-sc`).  |
+   | **Size**          | The DataVolume size. Enter a number and select a unit: `Gi`, `Mi`, or `Ti`.                                   |
+   | **Access Mode**   | `ReadWriteOnce`, `ReadWriteMany`, or `ReadOnlyMany`. The StorageClass must support the mode you select.       |
+   | **Volume Mode**   | `Block` or `Filesystem`.                                                                                      |
+
+4. Select a **Source** and configure its type-specific fields.
+
+   <Tabs groupId="datavolume-source">
+
+   <TabItem value="upload" label="Upload">
+
+   Upload a local file through the CDI upload proxy.
+
+   | **Field** | **Description**                                                                                                                    |
+   | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+   | **Image** | Leave cleared when uploading an ISO for a CD-ROM installer. Select when uploading a disk image for a boot disk or template source. |
+   | **File**  | Choose a local file. Accepts `.iso`, `.img`, and `.qcow2` files.                                                                   |
+
+   </TabItem>
+
+   <TabItem value="url" label="URL">
+
+   Import from an HTTP or HTTPS URL.
+
+   | **Field**      | **Description**                                                                                                                    |
+   | -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+   | **Image**      | Leave cleared when importing an ISO for a CD-ROM installer. Select when importing a disk image for a boot disk or template source. |
+   | **Source URL** | The HTTP or HTTPS URL to the disk image.                                                                                           |
+
+   </TabItem>
+
+   <TabItem value="blank" label="Blank">
+
+   Create an empty disk of the size specified in the common fields. Useful for boot disks or scratch volumes.
+
+   </TabItem>
+
+   <TabItem value="clone" label="Clone">
+
+   Clone an existing PVC or DataVolume.
+
+   | **Field**            | **Description**                         |
+   | -------------------- | --------------------------------------- |
+   | **Source Namespace** | The namespace that contains the source. |
+   | **Source PVC**       | The PVC to clone from.                  |
+
+   </TabItem>
+
+   <TabItem value="registry" label="Registry">
+
+   Import from a public container registry.
+
+   | **Field**           | **Description**                                                                                                                                |
+   | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Image**           | Leave cleared when importing an ISO for a CD-ROM installer. Select when importing a disk image for a boot disk or template source.             |
+   | **Image Reference** | Public container image reference, for example, `docker://quay.io/org/image:tag`. VMO adds the `docker://` prefix automatically if you omit it. |
+
+   :::info
+
+   VMO doesn't yet support private registries that require authentication.
+
+   :::
+
+   </TabItem>
+
+   </Tabs>
+
+### Delete a DataVolume
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Data Volumes**.
+
+2. Locate the DataVolume and choose one of the following actions:
+
+   - Select the trash icon in the row's **Actions** column.
+   - Check the boxes on the rows you want to delete, then select **Delete _N_**.
+
+3. In the confirmation dialog, type the DataVolume name and select **Delete**.
+
+:::warning
+
+Deletion is irreversible. Ensure you have backups or snapshots if the data is important.
+
+:::
 
 ## Persistent Volume Claims
 

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -2,8 +2,8 @@
 sidebar_label: "Storage"
 title: "Storage"
 description:
-  "Manage StorageClasses, storage pools, PersistentVolumeClaims, and DataVolumes that back virtual machine disks on the
-  Launchpad for VMs appliance."
+  "Manage StorageClasses, storage pools, and DataVolumes that back virtual machine disks on the Launchpad for VMs
+  appliance."
 icon: " "
 hide_table_of_contents: false
 sidebar_position: 20
@@ -11,8 +11,7 @@ tags: ["vmo", "vm launchpad appliance", "infrastructure", "storage"]
 ---
 
 Virtual Machine Orchestrator (VMO) manages the storage that backs VM disks. From **Infrastructure** > **Storage**, you
-can manage [StorageClasses](https://kubernetes.io/docs/concepts/storage/storage-classes/), storage pools,
-[PersistentVolumeClaims (PVCs)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/), and
+can manage [StorageClasses](https://kubernetes.io/docs/concepts/storage/storage-classes/), storage pools, and
 [DataVolumes](https://kubevirt.io/user-guide/storage/containerized_data_importer/). The Launchpad for VMs appliance
 ships with Piraeus/LINSTOR as the default storage backend, but VMO works with any StorageClass that supports dynamic
 provisioning.
@@ -50,34 +49,80 @@ StorageClass operations.
 
 3. Configure the following fields.
 
-   | **Field**                                          | **Description**                                                                                                      |
-   | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-   | **Class Name**                                     | The StorageClass name. Follow Kubernetes naming rules (lowercase, alphanumeric, hyphens); up to 128 characters.      |
-   | **Default Class**                                  | Select to mark this StorageClass as the cluster default. New PVCs that don't specify a StorageClass use the default. |
-   | **Allow Expansion**                                | Select to let PVCs expand. The underlying provider must support volume expansion.                                    |
-   | **Allow for VMs**                                  | Select to make this StorageClass available for VM workloads.                                                         |
-   | **Create StorageProfile for CSI-assisted cloning** | Select to enable offloaded (`csi-clone`) DataVolume clones on Block volumes for this StorageClass.                   |
-   | **Reclaim Policy**                                 | The Kubernetes reclaim policy: `Delete` or `Retain`. Controls what happens to a PV when its PVC is released.         |
-   | **Binding Mode**                                   | `Immediate` or `WaitForFirstConsumer`. Controls when volume binding and dynamic provisioning happen.                 |
+   | **Field**                                          | **Description**                                                                                                       |
+   | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+   | **Class Name**                                     | The StorageClass name. Follow Kubernetes naming rules (lowercase, alphanumeric, hyphens); up to 128 characters.       |
+   | **Default Class**                                  | Select to mark this StorageClass as the cluster default. New PVCs that do not specify a StorageClass use the default. |
+   | **Allow Expansion**                                | Select to let PVCs expand. The underlying provider must support volume expansion.                                     |
+   | **Allow for VMs**                                  | Select to make this StorageClass available for VM workloads.                                                          |
+   | **Create StorageProfile for CSI-assisted cloning** | Select to enable offloaded (`csi-clone`) DataVolume clones on Block volumes for this StorageClass.                    |
+   | **Reclaim Policy**                                 | The Kubernetes reclaim policy: `Delete` or `Retain`. Controls what happens to a PV when its PVC is released.          |
+   | **Binding Mode**                                   | `Immediate` or `WaitForFirstConsumer`. Controls when volume binding and dynamic provisioning happen.                  |
 
 4. Under **Parameters**, configure how VMO provisions volumes. The available parameters depend on the storage provider.
    The following parameters apply to Piraeus/LINSTOR.
 
-   | **Field**                            | **Description**                                                                                                              |
-   | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-   | **Select a Policy**                  | Select a Storage Policy to fill in the parameters below, or choose **No Policy (manual parameters)** to enter them manually. |
-   | **Storage Pool**                     | The name of the LINSTOR storage pool to provision from.                                                                      |
-   | **Placement Count**                  | The number of replicas for each volume.                                                                                      |
-   | **Resource Group**                   | The LINSTOR resource group name.                                                                                             |
-   | **Advanced Parameters** _(Optional)_ | Expand to configure other provider-specific parameters as key-value pairs.                                                   |
+   | **Field**                            | **Description**                                                                                                                                   |
+   | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Select a Policy**                  | Select a [Storage Policy](#storage-policies) to fill in the parameters below, or choose **No Policy (manual parameters)** to enter them manually. |
+   | **Storage Pool**                     | The name of the LINSTOR storage pool to provision from.                                                                                           |
+   | **Placement Count**                  | The number of replicas for each volume.                                                                                                           |
+   | **Resource Group**                   | The LINSTOR resource group name.                                                                                                                  |
+   | **Advanced Parameters** _(Optional)_ | Expand to configure other provider-specific parameters as key-value pairs.                                                                        |
 
 5. Select **Create Storage Class**.
+
+### Set the Default StorageClass
+
+Only one StorageClass can be the cluster default at a time. New PVCs that do not specify a StorageClass use the default.
+Set the default in one of two ways:
+
+- **During creation**: select the **Default Class** checkbox in the [Create Storage Class](#create-a-storageclass)
+  modal.
+- **On an existing StorageClass**: edit the StorageClass and select the **Default Class** checkbox.
+
+:::warning
+
+StorageClasses are immutable in Kubernetes. Saving an edit deletes the existing StorageClass and recreates it with the
+updated settings. The same delete-and-recreate applies to the _previous_ default when you mark a new one, because VMO
+clears the previous default in the same way. If any PVCs or DataVolumes reference the affected StorageClass, whether the
+one you are editing or the previous default when switching, the deletion step fails and the save is rejected. Delete or
+reassign the dependent volumes before editing or switching the default.
+
+:::
+
+To set the default on an existing StorageClass, take the following steps.
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Classes**.
+
+2. In the Storage Classes list, select the row of the StorageClass you want to make the default. The details panel opens
+   on the right.
+
+3. Select **Edit**.
+
+4. Select the **Default Class** checkbox.
+
+5. Select **Save**.
+
+### Delete a StorageClass
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Classes**.
+
+2. In the Storage Classes list, select the row of the StorageClass you want to delete. The details panel opens on the
+   right.
+
+3. Select **Delete Storage Class**.
+
+4. In the confirmation dialog, confirm the deletion.
+
+If any PVCs or DataVolumes reference the StorageClass, VMO blocks the deletion and lists the dependent volumes. Delete
+or reassign the dependent resources before retrying.
 
 ## Storage Profiles
 
 Storage Profiles are CDI resources that define how VMO provisions DataVolumes for each StorageClass. VMO auto-creates a
-StorageProfile for a StorageClass when the **Create StorageProfile for CSI-assisted cloning** option is selected during
-StorageClass creation.
+StorageProfile when you enable **Create StorageProfile for CSI-assisted cloning** during StorageClass creation. The UI
+exposes only editing; VMO manages Storage Profile creation and deletion for you.
 
 ### Edit a Storage Profile
 
@@ -87,10 +132,10 @@ StorageClass creation.
 
 3. Configure the following fields.
 
-   | **Field**          | **Description**                                                                                                                                                     |
-   | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   | **Volume Mode**    | `Block` or `Filesystem`. `Block` with `csi-clone` is recommended for Piraeus/LINSTOR. Choose `Filesystem` only when the storage backend lacks Block volume support. |
-   | **Clone Strategy** | `csi-clone`, `copy`, or `snapshot`. Controls how VMO clones DataVolumes backed by this StorageClass.                                                                |
+   | **Field**          | **Description**                                                                                                                                                    |
+   | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+   | **Volume Mode**    | `Block` or `Filesystem`. For Piraeus/LINSTOR, we recommend `Block` with `csi-clone`. Choose `Filesystem` only when the storage backend lacks Block volume support. |
+   | **Clone Strategy** | `csi-clone`, `copy`, or `snapshot`. Controls how VMO clones DataVolumes backed by this StorageClass.                                                               |
 
 4. Select **Save**.
 
@@ -172,6 +217,21 @@ Storage Pool creation is provider-specific. The following steps apply to Piraeus
 
 5. Select **Create Storage Pool**.
 
+### Delete a Storage Pool
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Pools**.
+
+2. In the Storage Pools list, select the row of the pool you want to delete. The details panel opens on the right.
+
+3. Select **Delete Storage Pool**.
+
+4. In the confirmation dialog, confirm the deletion.
+
+If the storage pool is not empty, VMO blocks the deletion. Remove any resources that reference the pool before retrying.
+
+The Storage Pools UI does not include an edit option. To change a pool's device selection or type, delete the pool and
+recreate it.
+
 ### OS Disk Exclusion
 
 VMO automatically excludes disks that back critical OS mount points (`/`, `/boot`, `/boot/efi`, `/efi`, and `/usr`) from
@@ -184,7 +244,9 @@ The exclusion covers the full parent disk, not just the mounted partition. For e
 ## Storage Policies
 
 Storage Policies are reusable parameter presets for StorageClass creation. When creating a StorageClass, select a policy
-from the **Select a Policy** dropdown to fill in provider-specific parameters instead of entering them manually.
+from the **Select a Policy** drop-down to fill in provider-specific parameters instead of entering them manually. VMO
+ships with a built-in **Piraeus DRBD Performance Tuning** policy for Piraeus/LINSTOR workloads with live-migration
+support.
 
 ### Create a Storage Policy
 
@@ -194,17 +256,48 @@ from the **Select a Policy** dropdown to fill in provider-specific parameters in
 
 3. Configure the following fields.
 
-   | **Field**                    | **Description**                                                                                                                 |
-   | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-   | **Policy Name**              | The policy name. Follow Kubernetes naming rules (lowercase, alphanumeric, hyphens); up to 128 characters.                       |
-   | **Display Name**             | A human-readable name for the policy. Shown in the Storage Policies list and in the Storage Class **Select a Policy** dropdown. |
-   | **Description** _(Optional)_ | A short description of the policy.                                                                                              |
-   | **Provider**                 | The storage provider the policy applies to (for example, `piraeus`).                                                            |
+   | **Field**                    | **Description**                                                                                                                  |
+   | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+   | **Policy Name**              | The policy name. Follow Kubernetes naming rules (lowercase, alphanumeric, hyphens); up to 128 characters.                        |
+   | **Display Name**             | A human-readable name for the policy. Shown in the Storage Policies list and in the Storage Class **Select a Policy** drop-down. |
+   | **Description** _(Optional)_ | A short description of the policy.                                                                                               |
+   | **Provider**                 | The storage provider the policy applies to (for example, `piraeus`).                                                             |
 
 4. Use **Add Group** and **Add Parameter** to define the parameters the policy sets. VMO applies these parameters when
-   the policy is selected during StorageClass creation.
+   you select the policy during StorageClass creation.
 
 5. Select **Save**.
+
+### Edit a Storage Policy
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Policies**.
+
+2. In the Storage Policies list, select the row of the policy you want to edit. The details panel opens on the right.
+
+3. Select **Edit Policy**.
+
+4. Adjust the parameter values in the **Edit Policy** modal.
+
+5. Select **Save**.
+
+:::info
+
+Built-in policies (labeled with a **Built-in** tag) restrict edits to parameter values only. The policy name,
+description, and parameter structure are managed by the system. Policies you create yourself allow full edits.
+
+:::
+
+### Delete a Storage Policy
+
+1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Policies**.
+
+2. In the Storage Policies list, select the row of the policy you want to delete. The details panel opens on the right.
+
+3. Select **Delete Policy**.
+
+4. In the confirmation dialog, confirm the deletion.
+
+Built-in policies cannot be deleted. The **Delete Policy** button is only available on policies you create yourself.
 
 ## DataVolumes
 
@@ -220,7 +313,10 @@ disks. VMO supports the following DataVolume sources.
 | **Clone**    | Clone from an existing PVC or DataVolume.         |
 | **Registry** | Import from a container registry.                 |
 
-VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create, resize, and delete them.
+VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create and delete them.
+
+The DataVolumes UI does not include a resize option. To change a DataVolume's size, delete and recreate it at the
+desired size.
 
 ### Create a DataVolume
 
@@ -233,13 +329,16 @@ VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create,
    | **Field**         | **Description**                                                                                               |
    | ----------------- | ------------------------------------------------------------------------------------------------------------- |
    | **Name**          | The DataVolume name. Follow Kubernetes naming rules (lowercase, alphanumeric, hyphens); up to 128 characters. |
-   | **Namespace**     | The namespace in which the appliance creates the DataVolume.                                                  |
+   | **Namespace**     | The namespace where VMO creates the DataVolume.                                                               |
    | **Storage Class** | The StorageClass that backs the DataVolume. Defaults to the cluster default (for example, `vmo-default-sc`).  |
    | **Size**          | The DataVolume size. Enter a number and select a unit: `Gi`, `Mi`, or `Ti`.                                   |
    | **Access Mode**   | `ReadWriteOnce`, `ReadWriteMany`, or `ReadOnlyMany`. The StorageClass must support the mode you select.       |
    | **Volume Mode**   | `Block` or `Filesystem`.                                                                                      |
 
-4. Select a **Source** and configure its type-specific fields.
+4. Select a **Source** and configure its type-specific fields. For **Upload**, **URL**, and **Registry** sources, use
+   the **Image** checkbox to control how VMO treats the volume. Leave the checkbox cleared for installer media, which
+   VMO attaches as a CD-ROM drive in the VM. Select the checkbox for a bootable disk image or template source, which VMO
+   clones as a VM boot disk.
 
    <Tabs groupId="datavolume-source">
 
@@ -247,10 +346,9 @@ VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create,
 
    Upload a local file through the CDI upload proxy.
 
-   | **Field** | **Description**                                                                                                                    |
-   | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-   | **Image** | Leave cleared when uploading an ISO for a CD-ROM installer. Select when uploading a disk image for a boot disk or template source. |
-   | **File**  | Choose a local file. Accepts `.iso`, `.img`, and `.qcow2` files.                                                                   |
+   | **Field** | **Description**                                                  |
+   | --------- | ---------------------------------------------------------------- |
+   | **File**  | Choose a local file. Accepts `.iso`, `.img`, and `.qcow2` files. |
 
    </TabItem>
 
@@ -258,10 +356,9 @@ VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create,
 
    Import from an HTTP or HTTPS URL.
 
-   | **Field**      | **Description**                                                                                                                    |
-   | -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-   | **Image**      | Leave cleared when importing an ISO for a CD-ROM installer. Select when importing a disk image for a boot disk or template source. |
-   | **Source URL** | The HTTP or HTTPS URL to the disk image.                                                                                           |
+   | **Field**      | **Description**                          |
+   | -------------- | ---------------------------------------- |
+   | **Source URL** | The HTTP or HTTPS URL to the disk image. |
 
    </TabItem>
 
@@ -288,7 +385,6 @@ VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create,
 
    | **Field**           | **Description**                                                                                                                                |
    | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-   | **Image**           | Leave cleared when importing an ISO for a CD-ROM installer. Select when importing a disk image for a boot disk or template source.             |
    | **Image Reference** | Public container image reference, for example, `docker://quay.io/org/image:tag`. VMO adds the `docker://` prefix automatically if you omit it. |
 
    :::info
@@ -321,13 +417,10 @@ Deletion is irreversible. Ensure you have backups or snapshots if the data is im
 
 ## Persistent Volume Claims
 
-VMO provides PVC operations from **Infrastructure** > **Storage**.
-
-| Operation  | Description                                                                                     |
-| ---------- | ----------------------------------------------------------------------------------------------- |
-| **List**   | View PVCs across namespaces.                                                                    |
-| **Resize** | Expand a PVC's capacity when the StorageClass and underlying provider support volume expansion. |
-| **Delete** | Remove a PVC. Confirm that no VMs or DataVolumes reference the PVC before deleting.             |
+The VMO UI does not include operations for managing
+[PersistentVolumeClaims (PVCs)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) directly. Provision VM
+storage using [DataVolumes](#datavolumes), which provide the user-facing abstraction; VMO manages the underlying PVCs
+for you. To inspect or modify PVCs directly, use `kubectl` or another Kubernetes tool.
 
 ## StorageClass Auto-Detection
 
@@ -340,7 +433,7 @@ data PVC, such as `vmo-manager-data`, and caches the value. VMO uses the detecte
 - Builder disks.
 
 If VMO does not detect a StorageClass, such as when no bound PVC exists, VMO falls back to the cluster default. When no
-cluster default is configured, you must specify a StorageClass explicitly when creating resources.
+cluster default exists, you must specify a StorageClass explicitly when creating resources.
 
 :::tip
 

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -1,0 +1,121 @@
+---
+sidebar_label: "Storage"
+title: "Storage"
+description:
+  "Manage StorageClasses, storage pools, PersistentVolumeClaims, and DataVolumes that back virtual machine disks on the
+  Launchpad for VMs appliance."
+icon: " "
+hide_table_of_contents: false
+sidebar_position: 20
+tags: ["vmo", "vm launchpad appliance", "infrastructure", "storage"]
+draft: true
+---
+
+Virtual Machine Orchestrator (VMO) manages the storage that backs VM disks. From **Infrastructure** > **Storage**, you
+can manage [StorageClasses](https://kubernetes.io/docs/concepts/storage/storage-classes/), storage pools,
+[PersistentVolumeClaims (PVCs)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/), and
+[DataVolumes](https://kubevirt.io/user-guide/storage/containerized_data_importer/). The Launchpad for VMs appliance
+ships with Piraeus/LINSTOR as the default storage backend, but VMO works with any StorageClass that supports dynamic
+provisioning.
+
+## Storage Providers
+
+VMO does not assume a specific storage backend. It works with any Kubernetes StorageClass that supports dynamic
+provisioning.
+
+The default appliance backend is **Piraeus/LINSTOR**, which provides:
+
+- Replicated storage for VM disks.
+- StorageClass-based provisioning.
+- LVM-based storage pools.
+
+You can use other providers, such as host-path or Rook-Ceph, depending on the cluster configuration.
+
+## StorageClasses
+
+StorageClasses define how VMO provisions PVCs. From **Infrastructure** > **Storage**, you can perform the following
+StorageClass operations.
+
+| Operation       | Description                                                                                                                      |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **List**        | View all StorageClasses in the cluster.                                                                                          |
+| **Create**      | Create a new StorageClass, when the underlying provider supports it.                                                             |
+| **Delete**      | Remove a StorageClass. If any PVCs or DataVolumes use the StorageClass, VMO blocks the deletion and lists the dependent volumes. |
+| **Set default** | Mark one StorageClass as the cluster default. New PVCs that do not specify a StorageClass use the default.                       |
+
+## Storage Pools
+
+Storage pools are provider-specific constructs. For Piraeus/LINSTOR, VMO supports the following storage pool operations.
+
+| Operation            | Description                                                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Create**           | Create a new storage pool with a name and one or more block devices.                                                                                        |
+| **Delete**           | Remove a storage pool. You can remove a pool only when it is empty.                                                                                         |
+| **Device selection** | When creating a pool, select block devices from cluster nodes. The `vmo-node-agent` DaemonSet discovers physical block devices on each node and lists them. |
+
+:::info
+
+Storage pool management depends on the storage provider. VMO supports Piraeus/LINSTOR pools directly. Other providers
+may expose different APIs or require configuration outside VMO.
+
+:::
+
+### OS Disk Exclusion
+
+VMO automatically excludes disks that back critical OS mount points (`/`, `/boot`, `/boot/efi`, `/efi`, and `/usr`) from
+the device picker and marks them as in-use. This prevents you from accidentally adding a node's operating system disk to
+a storage pool.
+
+The exclusion covers the full parent disk, not just the mounted partition. For example, if `/dev/sda1` is mounted at
+`/`, VMO hides the entire `sda` disk from the device list.
+
+## DataVolumes
+
+[DataVolumes](https://kubevirt.io/user-guide/storage/containerized_data_importer/) are
+[Containerized Data Importer (CDI)](https://github.com/kubevirt/containerized-data-importer) resources that back VM
+disks. VMO supports the following DataVolume sources.
+
+| Source     | Description                                       |
+| ---------- | ------------------------------------------------- |
+| **Blank**  | An empty disk of the specified size.              |
+| **URL**    | Import from an HTTP or HTTPS URL.                 |
+| **Clone**  | Clone from an existing PVC or DataVolume.         |
+| **Upload** | Upload from a browser. Uses the CDI upload proxy. |
+
+VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create, resize, and delete them.
+
+When creating a DataVolume from **Upload**, **URL**, or **Registry**, use the **Image** checkbox to control how VMO
+treats the volume during VM creation.
+
+- **Cleared**: VMO treats the DataVolume as installer media and attaches it as a CD-ROM drive in the VM.
+- **Selected**: VMO treats the DataVolume as a ready-to-boot disk or template image and clones it as a VM boot disk.
+
+## Persistent Volume Claims
+
+VMO provides PVC operations from **Infrastructure** > **Storage**.
+
+| Operation  | Description                                                                                     |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| **List**   | View PVCs across namespaces.                                                                    |
+| **Resize** | Expand a PVC's capacity when the StorageClass and underlying provider support volume expansion. |
+| **Delete** | Remove a PVC. Confirm that no VMs or DataVolumes reference the PVC before deleting.             |
+
+## StorageClass Auto-Detection
+
+VMO does not require a static StorageClass configuration. On startup, VMO reads the `spec.storageClassName` of its own
+data PVC, such as `vmo-manager-data`, and caches the value. VMO uses the detected StorageClass as the default for:
+
+- New VM disks.
+- Golden image DataVolumes.
+- Virtio PVCs.
+- Builder disks.
+
+If VMO does not detect a StorageClass, such as when no bound PVC exists, VMO falls back to the cluster default. When no
+cluster default is configured, you must specify a StorageClass explicitly when creating resources.
+
+:::tip
+
+To control the default storage for VM disks, configure the VMO data PVC with the StorageClass you want to use. This PVC
+is the single source of truth for default storage.
+
+:::

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -19,7 +19,7 @@ provisioning.
 
 ## Storage Providers
 
-VMO does not assume a specific storage backend. It works with any Kubernetes StorageClass that supports dynamic
+VMO does not require a specific storage backend. It works with any Kubernetes StorageClass that supports dynamic
 provisioning.
 
 The default appliance backend is Piraeus/LINSTOR, which provides:
@@ -44,13 +44,13 @@ StorageClass operations.
 
 ## Storage Pools
 
-Storage pools are provider-specific constructs. For Piraeus/LINSTOR, VMO supports the following storage pool operations.
+Storage pools are provider-specific. For Piraeus/LINSTOR, VMO supports the following storage pool operations.
 
-| Operation            | Description                                                                                                                                                 |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Create**           | Create a new storage pool with a name and one or more block devices.                                                                                        |
-| **Delete**           | Remove a storage pool. You can remove a pool only when it is empty.                                                                                         |
-| **Device selection** | When creating a pool, select block devices from cluster nodes. The `vmo-node-agent` DaemonSet discovers physical block devices on each node and lists them. |
+| Operation            | Description                                                                                                                                                                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Create**           | Create a new storage pool with a name and one or more block devices.                                                                                                             |
+| **Delete**           | Remove a storage pool. You can remove a pool only when it is empty.                                                                                                              |
+| **Device selection** | When creating a pool, select block devices from cluster nodes. The `vmo-node-agent` DaemonSet discovers physical block devices on each node and lists them in the device picker. |
 
 :::info
 
@@ -74,20 +74,21 @@ The exclusion covers the full parent disk, not just the mounted partition. For e
 [Containerized Data Importer (CDI)](https://github.com/kubevirt/containerized-data-importer) resources that back VM
 disks. VMO supports the following DataVolume sources.
 
-| Source     | Description                                       |
-| ---------- | ------------------------------------------------- |
-| **Blank**  | An empty disk of the specified size.              |
-| **URL**    | Import from an HTTP or HTTPS URL.                 |
-| **Clone**  | Clone from an existing PVC or DataVolume.         |
-| **Upload** | Upload from a browser. Uses the CDI upload proxy. |
+| Source       | Description                                       |
+| ------------ | ------------------------------------------------- |
+| **Upload**   | Upload from a browser. Uses the CDI upload proxy. |
+| **URL**      | Import from an HTTP or HTTPS URL.                 |
+| **Blank**    | An empty disk of the specified size.              |
+| **Clone**    | Clone from an existing PVC or DataVolume.         |
+| **Registry** | Import from a container registry.                 |
 
 VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create, resize, and delete them.
 
 When creating a DataVolume from **Upload**, **URL**, or **Registry**, use the **Image** checkbox to control how VMO
 treats the volume during VM creation.
 
-- **Cleared**: VMO treats the DataVolume as installer media and attaches it as a CD-ROM drive in the VM.
-- **Selected**: VMO treats the DataVolume as a ready-to-boot disk or template image and clones it as a VM boot disk.
+- **Cleared**: VMO treats the DataVolume as an ISO for a CD-ROM installer.
+- **Selected**: VMO treats the DataVolume as a disk image for a boot disk or template source.
 
 ## Persistent Volume Claims
 

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -293,7 +293,8 @@ VMO lists DataVolumes on **Infrastructure** > **Storage**, where you can create,
 
    :::info
 
-   The VMO UI does not include an option to add private registries that require authentication. Contact [Spectro Cloud Support](mailto:support@spectrocloud.com) for manual configuration steps.
+   The VMO UI does not include an option to add private registries that require authentication. Contact
+   [Spectro Cloud Support](mailto:support@spectrocloud.com) for manual configuration steps.
 
    :::
 

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -31,8 +31,8 @@ You can use other providers, such as host-path or Rook-Ceph, depending on the cl
 
 ## StorageClasses
 
-StorageClasses define how VMO provisions PVCs. From **Infrastructure** > **Storage**, you can perform the following
-StorageClass operations.
+StorageClasses define how VMO provisions PersistentVolumeClaims (PVCs). From **Infrastructure** > **Storage**, you can
+perform the following StorageClass operations.
 
 | Operation       | Description                                                                                                                      |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -55,7 +55,7 @@ StorageClass operations.
    | **Default Class**                                  | Select to mark this StorageClass as the cluster default. New PVCs that do not specify a StorageClass use the default. |
    | **Allow Expansion**                                | Select to let PVCs expand. The underlying provider must support volume expansion.                                     |
    | **Allow for VMs**                                  | Select to make this StorageClass available for VM workloads.                                                          |
-   | **Create StorageProfile for CSI-assisted cloning** | Select to enable offloaded (`csi-clone`) DataVolume clones on Block volumes for this StorageClass.                    |
+   | **Create StorageProfile for CSI-assisted cloning** | Select to enable offloaded DataVolume clones (`csi-clone`) on Block volumes for this StorageClass.                    |
    | **Reclaim Policy**                                 | The Kubernetes reclaim policy: `Delete` or `Retain`. Controls what happens to a PV when its PVC is released.          |
    | **Binding Mode**                                   | `Immediate` or `WaitForFirstConsumer`. Controls when volume binding and dynamic provisioning happen.                  |
 
@@ -77,9 +77,9 @@ StorageClass operations.
 Only one StorageClass can be the cluster default at a time. New PVCs that do not specify a StorageClass use the default.
 Set the default in one of two ways:
 
-- **During creation**: select the **Default Class** checkbox in the [Create Storage Class](#create-a-storageclass)
+- **During creation**: Select the **Default Class** checkbox in the [Create Storage Class](#create-a-storageclass)
   modal.
-- **On an existing StorageClass**: edit the StorageClass and select the **Default Class** checkbox.
+- **On an existing StorageClass**: Edit the StorageClass and select the **Default Class** checkbox.
 
 :::warning
 
@@ -169,7 +169,7 @@ Storage Pool creation is provider-specific. The following steps apply to Piraeus
    | **Field**        | **Description**                                                                                                                   |
    | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
    | **Pool Name**    | The storage pool name. Up to 128 characters.                                                                                      |
-   | **Pool Type**    | The backing storage type: **LVM Thin**, **LVM**, **ZFS**, **ZFS Thin**, **File**, or **File Thin**.                               |
+   | **Pool Type**    | The backing storage type: `LVM Thin`, `LVM`, `ZFS`, `ZFS Thin`, `File`, or `File Thin`.                                           |
    | **Host Devices** | Block devices from cluster nodes to include in the pool. If no devices appear, enter a device path (for example, `/dev/nvme0n1`). |
 
 4. Configure the fields for the selected **Pool Type**.
@@ -217,6 +217,11 @@ Storage Pool creation is provider-specific. The following steps apply to Piraeus
 
 5. Select **Create Storage Pool**.
 
+### Edit a Storage Pool
+
+The Storage Pools UI does not include an edit option. To change a pool's device selection or type, delete the pool and
+recreate it.
+
 ### Delete a Storage Pool
 
 1. From the VMO left main menu, select **Infrastructure** > **Storage** > **Storage Pools**.
@@ -228,9 +233,6 @@ Storage Pool creation is provider-specific. The following steps apply to Piraeus
 4. In the confirmation dialog, confirm the deletion.
 
 If the storage pool is not empty, VMO blocks the deletion. Remove any resources that reference the pool before retrying.
-
-The Storage Pools UI does not include an edit option. To change a pool's device selection or type, delete the pool and
-recreate it.
 
 ### OS Disk Exclusion
 

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -113,7 +113,7 @@ data PVC, such as `vmo-manager-data`, and caches the value. VMO uses the detecte
 If VMO does not detect a StorageClass, such as when no bound PVC exists, VMO falls back to the cluster default. When no
 cluster default is configured, you must specify a StorageClass explicitly when creating resources.
 
-:::tip
+:::info
 
 To control the default storage for VM disks, configure the VMO data PVC with the StorageClass you want to use. This PVC
 is the single source of truth for default storage.

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -8,7 +8,6 @@ icon: " "
 hide_table_of_contents: false
 sidebar_position: 20
 tags: ["vmo", "vm launchpad appliance", "infrastructure", "storage"]
-draft: true
 ---
 
 Virtual Machine Orchestrator (VMO) manages the storage that backs VM disks. From **Infrastructure** > **Storage**, you

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -113,7 +113,7 @@ data PVC, such as `vmo-manager-data`, and caches the value. VMO uses the detecte
 If VMO does not detect a StorageClass, such as when no bound PVC exists, VMO falls back to the cluster default. When no
 cluster default is configured, you must specify a StorageClass explicitly when creating resources.
 
-:::info
+:::tip
 
 To control the default storage for VM disks, configure the VMO data PVC with the StorageClass you want to use. This PVC
 is the single source of truth for default storage.

--- a/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/launchpad-for-vms/infrastructure/storage.md
@@ -22,7 +22,7 @@ provisioning.
 VMO does not assume a specific storage backend. It works with any Kubernetes StorageClass that supports dynamic
 provisioning.
 
-The default appliance backend is **Piraeus/LINSTOR**, which provides:
+The default appliance backend is Piraeus/LINSTOR, which provides:
 
 - Replicated storage for VM disks.
 - StorageClass-based provisioning.


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adds the Storage page to the Launchpad for VMs Infrastructure section and links it from the section index. Second page in the stacked DOC-2857 build, targeting doc-2857-infrastructure-section.

The page documents everything under **Infrastructure > Storage** as verified in the UI: 

- StorageClasses (including default-switch cascade and block-on-delete)
- Storage Profiles
- Storage Pools
- Storage Policies
- DataVolumes
- auto-detection
- Storage Providers. 

The new page only calls out the UI-only behaviors that aren't obvious from the underlying Kubernetes/KubeVirt concepts, and redirects PVC readers to DataVolumes since VMO doesn't surface PVC operations in the UI.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Infrastructure Page](https://deploy-preview-11008--docs-spectrocloud.netlify.app/vm-management/launchpad-for-vms/infrastructure/)
- [Infrastructure: Storage Page](https://deploy-preview-11008--docs-spectrocloud.netlify.app/vm-management/launchpad-for-vms/infrastructure/storage/)

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

Parent branch has the JIRA