### PR TITLE
adding comment to get zizmor to ignore pull_request_target as script …

### DIFF
--- a/.github/workflows/persona-check.yaml
+++ b/.github/workflows/persona-check.yaml
@@ -19,9 +19,19 @@ name: "Persona Check"
 # available (they are withheld from fork-triggered `pull_request` runs). We
 # check out PR head content but only ever read it as text for the LLM — no
 # PR-supplied code is executed. Our own scripts run from the trusted base ref.
+#
+# zizmor flags `pull_request_target` via the `dangerous-triggers` rule (a
+# blanket rule that can't infer our mode-gating). The classic footgun —
+# checking out and executing untrusted PR head under a privileged token — is
+# not present here: the `pull_request_target` (labeled) path stays in "prompt"
+# mode, which never checks out PR head, never pulls Vault/API secrets, and
+# only runs base-ref scripts to post a preview comment. The `issue_comment`
+# path is additionally gated by an OWNER/MEMBER/COLLABORATOR author_association
+# check before it runs. The ignore directive below reflects this — bump or
+# revisit if the labeled path ever needs PR-head content or extra secrets.
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [labeled]
   issue_comment:
     types: [created]


### PR DESCRIPTION
…is already secure

# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [ ] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [ ] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR puts in a comment to get zizmor to ignore `pull_request_target` in `persona-check.yaml` file. The script is already secure. 

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-3006)
