### PR TITLE
docs: add Cursor guide and configuration

### DIFF
--- a/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
@@ -20,3 +20,4 @@ you the steps to do it without teaching background concepts.
 | [Deploy a Model](./deploy-a-model.md)               | Deploy an LLM to the cluster and verify it is serving.                          |
 | [Set the Default Model](./set-the-default-model.md) | Configure which model handles requests that do not name a model explicitly.     |
 | [Use Claude Code](./use-claude-code.md)             | Connect Claude Code to the appliance so a local model serves each request.      |
+| [Use Cursor](./use-cursor.md)                       | Connect Cursor's Ask mode to the appliance through a uniquely named model alias. |

--- a/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
@@ -14,10 +14,10 @@ you the steps to do it without teaching background concepts.
 
 ## Contents
 
-| **Guide**                                           | **What you do**                                                                 |
-| --------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Install the Appliance](./install-the-appliance.md) | Flash the installer ISO, boot the hardware, and bring up the appliance console. |
-| [Deploy a Model](./deploy-a-model.md)               | Deploy an LLM to the cluster and verify it is serving.                          |
-| [Set the Default Model](./set-the-default-model.md) | Configure which model handles requests that do not name a model explicitly.     |
-| [Use Claude Code](./use-claude-code.md)             | Connect Claude Code to the appliance so a local model serves each request.      |
+| **Guide**                                           | **What you do**                                                                  |
+| --------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [Install the Appliance](./install-the-appliance.md) | Flash the installer ISO, boot the hardware, and bring up the appliance console.  |
+| [Deploy a Model](./deploy-a-model.md)               | Deploy an LLM to the cluster and verify it is serving.                           |
+| [Set the Default Model](./set-the-default-model.md) | Configure which model handles requests that do not name a model explicitly.      |
+| [Use Claude Code](./use-claude-code.md)             | Connect Claude Code to the appliance so a local model serves each request.       |
 | [Use Cursor](./use-cursor.md)                       | Connect Cursor's Ask mode to the appliance through a uniquely named model alias. |

