### PR TITLE
docs: add Gemma 4 to certified models reference and product landing page

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/docs-content/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -42,7 +42,7 @@ The appliance ships with the following pre-integrated components.
 | Orchestration         | Kubernetes                                      |
 | LLM inference runtime | vLLM                                            |
 | Intelligent routing   | Routing by task type and data sensitivity       |
-| Local models          | GLM, DeepSeek, Kimi                             |
+| Local models          | GLM, DeepSeek, Kimi, Gemma                      |
 | Platform services     | Authentication, RBAC, monitoring, observability |
 | GPU support           | NVIDIA, AMD                                     |
 
@@ -51,9 +51,9 @@ read-only runtime prevents configuration drift and keeps the appliance in a know
 manages the lifecycle of containerized workloads on top, handling scheduling, scaling, and health recovery.
 
 vLLM serves language models with high GPU throughput and handles concurrent requests from multiple users. The appliance
-ships GLM, DeepSeek, and Kimi as local open-weight models that run entirely on-premises with no external API calls.
-NVIDIA and AMD GPU support provides the parallel processing that large language models require to respond at production
-speed.
+ships GLM, DeepSeek, Kimi, and Gemma as local open-weight models that run entirely on-premises with no external API
+calls. NVIDIA and AMD GPU support provides the parallel processing that large language models require to respond at
+production speed.
 
 Intelligent routing directs each request to the most appropriate model. Requests that involve private data or require
 low latency stay local. Other requests can route outbound when the network allows.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
@@ -31,16 +31,16 @@ discuss your use case.
 
 | **GPU configuration**   | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** | **Gemma 4** |
 | ----------------------- | :---------: | :-----------------: | :----------: | :---------: |
