### PR TITLE
DOC-2472 (additional) - Auto merge PR and format improvements to Monthly Assessments

### DIFF
--- a/.github/monthly-assessment/fetch-top-pages.mjs
+++ b/.github/monthly-assessment/fetch-top-pages.mjs
@@ -272,7 +272,8 @@ async function main() {
     );
   }
 
-  fs.writeFileSync(OUT_PATH, JSON.stringify(top, null, 2));
+  // Trailing newline so Prettier (which runs on committed JSON) leaves it unchanged.
+  fs.writeFileSync(OUT_PATH, JSON.stringify(top, null, 2) + "\n");
   console.log(`[monthly-assessment] wrote ${top.length} pages to ${OUT_PATH}:`);
   for (const [i, p] of top.entries()) console.log(`  ${i + 1}. ${p.path} (${p.views} views)`);
 }

--- a/.github/monthly-assessment/publish-confluence.mjs
+++ b/.github/monthly-assessment/publish-confluence.mjs
@@ -32,8 +32,30 @@ const baseUrl = config.confluence.baseUrl.replace(/\/$/, "");
 export function esc(s) {
   return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
-function verdictLabel(v) {
-  return { PASS: "✅ PASS", PARTIAL: "🟡 PARTIAL", FAIL: "❌ FAIL", ERROR: "⚠️ ERROR", UNKNOWN: "❔" }[v] || esc(v);
+// Score legend explaining the 1-5 rating, rendered just after the intro.
+export function scoreLegend() {
+  const rows = [
+    [5, "Reader can complete the task using only this page"],
+    [4, "Minor gaps; succeeds with little friction"],
+    [3, "Usable, but real gaps slow the reader down"],
+    [2, "Significant gaps; likely to get stuck"],
+    [1, "Reader cannot complete the task from this page"],
+  ]
+    .map(([n, meaning]) => `<tr><td>${n}</td><td>${meaning}</td></tr>`)
+    .join("");
+  return (
+    "<p><strong>Score</strong> rates how well a reader can accomplish their task on the page:</p>" +
+    "<table><tbody><tr><th>Score</th><th>What it means</th></tr>" +
+    rows +
+    "</tbody></table>"
+  );
+}
+
+// A page's top gaps as a bullet list (or an em dash when there are none).
+function gapList(p) {
+  const gaps = p.gaps || [];
+  if (!gaps.length) return "<p>—</p>";
+  return "<ul>" + gaps.map((g) => `<li>${esc(g)}</li>`).join("") + "</ul>";
 }
 
 // Load the trend window: the newest N month records, newest first.
@@ -47,31 +69,26 @@ export function loadRecords(dir) {
   return files.map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), "utf8")));
 }
 
