### PR TITLE
docs: align coding-tool guides with the connect-agent modal

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-claude-code.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-claude-code.md
@@ -32,6 +32,15 @@ Claude Code at the appliance with two environment variables, and confirm the con
 
 On the machine where you run Claude Code, set the following environment variables.
 
+:::tip
+
+You do not have to assemble these variables by hand. In the console, select **Connect coding agent** and open the
+**Claude Code** tab to generate a ready-to-paste configuration snippet. The snippet can also set optional per-tier model
+aliases and a reasoning-effort level. For the full list of values it can set, refer to
+[Claude Code Configuration](../reference/claude-code-reference.md).
+
+:::
+
 ```bash
 export ANTHROPIC_BASE_URL=https://<appliance-host>
 export ANTHROPIC_AUTH_TOKEN=<lpai-token>
@@ -52,12 +61,12 @@ To persist the settings instead of exporting them each session, add them to the 
 }
 ```
 
-Claude Code requests a Claude alias, such as `claude-sonnet-4-5`. To pin every request to one alias, set
-`ANTHROPIC_MODEL` to it. For the aliases the appliance accepts, refer to
+Claude Code requests a Claude alias, such as `claude-opus-4-8`. To pin every request to one alias, set `ANTHROPIC_MODEL`
+to it. For the aliases the appliance accepts, refer to
 [Claude Code Configuration](../reference/claude-code-reference.md).
 
 ```bash
-export ANTHROPIC_MODEL=claude-sonnet-4-5
+export ANTHROPIC_MODEL=claude-opus-4-8
 ```
 
 We strongly recommend giving the appliance a DNS name and a valid, publicly trusted TLS certificate. The connection uses

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-codex.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-codex.md
@@ -35,6 +35,14 @@ model provider to the Codex configuration file, and confirm the connection.
 Codex uses the Responses API, so you add a custom model provider that points at the appliance. For a description of each
 field, refer to [OpenAI Codex Configuration](../reference/codex-reference.md).
 
+:::tip
+
+The console can generate a starter version of this configuration for you. Select **Connect coding agent** and open the
+**Codex** tab to copy a `config.toml` snippet pre-filled with your appliance's endpoint. Review the model and provider
+values against the steps below before you save it.
+
+:::
+
 1. Add the following custom provider to the Codex configuration file at `~/.codex/config.toml`. Replace
    `<appliance-host>` with your appliance address.
 
@@ -58,6 +66,8 @@ field, refer to [OpenAI Codex Configuration](../reference/codex-reference.md).
    ```bash
    export LPAI_KEY=<lpai-token>
    ```
+
+{/* NEEDS REVIEW: this guide says `model` must be a real served id (not an alias) because the Responses API passes the model straight to the engine, but the console's "Connect coding agent" > Codex snippet sets `model = "claude-opus-4-8"`, a tier-map alias. Confirm with an SME whether the tier map resolves aliases over the Responses API. */}
 
 ## Verify the Connection
 

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-cursor.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-cursor.md
@@ -45,6 +45,8 @@ name matches a model already in Cursor's catalog, such as `glm-5.2` or `gpt-4o`,
 backend and never contacts your appliance. To force Cursor to use the appliance, serve the model under a unique alias
 name that does not exist in Cursor's catalog.
 
