### PR TITLE
DOC-2472 - Fix auto-merge and approval notice for Monthly Assessments

### DIFF
--- a/.github/workflows/monthly-assessment.yaml
+++ b/.github/workflows/monthly-assessment.yaml
@@ -177,10 +177,15 @@ jobs:
           # the version-* branches the backport workflow targets, whose ruleset grants the
           # bot bypass). Instead, enable GitHub auto-merge: GitHub merges the PR itself once
           # a code owner approves and the required checks (Build / Pre-merge) pass.
-          if gh pr merge "$PR" --squash --auto; then
-            echo "Auto-merge enabled on PR #${PR}; it merges once a docs-education code owner approves and checks pass."
+          gh pr merge "$PR" --squash --auto || echo "::warning::'gh pr merge --auto' returned non-zero on PR #${PR}."
+
+          # Verify auto-merge actually got enabled (the enable call can silently no-op).
+          # If enabled, GitHub merges the PR once a code owner approves and checks pass; if
+          # not, a reviewer approves AND merges it by hand — the Slack link covers both.
+          if [[ "$(gh pr view "$PR" --json autoMergeRequest --jq '.autoMergeRequest != null')" == "true" ]]; then
+            echo "✅ Auto-merge IS enabled on PR #${PR} — it will merge once approved and checks pass."
           else
-            echo "::warning::Could not enable auto-merge on PR #${PR} (it may already be enabled). Review the PR manually."
+            echo "::warning::Auto-merge is NOT enabled on PR #${PR} — a reviewer must approve AND merge it manually."
           fi
 
           # Expose the PR URL so the Slack notification can link reviewers straight to it.
@@ -196,7 +201,7 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "✅ The monthly documentation persona assessment is complete and published to Confluence: [Monthly Assessment Scorecard](https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/3936944142/Monthly+Assessment+Scorecard). A pull request with this month's results is open and will merge automatically once approved — 👉 [Approve and merge the PR](${{ steps.open_pr.outputs.url || format('{0}/{1}/pulls', github.server_url, github.repository) }})."
+          SLACK_MESSAGE: "✅ The monthly documentation persona assessment is complete and published to Confluence: [Monthly Assessment Scorecard](https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/3936944142/Monthly+Assessment+Scorecard). A pull request with this month's results is open — 👉 [Approve and merge the PR](${{ steps.open_pr.outputs.url || format('{0}/{1}/pulls', github.server_url, github.repository) }}) to add it to the in-repo trend history."
 
       - name: Failure Slack Notification
         if: ${{ failure() }}

--- a/.github/workflows/monthly-assessment.yaml
+++ b/.github/workflows/monthly-assessment.yaml
@@ -10,7 +10,8 @@ name: "Monthly Assessment"
 #      forced VERDICT/SCORE/GAPS block (run-assessment.mjs).
 #   3. Publish the scorecard + rolling 3-month trend to a Confluence page in the
 #      DE space (publish-confluence.mjs; self-disables without credentials).
-#   4. Open and auto-merge a PR committing the month's scorecard JSON/MD (the trend history).
+#   4. Open a PR with the month's scorecard JSON/MD (the trend history); it auto-merges once a
+#      docs-education code owner approves. Confluence (step 3) is published first, independent of the PR.
 #
 # Assigning owners and curating quick wins remain a manual team step.
 
@@ -135,7 +136,8 @@ jobs:
           MA_MONTH: ${{ inputs.month }}
         run: node ${{ env.MA_DIR }}/publish-confluence.mjs
 
-      - name: Open and auto-merge the month's scorecard PR
+      - name: Open the scorecard PR and enable auto-merge
+        id: open_pr
         env:
           GH_TOKEN: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
         run: |
@@ -162,47 +164,27 @@ jobs:
               --base master \
               --head "$PR_BRANCH" \
               --title "docs: monthly assessment scorecard ${MONTH}" \
-              --body "Automated monthly persona assessment scorecard for **${MONTH}** (DOC-2472). Adds \`${MA_DIR}/scorecards/${MONTH}.{json,md}\`. The Confluence page has already been updated (if configured); this PR preserves the trend history in-repo and is merged automatically once its checks pass."
+              --body "Automated monthly persona assessment scorecard for **${MONTH}** (DOC-2472). Adds \`${MA_DIR}/scorecards/${MONTH}.{json,md}\`. The Confluence page has already been updated (if configured); this PR preserves the trend history in-repo. Auto-merge is enabled — it merges once a spectrocloud/docs-education code owner approves and the checks pass."
             PR=$(gh pr list --head "$PR_BRANCH" --state open --json number --jq '.[0].number // empty')
           else
             echo "🔄 Updated existing PR #$PR (branch re-pushed)."
           fi
           [[ -z "$PR" ]] && { echo "::error::Could not resolve the scorecard PR number."; exit 1; }
 