--- a/docs/docs-content/launchpad-for-ai/how-to-guides/use-claude-code.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/use-claude-code.md
@@ -75,8 +75,8 @@ Claude Code requests a Claude alias, such as `claude-sonnet-4-5`. To pin every r
 export ANTHROPIC_MODEL=claude-sonnet-4-5
 ```
 
-We strongly recommend giving the appliance a DNS name and a valid, publicly trusted TLS certificate. The connection
-uses HTTPS, so a valid certificate protects your token in transit.
+We strongly recommend giving the appliance a DNS name and a valid, publicly trusted TLS certificate. The connection uses
+HTTPS, so a valid certificate protects your token in transit.
 
 :::warning
 

--- a/docs/docs-content/launchpad-for-ai/how-to-guides/use-cursor.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/use-cursor.md
@@ -1,0 +1,142 @@
+---
+sidebar_label: "Use Cursor"
+title: "Use Launchpad for AI with Cursor"
+description:
+  "Connect the Cursor code editor to a Launchpad for AI appliance so that a model on the appliance serves your requests
+  in Cursor's Ask mode."
+hide_table_of_contents: false
+sidebar_position: 4
+tags: ["launchpad-for-ai", "cursor", "how-to"]
+keywords: ["launchpad", "ai", "cursor", "openai-compatible", "model alias", "ask mode", "api token"]
+---
+
+<PartialsComponent category="launchpad-for-ai" name="unreleased-banner" />
+
+This guide explains how to connect Cursor to a Launchpad for AI appliance so that a model running on the appliance
+serves your requests instead of a cloud provider. You generate an API token, create a uniquely named model alias on the
+appliance, point Cursor at the appliance, and confirm that requests route through the appliance.
+
+:::warning
+
+Cursor routes only **Ask** mode (chat) requests to a custom endpoint. Agent, Edit, and Tab remain locked to Cursor's own
+models. This is a limitation of Cursor's bring-your-own-key support, not of the appliance, so those modes do not use the
+appliance even after you complete this guide.
+
+:::
+
+## Prerequisites
+
+- Cursor installed and already working. For installation, refer to the [Cursor documentation](https://docs.cursor.com).
+- A running Launchpad for AI appliance with at least one model deployed and serving. To deploy a model, refer to
+  [Deploy a Model](./deploy-a-model.md).
+- Operator access to the Launchpad for AI console, or an operator who can generate an API token and create a model alias
+  for you. Both tasks can require operator access.
+- The appliance reachable at a DNS name with a valid, publicly trusted TLS certificate. Cursor sends requests from its
+  own cloud servers, so a self-signed certificate does not work and there is no client-side workaround.
+
+## Generate an API Token
+
+If an administrator already gave you an API token, skip to [Create a Model Alias](#create-a-model-alias).
+
+1. Open the appliance console in a browser and sign in.
+
+2. From the left main menu, select **Access & Policy** > **Users**.
+
+3. Create a token.
+
+4. Copy the token when the console reveals it. The token begins with `lpai_`.
+
+:::warning
+
+The console shows the token only once and stores only a hash of it. Copy it now. If you lose it, revoke the token and
+create a new one.
+
+:::
+
+## Create a Model Alias
+
+Cursor sends model requests from its own cloud servers and decides where to route each request by the model name. If the
+name matches a model already in Cursor's catalog, such as `glm-5.2` or `gpt-4o`, Cursor routes the request to its own
+backend and never contacts your appliance. To force Cursor to use the appliance, serve the model under a unique alias
+name that does not exist in Cursor's catalog.
+
+Creating an alias is an operator task. If you do not have operator access, ask an administrator to create the alias and
+give you its name, then continue to [Configure Cursor](#configure-cursor).
+
+The appliance can serve any model id as an alias of a model it already runs. On the appliance, alias a unique name to a
+served model. Replace `<appliance-host>` with your appliance address and `<admin-session-token>` with an operator
+session token.
+
+```bash
+curl --silent "https://<appliance-host>/admin/apply" \
+  --header "Authorization: Bearer <admin-session-token>" \
+  --header "Content-Type: application/json" \
+  --data '{"proposed_op":{"op":"set_tier","alias_prefix":"launchpad-glm52","model":"zai-org/GLM-5.2","thinking":"off","confirmed":true}}'
+```
+
+Set `alias_prefix` to the unique name Cursor requests, and set `model` to the id of a model the appliance already
+serves, such as `zai-org/GLM-5.2`. To find the served model id, check the appliance's `/v1/models` endpoint or the admin
+view in the console.
+
+The alias then appears in the appliance's `/v1/models` response and routes to the real model. The `alias_prefix` value,
+such as `launchpad-glm52`, is the name you enter in Cursor.
+
+{/* NEEDS REVIEW: the alias command and its admin-session bearer token ($ADMIN_SESSION) come verbatim from the connect guide; confirm how an operator obtains that session token. */}
+
+## Configure Cursor
+
+Point Cursor at the appliance in Cursor's settings. For the full list of settings and their example values, refer to
+[Cursor Configuration](../reference/cursor-reference.md).
+
+1. In Cursor, open **Settings** > **Models**.
+
+2. Enable **Override OpenAI Base URL**, and enter your appliance address with the `/v1` path appended, such as
+   `https://<appliance-host>/v1`.
+
+3. In the **OpenAI API Key** field, enter your `lpai_` token.
+
+4. Under **OpenAI API Key**, select **Add model**, and enter the unique alias name, such as `launchpad-glm52`. A unique
+   name forces Cursor to treat the model as your custom model and send the request to your endpoint.
+
+5. Turn off Cursor's built-in models so that only your alias is active.
+
+## Verify the Connection
+
+Confirm that Cursor routes a request to the appliance instead of to its own backend.
+
+1. In Cursor, open a chat and set the mode to **Ask**.
+
+2. In the model picker, select your alias, such as `launchpad-glm52`.
+
+3. Send a test prompt.
+
+   ```text
+   reply with exactly CURSOR_OK and nothing else
+   ```
+
+4. Confirm that Cursor displays the reply `CURSOR_OK`.
+
+Because the alias name exists only on your appliance, Cursor cannot serve it from its own backend. A reply confirms that
+the chat request reached the appliance, that a model there served it, and that the base URL, token, alias, and routing
+all work.
+
+:::warning
+
+If Cursor returns `We're having trouble finding the resource you requested`, the alias name matches a model in Cursor's
+catalog, so Cursor routed the request to its own backend and never contacted the appliance. Create the alias again with
+a more unique name, and select the new name in Cursor.
+
+:::
+
+## Request Routing and Quotas
+
+Requests you send through the appliance are subject to the routing rule and quota configured for your API token. If an
+operator configured a routing rule for your token, the appliance can redirect a request to a frontier model instead of a
+local one. Token quotas apply per API token, and when a token exhausts its quota, the appliance returns an HTTP `429`
+response.
+{/* TODO: link to the intelligent routing how-to and the token quotas and metering reference once they exist */}
+
+## Next Steps
+
+To look up the base URL, alias, and the Cursor modes the appliance supports, refer to
+[Cursor Configuration](../reference/cursor-reference.md).