+{/* NEEDS REVIEW: the console's "Connect coding agent" > Cursor tab suggests adding the model `claude-opus-4-8`. That name likely matches Cursor's built-in catalog, so it would route to Cursor's own backend rather than the appliance, the problem this section prevents. Confirm with an SME; the unique-alias approach in this section is what reliably reaches the appliance. */}
+
 Creating an alias is an operator task. If you do not have operator access, ask an administrator to create the alias and
 give you its name, then continue to [Configure Cursor](#configure-cursor).
 
@@ -72,6 +74,14 @@ such as `launchpad-glm52`, is the name you enter in Cursor.
 
 Point Cursor at the appliance in Cursor's settings. For the full list of settings and their example values, refer to
 [Cursor Configuration](../reference/cursor-reference.md).
+
+:::tip
+
+The console lists these same steps for you. Select **Connect coding agent** and open the **Cursor** tab for the base URL
+and key to enter. Use the unique alias from [Create a Model Alias](#create-a-model-alias) as the model name, not a
+built-in model name that Cursor already knows.
+
+:::
 
 1. In Cursor, open **Settings** > **Models**.
 

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-opencode.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-opencode.md
@@ -34,6 +34,14 @@ OpenCode connects to any OpenAI-compatible endpoint through a custom provider. A
 OpenCode configuration file. For a description of each field, refer to
 [OpenCode Configuration](../reference/opencode-reference.md).
 
+:::tip
+
+The console can generate a starter version of this file for you. Select **Connect coding agent** and open the
+**OpenCode** tab to copy an `opencode.json` snippet pre-filled with your appliance's endpoint. Review the `baseURL` and
+`models` values against the steps below before you save it.
+
+:::
+
 1. Add the following provider to the OpenCode configuration file at `~/.config/opencode/opencode.json`. Replace
    `<appliance-host>` with your appliance address and `<lpai-token>` with the token you copied.
 

--- a/docs/docs-content/paletteai-inference-launchpad/reference/claude-code-reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/claude-code-reference.md
@@ -18,11 +18,17 @@ the steps to set them, refer to
 
 ## Environment Variables
 
-| **Variable**           | **Description**                                                                                                                             | **Example value**                   |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `ANTHROPIC_BASE_URL`   | The PaletteAI Inference Launchpad inference endpoint. Use the appliance address with no path. Claude Code appends `/v1/messages`.           | `https://amd.spectrocloud.com:8443` |
-| `ANTHROPIC_AUTH_TOKEN` | The API token generated in the console. It begins with `lpai_`. `ANTHROPIC_API_KEY` is also accepted.                                       | `lpai_YOUR_TOKEN`                   |
-| `ANTHROPIC_MODEL`      | Optional. The Claude alias Claude Code requests. The appliance maps the alias to the model it serves, so you do not pick the backend model. | `claude-sonnet-4-5`                 |
+| **Variable**                     | **Description**                                                                                                                             | **Example value**                   |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `ANTHROPIC_BASE_URL`             | The PaletteAI Inference Launchpad inference endpoint. Use the appliance address with no path. Claude Code appends `/v1/messages`.           | `https://amd.spectrocloud.com:8443` |
+| `ANTHROPIC_AUTH_TOKEN`           | The API token generated in the console. It begins with `lpai_`. `ANTHROPIC_API_KEY` is also accepted.                                       | `lpai_YOUR_TOKEN`                   |
+| `ANTHROPIC_MODEL`                | Optional. The Claude alias Claude Code requests. The appliance maps the alias to the model it serves, so you do not pick the backend model. | `claude-opus-4-8`                   |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL`   | Optional. The alias Claude Code requests for its Opus-tier work. The appliance maps the alias to the model it serves.                       | `claude-opus-4-8`                   |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | Optional. The alias Claude Code requests for its Sonnet-tier work.                                                                          | `claude-sonnet-4-5`                 |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL`  | Optional. The alias Claude Code requests for its Haiku-tier, background work.                                                               | `claude-haiku-4-5`                  |
+| `CLAUDE_CODE_EFFORT_LEVEL`       | Optional. Sets Claude Code's reasoning effort. One of `low`, `medium`, `high`, or `max`.                                                    | `max`                               |
+
+{/* TODO: confirm the ANTHROPIC_DEFAULT_* and CLAUDE_CODE_EFFORT_LEVEL rows with an SME. The console's "Connect coding agent" snippet emits them, but their appliance behavior is unverified. */}
 
 ## Endpoint URL
 

--- a/docs/docs-content/paletteai-inference-launchpad/reference/codex-reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/codex-reference.md
@@ -64,6 +64,8 @@ Codex sends the value of `model` straight to the appliance engine over the Respo
 appliance serves, such as `glm-5.2`. Do not use `auto`. The served model ids appear in the console model list and in the
 appliance's `/v1/models` API response.
 
+{/* NEEDS REVIEW: the console's "Connect coding agent" > Codex snippet sets `model = "claude-opus-4-8"`, a tier-map alias rather than a served id. Confirm with an SME whether the tier map resolves aliases over the Responses API, which would contradict the preceding guidance. */}
+
 ## Requirements
 
 - The appliance must present a valid, publicly trusted TLS certificate on a DNS hostname. Codex validates TLS strictly

--- a/docs/docs-content/paletteai-inference-launchpad/reference/cursor-reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/cursor-reference.md
@@ -46,6 +46,8 @@ An operator creates the alias on the appliance, which maps it to a model the app
 `zai-org/GLM-5.2`. Both the alias and the ids of the models the appliance serves appear in the console model list and in
 the appliance's `/v1/models` API response.
 
+{/* NEEDS REVIEW: the console's "Connect coding agent" > Cursor tab suggests the model `claude-opus-4-8`, which likely matches Cursor's built-in catalog and would route to Cursor's own backend. Confirm with an SME; the unique-alias approach is what reliably reaches the appliance. */}
+
 ## Supported Modes
 
 | **Cursor mode** | **Supported** | **Notes**                                                    |


### PR DESCRIPTION
Add a tip to each coding-tool how-to that points to the console's Connect coding agent generator.

Switch the Claude Code model example to claude-opus-4-8 and document the ANTHROPIC_DEFAULT_* and CLAUDE_CODE_EFFORT_LEVEL variables in the reference, flagged for SME confirmation.

Keep the Codex, Cursor, and OpenCode model examples and flag where the generator's claude-opus-4-8 example conflicts with each guide's documented routing behavior.