-          # Let CI gate the merge: wait for the PR's checks (the required "Build" /
-          # Pre-merge Checks, plus the rest) to finish, and merge only if they pass.
-          # `gh pr checks --watch` errors until checks register, so poll for them.
-          echo "Waiting for checks on PR #${PR}..."
-          for attempt in $(seq 1 30); do
-            if out=$(gh pr checks "$PR" --watch --fail-fast 2>&1); then
-              echo "$out"
-              echo "All checks passed on PR #${PR}."
-              break
-            fi
-            if echo "$out" | grep -qiE "no checks reported|no pull requests found"; then
-              [[ "$attempt" -eq 30 ]] && { echo "::error::Checks never registered on PR #${PR}."; exit 1; }
-              echo "Checks not registered yet (attempt ${attempt}/30); waiting 20s..."
-              sleep 20
-              continue
-            fi
-            echo "$out"
-            echo "::error::A check failed on PR #${PR} — not merging."
-            exit 1
-          done
+          # master is covered by the org ruleset "Public Repos Enforce Branch Protections",
+          # which requires a code-owner review from spectrocloud/docs-education and allows
+          # NO bypass — so neither --admin nor the Vault token can merge unattended (unlike
+          # the version-* branches the backport workflow targets, whose ruleset grants the
+          # bot bypass). Instead, enable GitHub auto-merge: GitHub merges the PR itself once
+          # a code owner approves and the required checks (Build / Pre-merge) pass.
+          if gh pr merge "$PR" --squash --auto; then
+            echo "Auto-merge enabled on PR #${PR}; it merges once a docs-education code owner approves and checks pass."
+          else
+            echo "::warning::Could not enable auto-merge on PR #${PR} (it may already be enabled). Review the PR manually."
+          fi
 
-          # Checks are green. Admin-merge with the Vault token: vault-token-factory-
-          # spectrocloud[bot] is a repo admin, so --admin bypasses the required code-owner
-          # review (the same admin bypass the backport workflow relies on). CI already gated.
-          for m in 1 2 3; do
-            if gh pr merge "$PR" --squash --admin; then
-              echo "Merged PR #${PR}."
-              exit 0
-            fi
-            echo "::warning::merge attempt ${m} failed; retrying in 15s"
-            sleep 15
-          done
-          echo "::error::Admin-merge failed after checks passed."
-          exit 1
+          # Expose the PR URL so the Slack notification can link reviewers straight to it.
+          echo "url=$(gh pr view "$PR" --json url --jq .url)" >> "$GITHUB_OUTPUT"
 
       - name: Report Slack Notification
         if: ${{ success() }}
@@ -214,7 +196,7 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACKIFY_MARKDOWN: true
           ENABLE_ESCAPES: true
-          SLACK_MESSAGE: "✅ The monthly documentation persona assessment is complete. View the latest scorecard and rolling 3-month trend: [Monthly Assessment Scorecard](https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/3936944142/Monthly+Assessment+Scorecard)."
+          SLACK_MESSAGE: "✅ The monthly documentation persona assessment is complete and published to Confluence: [Monthly Assessment Scorecard](https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/3936944142/Monthly+Assessment+Scorecard). A pull request with this month's results is open and will merge automatically once approved — 👉 [Approve and merge the PR](${{ steps.open_pr.outputs.url || format('{0}/{1}/pulls', github.server_url, github.repository) }})."
 
       - name: Failure Slack Notification
         if: ${{ failure() }}


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Ensure all **Vale comments** are resolved.
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

**Fix.** Instead of force-merging, the workflow now enables GitHub auto-merge and surfaces the PR for a one-click approval:

- **`gh pr merge --squash --auto`** — the scorecard PR merges automatically once a docs-education code owner approves and the required `Build` check passes.
- The success **Slack notification now includes an "Approve and merge the PR" link** — the PR step exposes the PR URL as a step output (falling back to the repo's PR list).
- **Confluence publishing is unchanged** and still runs *before* the PR step, so the scorecard publishes on every run regardless of whether/when the PR is approved.

Net: the monthly run no longer errors; the only manual step is a code-owner approval, after which the PR auto-merges and that month joins the in-repo trend history. Tooling only under `.github/` — **no user-facing documentation changes.**

**Files:**

- **`.github/workflows/monthly-assessment.yaml`** — switch the PR step from `--admin` to `--auto`, expose the PR URL as a step output, and add the **Approve and merge the PR** link to the success Slack message.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

No public changes.

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-2472](https://spectrocloud.atlassian.net/browse/DOC-2472)


[DOC-2472]: https://spectrocloud.atlassian.net/browse/DOC-2472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
