### PR TITLE
docs: add how-to guides for creating and managing clients

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/explanation/clients-and-quotas.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/clients-and-quotas.md
@@ -80,7 +80,7 @@ and the client is back under the limit.
 
 {/* NEEDS REVIEW: quota enforcement is off by default (global switch) per current working assumption. Confirm with an SME before publishing. */}
 
-{/* TODO: link to the quota how-to and Quota & Rate Limit reference (DOC-2925) once those pages exist. */}
+{/* TODO: link to the Set and Manage Quotas how-to (DOC-2940) and Quota & Rate Limit reference (DOC-2941) once they exist. */}
 
 ## What Clients Can Access
 
@@ -108,6 +108,8 @@ so it is ready to run on every request.
 
 ## Resources
 
+- [Create a Client](../how-to-guides/create-a-client.md) walks through creating a client and issuing its first API
+  token.
 - [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md) walks through connecting a
   coding assistant to a client with an API key.
 - [Architecture Overview](./architecture.md) explains how the appliance routes requests and where its components sit.

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/create-a-client.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/create-a-client.md
@@ -1,0 +1,89 @@
+---
+sidebar_label: "Create a Client"
+title: "Create a Client"
+description:
+  "Step-by-step guidance for platform administrators on how to create a client on a PaletteAI Inference Launchpad
+  appliance by stepping through the Add client wizard and issuing the client's first API token."
+hide_table_of_contents: false
+sidebar_position: 4
+tags: ["paletteai-inference-launchpad", "clients", "how-to"]
+keywords: ["launchpad", "ai", "clients", "add client", "api token", "lpai"]
+---
+
+<PartialsComponent category="paletteai-inference-launchpad" name="unreleased-banner" />
+
+This guide explains how a platform administrator creates a client on a PaletteAI Inference Launchpad appliance. A client
+is a named team, business unit, or workload, represented by one or more API tokens. To understand what a client is and
+how clients, API tokens, and quotas relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+To generate an API token by itself, without stepping through the full client setup, refer to
+[Generate an API Token](./generate-an-api-token.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- Console access with permission to manage clients. Managing clients can require operator access.
+
+## Create a Client
+
+Create a client through the **Add client** wizard. The wizard names the client, optionally sets a quota, optionally
+grants model access, and optionally issues the client's first API token.
+
+1. Open the appliance console in a browser and sign in.
+
+2. From the left main menu, select **Access & Policy**. The **Clients & API tokens** page opens.
+
+3. Select **Add client**. The **Add client** wizard opens on the **Overview** step.
+
+4. On the **Overview** step, enter a **Client name**, and then select **Next step**. The appliance assigns the client an
+   immutable identifier and registers it as active.
+
+5. _(Optional)_ On the **Quotas** step, add usage limits for the client, and then select **Next step**. For details,
+   refer to [Set and Manage Client Quotas](./manage-client-quotas.md).
+
+6. _(Optional)_ On the **Egress** step, allow the client to reach external models, and then select **Next step**. For
+   details, refer to [Manage a Client's Model Access](./manage-client-model-access.md).
+
+7. _(Optional)_ On the **Routing** step, route the client to specific models, and then select **Next step**. For
+   details, refer to [Manage a Client's Model Access](./manage-client-model-access.md).
+
+8. On the **API tokens** step, select **Mint an API token** to issue the client's first token. Optionally enter a
+   **Label** and an **Expires** date. Leave **Expires** blank for a token that never expires.
+
+9. Select **Create client**.
+
+10. When the console reveals the token, select **Copy**. The token begins with `lpai_`.
+
+:::warning
+
+The console shows the token only once and stores only a hash of it. Copy it now. If you lose it, revoke the token and
+create a new one.
+
+:::
+
+A client can hold more than one API token. To add another token to a client later, refer to
+[Generate an API Token](./generate-an-api-token.md).
+
+## Verify the Client
+
+Confirm that the appliance registered the client and its API token.
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, confirm the new client appears in the list under the name you gave it.
+
+3. Select the client to open its detail panel, and then select the **API tokens** section.
+
+4. Confirm the token you minted appears with a state of **active**.
+
+The client is ready to use once its token is active. To confirm the token works from end to end, connect a coding
+assistant to the appliance with it, as described in [Use Claude Code](./use-claude-code.md).
+
+## Next Steps
+
+After you create a client, configure how much it can consume and which models it can reach.
+
+- [Set and Manage Client Quotas](./manage-client-quotas.md)
+- [Manage a Client's Model Access](./manage-client-model-access.md)
+- [View Client Usage](./view-client-usage.md)
+- [Revoke or Delete a Client](./revoke-or-delete-a-client.md)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/generate-an-api-token.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/generate-an-api-token.md
@@ -14,7 +14,8 @@ keywords: ["launchpad", "ai", "api token", "authentication", "lpai", "coding age
 
 This guide explains how to generate an API token in the PaletteAI Inference Launchpad console. Clients such as coding
 assistants use the token to authenticate their requests to the appliance. To understand how tokens, clients, and quotas
-relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md). To create a client and then set its quotas
+and model access, start with [Create a Client](./create-a-client.md).
 
 ## Prerequisites
 

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -15,13 +15,18 @@ you the steps to do it without teaching background concepts.
 
 ## Contents
 
-| **Guide**                                           | **What you do**                                                                  |
-| --------------------------------------------------- | -------------------------------------------------------------------------------- |
-| [Install the Appliance](./install-the-appliance.md) | Flash the installer ISO, boot the hardware, and bring up the appliance console.  |
-| [Deploy a Model](./deploy-a-model.md)               | Deploy an LLM to the cluster and verify it is serving.                           |
-| [Set the Default Model](./set-the-default-model.md) | Configure which model handles requests that do not name a model explicitly.      |
-| [Generate an API Token](./generate-an-api-token.md) | Create an API token that clients use to authenticate to the appliance.           |
-| [Use Claude Code](./use-claude-code.md)             | Connect Claude Code to the appliance so a local model serves each request.       |
-| [Use Cursor](./use-cursor.md)                       | Connect Cursor's Ask mode to the appliance through a uniquely named model alias. |
-| [Use OpenAI Codex](./use-codex.md)                  | Connect the OpenAI Codex CLI to the appliance with a custom model provider.      |
-| [Use OpenCode](./use-opencode.md)                   | Connect the OpenCode terminal agent to the appliance through a custom provider.  |
+| **Guide**                                                         | **What you do**                                                                  |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [Install the Appliance](./install-the-appliance.md)               | Flash the installer ISO, boot the hardware, and bring up the appliance console.  |
+| [Deploy a Model](./deploy-a-model.md)                             | Deploy an LLM to the cluster and verify it is serving.                           |
+| [Set the Default Model](./set-the-default-model.md)               | Configure which model handles requests that do not name a model explicitly.      |
+| [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.           |
+| [Create a Client](./create-a-client.md)                           | Create a client and issue its first API token.                                   |
+| [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, and remove a client's request, token, and cost limits.                |
+| [Manage a Client's Model Access](./manage-client-model-access.md) | Route a client to models and allow it to reach external models.                  |
+| [View Client Usage](./view-client-usage.md)                       | View a client's per-token consumption, requests, and cost.                       |
+| [Revoke or Delete a Client](./revoke-or-delete-a-client.md)       | Find expired keys, revoke a token, or delete a client.                           |
+| [Use Claude Code](./use-claude-code.md)                           | Connect Claude Code to the appliance so a local model serves each request.       |
+| [Use Cursor](./use-cursor.md)                                     | Connect Cursor's Ask mode to the appliance through a uniquely named model alias. |
+| [Use OpenAI Codex](./use-codex.md)                                | Connect the OpenAI Codex CLI to the appliance with a custom model provider.      |
+| [Use OpenCode](./use-opencode.md)                                 | Connect the OpenCode terminal agent to the appliance through a custom provider.  |

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
@@ -1,0 +1,82 @@
+---
+sidebar_label: "Manage a Client's Model Access"
+title: "Manage a Client's Model Access"
+description:
+  "Step-by-step guidance for platform administrators on how to route a client to specific models and allow a client to
+  reach external models on a PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 6
+tags: ["paletteai-inference-launchpad", "clients", "models", "how-to"]
+keywords: ["launchpad", "ai", "clients", "model access", "routing", "tier map", "egress", "frontier"]
+---
+
+<PartialsComponent category="paletteai-inference-launchpad" name="unreleased-banner" />
+
+This guide explains how a platform administrator controls which models a client uses on a PaletteAI Inference Launchpad
+appliance. Model access depends on whether a model runs locally on the appliance or is reached through an external
+provider.
+
+- **Local models.** Every client with a valid API token can call every model served locally on the appliance. You do not
+  grant access to local models. To choose which local model handles a client's requests, route the client with a tier
+  map.
+- **External models.** A new client cannot reach external, or frontier, models until you enable egress for it. External
+  access is denied by default and is granted per client.
+
+To understand how clients and models relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- An existing client. To create one, refer to [Create a Client](./create-a-client.md).
+- Console access with permission to manage clients. Managing clients can require operator access.
+- _(External models only)_ A provider key for the external provider.
+
+## Route a Client to Specific Models
+
+Use a client's tier map to route the client's model aliases to the models you choose.
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Routing** section.
+
+4. In the **Tier map**, select **Add alias rule**, or edit an existing row.
+
+5. Set the **Alias prefix**, such as `claude-opus-`, and the **Model** it routes to.
+
+6. Save the client.
+
+The tier map applies to the selected client. Requests from other clients follow their own tier maps, so they are not
+routed to that model unless you configure their tier maps as well.
+
+<!--TODO: once published, add a sentence here linking to Configure Intelligent Routing and Semantic Domains (DOC-2926) for routing that goes beyond client-level model selection, such as semantic domains.-->
+
+{/* NEEDS REVIEW: the tier map governs which model handles a client's requests by default. It is a routing overlay, not a hard access gate for local models. Confirm the operator-facing framing with an SME. */}
+
+## Allow a Client to Reach External Models
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Egress** section.
+
+4. Select **Enable egress**.
+
+5. Add a provider key for the external provider.
+
+6. Set a daily spend cap for the client. Egress is fail-closed on the cap, so a cap of `0` blocks egress.
+
+7. _(Optional)_ List the provider models the client may reach. Leave the list empty to allow every model from that
+   provider.
+
+8. Save the client.
+
+Frontier-model bursting is configured separately and is out of scope for this guide.
+{/* TODO: link to the frontier-model bursting guide once published. */}
+
+## Next Steps
+
+- [Set and Manage Client Quotas](./manage-client-quotas.md)
+- [View Client Usage](./view-client-usage.md)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/manage-client-quotas.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/manage-client-quotas.md
@@ -1,0 +1,64 @@
+---
+sidebar_label: "Set and Manage Client Quotas"
+title: "Set and Manage Client Quotas"
+description:
+  "Step-by-step guidance for platform administrators on how to set, edit, and remove usage quotas on a client on a
+  PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 5
+tags: ["paletteai-inference-launchpad", "clients", "quotas", "how-to"]
+keywords: ["launchpad", "ai", "clients", "quota", "rate limit", "requests", "tokens", "cost", "429"]
+---
+
+<PartialsComponent category="paletteai-inference-launchpad" name="unreleased-banner" />
+
+This guide explains how a platform administrator sets and manages usage quotas on a client on a PaletteAI Inference
+Launchpad appliance. A quota limits how much a client consumes. A quota applies to the client, so every API token that
+belongs to the client draws on the same limits. To understand how quotas fit with clients and API tokens, refer to
+[Clients and Quotas](../explanation/clients-and-quotas.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- An existing client. To create one, refer to [Create a Client](./create-a-client.md).
+- Console access with permission to manage clients. Managing clients can require operator access.
+
+## Set a Client Quota
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Quotas** section.
+
+4. Select **Add window limit**.
+
+5. Choose the dimension to limit: **requests**, **tokens**, or **cost**.
+
+6. Choose the window the limit applies over: **second**, **minute**, **hour**, or **day**.
+
+7. Enter the limit for that dimension and window.
+
+8. Repeat the previous steps for each limit you want. For example, add a requests-per-minute limit, a tokens-per-day
+   limit, and a cost-per-day limit.
+
+9. Save the client.
+
+Each row limits one dimension over one window. A window with no row stays uncapped.
+
+## Edit or Remove a Quota
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Quotas** section.
+
+4. Change a limit, or remove a window-limit row.
+
+5. Save the client.
+
+## Next Steps
+
+- [Manage a Client's Model Access](./manage-client-model-access.md)
+- [View Client Usage](./view-client-usage.md)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/revoke-or-delete-a-client.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/revoke-or-delete-a-client.md
@@ -1,0 +1,65 @@
+---
+sidebar_label: "Revoke or Delete a Client"
+title: "Revoke or Delete a Client"
+description:
+  "Step-by-step guidance for platform administrators on how to find expired keys, revoke an API token, and delete a
+  client on a PaletteAI Inference Launchpad appliance, and what happens to in-flight requests."
+hide_table_of_contents: false
+sidebar_position: 8
+tags: ["paletteai-inference-launchpad", "clients", "api token", "how-to"]
+keywords: ["launchpad", "ai", "clients", "revoke", "delete", "expired", "api token", "in-flight"]
+---
+
+<PartialsComponent category="paletteai-inference-launchpad" name="unreleased-banner" />
+
+This guide explains how a platform administrator ends a client's access on a PaletteAI Inference Launchpad appliance:
+finding expired or revoked tokens, revoking a single API token, and deleting a client. To understand how clients and API
+tokens relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- An existing client. To create one, refer to [Create a Client](./create-a-client.md).
+- Console access with permission to manage clients. Managing clients can require operator access.
+
+## Find Expired or Revoked Keys
+
+An API token that passes its expiration date becomes expired, and the appliance rejects any request that presents it,
+fail-closed. The console shows each token's state so you can find expired tokens.
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **API tokens** section. Each token shows a state of **active**, **expired**, or **revoked**.
+
+The **Usage** page also shows a token's state in its per-token detail. For usage, refer to
+[View Client Usage](./view-client-usage.md).
+
+{/* NEEDS REVIEW: the ticket (DOC-2927) also asks for expired keys to be flagged on an overview page, but the appliance Overview dashboard, the client Overview section, and the client list do not flag expired tokens. Expired state appears only in a client's API tokens section and in the Usage per-token detail. Confirm the intended surface with the ticket owner. */}
+
+## Revoke an API Token
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **API tokens** section.
+
+4. Find the token, and then select **Revoke**.
+
+Revoking a token is immediate and cannot be undone.
+
+## Delete a Client
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client's delete action, and then confirm.
+   {/* NEEDS REVIEW: exact delete control and confirmation wording. */}
+
+Deleting a client revokes every API token that belongs to it.
+
+## Next Steps
+
+- [Create a Client](./create-a-client.md)
+- [Generate an API Token](./generate-an-api-token.md)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-claude-code.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-claude-code.md
@@ -5,7 +5,7 @@ description:
   "Connect Anthropic's Claude Code coding agent to a PaletteAI Inference Launchpad appliance so that a model on the
   appliance serves every request."
 hide_table_of_contents: false
-sidebar_position: 4
+sidebar_position: 9
 tags: ["paletteai-inference-launchpad", "claude-code", "how-to"]
 keywords: ["launchpad", "ai", "claude code", "anthropic", "coding agent", "api token"]
 ---

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-codex.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-codex.md
@@ -5,7 +5,7 @@ description:
   "Connect the OpenAI Codex CLI to a PaletteAI Inference Launchpad appliance so that a model on the appliance serves
   every request."
 hide_table_of_contents: false
-sidebar_position: 6
+sidebar_position: 11
 tags: ["paletteai-inference-launchpad", "codex", "how-to"]
 keywords: ["launchpad", "ai", "openai codex", "codex cli", "responses api", "config.toml", "api token"]
 ---

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-cursor.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-cursor.md
@@ -5,7 +5,7 @@ description:
   "Connect the Cursor code editor to a PaletteAI Inference Launchpad appliance so that a model on the appliance serves
   your requests in Cursor's Ask mode."
 hide_table_of_contents: false
-sidebar_position: 5
+sidebar_position: 10
 tags: ["paletteai-inference-launchpad", "cursor", "how-to"]
 keywords: ["launchpad", "ai", "cursor", "openai-compatible", "model alias", "ask mode", "api token"]
 ---

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-opencode.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-opencode.md
@@ -5,7 +5,7 @@ description:
   "Connect the OpenCode terminal coding agent to a PaletteAI Inference Launchpad appliance so that a model on the
   appliance serves every request."
 hide_table_of_contents: false
-sidebar_position: 7
+sidebar_position: 12
 tags: ["paletteai-inference-launchpad", "opencode", "how-to"]
 keywords: ["launchpad", "ai", "opencode", "openai-compatible", "custom provider", "opencode.json", "api token"]
 ---

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
@@ -1,0 +1,52 @@
+---
+sidebar_label: "View Client Usage"
+title: "View Client Usage"
+description:
+  "Step-by-step guidance for platform administrators on how to view per-client and per-token consumption on a PaletteAI
+  Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 7
+tags: ["paletteai-inference-launchpad", "clients", "usage", "how-to"]
+keywords: ["launchpad", "ai", "clients", "usage", "tokens", "requests", "cost", "metrics"]
+---
+
+<PartialsComponent category="paletteai-inference-launchpad" name="unreleased-banner" />
+
+This guide explains how a platform administrator views consumption per client and per API token on a PaletteAI Inference
+Launchpad appliance. To understand how usage relates to clients and quotas, refer to
+[Clients and Quotas](../explanation/clients-and-quotas.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- One or more clients with API tokens. To create a client, refer to [Create a Client](./create-a-client.md).
+- Console access with permission to view usage.
+
+## View Usage by Client
+
+1. From the left main menu, select **Usage**.
+
+2. Select the **By client** tab.
+
+3. Select a client.
+
+The client view shows:
+
+- Per-client totals for local input tokens, local output tokens, egress tokens, and egress cost.
+- A per-token table with each token's label, prefix, status, last-used time, creation time, expiration, request count,
+  input tokens, output tokens, total tokens, and cost.
+- The percentage of each quota used, which indicates how much of each limit is still available.
+- A conversation-routing breakdown that shows which models handled the client's requests.
+
+:::info
+
+Usage counts reflect activity since the appliance gateway last restarted.
+
+:::
+
+<!--TODO: once these sibling pages publish, add a "Further reading" list here linking to: View Token Usage and Consumption Metrics (DOC-2925) for more detail on usage metrics; and the Usage Metrics Reference (DOC-2942) for every metric and field. -->
+
+## Next Steps
+
+- [Set and Manage Client Quotas](./manage-client-quotas.md)
+- [Revoke or Delete a Client](./revoke-or-delete-a-client.md)


### PR DESCRIPTION
Add five task-focused how-to guides covering the full client lifecycle on a
PaletteAI Inference Launchpad appliance: creating a client, setting and
managing quotas, managing model access, viewing usage, and revoking or
deleting a client.