--- a/docs/docs-content/launchpad-for-ai/reference/cursor-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/cursor-reference.md
@@ -18,11 +18,11 @@ them, refer to [Use Launchpad for AI with Cursor](../how-to-guides/use-cursor.md
 
 Set the following in Cursor under **Settings** > **Models**.
 
-| Setting                     | Description                                                                                                        | Example value                          |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
-| **Override OpenAI Base URL** | The Launchpad for AI inference endpoint. Use the appliance address with the `/v1` path appended.                   | `https://amd.spectrocloud.com:8443/v1` |
-| **OpenAI API Key**          | The API token generated in the console. It begins with `lpai_`.                                                    | `lpai_YOUR_TOKEN`                      |
-| **Add model**               | The unique alias name the appliance serves. Enter the alias, not the backend model id.                             | `launchpad-glm52`                      |
+| Setting                      | Description                                                                                      | Example value                          |
+| ---------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| **Override OpenAI Base URL** | The Launchpad for AI inference endpoint. Use the appliance address with the `/v1` path appended. | `https://amd.spectrocloud.com:8443/v1` |
+| **OpenAI API Key**           | The API token generated in the console. It begins with `lpai_`.                                  | `lpai_YOUR_TOKEN`                      |
+| **Add model**                | The unique alias name the appliance serves. Enter the alias, not the backend model id.           | `launchpad-glm52`                      |
 
 ## Endpoint URL
 
@@ -38,7 +38,8 @@ certificate verification.
 
 Cursor decides where to route a request by the model name. If the name matches a model in Cursor's built-in catalog,
 such as `glm-5.2` or `gpt-4o`, Cursor routes the request to its own backend, and the appliance receives nothing. To
-reach the appliance, an operator must serve the model under a unique alias name that does not appear in Cursor's catalog.
+reach the appliance, an operator must serve the model under a unique alias name that does not appear in Cursor's
+catalog.
 
 An operator creates the alias on the appliance, which maps it to a model the appliance already serves, such as
 `zai-org/GLM-5.2`. Both the alias and the ids of the models the appliance serves appear in the console model list and in
@@ -46,12 +47,12 @@ the appliance's `/v1/models` API response.
 
 ## Supported Modes
 
-| Cursor mode      | Supported | Notes                                                                                     |
-| ---------------- | --------- | ----------------------------------------------------------------------------------------- |
-| Ask (chat)       | Yes       | Routes to the appliance through the model alias.                                          |
-| Agent            | No        | Locked to Cursor's own models for bring-your-own-key setups.                              |
-| Edit             | No        | Locked to Cursor's own models for bring-your-own-key setups.                              |
-| Tab              | No        | Locked to Cursor's own models for bring-your-own-key setups.                              |
+| Cursor mode | Supported | Notes                                                        |
+| ----------- | --------- | ------------------------------------------------------------ |
+| Ask (chat)  | Yes       | Routes to the appliance through the model alias.             |
+| Agent       | No        | Locked to Cursor's own models for bring-your-own-key setups. |
+| Edit        | No        | Locked to Cursor's own models for bring-your-own-key setups. |
+| Tab         | No        | Locked to Cursor's own models for bring-your-own-key setups. |
 
 The unsupported modes are a limitation of Cursor's bring-your-own-key support, not of the appliance.
 

--- a/docs/docs-content/launchpad-for-ai/reference/cursor-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/cursor-reference.md
@@ -1,0 +1,68 @@
+---
+sidebar_label: "Cursor Configuration"
+title: "Launchpad for AI Cursor Configuration"
+description:
+  "Reference for the settings and values used to connect the Cursor code editor to a Launchpad for AI appliance."
+hide_table_of_contents: false
+sidebar_position: 6
+tags: ["launchpad-for-ai", "cursor", "reference"]
+keywords: ["launchpad", "ai", "cursor", "openai-compatible", "base url", "model alias", "api token"]
+---
+
+<PartialsComponent category="launchpad-for-ai" name="unreleased-banner" />
+
+This page lists the configuration values Cursor uses to connect to a Launchpad for AI appliance. For the steps to set
+them, refer to [Use Launchpad for AI with Cursor](../how-to-guides/use-cursor.md).
+
+## Settings
+
+Set the following in Cursor under **Settings** > **Models**.
+
+| Setting                     | Description                                                                                                        | Example value                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| **Override OpenAI Base URL** | The Launchpad for AI inference endpoint. Use the appliance address with the `/v1` path appended.                   | `https://amd.spectrocloud.com:8443/v1` |
+| **OpenAI API Key**          | The API token generated in the console. It begins with `lpai_`.                                                    | `lpai_YOUR_TOKEN`                      |
+| **Add model**               | The unique alias name the appliance serves. Enter the alias, not the backend model id.                             | `launchpad-glm52`                      |
+
+## Endpoint URL
+
+Cursor uses the OpenAI-compatible API, which the gateway serves at `/v1`. Set **Override OpenAI Base URL** to your
+appliance's address, the same host you use to reach the console, with `/v1` appended. This differs from Claude Code,
+which uses the Anthropic Messages API and adds the path itself.
+
+The appliance must have a valid, publicly trusted TLS certificate on a DNS name. Cursor sends the request from its own
+cloud servers rather than from your machine, so it does not accept a self-signed certificate and offers no way to skip
+certificate verification.
+
+## Model Name and Aliases
+
+Cursor decides where to route a request by the model name. If the name matches a model in Cursor's built-in catalog,
+such as `glm-5.2` or `gpt-4o`, Cursor routes the request to its own backend, and the appliance receives nothing. To
+reach the appliance, an operator must serve the model under a unique alias name that does not appear in Cursor's catalog.
+
+An operator creates the alias on the appliance, which maps it to a model the appliance already serves, such as
+`zai-org/GLM-5.2`. Both the alias and the ids of the models the appliance serves appear in the console model list and in
+the appliance's `/v1/models` API response.
+
+## Supported Modes
+
+| Cursor mode      | Supported | Notes                                                                                     |
+| ---------------- | --------- | ----------------------------------------------------------------------------------------- |
+| Ask (chat)       | Yes       | Routes to the appliance through the model alias.                                          |
+| Agent            | No        | Locked to Cursor's own models for bring-your-own-key setups.                              |
+| Edit             | No        | Locked to Cursor's own models for bring-your-own-key setups.                              |
+| Tab              | No        | Locked to Cursor's own models for bring-your-own-key setups.                              |
+
+The unsupported modes are a limitation of Cursor's bring-your-own-key support, not of the appliance.
+
+## Token Quotas
+
+If the token's quota is exhausted, the appliance returns an HTTP `429` response and Cursor surfaces the error.
+{/* TODO: link to the token quotas and metering reference once it exists */}
+
+## Resources
+
+- [Use Launchpad for AI with Cursor](../how-to-guides/use-cursor.md)
+- [Use Launchpad for AI with Claude Code](../how-to-guides/use-claude-code.md)
+- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- Token quotas and metering {/* TODO: link once page exists */}

--- a/docs/docs-content/launchpad-for-ai/reference/reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/reference.md
@@ -20,3 +20,4 @@ is configured, not how to accomplish a task.
 | [Hardware Requirements](./hardware-requirements.md)               | GPU and multi-node cluster sizing for the appliance.                            |
 | [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration. |
 | [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.     |
+| [Cursor Configuration](./cursor-reference.md)                     | Settings and values for pointing Cursor at the appliance.                       |


### PR DESCRIPTION
Add a how-to that connects Cursor's Ask mode to a Launchpad for AI appliance through a uniquely named model alias.

Add a companion reference page for the Cursor base URL, model alias, and supported modes.