### PR TITLE
docs: add air-gapped model upload how-to and reference

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
@@ -21,7 +21,8 @@ lifecycle work, refer to [Model Provisioning Lifecycle](../explanation/architect
 - At least one node with free capacity for the model you intend to deploy.
 - The model present in the appliance catalog and able to fit the appliance's available GPU resources. To confirm
   support, refer to [Certified Models by Hardware](../reference/certified-models-by-hardware.md) and
-  [Suggested Hardware](../reference/hardware-requirements.md).
+  [Suggested Hardware](../reference/hardware-requirements.md). On an air-gapped appliance, place the model in the
+  catalog first by following [Upload a Model (Air-Gapped)](./upload-a-model-air-gapped.md).
 
 ## Deploy a Model
 

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -19,6 +19,7 @@ you the steps to do it without teaching background concepts.
 | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | [Install the Appliance](./install-the-appliance.md)               | Flash the installer ISO, boot the hardware, and bring up the appliance console.  |
 | [Deploy a Model](./deploy-a-model.md)                             | Deploy an LLM to the cluster and verify it is serving.                           |
+| [Upload a Model (Air-Gapped)](./upload-a-model-air-gapped.md)     | Download a model on a workstation and upload it to an air-gapped appliance.      |
 | [Set the Default Model](./set-the-default-model.md)               | Configure which model handles requests that do not name a model explicitly.      |
 | [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.           |
 | [Create a Client](./create-a-client.md)                           | Create a client and issue its first API token.                                   |

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/upload-a-model-air-gapped.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/upload-a-model-air-gapped.md
@@ -1,0 +1,112 @@
+---
+sidebar_label: "Upload a Model (Air-Gapped)"
+title: "Upload a Model to an Air-Gapped Appliance"
+description:
+  "Step-by-step guidance for platform operators on how to download a model on a connected workstation and upload it to
+  an air-gapped PaletteAI Inference Launchpad appliance with the Palette CLI over SSH."
+hide_table_of_contents: false
+sidebar_position: 1.5
+tags: ["paletteai-inference-launchpad", "models", "how-to", "air-gapped"]
+keywords: ["launchpad", "ai", "air-gapped", "model upload", "palette cli", "huggingface", "rsync", "ssh"]
+---
+
+<PartialsComponent category="paletteai-inference-launchpad" name="unreleased-banner" />
+
+This guide explains how to place a model on an air-gapped PaletteAI Inference Launchpad appliance. Because an air-gapped
+appliance has no outbound internet access, it cannot pull a model from Hugging Face when you deploy. Instead, you
+download the model on a connected workstation and ship it to the appliance over SSH, after which the model appears in
+the appliance's deploy catalog.
+
+This guide comes before [Deploy a Model](./deploy-a-model.md): the upload puts the model in the catalog, and the deploy
+serves it. For the full command flags and metadata file fields, refer to
+[Model Upload Reference](../reference/model-upload-reference.md).
+
+## Prerequisites
+
+- A connected administrative workstation on the appliance network, provisioned with the Palette CLI, an SSH client and
+  key pair (or password authentication), and enough local disk to stage model downloads. For details, refer to
+  [Administrative Workstation](../reference/hardware-requirements.md#administrative-workstation). The workstation also
+  needs outbound access to Hugging Face; refer to
+  [Model Download Access](../reference/hardware-requirements.md#model-download-access-recommended).
+- `rsync` on the workstation. The Palette CLI uses it to transfer the model to the appliance over SSH.
+- The metadata YAML for the model you intend to upload, obtained from Artifact Studio. For its fields, refer to
+  [Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
+- The appliance's SSH host address (IP or DNS name) and an SSH user.
+- _(Gated or private Hugging Face repositories)_ A Hugging Face access token.
+
+{/* NEEDS REVIEW: the source specifies rsync 3.2.3+ and OpenSSH 8.4+ on the workstation. Confirm the minimum versions before publishing. */}
+
+## Download the Model on the Workstation
+
+On the connected workstation, download the model from Hugging Face into a local directory.
+
+1. Run the download command, using the path to your metadata file and the directory to download into.
+
+   ```bash
+   palette content model download \
+       --metadata model.yaml \
+       --model-dir ./models
+   ```
+
+   The model downloads to `<model-dir>/<name>/<version>/`, where `<name>` and `<version>` come from the metadata file.
+
+2. _(Gated or private Hugging Face repositories)_ Provide a Hugging Face token through the `HF_TOKEN` environment
+   variable.
+
+   ```bash
+   HF_TOKEN=<hugging-face-token> palette content model download \
+       --metadata model.yaml \
+       --model-dir ./models
+   ```
+
+## Upload the Model to the Appliance
+
+Ship the downloaded directory to the appliance over SSH. On a multi-node appliance, upload to a single node; the
+appliance syncs the model to the remaining nodes automatically.
+
+1. Run the upload command with the model directory and the appliance's SSH details.
+
+   ```bash
+   palette content model upload \
+       --metadata model.yaml \
+       --model-dir ./models \
+       --ssh-user <ssh-user> \
+       --ssh-host <appliance-host> \
+       --ssh-key <private-key-path>
+   ```
+
+   Replace `<ssh-user>` and `<appliance-host>` with the appliance's SSH user and address, and `<private-key-path>` with
+   the path to your private key, such as `~/.ssh/id_ed25519`.
+
+The upload command accepts other flags, including password authentication (`--ssh-password`), one-step download and
+upload (`--download`), and metadata-only sync (`--metadata-only`). For the full list, refer to
+[Model Upload Reference](../reference/model-upload-reference.md#palette-content-model-upload).
+
+## Verify the Model and Deploy It
+
+:::warning
+
+The appliance surfaces an uploaded model only when it matches an entry in the appliance's curated model catalog. If you
+upload a model that is not in the curated catalog, the upload succeeds but the model does not appear in the deploy
+catalog.
+
+:::
+
+{/* NEEDS REVIEW: per the source, an uploaded model that does not match a curated catalog entry is logged but not surfaced today, with a schema-gap follow-up planned. Confirm current behavior before publishing. */}
+
+{/* NEEDS REVIEW: multi-node catalog states and automatic peer sync are from the engineering source. Confirm the labels and behavior before publishing. */}
+
+1. In the appliance console, select **Cluster** from the left main menu, then select **Deploy model** to open the deploy
+   panel.
+
+2. Open the model drop-down menu and confirm the model you uploaded is listed. On a single-node appliance, the model
+   appears on the next catalog scan after the upload finishes. On a multi-node appliance, the catalog shows the model's
+   cluster-wide state: `Available` when the model is ready on every node, `Pending N/M` while nodes are still syncing,
+   or `Missing`. Only an `Available` model can be deployed.
+
+3. Deploy the model by following [Deploy a Model](./deploy-a-model.md).
+
+## Next Steps
+
+- [Deploy a Model](./deploy-a-model.md) — deploy the uploaded model and verify it is serving.
+- [Model Upload Reference](../reference/model-upload-reference.md) — the full command flags and metadata file fields.

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/upload-a-model-air-gapped.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/upload-a-model-air-gapped.md
@@ -108,5 +108,7 @@ catalog.
 
 ## Next Steps
 
-- [Deploy a Model](./deploy-a-model.md) — deploy the uploaded model and verify it is serving.
-- [Model Upload Reference](../reference/model-upload-reference.md) — the full command flags and metadata file fields.
+- **Deploy the model:** Follow [Deploy a Model](./deploy-a-model.md) to deploy the uploaded model and verify it is
+  serving.
+- **Review the reference:** Refer to [Model Upload Reference](../reference/model-upload-reference.md) for the full
+  command flags and metadata file fields.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/model-upload-reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/model-upload-reference.md
@@ -1,0 +1,122 @@
+---
+sidebar_label: "Model Upload Reference"
+title: "PaletteAI Inference Launchpad Model Upload Reference"
+description:
+  "Reference for the Palette CLI model download and upload commands and the model metadata file used to place models on
+  an air-gapped PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 4.5
+tags: ["paletteai-inference-launchpad", "reference", "models", "air-gapped"]
+keywords: ["launchpad", "ai", "palette cli", "model upload", "metadata", "huggingface", "air-gapped"]
+---
+
+<PartialsComponent category="paletteai-inference-launchpad" name="unreleased-banner" />
+
+This reference lists the flags for the Palette CLI model commands and the fields of the model metadata file. It supports
+the [Upload a Model (Air-Gapped)](../how-to-guides/upload-a-model-air-gapped.md) how-to, which walks through the
+download and upload flow.
+
+{/* NEEDS REVIEW: `palette content model download` and `palette content model upload` are a new command surface from the engineering source and are not yet in the published Palette CLI reference. Confirm the command names, flags, and defaults before publishing. */}
+
+## palette content model download
+
+Downloads a model from Hugging Face into a local directory on a connected workstation and records a completion manifest
+that a later upload validates against.
+
+| **Flag**                   | **Description**                                                                                          | **Required** |
+| -------------------------- | -------------------------------------------------------------------------------------------------------- | ------------ |
+| `--metadata`, `-f`         | Path to the model metadata YAML (from Artifact Studio), or a `.tar.gz` bundle of the metadata and files. | Yes          |
+| `--model-dir`              | Local directory to download into. The model lands at `<model-dir>/<name>/<version>/`.                    | Yes          |
+| `--hf-token` (`$HF_TOKEN`) | Hugging Face token for gated or private repositories.                                                    | No           |
+
+## palette content model upload
+
+Ships an already-downloaded model directory to one appliance node over `rsync` and SSH. By default the upload never
+contacts Hugging Face and fails if `--model-dir` is missing or incomplete; pass `--download` to fetch the model first.
+
+**Required flags**
+
+| **Flag**                        | **Description**                                                                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `--metadata`, `-f`              | Path to the model metadata YAML, or a `.tar.gz` bundle of the metadata and files.                                        |
+| `--model-dir`                   | Local directory holding the model at `<model-dir>/<name>/<version>/`. Required unless `--download` or `--metadata-only`. |
+| `--ssh-user`                    | SSH user on the target appliance node.                                                                                   |
+| `--ssh-host`                    | Address (IP or DNS name) of the target appliance node.                                                                   |
+| `--ssh-key` or `--ssh-password` | SSH authentication. Mutually exclusive; `--ssh-password` is supported on Unix workstations only.                         |
+
+**Optional flags**
+
+| **Flag**                         | **Description**                                                                                                                                     |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--download`                     | Fetch (or resume) the model from Hugging Face when `--model-dir` is not already complete, then upload. Mutually exclusive with `--metadata-only`.   |
+| `--metadata-only`                | Sync only `metadata.yaml` (and any logo); skip the weights. Mutually exclusive with `--download`.                                                   |
+| `--ssh-port`                     | SSH port. Defaults to `22`.                                                                                                                         |
+| `--hf-token` (`$HF_TOKEN`)       | Hugging Face token, used with `--download` or to fetch a logo hosted on Hugging Face.                                                               |
+| `--keep-model-dir`               | Retain a temporary model directory after a successful upload. Applies only when `--model-dir` is omitted; an explicit `--model-dir` is always kept. |
+| `--insecure-skip-host-key-check` | Disable SSH host key verification.                                                                                                                  |
+
+## Model Metadata File
+
+The metadata file is the operator's contract with the appliance. Only `name`, `version`, and `huggingface.repo` are
+required; everything else is optional. The parser rejects unknown top-level fields.
+
+| **Field**              | **Description**                                                                                                                             | **Required** |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `name`                 | Model name. Sets the `<name>` path segment on the appliance.                                                                                | Yes          |
+| `version`              | Model version. Sets the `<version>` path segment on the appliance.                                                                          | Yes          |
+| `huggingface.repo`     | Source Hugging Face repository.                                                                                                             | Yes          |
+| `huggingface.files`    | One or more globs selecting which repository files to download. When omitted, every file is downloaded.                                     | No           |
+| `huggingface.revision` | Hugging Face revision (branch, tag, or commit). Defaults to `main`.                                                                         | No           |
+| `huggingface.logo`     | Path inside the Hugging Face repository to a logo image, downloaded alongside the weights.                                                  | No           |
+| `logo`                 | A logo bundled from local disk. Mutually exclusive with `huggingface.logo`.                                                                 | No           |
+| `launchpad`            | Optional gateway tuning block (engine, variants, and so on). The Palette CLI ships it to the appliance unchanged and does not interpret it. | No           |
+
+The following example downloads a set of GGUF weights from a Hugging Face repository and includes a `launchpad` tuning
+block.
+
+```yaml
+name: llama-3-8b-instruct
+version: 1.0.0
+displayName: "Llama 3 8B Instruct"
+description: "Meta's Llama 3 8B instruct-tuned model."
+author: Meta AI
+license: llama-3
+
+huggingface:
+  repo: bartowski/Llama-3.2-1B-Instruct-GGUF
+  revision: main
+  files:
+    - "*.gguf"
+  logo: assets/logo.png # optional: pulled from the Hugging Face repo, saved as logo.<ext>
+
+# logo: ./local-logo.png # OR bundle a local file from disk (mutually exclusive with huggingface.logo)
+
+launchpad: # optional: gateway tuning block, shipped verbatim (the Palette CLI does not interpret it)
+  engine: vllm
+  min_engine_version: "0.23.0"
+  variants:
+    - vendor: amd
+      gpu_product: MI325X
+      vram_gb: 256
+      min_gpus: 8
+      serve:
+        image: rocm/vllm-dev:nightly
+        tensor_parallel_size: 8
+```
+
+After a successful upload, the model directory on the appliance node has the following layout.
+
+```text
+/usr/local/spectrocloud/content/models/<name>/<version>/
+├── ...model files...   # written first (per huggingface.files globs)
+├── metadata.yaml       # written last — readiness signal
+└── logo.<ext>          # optional (local or Hugging Face-sourced)
+```
+
+{/* NEEDS REVIEW: the appliance path /usr/local/spectrocloud/content/models/<name>/<version>/ is from the engineering source. Confirm before publishing. */}
+
+## Resources
+
+- [Upload a Model (Air-Gapped)](../how-to-guides/upload-a-model-air-gapped.md) walks through the download and upload
+  flow.
+- [Deploy a Model](../how-to-guides/deploy-a-model.md) deploys an uploaded model and verifies it is serving.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/reference.md
@@ -14,13 +14,14 @@ is configured, not how to accomplish a task.
 
 ## Contents
 
-| **Reference**                                                     | **What it covers**                                                              |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Glossary](./glossary.md)                                         | Definitions of the AI, product, and platform terms used across the docs.        |
-| [Suggested Hardware](./hardware-requirements.md)                  | Compute, GPU, memory, storage, and network requirements for the appliance.      |
-| [Example Server Configurations](./server-configurations.md)       | Example AMD and NVIDIA server configurations for the appliance.                 |
-| [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration. |
-| [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.     |
-| [Cursor Configuration](./cursor-reference.md)                     | Settings and values for pointing Cursor at the appliance.                       |
-| [OpenAI Codex Configuration](./codex-reference.md)                | Configuration file fields and values for pointing Codex at the appliance.       |
-| [OpenCode Configuration](./opencode-reference.md)                 | Configuration file fields and values for pointing OpenCode at the appliance.    |
+| **Reference**                                                     | **What it covers**                                                               |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [Glossary](./glossary.md)                                         | Definitions of the AI, product, and platform terms used across the docs.         |
+| [Suggested Hardware](./hardware-requirements.md)                  | Compute, GPU, memory, storage, and network requirements for the appliance.       |
+| [Example Server Configurations](./server-configurations.md)       | Example AMD and NVIDIA server configurations for the appliance.                  |
+| [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration.  |
+| [Model Upload Reference](./model-upload-reference.md)             | Palette CLI model download and upload flags, and the model metadata file fields. |
+| [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.      |
+| [Cursor Configuration](./cursor-reference.md)                     | Settings and values for pointing Cursor at the appliance.                        |
+| [OpenAI Codex Configuration](./codex-reference.md)                | Configuration file fields and values for pointing Codex at the appliance.        |
+| [OpenCode Configuration](./opencode-reference.md)                 | Configuration file fields and values for pointing OpenCode at the appliance.     |


### PR DESCRIPTION
Add a how-to guide that walks platform operators through downloading a model on a connected workstation and uploading it to an air-gapped PaletteAI Inference Launchpad appliance with the Palette CLI over SSH.

Add a companion reference documenting the palette content model download and upload flags and the model metadata file fields.
