### PR TITLE
docs: add OpenCode guide and configuration

### DIFF
--- a/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/how-to-guides.md
@@ -22,3 +22,4 @@ you the steps to do it without teaching background concepts.
 | [Use Claude Code](./use-claude-code.md)             | Connect Claude Code to the appliance so a local model serves each request.       |
 | [Use Cursor](./use-cursor.md)                       | Connect Cursor's Ask mode to the appliance through a uniquely named model alias. |
 | [Use OpenAI Codex](./use-codex.md)                  | Connect the OpenAI Codex CLI to the appliance with a custom model provider.      |
+| [Use OpenCode](./use-opencode.md)                   | Connect the OpenCode terminal agent to the appliance through a custom provider.  |

--- a/docs/docs-content/launchpad-for-ai/how-to-guides/use-opencode.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/use-opencode.md
@@ -46,7 +46,8 @@ create a new one.
 ## Configure OpenCode
 
 OpenCode connects to any OpenAI-compatible endpoint through a custom provider. Add a provider for the appliance to the
-OpenCode configuration file.
+OpenCode configuration file. For a description of each field, refer to
+[OpenCode Configuration](../reference/opencode-reference.md).
 
 1. Add the following provider to the OpenCode configuration file at `~/.config/opencode/opencode.json`. Replace
    `<appliance-host>` with your appliance address and `<lpai-token>` with the token you copied.
@@ -122,6 +123,7 @@ response.
 
 ## Next Steps
 
-To connect a different coding tool, refer to [Use Launchpad for AI with Claude Code](./use-claude-code.md),
+To look up each configuration value, refer to [OpenCode Configuration](../reference/opencode-reference.md). To connect a
+different coding tool, refer to [Use Launchpad for AI with Claude Code](./use-claude-code.md),
 [Use Launchpad for AI with Cursor](./use-cursor.md), or [Use Launchpad for AI with OpenAI Codex](./use-codex.md). To
 deploy another model to the appliance, refer to [Deploy a Model](./deploy-a-model.md).

