### PR TITLE
docs: add OpenAI Codex guide and configuration

### DIFF
--- a/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
@@ -21,3 +21,4 @@ you the steps to do it without teaching background concepts.
 | [Set the Default Model](./set-the-default-model.md) | Configure which model handles requests that do not name a model explicitly.      |
 | [Use Claude Code](./use-claude-code.md)             | Connect Claude Code to the appliance so a local model serves each request.       |
 | [Use Cursor](./use-cursor.md)                       | Connect Cursor's Ask mode to the appliance through a uniquely named model alias. |
+| [Use OpenAI Codex](./use-codex.md)                  | Connect the OpenAI Codex CLI to the appliance with a custom model provider.       |

--- a/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
@@ -21,4 +21,4 @@ you the steps to do it without teaching background concepts.
 | [Set the Default Model](./set-the-default-model.md) | Configure which model handles requests that do not name a model explicitly.      |
 | [Use Claude Code](./use-claude-code.md)             | Connect Claude Code to the appliance so a local model serves each request.       |
 | [Use Cursor](./use-cursor.md)                       | Connect Cursor's Ask mode to the appliance through a uniquely named model alias. |
-| [Use OpenAI Codex](./use-codex.md)                  | Connect the OpenAI Codex CLI to the appliance with a custom model provider.       |
+| [Use OpenAI Codex](./use-codex.md)                  | Connect the OpenAI Codex CLI to the appliance with a custom model provider.      |

