### PR TITLE
docs: add Claude Code guide and configuration

### DIFF
--- a/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
@@ -19,3 +19,4 @@ you the steps to do it without teaching background concepts.
 | [Install the Appliance](./install-the-appliance.md) | Flash the installer ISO, boot the hardware, and bring up the appliance console. |
 | [Deploy a Model](./deploy-a-model.md)               | Deploy an LLM to the cluster and verify it is serving.                          |
 | [Set the Default Model](./set-the-default-model.md) | Configure which model handles requests that do not name a model explicitly.     |
+| [Use Claude Code](./use-claude-code.md)             | Connect Claude Code to the appliance so a local model serves each request.      |

--- a/docs/docs-content/launchpad-for-ai/how-to-guides/use-claude-code.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/use-claude-code.md
@@ -100,8 +100,8 @@ session uses, run the `/status` command in Claude Code and review the **Anthropi
 
 ## Token Quotas
 
-If requests return an HTTP `429` response, you have exceeded your token quota. Wait for the quota window to reset, or ask
-an operator to raise your limit. {/* TODO: link once the token quotas and metering reference page exists */}
+If requests return an HTTP `429` response, you have exceeded your token quota. Wait for the quota window to reset, or
+ask an operator to raise your limit. {/* TODO: link once the token quotas and metering reference page exists */}
 
 ## Next Steps
 