--- a/docs/docs-content/launchpad-for-ai/how-to-guides/use-opencode.md
+++ b/docs/docs-content/launchpad-for-ai/how-to-guides/use-opencode.md
@@ -1,0 +1,127 @@
+---
+sidebar_label: "Use OpenCode"
+title: "Use Launchpad for AI with OpenCode"
+description:
+  "Connect the OpenCode terminal coding agent to a Launchpad for AI appliance so that a model on the appliance serves
+  every request."
+hide_table_of_contents: false
+sidebar_position: 6
+tags: ["launchpad-for-ai", "opencode", "how-to"]
+keywords: ["launchpad", "ai", "opencode", "openai-compatible", "custom provider", "opencode.json", "api token"]
+---
+
+<PartialsComponent category="launchpad-for-ai" name="unreleased-banner" />
+
+This guide explains how to connect OpenCode to a Launchpad for AI appliance so that a model running on the appliance
+serves every request instead of a cloud provider. You generate an API token, add a custom provider to the OpenCode
+configuration file, and confirm the connection.
+
+## Prerequisites
+
+- OpenCode installed and already working. For installation details, refer to the
+  [OpenCode website](https://opencode.ai).
+- A running Launchpad for AI appliance with at least one model deployed and serving. To deploy a model, refer to
+  [Deploy a Model](./deploy-a-model.md).
+- Admin access to the Launchpad for AI console, or an API token that an administrator generated for you.
+
+## Generate an API Token
+
+If an administrator already gave you an API token, skip to [Configure OpenCode](#configure-opencode).
+
+1. Open the appliance console in a browser and sign in.
+
+2. From the left main menu, select **Access & Policy** > **Users**.
+
+3. Create a token.
+
+4. Copy the token when the console reveals it. The token begins with `lpai_`.
+
+:::warning
+
+The console shows the token only once and stores only a hash of it. Copy it now. If you lose it, revoke the token and
+create a new one.
+
+:::
+
+## Configure OpenCode
+
+OpenCode connects to any OpenAI-compatible endpoint through a custom provider. Add a provider for the appliance to the
+OpenCode configuration file.
+
+1. Add the following provider to the OpenCode configuration file at `~/.config/opencode/opencode.json`. Replace
+   `<appliance-host>` with your appliance address and `<lpai-token>` with the token you copied.
+
+   ```json
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "provider": {
+       "launchpad": {
+         "npm": "@ai-sdk/openai-compatible",
+         "name": "Launchpad for AI",
+         "options": {
+           "baseURL": "https://<appliance-host>/v1",
+           "apiKey": "<lpai-token>"
+         },
+         "models": {
+           "glm-5.2": { "name": "GLM-5.2 (Launchpad)" }
+         }
+       }
+     }
+   }
+   ```
+
+2. Set `baseURL` to your appliance address with the `/v1` path appended.
+
+3. Set `apiKey` to your `lpai_` token.
+
+4. Under `models`, list each model id the appliance serves that you want to use, such as `glm-5.2`. The `launchpad` key
+   is a name you choose for the provider. OpenCode identifies a model by that provider name and a model id joined with a
+   slash, such as `launchpad/glm-5.2`, which you pass to the `--model` flag when you run OpenCode in the next section.
+
+5. We strongly recommend giving the appliance a DNS name and a valid, publicly trusted TLS certificate. The connection
+   uses HTTPS, so a valid certificate protects your token in transit.
+
+   :::warning
+
+   If the appliance uses a self-signed certificate, OpenCode rejects the connection by default because it runs on
+   Node.js. As a temporary measure for testing, set `NODE_TLS_REJECT_UNAUTHORIZED=0` before you start OpenCode. This
+   disables certificate verification, so do not use it outside short-lived testing.
+
+   :::
+
+## Verify the Connection
+
+Run a single prompt to confirm the appliance answers. The `--model` flag takes a `provider/model` value that combines
+the provider key from your configuration file with a model id.
+
+```bash
+opencode run --model launchpad/glm-5.2 "reply with exactly OPENCODE_OK"
+```
+
+```bash hideClipboard title="Expected output"
+OPENCODE_OK
+```
+
+A reply confirms that the base URL, token, provider, and model routing all work. OpenCode splits the `--model` value on
+the first slash, so `launchpad/glm-5.2` selects the `glm-5.2` model from the `launchpad` provider.
+
+:::tip
+
+If you use a reasoning model and the reply comes back empty, raise the output limit. Hidden reasoning tokens can consume
+a small output budget entirely, which leaves no room for the visible reply.
+
+:::
+
+## Request Routing and Quotas
+
+Requests you send through the appliance are subject to the routing rule and quota configured for your API token. If an
+operator configured a routing rule for your token, the appliance can redirect a request to a frontier model instead of a
+local one. Token quotas apply per API token, and when a token exhausts its quota, the appliance returns an HTTP `429`
+response.
+{/* TODO: link to the intelligent routing how-to and the token quotas and metering reference once they exist */}
+
+## Next Steps
+
+To connect a different coding tool, refer to [Use Launchpad for AI with Claude Code](./use-claude-code.md),
+[Use Launchpad for AI with Cursor](./use-cursor.md), or [Use Launchpad for AI with OpenAI Codex](./use-codex.md). To
+deploy another model to the appliance, refer to [Deploy a Model](./deploy-a-model.md).

--- a/docs/docs-content/launchpad-for-ai/reference/claude-code-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/claude-code-reference.md
@@ -16,7 +16,7 @@ set them, refer to [Use Launchpad for AI with Claude Code](../how-to-guides/use-
 
 ## Environment Variables
 
-| Variable               | Description                                                                                                                                 | Example value                       |
+| **Variable**           | **Description**                                                                                                                             | **Example value**                   |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | `ANTHROPIC_BASE_URL`   | The Launchpad for AI inference endpoint. Use the appliance address with no path. Claude Code appends `/v1/messages`.                        | `https://amd.spectrocloud.com:8443` |
 | `ANTHROPIC_AUTH_TOKEN` | The API token generated in the console. It begins with `lpai_`. `ANTHROPIC_API_KEY` is also accepted.                                       | `lpai_YOUR_TOKEN`                   |

--- a/docs/docs-content/launchpad-for-ai/reference/codex-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/codex-reference.md
@@ -32,7 +32,7 @@ wire_api = "responses"
 
 ## Fields
 
-| Field            | Description                                                                                                                               | Example value                          |
+| **Field**        | **Description**                                                                                                                           | **Example value**                      |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
 | `model`          | The id of a model the appliance serves. Use a real served model id, not `auto`, because the Responses API passes the model to the engine. | `glm-5.2`                              |
 | `model_provider` | The provider Codex uses. Must match the name of the `[model_providers.<name>]` table.                                                     | `lpai`                                 |

--- a/docs/docs-content/launchpad-for-ai/reference/cursor-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/cursor-reference.md
@@ -18,7 +18,7 @@ them, refer to [Use Launchpad for AI with Cursor](../how-to-guides/use-cursor.md
 
 Set the following in Cursor under **Settings** > **Models**.
 
-| Setting                      | Description                                                                                      | Example value                          |
+| **Setting**                  | **Description**                                                                                  | **Example value**                      |
 | ---------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------- |
 | **Override OpenAI Base URL** | The Launchpad for AI inference endpoint. Use the appliance address with the `/v1` path appended. | `https://amd.spectrocloud.com:8443/v1` |
 | **OpenAI API Key**           | The API token generated in the console. It begins with `lpai_`.                                  | `lpai_YOUR_TOKEN`                      |
@@ -47,12 +47,12 @@ the appliance's `/v1/models` API response.
 
 ## Supported Modes
 
-| Cursor mode | Supported | Notes                                                        |
-| ----------- | --------- | ------------------------------------------------------------ |
-| Ask (chat)  | Yes       | Routes to the appliance through the model alias.             |
-| Agent       | No        | Locked to Cursor's own models for bring-your-own-key setups. |
-| Edit        | No        | Locked to Cursor's own models for bring-your-own-key setups. |
-| Tab         | No        | Locked to Cursor's own models for bring-your-own-key setups. |
+| **Cursor mode** | **Supported** | **Notes**                                                    |
+| --------------- | ------------- | ------------------------------------------------------------ |
+| Ask (chat)      | Yes           | Routes to the appliance through the model alias.             |
+| Agent           | No            | Locked to Cursor's own models for bring-your-own-key setups. |
+| Edit            | No            | Locked to Cursor's own models for bring-your-own-key setups. |
+| Tab             | No            | Locked to Cursor's own models for bring-your-own-key setups. |
 
 The unsupported modes are a limitation of Cursor's bring-your-own-key support, not of the appliance.
 

--- a/docs/docs-content/launchpad-for-ai/reference/opencode-reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/opencode-reference.md
@@ -1,0 +1,92 @@
+---
+sidebar_label: "OpenCode Configuration"
+title: "Launchpad for AI OpenCode Configuration"
+description:
+  "Reference for the configuration file fields and values used to connect the OpenCode terminal coding agent to a
+  Launchpad for AI appliance."
+hide_table_of_contents: false
+sidebar_position: 8
+tags: ["launchpad-for-ai", "opencode", "reference"]
+keywords: ["launchpad", "ai", "opencode", "opencode.json", "openai-compatible", "custom provider", "api token", "model"]
+---
+
+<PartialsComponent category="launchpad-for-ai" name="unreleased-banner" />
+
+This page lists the configuration values OpenCode uses to connect to a Launchpad for AI appliance. For the steps to set
+them, refer to [Use Launchpad for AI with OpenCode](../how-to-guides/use-opencode.md).
+
+## Configuration File
+
+OpenCode reads its configuration from `~/.config/opencode/opencode.json`. Add a custom provider for the appliance.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "launchpad": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Launchpad for AI",
+      "options": {
+        "baseURL": "https://amd.spectrocloud.com:8443/v1",
+        "apiKey": "<lpai-token>"
+      },
+      "models": {
+        "glm-5.2": { "name": "GLM-5.2 (Launchpad)" }
+      }
+    }
+  }
+}
+```
+
+## Fields
+
+| **Field**         | **Description**                                                                                                                  | **Example value**                      |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `$schema`         | The OpenCode configuration schema. Enables validation and autocompletion in an editor.                                           | `https://opencode.ai/config.json`      |
+| `provider.<key>`  | A custom provider entry. The key, such as `launchpad`, is the provider name you combine with a model id when you select a model. | `launchpad`                            |
+| `npm`             | The provider plugin OpenCode loads. For an OpenAI-compatible endpoint, use `@ai-sdk/openai-compatible`.                          | `@ai-sdk/openai-compatible`            |
+| `name`            | A display name for the provider.                                                                                                 | `Launchpad for AI`                     |
+| `options.baseURL` | The appliance inference endpoint, with the `/v1` path appended.                                                                  | `https://amd.spectrocloud.com:8443/v1` |
+| `options.apiKey`  | Your API token. The console generates it, and it begins with `lpai_`.                                                            | `<lpai-token>`                         |
+| `models`          | A map of the model ids the appliance serves that you want to use. Each key is a served model id, and its `name` is a label.      | `glm-5.2`                              |
+
+## Endpoint URL
+
+Set `baseURL` to your appliance's address, the same host you use to reach the console, with `/v1` appended. The gateway
+serves the OpenAI-compatible API under `/v1`, and the `@ai-sdk/openai-compatible` provider appends the remaining path,
+such as `/chat/completions`, itself, so `baseURL` ends at `/v1`. If you do not know the address, ask the administrator
+who set up the appliance.
+
+## API Token
+
+OpenCode reads the token from the `apiKey` field in the provider's `options`. The token is generated in the console and
+begins with `lpai_`.
+
+## Model Name
+
+OpenCode selects a model by a `provider/model` value, such as `launchpad/glm-5.2`, and splits the value on the first
+slash. The part before the slash is the provider key, and the part after it is a model id you listed under `models`. Use
+a model the appliance serves, such as `glm-5.2`. The served model ids appear in the console model list and in the
+appliance's `/v1/models` API response.
+
+## Requirements
+
+- The connection uses HTTPS. We strongly recommend a DNS hostname with a valid, publicly trusted TLS certificate so that
+  the certificate protects your token in transit.
+- OpenCode runs on Node.js. If the appliance uses a self-signed certificate, OpenCode rejects the connection by default.
+  As a temporary measure for testing, set `NODE_TLS_REJECT_UNAUTHORIZED=0` before you start OpenCode. This disables
+  certificate verification, so do not use it outside short-lived testing.
+
+## Token Quotas
+
+If the token's quota is exhausted, the appliance returns an HTTP `429` response and OpenCode surfaces the error.
+{/* TODO: link to the token quotas and metering reference once it exists */}
+
+## Resources
+
+- [Use Launchpad for AI with OpenCode](../how-to-guides/use-opencode.md)
+- [Use Launchpad for AI with Claude Code](../how-to-guides/use-claude-code.md)
+- [Use Launchpad for AI with Cursor](../how-to-guides/use-cursor.md)
+- [Use Launchpad for AI with OpenAI Codex](../how-to-guides/use-codex.md)
+- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- Token quotas and metering {/* TODO: link once page exists */}

--- a/docs/docs-content/launchpad-for-ai/reference/reference.md
+++ b/docs/docs-content/launchpad-for-ai/reference/reference.md
@@ -22,3 +22,4 @@ is configured, not how to accomplish a task.
 | [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.     |
 | [Cursor Configuration](./cursor-reference.md)                     | Settings and values for pointing Cursor at the appliance.                       |
 | [OpenAI Codex Configuration](./codex-reference.md)                | Configuration file fields and values for pointing Codex at the appliance.       |
+| [OpenCode Configuration](./opencode-reference.md)                 | Configuration file fields and values for pointing OpenCode at the appliance.    |


### PR DESCRIPTION
Add a guide for connecting OpenCode through an OpenAI-compatible custom provider.

Add a reference page listing the OpenCode configuration file fields and values.