-// --- Latest scorecard table -------------------------------------------------
-export function scorecardTable(rec) {
-  const rows = rec.pages
-    .map((p, i) => {
-      const gaps = (p.gaps || []).map(esc).join("<br/>") || "—";
-      return (
-        `<tr><td>${i + 1}</td>` +
+// --- Latest scorecard: one small table per page, with top gaps as a bullet
+// list beneath it (labelled "Top gaps:"). ------------------------------------
+export function scorecardBlocks(rec) {
+  return rec.pages
+    .map(
+      (p) =>
+        "<table><tbody>" +
+        "<tr><th>Views</th><th>Page</th><th>Persona</th><th>Score</th></tr>" +
+        `<tr><td>${esc(p.views ?? "")}</td>` +
         `<td><a href="${esc(p.url)}">${esc(p.path)}</a></td>` +
-        `<td style="text-align:right">${esc(p.views ?? "")}</td>` +
         `<td>${esc(p.persona)}</td>` +
-        `<td>${verdictLabel(p.verdict)}</td>` +
-        `<td style="text-align:center">${p.score ?? "—"}</td>` +
-        `<td>${gaps}</td></tr>`
-      );
-    })
+        `<td>${p.score ?? "—"}</td></tr>` +
+        "</tbody></table>" +
+        `<p><strong>Top gaps for '${esc(p.path)}':</strong></p>` +
+        gapList(p),
+    )
     .join("");
-  return (
-    "<table><tbody>" +
-    "<tr><th>#</th><th>Page</th><th>Views</th><th>Persona</th><th>Verdict</th><th>Score</th><th>Top gaps</th></tr>" +
-    rows +
-    "</tbody></table>"
-  );
 }
 
-// --- Rolling trend table (verdict + score per page across months) -----------
+// --- Rolling trend table (score per page across months) ---------------------
 export function trendTable(recs) {
   const months = recs.map((r) => r.month); // newest first
   const paths = [];
@@ -94,7 +111,7 @@ export function trendTable(recs) {
       const cells = months
         .map((m) => {
           const p = byMonthPath.get(`${m}|${pth}`);
-          return `<td>${p ? `${verdictLabel(p.verdict)} (${p.score ?? "—"})` : "—"}</td>`;
+          return `<td>${p ? (p.score ?? "—") : "—"}</td>`;
         })
         .join("");
       return `<tr><td>${esc(pth)}</td>${cells}</tr>`;
@@ -103,11 +120,12 @@ export function trendTable(recs) {
   const summary = months
     .map((m) => {
       const r = recs.find((x) => x.month === m);
-      const pass = r.pages.filter((p) => p.verdict === "PASS").length;
-      return `<td><strong>${pass}/${r.pages.length} pass</strong></td>`;
+      const scored = r.pages.filter((p) => typeof p.score === "number");
+      const avg = scored.length ? (scored.reduce((s, p) => s + p.score, 0) / scored.length).toFixed(1) : "—";
+      return `<td><strong>${avg}</strong></td>`;
     })
     .join("");
-  return "<table><tbody>" + header + rows + `<tr><td><strong>Pass rate</strong></td>${summary}</tr>` + "</tbody></table>";
+  return "<table><tbody>" + header + rows + `<tr><td><strong>Average score</strong></td>${summary}</tr>` + "</tbody></table>";
 }
 
 // Parent "Monthly Assessments" page; deep-links to its "Ignored paths" section
@@ -122,10 +140,11 @@ export function renderBody(latest, records) {
     `Advisory AI feedback — not a substitute for human review. Owners and quick-wins are assigned manually. ` +
     `Some high-traffic front-facing pages are excluded from the ranking — see ` +
     `<a href="${IGNORED_PATHS_URL}">Ignored paths</a>.</p>` +
+    scoreLegend() +
     `<h2>Latest scorecard — ${esc(latest.month)}</h2>` +
     `<p>Provider <code>${esc(latest.provider)}</code>, model <code>${esc(latest.model)}</code>. ` +
     `Generated ${esc(latest.generatedAt)}.</p>` +
-    scorecardTable(latest) +
+    scorecardBlocks(latest) +
     `<h2>Rolling ${records.length}-month trend</h2>` +
     trendTable(records)
   );

--- a/.github/monthly-assessment/run-assessment.mjs
+++ b/.github/monthly-assessment/run-assessment.mjs
@@ -177,7 +177,10 @@ const record = {
   pages: results.map(({ response, ok, error, ...keep }) => keep), // JSON stays compact; prose lives in the md
 };
 const jsonPath = path.join(outDir, `${month}.json`);
-fs.writeFileSync(jsonPath, JSON.stringify(record, null, 2));
+// Trailing newline for a POSIX-clean file (avoids a "no newline at EOF" diff).
+// This scorecard JSON is also Prettier-ignored (see .prettierignore) because its
+// per-page gap arrays would otherwise be reformatted by Prettier's array collapsing.
+fs.writeFileSync(jsonPath, JSON.stringify(record, null, 2) + "\n");
 
 // --- Write the Markdown scorecard (human artifact / Confluence fallback) ----
 function verdictBadge(v) {
@@ -188,6 +191,11 @@ const partials = results.filter((r) => r.verdict === "PARTIAL").length;
 const fails = results.filter((r) => r.verdict === "FAIL").length;
 
 const md = [];
+// Disable Vale on this generated file. The AI-written gap text otherwise floods
+// the scorecard PR with reviewdog/Vale comments. Repo convention: the directive
+// on the first line (with a blank line under it) turns Vale off for the file.
+md.push("<!-- vale off -->");
+md.push("");
 md.push(`# Docs Monthly Assessment — ${month}`);
 md.push("");
 md.push(

--- a/.github/workflows/monthly-assessment.yaml
+++ b/.github/workflows/monthly-assessment.yaml
@@ -162,23 +162,46 @@ jobs:
               --base master \
               --head "$PR_BRANCH" \
               --title "docs: monthly assessment scorecard ${MONTH}" \
-              --body "Automated monthly persona assessment scorecard for **${MONTH}** (DOC-2472). Adds \`${MA_DIR}/scorecards/${MONTH}.{json,md}\`. The Confluence page has already been updated (if configured); this PR preserves the trend history in-repo and is merged automatically."
+              --body "Automated monthly persona assessment scorecard for **${MONTH}** (DOC-2472). Adds \`${MA_DIR}/scorecards/${MONTH}.{json,md}\`. The Confluence page has already been updated (if configured); this PR preserves the trend history in-repo and is merged automatically once its checks pass."
+            PR=$(gh pr list --head "$PR_BRANCH" --state open --json number --jq '.[0].number // empty')
           else
             echo "🔄 Updated existing PR #$PR (branch re-pushed)."
           fi
+          [[ -z "$PR" ]] && { echo "::error::Could not resolve the scorecard PR number."; exit 1; }
 
-          # Auto-merge with the Vault token: vault-token-factory-spectrocloud[bot] is a
-          # repo admin, so --admin bypasses branch protection (the same admin bypass the
-          # backport workflow relies on). Retry while GitHub computes mergeability.
-          for attempt in 1 2 3; do
-            if gh pr merge "$PR_BRANCH" --squash --admin; then
-              echo "Auto-merged the scorecard PR."
+          # Let CI gate the merge: wait for the PR's checks (the required "Build" /
+          # Pre-merge Checks, plus the rest) to finish, and merge only if they pass.
+          # `gh pr checks --watch` errors until checks register, so poll for them.
+          echo "Waiting for checks on PR #${PR}..."
+          for attempt in $(seq 1 30); do
+            if out=$(gh pr checks "$PR" --watch --fail-fast 2>&1); then
+              echo "$out"
+              echo "All checks passed on PR #${PR}."
+              break
+            fi
+            if echo "$out" | grep -qiE "no checks reported|no pull requests found"; then
+              [[ "$attempt" -eq 30 ]] && { echo "::error::Checks never registered on PR #${PR}."; exit 1; }
+              echo "Checks not registered yet (attempt ${attempt}/30); waiting 20s..."
+              sleep 20
+              continue
+            fi
+            echo "$out"
+            echo "::error::A check failed on PR #${PR} — not merging."
+            exit 1
+          done
+
+          # Checks are green. Admin-merge with the Vault token: vault-token-factory-
+          # spectrocloud[bot] is a repo admin, so --admin bypasses the required code-owner
+          # review (the same admin bypass the backport workflow relies on). CI already gated.
+          for m in 1 2 3; do
+            if gh pr merge "$PR" --squash --admin; then
+              echo "Merged PR #${PR}."
               exit 0
             fi
-            echo "::warning::merge attempt ${attempt} failed (mergeability may still be computing); retrying in 15s"
+            echo "::warning::merge attempt ${m} failed; retrying in 15s"
             sleep 15
           done
-          echo "::error::Auto-merge failed after 3 attempts."
+          echo "::error::Admin-merge failed after checks passed."
           exit 1
 
       - name: Report Slack Notification

--- a/.github/workflows/monthly-assessment.yaml
+++ b/.github/workflows/monthly-assessment.yaml
@@ -10,7 +10,7 @@ name: "Monthly Assessment"
 #      forced VERDICT/SCORE/GAPS block (run-assessment.mjs).
 #   3. Publish the scorecard + rolling 3-month trend to a Confluence page in the
 #      DE space (publish-confluence.mjs; self-disables without credentials).
-#   4. Open a PR committing the month's scorecard JSON/MD (the trend history).
+#   4. Open and auto-merge a PR committing the month's scorecard JSON/MD (the trend history).
 #
 # Assigning owners and curating quick wins remain a manual team step.
 
@@ -135,7 +135,7 @@ jobs:
           MA_MONTH: ${{ inputs.month }}
         run: node ${{ env.MA_DIR }}/publish-confluence.mjs
 
-      - name: Open PR with the month's scorecard
+      - name: Open and auto-merge the month's scorecard PR
         env:
           GH_TOKEN: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
         run: |
@@ -156,16 +156,30 @@ jobs:
           git commit -m "docs: monthly assessment scorecard ${MONTH}"
           git push --force origin "$PR_BRANCH"
 
-          EXISTING=$(gh pr list --head "$PR_BRANCH" --state open --json number --jq '.[0].number // empty')
-          if [[ -n "$EXISTING" ]]; then
-            echo "🔄 Updated existing PR #$EXISTING."
-          else
+          PR=$(gh pr list --head "$PR_BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [[ -z "$PR" ]]; then
             gh pr create \
               --base master \
               --head "$PR_BRANCH" \
               --title "docs: monthly assessment scorecard ${MONTH}" \
-              --body "Automated monthly persona assessment scorecard for **${MONTH}** (DOC-2472). Adds \`${MA_DIR}/scorecards/${MONTH}.{json,md}\`. The Confluence page has already been updated (if configured); this PR preserves the trend history in-repo."
+              --body "Automated monthly persona assessment scorecard for **${MONTH}** (DOC-2472). Adds \`${MA_DIR}/scorecards/${MONTH}.{json,md}\`. The Confluence page has already been updated (if configured); this PR preserves the trend history in-repo and is merged automatically."
+          else
+            echo "🔄 Updated existing PR #$PR (branch re-pushed)."
           fi
+
+          # Auto-merge with the Vault token: vault-token-factory-spectrocloud[bot] is a
+          # repo admin, so --admin bypasses branch protection (the same admin bypass the
+          # backport workflow relies on). Retry while GitHub computes mergeability.
+          for attempt in 1 2 3; do
+            if gh pr merge "$PR_BRANCH" --squash --admin; then
+              echo "Auto-merged the scorecard PR."
+              exit 0
+            fi
+            echo "::warning::merge attempt ${attempt} failed (mergeability may still be computing); retrying in 15s"
+            sleep 15
+          done
+          echo "::error::Auto-merge failed after 3 attempts."
+          exit 1
 
       - name: Report Slack Notification
         if: ${{ success() }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,13 @@ static/generated/security-bulletins/reports/*.html
 # Ignore partials
 _partials/
 scripts/release/
+
+# Generated monthly-assessment scorecards. Prettier's mdx parser reflows the
+# AI-written Markdown, and its width-based array collapsing reformats the per-page
+# "gaps" lists in a data-dependent way the generator can't reliably match. Both are
+# generated artifacts, so ignore them. README.md is hand-authored — keep it checked.
+# (pages.json lives one level up and has no collapsible arrays, so the generator's
+# trailing newline keeps it Prettier-clean; it is intentionally not ignored.)
+.github/monthly-assessment/scorecards/*.md
+.github/monthly-assessment/scorecards/*.json
+!.github/monthly-assessment/scorecards/README.md


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Ensure all **Vale comments** are resolved.
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Follow-up refinements to the Monthly Assessments workflow shipped in #10998 (DOC-2472). Two themes: a cleaner scorecard layout, and making the monthly run fully unattended, and only fails if CI fails.

- **Scorecard layout.** Reworked the Confluence scorecard: dropped the `#` and `Verdict` columns, led with **Views**, kept the 1–5 **Score** and added a **score legend**, and moved each page's **Top gaps** into a path-labelled bullet list (`Top gaps for '<path>':`) beneath a small per-page table. The rolling trend now shows the **score** (not the verdict) with an **average-score** row.
- **Auto-merge (CI-gated).** The workflow now opens its own scorecard PR, **waits for the required CI checks to pass**, then merges it with the Vault admin token — `--admin` bypasses only the required code-owner review (the same admin bypass the backport workflow relies on) — so the in-repo archive and the rolling trend advance with no manual merge.
- **No CI churn on the generated files.** The generated Markdown starts with `<!-- vale off -->` so Vale/reviewdog stops flooding the PR; the scorecard `.md`/`.json` are added to `.prettierignore` (Prettier's mdx reflow and width-based array collapsing can't be reliably matched); and the JSON is written with a trailing newline so the non-ignored `pages.json` stays Prettier-clean.

Tooling only under `.github/` — **no user-facing documentation changes.**

**Files:**

- **`.github/monthly-assessment/publish-confluence.mjs`** — Format B scorecard (per-page blocks + path-labelled gap bullets), the score legend, and a score-based rolling trend with an average-score row; removed the verdict rendering.
- **`.github/workflows/monthly-assessment.yaml`** — the PR step now opens the scorecard PR, **waits for its CI checks (`gh pr checks --watch`), then auto-merges** with the admin Vault token (`gh pr merge --squash --admin`, which bypasses only the required code-owner review).
- **`.github/monthly-assessment/run-assessment.mjs`** — prepend `<!-- vale off -->` to the generated `.md`; write the scorecard JSON with a trailing newline.
- **`.github/monthly-assessment/fetch-top-pages.mjs`** — write `pages.json` with a trailing newline (keeps it Prettier-clean).
- **`.prettierignore`** — ignore the generated scorecard `.md`/`.json` (the hand-authored `README.md` stays Prettier-checked).

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

No public changes.

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-2472](https://spectrocloud.atlassian.net/browse/DOC-2472)


[DOC-2472]: https://spectrocloud.atlassian.net/browse/DOC-2472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