--- a/docs/docs-content/launchpad-for-ai/how-to-guides/use-claude-code.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/use-claude-code.md
@@ -1,0 +1,110 @@
+---
+sidebar_label: "Use Claude Code"
+title: "Use Launchpad for AI with Claude Code"
+description:
+  "Connect Anthropic's Claude Code coding agent to a Launchpad for AI appliance so that a model on the appliance serves
+  every request."
+hide_table_of_contents: false
+sidebar_position: 3
+tags: ["launchpad-for-ai", "claude-code", "how-to"]
+keywords: ["launchpad", "ai", "claude code", "anthropic", "coding agent", "api token"]
+---
+
+<PartialsComponent category="launchpad-for-ai" name="unreleased-banner" />
+
+This guide explains how to connect Claude Code to a Launchpad for AI appliance so that a model running on the appliance
+serves every request instead of Anthropic's hosted API. You generate an API token in the console, point Claude Code at
+the appliance with two environment variables, and confirm the connection.
+
+## Prerequisites
+
+- Claude Code installed and already working against Anthropic's hosted API. For installation, refer to the
+  [Claude Code documentation](https://docs.claude.com/en/docs/claude-code).
+- A running Launchpad for AI appliance with at least one model deployed and serving. To deploy a model, refer to
+  [Deploy a Model](./deploy-a-model.md).
+- Admin access to the Launchpad for AI console, or an API token that an administrator generated for you.
+
+## Generate an API Token
+
+If an administrator already gave you an API token, skip to [Configure Claude Code](#configure-claude-code).
+
+1. Open the appliance console in a browser and sign in.
+
+2. From the left main menu, select **Access & Policy** > **Users**.
+
+3. Create a token.
+
+4. Copy the token when the console reveals it. The token begins with `lpai_`.
+
+:::warning
+
+The console shows the token only once and stores only a hash of it. Copy it now. If you lose it, revoke the token and
+create a new one.
+
+:::
+
+## Configure Claude Code
+
+On the machine where you run Claude Code, set the following environment variables.
+
+```bash
+export ANTHROPIC_BASE_URL=https://<appliance-host>
+export ANTHROPIC_AUTH_TOKEN=<lpai-token>
+```
+
+Set `ANTHROPIC_BASE_URL` to your appliance's address with no path. Do not append `/v1`. Claude Code adds the API path
+itself. Use `ANTHROPIC_AUTH_TOKEN` for the token. `ANTHROPIC_API_KEY` also works, but do not set it globally if you also
+sign in to Claude Code with an Anthropic account.
+
+To persist the settings instead of exporting them each session, add them to the `~/.claude/settings.json` file.
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://<appliance-host>",
+    "ANTHROPIC_AUTH_TOKEN": "<lpai-token>"
+  }
+}
+```
+
+Claude Code requests a Claude alias, such as `claude-sonnet-4-5`. To pin every request to one alias, set
+`ANTHROPIC_MODEL` to it. For the aliases the appliance accepts, refer to
+[Claude Code Configuration](../reference/claude-code-reference.md).
+
+```bash
+export ANTHROPIC_MODEL=claude-sonnet-4-5
+```
+
+:::warning
+
+If your appliance uses a self-signed certificate, Claude Code rejects the connection by default. Set
+`NODE_TLS_REJECT_UNAUTHORIZED=0` for short-lived testing, or serve the appliance with a valid, publicly trusted
+certificate.
+
+:::
+
+## Verify the Connection
+
+Run a single prompt to confirm the appliance answers.
+
+```bash
+claude --print "reply with exactly CC_OK and nothing else"
+```
+
+```bash hideClipboard title="Expected output"
+CC_OK
+```
+
+A reply confirms that the base URL, token, and model routing all work. To confirm which endpoint and credential the
+session uses, run the `/status` command in Claude Code and review the **Anthropic base URL** and **Auth token** lines.
+
+## Token Quotas
+
+If requests return an HTTP `429` response, you have exceeded your token quota. Wait for the quota window to reset, or ask
+an operator to raise your limit. {/* TODO: link once the token quotas and metering reference page exists */}
+
+## Next Steps
+
+To look up any configuration value, refer to [Claude Code Configuration](../reference/claude-code-reference.md). To
+deploy another model to the appliance, refer to [Deploy a Model](./deploy-a-model.md).
+{/* TODO: add direction to the client and API token management, token quotas and metering, and intelligent routing pages once they exist */}

--- a/docs/docs-content/launchpad-for-ai/reference/claude-code-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/claude-code-reference.md
@@ -1,0 +1,48 @@
+---
+sidebar_label: "Claude Code Configuration"
+title: "Launchpad for AI Claude Code Configuration"
+description:
+  "Reference for the environment variables and values used to connect Claude Code to a Launchpad for AI appliance."
+hide_table_of_contents: false
+sidebar_position: 5
+tags: ["launchpad-for-ai", "claude-code", "reference"]
+keywords: ["launchpad", "ai", "claude code", "anthropic", "environment variables", "api token", "model"]
+---
+
+<PartialsComponent category="launchpad-for-ai" name="unreleased-banner" />
+
+This page lists the configuration values Claude Code uses to connect to a Launchpad for AI appliance. For the steps to
+set them, refer to [Use Launchpad for AI with Claude Code](../how-to-guides/use-claude-code.md).
+
+## Environment Variables
+
+| Variable               | Description                                                                                                                                | Example value                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
+| `ANTHROPIC_BASE_URL`   | The Launchpad for AI inference endpoint. Use the appliance address with no path. Claude Code appends `/v1/messages`.                       | `https://amd.spectrocloud.com:8443` |
+| `ANTHROPIC_AUTH_TOKEN` | The API token generated in the console. It begins with `lpai_`. `ANTHROPIC_API_KEY` is also accepted.                                      | `lpai_YOUR_TOKEN`                   |
+| `ANTHROPIC_MODEL`      | Optional. The Claude alias Claude Code requests. The appliance maps the alias to the model it serves, so you do not pick the backend model. | `claude-sonnet-4-5`                 |
+
+## Endpoint URL
+
+The endpoint is your appliance's address, the same host you use to reach the console, with no path appended. The gateway
+serves the Anthropic Messages API at `/v1/messages`, and Claude Code adds that path itself, so `ANTHROPIC_BASE_URL` must
+not include `/v1`. If you do not know the address, ask the administrator who set up the appliance.
+
+## Model Name
+
+Claude Code requests a Claude alias (`claude-opus-4-8`, `claude-sonnet-4-5`, or `claude-haiku-4-5`), and the appliance
+maps that alias to the model it serves. Set `ANTHROPIC_MODEL` to one of these aliases. You do not select a backend
+model directly. Both the aliases the appliance accepts and the ids of the models it serves, such as `glm-5.2`, appear
+in the console's model list and in the appliance's `/v1/models` API response.
+
+## Token Quotas
+
+If the token's quota is exhausted, the appliance returns an HTTP `429` response and Claude Code surfaces the error.
+{/* TODO: link once the token quotas and metering reference page exists */}
+
+## Resources
+
+- [Use Launchpad for AI with Claude Code](../how-to-guides/use-claude-code.md)
+- User and API token management {/* TODO: link once page exists */}
+- Token quotas and metering {/* TODO: link once page exists */}
+- Intelligent routing and tier maps {/* TODO: link once page exists */}

