### PR TITLE
docs: add glossary

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -24,3 +24,8 @@ Google.We = NO
 Google.Acronyms = NO
 Alex.Condescending = NO
 Google.OptionalPlurals = NO
+; A glossary legitimately uses single-letter section dividers (## A, ## B ...) and
+; term-name headings that Vale's general heading rules flag. Scope those off here.
+[docs/docs-content/paletteai-inference-launchpad/reference/glossary.md]
+spectrocloud-docs-internal.heading-all-caps = NO
+spectrocloud-docs-internal.headings-title = NO

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/architecture.md
@@ -75,8 +75,8 @@ name a model falls back to the default model. When you change the default model,
 place. The gateway does not restart, and it does not drain requests that are in progress. Requests that the gateway
 already routed continue on their assigned model, and the new default applies only to later requests.
 
-Before it routes a request, the gateway authenticates the calling client from its API key and enforces that client's
-quotas. For how clients, API keys, and quotas work together, refer to [Clients and Quotas](./clients-and-quotas.md).
+Before it routes a request, the gateway authenticates the calling client from its API token and enforces that client's
+quotas. For how clients, API tokens, and quotas work together, refer to [Clients and Quotas](./clients-and-quotas.md).
 
 ## Network Topology
 

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/clients-and-quotas.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/clients-and-quotas.md
@@ -2,13 +2,12 @@
 sidebar_label: "Clients and Quotas"
 title: "Clients and Quotas"
 description:
-  "An explanation of clients, API keys, and quotas in PaletteAI Inference Launchpad: what a client is, why the appliance
-  serves many clients such as AI coding assistants, and how it meters and limits their usage."
+  "An explanation of clients, API tokens, and quotas in PaletteAI Inference Launchpad: what a client is, why the
+  appliance serves many clients such as AI coding assistants, and how it meters and limits their usage."
 hide_table_of_contents: false
 sidebar_position: 2
 tags: ["paletteai-inference-launchpad", "explanation", "clients", "quotas"]
-keywords:
-  ["launchpad", "ai", "clients", "api key", "api token", "quota", "rate limit", "coding assistant", "claude code"]
+keywords: ["launchpad", "ai", "clients", "api token", "quota", "rate limit", "coding assistant", "claude code"]
 ---
 
 <PartialsComponent category="paletteai-inference-launchpad" name="unreleased-banner" />
@@ -17,8 +16,8 @@ AI coding assistants such as Claude Code, Cursor, OpenAI Codex, and OpenCode mak
 to a PaletteAI Inference Launchpad appliance, sending their requests to the appliance instead of to a cloud provider. A
 single appliance can serve many of these assistants at once, along with other workloads such as an internal chatbot or a
 nightly batch job. This page explains how the appliance tells those workloads apart, and how it meters and limits what
-each one consumes. It covers what a _client_ is, why one appliance serves many of them, and how clients, API keys, and
-quotas fit together. Read it to understand these ideas before you create clients, issue keys, or set quotas.
+each one consumes. It covers what a _client_ is, why one appliance serves many of them, and how clients, API tokens, and
+quotas fit together. Read it to understand these ideas before you create clients, issue tokens, or set quotas.
 
 ## What a Client Is
 
@@ -27,12 +26,12 @@ accounting. The appliance attributes every request to exactly one client and mea
 client.
 
 A client is more often a _workload_ than a person. Each AI coding assistant that connects to the appliance is a client.
-A single client might represent one engineering team, with each developer holding a separate API key, or a single coding
-tool. A customer support assistant or a data pipeline also makes a natural client, and most such workloads have no human
-operator at all.
+A single client might represent one engineering team, with each developer holding a separate API token, or a single
+coding tool. A customer support assistant or a data pipeline also makes a natural client, and most such workloads have
+no human operator at all.
 
 One appliance can serve many clients side by side. They draw on the same loaded models and the same GPU hardware, so the
-appliance needs a way to keep them from interfering with one another. That is what clients, keys, and quotas provide.
+appliance needs a way to keep them from interfering with one another. That is what clients, tokens, and quotas provide.
 
 ## Why the Appliance Serves Many Clients
 
@@ -45,23 +44,23 @@ cannot:
   from consuming all available throughput and starving the others.
 - **Attribute usage.** Per-client metrics show which team or tool consumed what, so you can identify where capacity goes
   and plan accordingly.
-- **Contain credentials.** A key that a developer commits to a repository by mistake affects only its client. You revoke
-  that one key without disrupting any other workload.
+- **Contain credentials.** A token that a developer commits to a repository by mistake affects only its client. You
+  revoke that one token without disrupting any other workload.
 - **Govern outbound reach.** When the appliance routes to external providers, you can control which clients may send
   requests off the appliance. For example, you can allow only certain coding assistants to reach a paid frontier model.
 
 Creating separate clients is not about distributing access for its own sake. It is how you keep a shared, finite
 appliance usable by many workloads at once.
 
-## Clients and API Keys
+## Clients and API Tokens
 
-A client proves its identity with an API key, a bearer token that begins with the prefix `lpai_`. Every request carries
-its key in the `Authorization` header. The appliance resolves the key to its client, applies that client's quotas, and
-records the request's usage against that client.
+A client proves its identity with an API token, a bearer credential that begins with the prefix `lpai_`. Every request
+carries its token in the `Authorization` header. The appliance resolves the token to its client, applies that client's
+quotas, and records the request's usage against that client.
 
-A client can hold more than one API key. When each developer or coding tool that shares a client carries its own key,
-revoking one key (for example, after a developer leaves the team) does not disturb the others. Revoking the client
-itself revokes every key that belongs to it.
+A client can hold more than one API token. When each developer or coding tool that shares a client carries its own
+token, revoking one token (for example, after a developer leaves the team) does not disturb the others. Revoking the
+client itself revokes every token that belongs to it.
 
 ## Quotas
 
@@ -98,19 +97,21 @@ Access to models depends on whether a model runs locally on the appliance or is 
 A single request from a coding assistant ties these ideas together.
 
 1. A code completion request arrives with `Authorization: Bearer lpai_...`.
-2. The appliance resolves the key to its client.
+2. The appliance resolves the token to its client.
 3. The appliance checks that client's quota for the requested dimension and window.
 4. If the client is within its limits, the appliance routes the request to the model and records the usage against the
    client. If the client is over a limit, the appliance rejects the request with `429` instead.
 
-Setting up a client builds this same chain ahead of time, starting with the client, then its keys, and then its quotas,
-so it is ready to run on every request.
+Setting up a client builds this same chain ahead of time, starting with the client, then its tokens, and then its
+quotas, so it is ready to run on every request.
 
 ## Resources
 
 - [Create a Client](../how-to-guides/create-a-client.md) walks through creating a client and issuing its first API
   token.
 - [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md) walks through connecting a
-  coding assistant to a client with an API key.
+  coding assistant to a client with an API token.
 - [Architecture Overview](./architecture.md) explains how the appliance routes requests and where its components sit.
 - [Model Certification](./model-certification.md) explains which models a client can call and how you choose them.
+- [Glossary](../reference/glossary.md) defines the client, API token, quota, and routing terms used throughout this
+  page.

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/explanation.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/explanation.md
@@ -17,6 +17,6 @@ They cover design decisions, component relationships, and trade-offs rather than
 | **Topic**                                       | **What you understand**                                                                                |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | [Architecture Overview](./architecture.md)      | The component stack, request routing, model provisioning lifecycle, and data residency model.          |
-| [Clients and Quotas](./clients-and-quotas.md)   | What a client is, why the appliance serves many clients, and how API keys and quotas govern usage.     |
+| [Clients and Quotas](./clients-and-quotas.md)   | What a client is, why the appliance serves many clients, and how API tokens and quotas govern usage.   |
 | [Model Certification](./model-certification.md) | What certified means, how models are certified, and how to choose models for your use case.            |
 | [Inference Engines](./inference-engines.md)     | What an inference engine is, automatic engine selection, the supported kinds, and when to override it. |

--- a/docs/docs-content/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/docs-content/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -97,3 +97,5 @@ different scales and deployment models.
   guide to go from bare hardware to a running appliance with the UI accessible.
 - **Deploy your first model:** Follow the [Deploy a Model](/paletteai-inference-launchpad/how-to-guides/deploy-a-model)
   guide to deploy a model on the running appliance and confirm it is serving requests.
+- **Look up a term:** New to AI infrastructure or this product? The
+  [Glossary](/paletteai-inference-launchpad/reference/glossary) defines the key terms used across this documentation.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/glossary.md
@@ -1,0 +1,346 @@
+---
+id: glossary
+title: "PaletteAI Inference Launchpad Glossary"
+description:
+  "Definitions of the key AI, product, and platform terms used across the PaletteAI Inference Launchpad documentation."
+sidebar_label: "Glossary"
+sidebar_position: 1
+toc_max_heading_level: 2
+tags: ["paletteai-inference-launchpad", "reference", "glossary"]
+keywords:
+  ["launchpad", "ai", "glossary", "definitions", "terms", "llm", "inference", "quota", "client", "token", "appliance"]
+---
+
+<PartialsComponent category="paletteai-inference-launchpad" name="unreleased-banner" />
+
+This glossary defines the key AI, product, and platform terms used across the PaletteAI Inference Launchpad
+documentation. Use it to look up an unfamiliar term without leaving the guide you are reading.
+
+**Go to:** [A](#a) · [C](#c) · [D](#d) · [E](#e) · [F](#f) · [H](#h) · [I](#i) · [K](#k) · [L](#l) · [M](#m) · [N](#n) ·
+[O](#o) · [P](#p) · [Q](#q) · [R](#r) · [S](#s) · [T](#t) · [V](#v)
+
+## A
+
+### Administrative Workstation
+
+A separate Linux machine, also called a jumpbox, that an operator uses to reach the appliance for installation,
+post-installation validation, and day-two operations with tools such as `kubectl`. It is not part of the appliance
+itself. Refer to [Suggested Hardware](./hardware-requirements.md).
+
+### Air-Gapped
+
+Describes a deployment that has no direct or indirect connection to the internet or other outside networks. The
+appliance is designed to run air-gapped, requiring no outbound internet access during normal operation.
+
+### API Token
+
+A credential that authenticates requests to the appliance's inference endpoint. Every request carries its token in the
+`Authorization` header, and tokens issued by the appliance begin with the prefix `lpai_`. Each token belongs to a
+[client](#client), can be given an expiration, and inherits that client's [quotas](#quota). Refer to
+[Clients and Quotas](../explanation/clients-and-quotas.md).
+
+### Appliance
+
+The self-contained PaletteAI Inference Launchpad unit: a single server that ships as a bootable image and runs the
+operating system, orchestration, inference engine, and management UI as one pre-integrated stack. It deploys with no
+Palette or PaletteAI dependency.
+
+### Appliance Console
+
+The web UI served by the appliance, sometimes referred to as the admin UI. Platform [operators](#operator) use it to
+deploy models, create clients, issue API tokens, set quotas, and view usage.
+
+## C
+
+### Central Mode
+
+A deployment mode in which the appliance's built-in inference engine is turned off and the [gateway](#launchpad-gateway)
+is managed by [PaletteAI](#paletteai). PaletteAI handles model deployment through its model-as-a-service flow, while the
+gateway continues to handle routing, [token metering](#token-metering), quota control, and the UI.
+
+{/* NEEDS REVIEW: central mode is defined in the source glossary but is not yet referenced in any shipped PAIIL doc. Confirm it is a user-facing term for GA before publishing. */}
+
+### Certified Model
+
+A model that Spectro Cloud has tested on a specific GPU configuration and confirmed runs correctly on the appliance,
+rather than assuming it works from public benchmarks. Refer to
+[Model Certification](../explanation/model-certification.md) and
+[Certified Models by Hardware](./certified-models-by-hardware.md).
+
+### Chargeback
+
+The practice of tracking token and dollar spend per [client](#client) so that an organization can allocate AI
+infrastructure costs back to the teams or workloads that consumed them. Per-client [metering](#token-metering) is what
+makes chargeback possible.
+
+{/* NEEDS REVIEW: chargeback is defined in the source glossary but does not yet appear in any shipped PAIIL doc. Confirm the term and framing with an SME before publishing. */}
+
+### Client
+
+The identity the appliance uses to recognize who is sending a request, and the unit of both access and accounting. The
+appliance attributes every request to exactly one client and measures every quota and usage metric per client. A client
+is more often a workload, such as an AI [coding assistant](#coding-assistant), an internal chatbot, or a data pipeline,
+than a person. Each client holds one or more [API tokens](#api-token), its own [quotas](#quota), and its own usage
+visibility. Refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+### Coding Assistant
+
+An AI development tool, such as Claude Code, Cursor, OpenAI Codex, or OpenCode, that sends its requests to a model.
+Coding assistants are the primary workloads the appliance is tuned for; each one connects to the appliance as a
+[client](#client) instead of to a cloud provider.
+
+### Context Window
+
+The maximum number of tokens a model can process in a single request, counting the prompt and the response together.
+Different models have different context window sizes.
+
+## D
+
+### Default Model
+
+The model the appliance routes a request to when the request does not name a specific model. Refer to
+[Set the Default Model](../how-to-guides/set-the-default-model.md).
+
+## E
+
+### Egress
+
+A client's ability to send requests off the appliance to an [external, or frontier, model](#frontier-model). Egress
+denies by default: a new client cannot reach external providers until an operator enables it. Refer to
+[Manage Client Model Access](../how-to-guides/manage-client-model-access.md).
+
+### Embedding
+
+A numerical representation of text, or other data, as a vector in a high-dimensional space, letting a system compare
+inputs by meaning rather than by exact wording. The appliance uses embeddings internally in its
+[intelligent routing](#intelligent-routing) layer to classify requests by semantic similarity.
+
+### Endpoint
+
+The network location, expressed as a URL path, at which the appliance exposes a served model or an API. Each loaded
+model is exposed as an [OpenAI-compatible endpoint](#openai-compatible-api) at paths such as `/v1/chat/completions`.
+
+## F
+
+### Frontier Model
+
+A cloud-hosted, state-of-the-art model reached through an external provider's API rather than served on the appliance.
+The appliance can route to a frontier model when [egress](#egress) is enabled and routing policy calls for it. Frontier
+usage incurs per-token API costs, unlike a [local model](#local-model).
+
+## H
+
+### Helm and Helm Chart
+
+Helm is the packaging format used to deploy and configure the software components inside the appliance's Kubernetes
+cluster, and a Helm chart is one such package. The appliance's components, including the gateway, are delivered as Helm
+charts, so individual layers can be updated independently.
+
+## I
+
+### Inference
+
+The process of running a trained model to generate a response or prediction from a given input. Serving inference on
+your own hardware is the core purpose of the appliance: once a model is loaded, each [prompt](#prompt) is answered
+locally rather than by a cloud provider.
+
+### Inference Engine
+
+The runtime that loads a model and serves its requests behind the model's endpoint. It determines how a model runs,
+which hardware it can use, and which serving features are available. The appliance selects an engine automatically by
+default. Refer to [Inference Engines](../explanation/inference-engines.md) for the supported kinds, such as
+[vLLM](#vllm), SGLang, Ollama, and llama.cpp.
+
+### Intelligent Routing
+
+The capability that directs each request to the most appropriate model, [local](#local-model) or
+[frontier](#frontier-model), based on rules an operator configures. Routing decisions can consider the request's
+content, the API token used, cost policy, or semantic classification, so routine work runs on local models and frontier
+models are used only when policy demands.
+
+## K
+
+### Kairos
+
+The immutable, image-based Linux operating system that the appliance runs on. Kairos is designed for edge and appliance
+deployments, and its read-only runtime prevents configuration drift. It is the foundation on which Kubernetes runs
+inside the appliance.
+
+### Kubernetes
+
+The orchestration layer that runs inside the appliance and manages the lifecycle of its containerized workloads,
+including scheduling, scaling, and health recovery. It runs on top of [Kairos](#kairos).
+
+### KV Cache
+
+The key-value cache that an [inference engine](#inference-engine) keeps in GPU and host memory while generating a
+response, holding the intermediate state for the tokens processed so far. Its size drives much of the appliance's memory
+and fast-storage requirements.
+
+## L
+
+### Large Language Model (LLM)
+
+A model trained on large amounts of text that can generate, summarize, translate, and reason over natural language. LLMs
+are the models that PaletteAI Inference Launchpad is built to host and serve on-premises.
+
+### Launchpad Gateway
+
+The proxy component that sits in front of the inference engine and handles every request. The gateway authenticates the
+calling [client](#client) from its [API token](#api-token), enforces that client's [quotas](#quota), meters usage, and
+routes the request to a local or frontier model. Refer to [Architecture Overview](../explanation/architecture.md).
+
+### Local Mode
+
+A deployment mode in which the appliance operates as a fully standalone unit, with the inference engine enabled and all
+features active. This is the mode used for a standalone appliance without [PaletteAI](#paletteai).
+
+{/* NEEDS REVIEW: local mode is defined in the source glossary but is not yet referenced in any shipped PAIIL doc. Confirm it is a user-facing term for GA before publishing. */}
+
+### Local Model
+
+A model deployed and served directly on the appliance's own hardware. Local inference keeps data on-premises and avoids
+the per-token API costs of a [frontier model](#frontier-model). Every client can call every local model; the appliance
+meters and limits usage through quotas but does not gate access.
+
+## M
+
+### Model
+
+In the PaletteAI Inference Launchpad context, a large language model that the appliance serves. Each served model is
+exposed as an [OpenAI-compatible endpoint](#openai-compatible-api) and records its name, backend engine, and current
+serving status. The appliance turns a model off when a [quota](#quota) that covers it is exhausted.
+
+### Model Alias
+
+An alternate name under which a model is served, so a [coding assistant](#coding-assistant) can request a model by a
+name it recognizes, such as an Anthropic or OpenAI model id. Some tools require a unique alias rather than a name that
+collides with their own catalog.
+
+### Model Weights
+
+The trained parameters of a model, shipped as a separate binary artifact from the software. Weights can be large, on the
+order of hundreds of gigabytes for a larger model, which is why the appliance sizes fast storage around them. Their
+[quantization](#quantization) affects how much space they occupy.
+
+### ModelGroupQuota
+
+The internal Kubernetes custom resource that represents a [quota](#quota) budget on the appliance's cluster. It selects
+the models it covers with label selectors and tracks usage across every dimension and time window. Operators interact
+with quotas through the [appliance console](#appliance-console); ModelGroupQuota is the underlying enforcement object.
+
+{/* NEEDS REVIEW: ModelGroupQuota is an internal CRD name from the source glossary and does not appear in any shipped PAIIL doc. Confirm whether it should be exposed to readers before publishing. */}
+
+## N
+
+### Node
+
+A single machine in the appliance's Kubernetes cluster. When you deploy a model, the appliance places it automatically
+on the best-fit node, the node with the most free GPUs that still fit the model. Most appliances are a single
+high-density GPU server, so they have a single node.
+
+## O
+
+### On-Premises
+
+Describes running the appliance on hardware you own and operate, inside your own environment, rather than as a cloud
+service. Running inference on-premises keeps data in your environment and turns per-token API costs into predictable
+infrastructure spend.
+
+### OpenAI-Compatible API
+
+The request and response format that the appliance exposes for each served model, matching the widely supported OpenAI
+API, at paths such as `/v1/chat/completions` and `/v1/models`. Because the interface is OpenAI-compatible, existing
+tools can point at the appliance by changing only the base URL and the API token.
+
+### Operator
+
+The person who administers the appliance, also referred to as a platform operator or administrator. Operators deploy
+models, create clients, issue tokens, and set quotas through the [appliance console](#appliance-console).
+
+## P
+
+### PaletteAI
+
+Spectro Cloud's multi-cluster AI platform for the AI factory, offering GPU-as-a-Service, model-as-a-service, and AI
+Studio at data-center scale. It is a distinct product from PaletteAI Inference Launchpad, which is a standalone
+appliance that requires no PaletteAI dependency. Refer to
+[What is PaletteAI Inference Launchpad?](../paletteai-inference-launchpad.md).
+
+### Piraeus
+
+The storage layer inside the appliance that provisions and manages the volumes used for [model weights](#model-weights)
+and the [KV cache](#kv-cache). Piraeus stripes a data pool across the appliance's NVMe drives to combine their read and
+write bandwidth.
+
+### Prompt
+
+The input text sent to a model to elicit a response. A prompt consumes input [tokens](#token-and-tokenization).
+
+## Q
+
+### Quantization
+
+A technique that stores a model's weights at a lower numeric precision to reduce its memory footprint and speed up
+inference, usually with little loss in quality. `FP8`, an 8-bit floating-point format referenced in the hardware
+requirements, is one such precision.
+
+### Quota
+
+A consumption limit attached to a [client](#client), enforced across three dimensions: requests (the number of calls),
+tokens (the number of tokens processed), and cost (the computed dollar spend). Each dimension is measured over rolling
+windows of one second, one minute, one hour, and one day; there is no monthly window. When a client reaches a limit, the
+appliance rejects further requests with HTTP `429 Too Many Requests` until the window rolls over. Refer to
+[Manage Client Quotas](../how-to-guides/manage-client-quotas.md).
+
+{/* NEEDS REVIEW: per the current working assumption, quota enforcement is off by default behind a global switch. Confirm with an SME before publishing. */}
+
+## R
+
+### Rate Limit
+
+A [quota](#quota) on the number of requests per unit of time, such as 60 requests per minute. Rate limits are the
+request-dimension quotas enforced over short windows.
+
+### Reasoning
+
+The ability of some models to work through a problem in intermediate steps before producing a final answer. A model that
+does this is called a reasoning model, and the depth of that effort can sometimes be tuned. Reasoning steps consume
+[tokens](#token-and-tokenization) like any other output.
+
+## S
+
+### Smoke Test
+
+A short check the appliance runs against a newly deployed model before it accepts traffic. A model becomes routable only
+after its signature is verified and its smoke test passes, so the appliance never presents a model as ready before it
+can serve requests.
+
+## T
+
+### Tier Map
+
+A routing overlay that governs which model handles a client's requests by default, mapping an incoming model name or
+alias to a served model. It selects the default target for a client's requests rather than acting as a hard access gate
+for local models. Refer to [Manage Client Model Access](../how-to-guides/manage-client-model-access.md).
+
+### Token and Tokenization
+
+A token is the unit of text that a model processes, roughly a word or a word fragment; tokenization is the process of
+splitting text into those units. Tokens are the primary unit of measurement for model usage and cost, and one of the
+dimensions a [quota](#quota) can limit. Both input tokens from your prompt and output tokens from the model's response
+are counted.
+
+### Token Metering
+
+The process of counting and tracking token consumption per request, per model, per [API token](#api-token), and per time
+window. The appliance meters input tokens, output tokens, and derived cost for every request, which is what enforces
+[quotas](#quota), gives operators usage visibility, and enables [chargeback](#chargeback).
+
+## V
+
+### vLLM
+
+An open source, high-throughput [inference engine](#inference-engine) for large language models. vLLM is one of the
+GPU-serving engines the appliance can run, exposing an [OpenAI-compatible endpoint](#openai-compatible-api) on the
+Kubernetes cluster.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/reference.md
@@ -16,6 +16,7 @@ is configured, not how to accomplish a task.
 
 | **Reference**                                                     | **What it covers**                                                              |
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [Glossary](./glossary.md)                                         | Definitions of the AI, product, and platform terms used across the docs.        |
 | [Suggested Hardware](./hardware-requirements.md)                  | Compute, GPU, memory, storage, and network requirements for the appliance.      |
 | [Example Server Configurations](./server-configurations.md)       | Example AMD and NVIDIA server configurations for the appliance.                 |
 | [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration. |


### PR DESCRIPTION
Rename the client credential term from API key to API token to match the product's current terminology.