### PR TITLE
docs: restrict workflow triggers to Spectro Cloud org

### DIFF
--- a/.github/workflows/update_component_updates.yaml
+++ b/.github/workflows/update_component_updates.yaml
@@ -19,7 +19,8 @@ jobs:
   update_component_updates:
     if: >
       github.event.issue.pull_request &&
-      !endsWith(github.actor, '[bot]')
+      !endsWith(github.actor, '[bot]') &&
+      contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/update_patch_release_notes.yaml
+++ b/.github/workflows/update_patch_release_notes.yaml
@@ -19,7 +19,8 @@ jobs:
   update_release_notes:
     if: >
       github.event.issue.pull_request &&
-      !endsWith(github.actor, '[bot]')
+      !endsWith(github.actor, '[bot]') &&
+      contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR restricts who can trigger workflows to only Spectro org.
MEMBER means the commenter is a member of the org that owns the repo (spectrocloud), and OWNER means they own it. 

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

No user-facing changes. 

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

No ticket.