--- a/docs/docs-content/launchpad-for-ai/how-to-guides/use-codex.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/use-codex.md
@@ -1,0 +1,110 @@
+---
+sidebar_label: "Use OpenAI Codex"
+title: "Use Launchpad for AI with OpenAI Codex"
+description:
+  "Connect the OpenAI Codex CLI to a Launchpad for AI appliance so that a model on the appliance serves every request."
+hide_table_of_contents: false
+sidebar_position: 5
+tags: ["launchpad-for-ai", "codex", "how-to"]
+keywords: ["launchpad", "ai", "openai codex", "codex cli", "responses api", "config.toml", "api token"]
+---
+
+<PartialsComponent category="launchpad-for-ai" name="unreleased-banner" />
+
+This guide explains how to connect the OpenAI Codex CLI to a Launchpad for AI appliance so that a model running on the
+appliance serves every request instead of OpenAI's hosted API. You generate an API token, add a custom model provider to
+the Codex configuration file, and confirm the connection.
+
+## Prerequisites
+
+- The OpenAI Codex CLI installed and already working. For installation, refer to the
+  [OpenAI Codex website](https://github.com/openai/codex).
+- A running Launchpad for AI appliance with at least one model deployed and serving. To deploy a model, refer to
+  [Deploy a Model](./deploy-a-model.md).
+- Admin access to the Launchpad for AI console, or an API token that an administrator generated for you.
+- The appliance reachable at a DNS hostname with a valid, publicly trusted TLS certificate. Codex validates TLS strictly
+  and cannot skip certificate verification, so a self-signed certificate does not work.
+
+## Generate an API Token
+
+If an administrator already gave you an API token, skip to [Configure Codex](#configure-codex).
+
+1. Open the appliance console in a browser and sign in.
+
+2. From the left main menu, select **Access & Policy** > **Users**.
+
+3. Create a token.
+
+4. Copy the token when the console reveals it. The token begins with `lpai_`.
+
+:::warning
+
+The console shows the token only once. Copy it now, because you cannot view it again. If you lose it, revoke the token
+and create a new one.
+
+:::
+
+## Configure Codex
+
+Codex uses the Responses API, so you add a custom model provider that points at the appliance. For a description of each
+field, refer to [OpenAI Codex Configuration](../reference/codex-reference.md).
+
+1. Add the following custom provider to the Codex configuration file at `~/.codex/config.toml`. Replace
+   `<appliance-host>` with your appliance address.
+
+   ```toml
+   model = "glm-5.2"            # a model the appliance serves, not "auto"
+   model_provider = "lpai"
+
+   [model_providers.lpai]
+   name = "Launchpad"
+   base_url = "https://<appliance-host>/v1"
+   env_key = "LPAI_KEY"
+   wire_api = "responses"       # Codex uses the Responses API
+   ```
+
+   Set `model` to a model the appliance serves, such as `glm-5.2`. Do not use `auto`, because the Responses API passes
+   the model straight to the engine. Set `base_url` to your appliance address with the `/v1` path appended.
+
+2. Export your API token in the environment variable named by `env_key`. This sets the token for the current shell
+   session. To persist it, add the line to your shell profile.
+
+   ```bash
+   export LPAI_KEY=<lpai-token>
+   ```
+
+## Verify the Connection
+
+Run a single prompt to confirm the appliance answers.
+
+```bash
+codex exec --skip-git-repo-check "reply with exactly CODEX_OK and nothing else"
+```
+
+```bash hideClipboard title="Expected output"
+CODEX_OK
+```
+
+A reply confirms that the base URL, token, provider, and model routing all work. The `--skip-git-repo-check` flag lets
+you run the test outside a git repository.
+
+:::info
+
+Codex may print a `Model metadata for glm-5.2 not found` warning. This warning is cosmetic and does not affect the
+request.
+
+:::
+
+## Request Routing and Quotas
+
+Requests you send through the appliance are subject to the routing rule and quota configured for your API token. If an
+operator configured a routing rule for your token, the appliance can redirect a request to a frontier model instead of a
+local one. Token quotas apply per API token, and when a token exhausts its quota, the appliance returns an HTTP `429`
+response.
+{/* TODO: link to the intelligent routing how-to and the token quotas and metering reference once they exist */}
+
+## Next Steps
+
+To look up each configuration value, refer to [OpenAI Codex Configuration](../reference/codex-reference.md). To connect
+a different coding tool, refer to [Use Launchpad for AI with Claude Code](./use-claude-code.md) or
+[Use Launchpad for AI with Cursor](./use-cursor.md).

--- a/docs/docs-content/launchpad-for-ai/reference/codex-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/codex-reference.md
@@ -38,14 +38,14 @@ wire_api = "responses"
 | `model_provider` | The provider Codex uses. Must match the name of the `[model_providers.<name>]` table.                                                     | `lpai`                                 |
 | `name`           | A display name for the provider.                                                                                                          | `Launchpad`                            |
 | `base_url`       | The appliance inference endpoint, with the `/v1` path appended.                                                                           | `https://amd.spectrocloud.com:8443/v1` |
-| `env_key`        | The name of the environment variable that holds your API token.                                                                          | `LPAI_KEY`                             |
+| `env_key`        | The name of the environment variable that holds your API token.                                                                           | `LPAI_KEY`                             |
 | `wire_api`       | The API Codex uses. Codex uses the Responses API, so set this to `responses`.                                                             | `responses`                            |
 
 ## Endpoint URL
 
 Set `base_url` to your appliance's address, the same host you use to reach the console, with `/v1` appended. The gateway
-serves the Responses API at `/v1/responses`, and Codex appends the `/responses` path itself, so `base_url` ends at `/v1`.
-If you do not know the address, ask the administrator who set up the appliance.
+serves the Responses API at `/v1/responses`, and Codex appends the `/responses` path itself, so `base_url` ends at
+`/v1`. If you do not know the address, ask the administrator who set up the appliance.
 
 ## API Token
 

--- a/docs/docs-content/launchpad-for-ai/reference/codex-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/codex-reference.md
@@ -1,0 +1,83 @@
+---
+sidebar_label: "OpenAI Codex Configuration"
+title: "Launchpad for AI OpenAI Codex Configuration"
+description:
+  "Reference for the configuration file fields and values used to connect the OpenAI Codex CLI to a Launchpad for AI
+  appliance."
+hide_table_of_contents: false
+sidebar_position: 7
+tags: ["launchpad-for-ai", "codex", "reference"]
+keywords: ["launchpad", "ai", "openai codex", "codex cli", "config.toml", "responses api", "api token", "model"]
+---
+
+<PartialsComponent category="launchpad-for-ai" name="unreleased-banner" />
+
+This page lists the configuration values the OpenAI Codex CLI uses to connect to a Launchpad for AI appliance. For the
+steps to set them, refer to [Use Launchpad for AI with OpenAI Codex](../how-to-guides/use-codex.md).
+
+## Configuration File
+
+Codex reads its configuration from `~/.codex/config.toml`. Add a custom model provider for the appliance.
+
+```toml
+model = "glm-5.2"
+model_provider = "lpai"
+
+[model_providers.lpai]
+name = "Launchpad"
+base_url = "https://amd.spectrocloud.com:8443/v1"
+env_key = "LPAI_KEY"
+wire_api = "responses"
+```
+
+## Fields
+
+| Field            | Description                                                                                                                               | Example value                          |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `model`          | The id of a model the appliance serves. Use a real served model id, not `auto`, because the Responses API passes the model to the engine. | `glm-5.2`                              |
+| `model_provider` | The provider Codex uses. Must match the name of the `[model_providers.<name>]` table.                                                     | `lpai`                                 |
+| `name`           | A display name for the provider.                                                                                                          | `Launchpad`                            |
+| `base_url`       | The appliance inference endpoint, with the `/v1` path appended.                                                                           | `https://amd.spectrocloud.com:8443/v1` |
+| `env_key`        | The name of the environment variable that holds your API token.                                                                          | `LPAI_KEY`                             |
+| `wire_api`       | The API Codex uses. Codex uses the Responses API, so set this to `responses`.                                                             | `responses`                            |
+
+## Endpoint URL
+
+Set `base_url` to your appliance's address, the same host you use to reach the console, with `/v1` appended. The gateway
+serves the Responses API at `/v1/responses`, and Codex appends the `/responses` path itself, so `base_url` ends at `/v1`.
+If you do not know the address, ask the administrator who set up the appliance.
+
+## API Token
+
+Codex reads the token from the environment variable named by `env_key`. Export it before you run Codex.
+
+```bash
+export LPAI_KEY=<lpai-token>
+```
+
+The token is generated in the console and begins with `lpai_`.
+
+## Model Name
+
+Codex sends the value of `model` straight to the appliance engine over the Responses API, so it must be a model the
+appliance serves, such as `glm-5.2`. Do not use `auto`. The served model ids appear in the console model list and in the
+appliance's `/v1/models` API response.
+
+## Requirements
+
+- The appliance must present a valid, publicly trusted TLS certificate on a DNS hostname. Codex validates TLS strictly
+  and cannot skip certificate verification, so a self-signed certificate does not work.
+- The gateway must accept the `developer` message role, which the Launchpad for AI gateway does.
+
+## Token Quotas
+
+If the token's quota is exhausted, the appliance returns an HTTP `429` response and Codex surfaces the error.
+{/* TODO: link to the token quotas and metering reference once it exists */}
+
+## Resources
+
+- [Use Launchpad for AI with OpenAI Codex](../how-to-guides/use-codex.md)
+- [Use Launchpad for AI with Claude Code](../how-to-guides/use-claude-code.md)
+- [Use Launchpad for AI with Cursor](../how-to-guides/use-cursor.md)
+- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- Token quotas and metering {/* TODO: link once page exists */}

--- a/docs/docs-content/launchpad-for-ai/reference/reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/reference.md
@@ -21,3 +21,4 @@ is configured, not how to accomplish a task.
 | [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration. |
 | [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.     |
 | [Cursor Configuration](./cursor-reference.md)                     | Settings and values for pointing Cursor at the appliance.                       |
+| [OpenAI Codex Configuration](./codex-reference.md)                | Configuration file fields and values for pointing Codex at the appliance.       |


### PR DESCRIPTION
Add a how-to that connects the OpenAI Codex CLI to a Launchpad for AI appliance through a custom model provider.

Add a companion reference page for the Codex configuration file fields and values.

