### PR TITLE
updating backport GHA so it properly copies pr reviewers

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -79,7 +79,7 @@ jobs:
         # Refer to issue https://github.com/sqren/backport-github-action/issues/79 for more details.
           github_token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
           auto_backport_label_prefix: backport-
-          add_original_reviewers: true
+          copy_source_pr_reviewers: true
 
       - name: Info log
         if: ${{ success() }} 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.

- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._


- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR updates `backport.yaml` so that the called to add original reviewers (originally targeted as `add_original_reviewers: true`) actually does it. Changed line to `copy_source_pr_reviewers: true`.  This was discovered by Claude as part of Dependabot tickets. 