-| 4 x H100 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❓      |
-| 8 x H100 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❓      |
-| 4 x H200 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❓      |
-| 8 x H200                |     ✅      |         ✅          |      ✅      |     ❓      |
-| 4 x H300 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❓      |
-| 8 x H300                |     ✅      |         ✅          |      ✅      |     ❓      |
-| 4 x GB100 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |     ❓      |
-| 8 x GB100               |     ✅      |         ✅          |      ✅      |     ❓      |
-| 4 x GB200 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |     ❓      |
-| 8 x GB200               |     ✅      |         ✅          |      ✅      |     ❓      |
+| 4 x H100                |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x H100                |     ❌      |         ❌          |      ❌      |     ✅      |
+| 4 x H200                |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x H200                |     ✅      |         ✅          |      ✅      |     ✅      |
+| 4 x H300 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❌      |
+| 8 x H300                |     ✅      |         ✅          |      ✅      |     ❌      |
+| 4 x GB100 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |     ❌      |
+| 8 x GB100               |     ✅      |         ✅          |      ✅      |     ❌      |
+| 4 x GB200 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |     ❌      |
+| 8 x GB200               |     ✅      |         ✅          |      ✅      |     ❌      |
 
 <sup>*</sup> No certified model for this configuration. [Contact Spectro Cloud](https://www.spectrocloud.com/contact) to
 discuss your use case.
@@ -51,14 +51,16 @@ discuss your use case.
 
 | **GPU configuration** | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** | **Gemma 4** |
 | --------------------- | :---------: | :-----------------: | :----------: | :---------: |
-| 4 x MI300X            |     ❌      |         ❌          |      ✅      |     ❓      |
-| 8 x MI300X            |     ✅      |         ❌          |      ❌      |     ❓      |
-| 4 x MI325X            |     ✅      |         ❌          |      ✅      |     ❓      |
-| 8 x MI325X            |     ✅      |         ❌          |      ❌      |     ❓      |
-| 4 x MI350X            |     ✅      |         ✅          |      ❌      |     ❓      |
-| 8 x MI350X            |     ✅      |         ✅          |      ❌      |     ❓      |
-| 4 x MI355X            |     ✅      |         ✅          |      ❌      |     ❓      |
-| 8 x MI355X            |     ✅      |         ✅          |      ❌      |     ❓      |
+| 4 x MI300X            |     ❌      |         ❌          |      ✅      |     ❌      |
+| 8 x MI300X            |     ✅      |         ❌          |      ❌      |     ❌      |
+| 4 x MI325X            |     ✅      |         ❌          |      ✅      |     ⏳      |
+| 8 x MI325X            |     ✅      |         ❌          |      ❌      |     ⏳      |
+| 4 x MI350X            |     ✅      |         ✅          |      ❌      |     ⏳      |
+| 8 x MI350X            |     ✅      |         ✅          |      ❌      |     ⏳      |
+| 4 x MI355X            |     ✅      |         ✅          |      ❌      |     ❌      |
+| 8 x MI355X            |     ✅      |         ✅          |      ❌      |     ❌      |
+
+⏳ Certification in progress.
 
 </TabItem>
 

--- a/docs/docs-content/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
@@ -29,18 +29,18 @@ discuss your use case.
 
 <TabItem label="NVIDIA" value="nvidia">
 
-| **GPU configuration**   | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** |
-| ----------------------- | :---------: | :-----------------: | :----------: |
-| 4 x H100 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |
-| 8 x H100 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |
-| 4 x H200 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |
-| 8 x H200                |     ✅      |         ✅          |      ✅      |
-| 4 x H300 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |
-| 8 x H300                |     ✅      |         ✅          |      ✅      |
-| 4 x GB100 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |
-| 8 x GB100               |     ✅      |         ✅          |      ✅      |
-| 4 x GB200 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |
-| 8 x GB200               |     ✅      |         ✅          |      ✅      |
+| **GPU configuration**   | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** | **Gemma 4** |
+| ----------------------- | :---------: | :-----------------: | :----------: | :---------: |
+| 4 x H100 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❓      |
+| 8 x H100 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❓      |
+| 4 x H200 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❓      |
+| 8 x H200                |     ✅      |         ✅          |      ✅      |     ❓      |
+| 4 x H300 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❓      |
+| 8 x H300                |     ✅      |         ✅          |      ✅      |     ❓      |
+| 4 x GB100 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |     ❓      |
+| 8 x GB100               |     ✅      |         ✅          |      ✅      |     ❓      |
+| 4 x GB200 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |     ❓      |
+| 8 x GB200               |     ✅      |         ✅          |      ✅      |     ❓      |
 
 <sup>*</sup> No certified model for this configuration. [Contact Spectro Cloud](https://www.spectrocloud.com/contact) to
 discuss your use case.
@@ -49,16 +49,16 @@ discuss your use case.
 
 <TabItem label="AMD" value="amd">
 
-| **GPU configuration** | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** |
-| --------------------- | :---------: | :-----------------: | :----------: |
-| 4 x MI300X            |     ❌      |         ❌          |      ✅      |
-| 8 x MI300X            |     ✅      |         ❌          |      ❌      |
-| 4 x MI325X            |     ✅      |         ❌          |      ✅      |
-| 8 x MI325X            |     ✅      |         ❌          |      ❌      |
-| 4 x MI350X            |     ✅      |         ✅          |      ❌      |
-| 8 x MI350X            |     ✅      |         ✅          |      ❌      |
-| 4 x MI355X            |     ✅      |         ✅          |      ❌      |
-| 8 x MI355X            |     ✅      |         ✅          |      ❌      |
+| **GPU configuration** | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** | **Gemma 4** |
+| --------------------- | :---------: | :-----------------: | :----------: | :---------: |
+| 4 x MI300X            |     ❌      |         ❌          |      ✅      |     ❓      |
+| 8 x MI300X            |     ✅      |         ❌          |      ❌      |     ❓      |
+| 4 x MI325X            |     ✅      |         ❌          |      ✅      |     ❓      |
+| 8 x MI325X            |     ✅      |         ❌          |      ❌      |     ❓      |
+| 4 x MI350X            |     ✅      |         ✅          |      ❌      |     ❓      |
+| 8 x MI350X            |     ✅      |         ✅          |      ❌      |     ❓      |
+| 4 x MI355X            |     ✅      |         ✅          |      ❌      |     ❓      |
+| 8 x MI355X            |     ✅      |         ✅          |      ❌      |     ❓      |
 
 </TabItem>
 


### PR DESCRIPTION
Add a Gemma 4 column to both the NVIDIA and AMD certification tables and add Gemma to the local models list and prose on the overview page.