--- a/docs/docs-content/launchpad-for-ai/reference/claude-code-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/claude-code-reference.md
@@ -16,10 +16,10 @@ set them, refer to [Use Launchpad for AI with Claude Code](../how-to-guides/use-
 
 ## Environment Variables
 
-| Variable               | Description                                                                                                                                | Example value                       |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
-| `ANTHROPIC_BASE_URL`   | The Launchpad for AI inference endpoint. Use the appliance address with no path. Claude Code appends `/v1/messages`.                       | `https://amd.spectrocloud.com:8443` |
-| `ANTHROPIC_AUTH_TOKEN` | The API token generated in the console. It begins with `lpai_`. `ANTHROPIC_API_KEY` is also accepted.                                      | `lpai_YOUR_TOKEN`                   |
+| Variable               | Description                                                                                                                                 | Example value                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `ANTHROPIC_BASE_URL`   | The Launchpad for AI inference endpoint. Use the appliance address with no path. Claude Code appends `/v1/messages`.                        | `https://amd.spectrocloud.com:8443` |
+| `ANTHROPIC_AUTH_TOKEN` | The API token generated in the console. It begins with `lpai_`. `ANTHROPIC_API_KEY` is also accepted.                                       | `lpai_YOUR_TOKEN`                   |
 | `ANTHROPIC_MODEL`      | Optional. The Claude alias Claude Code requests. The appliance maps the alias to the model it serves, so you do not pick the backend model. | `claude-sonnet-4-5`                 |
 
 ## Endpoint URL
@@ -31,9 +31,9 @@ not include `/v1`. If you do not know the address, ask the administrator who set
 ## Model Name
 
 Claude Code requests a Claude alias (`claude-opus-4-8`, `claude-sonnet-4-5`, or `claude-haiku-4-5`), and the appliance
-maps that alias to the model it serves. Set `ANTHROPIC_MODEL` to one of these aliases. You do not select a backend
-model directly. Both the aliases the appliance accepts and the ids of the models it serves, such as `glm-5.2`, appear
-in the console's model list and in the appliance's `/v1/models` API response.
+maps that alias to the model it serves. Set `ANTHROPIC_MODEL` to one of these aliases. You do not select a backend model
+directly. Both the aliases the appliance accepts and the ids of the models it serves, such as `glm-5.2`, appear in the
+console's model list and in the appliance's `/v1/models` API response.
 
 ## Token Quotas
 

--- a/docs/docs-content/launchpad-for-ai/reference/reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/reference.md
@@ -19,3 +19,4 @@ is configured, not how to accomplish a task.
 | [System Requirements](./system-requirements.md)                   | Minimum hardware, software, network, and operating system prerequisites.        |
 | [Hardware Requirements](./hardware-requirements.md)               | GPU and multi-node cluster sizing for the appliance.                            |
 | [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration. |
+| [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.     |


### PR DESCRIPTION
Walk developer through generating an API token, pointing Claude Code at the appliance with two environment variables, and verifying the connection.

Document the Claude Code environment variables, where to find the endpoint URL and model name, and the HTTP 429 quota response.