### PR TITLE
4.9.c - DOC-2999: k8s minor version skip

### DIFF
--- a/_partials/self-hosted/management-appliance/_upgrade-palette-upgrade-notes.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-upgrade-notes.mdx
@@ -3,6 +3,11 @@ partial_category: self-hosted
 partial_name: upgrade-palette-upgrade-notes
 ---
 
+- **(4.8.x to 4.9.23+)** Direct upgrades of {props.version} from any `4.8.x` release to `4.9.23` or later are not
+  supported, because they skip a Kubernetes minor version. The `4.8.x` series ships Kubernetes `1.32.9`, and `4.9.23`
+  and later ship Kubernetes `1.34.6`. To reach `4.9.23` or later from `4.8.x`, first upgrade to a `4.9.x` release on
+  Kubernetes `1.33.10` (we recommend `4.9.14`), then upgrade to your target `4.9.23` or later release.
+
 - **(4.7.27 to 4.7.29+)** If upgrading from version **4.7.27**, you must run an additional script before upgrading
   {props.version}. This script ensures the `linstor-lvm-storage` StorageClass has correct parameters and safely
   recreates the PVC while preserving data.

--- a/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/airgap.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/airgap.md
@@ -24,6 +24,10 @@ This guide takes you through the process of upgrading a self-hosted airgap Palet
 ### Specific Versions
 
 - <PartialsComponent category="self-hosted" name="nginx-traefik-upgrade" edition="Palette" />
+- **(4.8.x to 4.9.23+)** Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported, because they
+  skip a Kubernetes minor version. Upgrade to a `4.9.x` release on Kubernetes `1.33.10` first (we recommend `4.9.14`),
+  then upgrade to your target `4.9.23` or later release. Refer to the
+  [Kubernetes Version Constraint](../upgrade.md#kubernetes-version-constraint) section for details.
 - **(pre-4.6.32 to 4.6.32)** When upgrading airgapped self-hosted Palette to version 4.6.32, the IPAM controller may
   report an `Exhausted IP Pools` error despite having available IP addresses, preventing the cluster from upgrading.
   This is due to a race condition in CAPV version 1.12.0, which may lead to an orphaned IP claim. To resolve this,

--- a/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/non-airgap.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade-vmware/non-airgap.md
@@ -24,6 +24,11 @@ version available. Refer to the [Supported Upgrade Paths](../upgrade.md#supporte
 
 - <PartialsComponent category="self-hosted" name="nginx-traefik-upgrade" edition="Palette" />
 
+- **(4.8.x to 4.9.23+)** Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported, because they
+  skip a Kubernetes minor version. Upgrade to a `4.9.x` release on Kubernetes `1.33.10` first (we recommend `4.9.14`),
+  then upgrade to your target `4.9.23` or later release. Refer to the
+  [Kubernetes Version Constraint](../upgrade.md#kubernetes-version-constraint) section for details.
+
 - **(pre-4.4.14 to 4.4.14+)** If you are upgrading from a Palette version that is older than 4.4.14, ensure that you
   have executed the utility script to make the CNS mapping unique for the associated PVC. For more information, refer to
   the [Troubleshooting guide](../../../troubleshooting/enterprise-install.md#scenario---non-unique-vsphere-cns-mapping).

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -55,8 +55,8 @@ health status of MongoDB ReplicaSet members, refer to our
 
 Enterprise Cluster (EC) binary and Palette Management Appliance installations bundle a specific Kubernetes version with
 each Palette release. Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette
-upgrade cannot cross more than one Kubernetes minor version in a single hop. An upgrade that would skip a Kubernetes
-minor version fails mid-run and leaves the management cluster in an unrecoverable state.
+upgrade cannot cross more than one Kubernetes minor version. An upgrade that would skip a Kubernetes
+minor version may fail mid-run and leave the management cluster in an unrecoverable state.
 
 The following table lists the Kubernetes version bundled with each recent Palette release.
 
@@ -69,13 +69,13 @@ The following table lists the Kubernetes version bundled with each recent Palett
 
 Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
 `1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from
-`4.8.x`, upgrade in two hops.
+`4.8.x`, upgrade in two steps.
 
 1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
 
 Before you start any Palette upgrade, compare the Kubernetes version of your current release with that of the target
-release. If the delta is two or more minor versions, plan an intermediate hop through a release on the missing minor.
+release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the missing minor.
 This constraint applies to EC binary and Palette Management Appliance installations. It does not apply to Palette
 installed via Helm on a customer-managed Kubernetes cluster, where your Kubernetes version is managed independently of
 Palette.

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -51,6 +51,35 @@ health status of MongoDB ReplicaSet members, refer to our
 
 :::
 
+### Kubernetes Version Constraint
+
+Enterprise Cluster (EC) binary and Palette Management Appliance installations bundle a specific Kubernetes version with
+each Palette release. Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette
+upgrade cannot cross more than one Kubernetes minor version in a single hop. An upgrade that would skip a Kubernetes
+minor version fails mid-run and leaves the management cluster in an unrecoverable state.
+
+The following table lists the Kubernetes version bundled with each recent Palette release.
+
+| Palette Release                | Kubernetes Version |
+| :----------------------------- | :----------------: |
+| 4.7.40, 4.7.43                 |       1.31.8       |
+| 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
+| 4.9.5, 4.9.8, 4.9.14           |      1.33.10       |
+| 4.9.23 and later               |       1.34.6       |
+
+Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
+`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from `4.8.x`,
+upgrade in two hops.
+
+1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
+2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
+
+Before you start any Palette upgrade, compare the Kubernetes version of your current release with that of the target
+release. If the delta is two or more minor versions, plan an intermediate hop through a release on the missing minor.
+This constraint applies to EC binary and Palette Management Appliance installations. It does not apply to Palette
+installed via Helm on a customer-managed Kubernetes cluster, where your Kubernetes version is managed independently of
+Palette.
+
 <Tabs>
 <TabItem label="VMware" value="VMware">
 

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -55,8 +55,8 @@ health status of MongoDB ReplicaSet members, refer to our
 
 Enterprise Cluster (EC) binary and Palette Management Appliance installations bundle a specific Kubernetes version with
 each Palette release. Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette
-upgrade cannot cross more than one Kubernetes minor version. An upgrade that would skip a Kubernetes
-minor version may fail mid-run and leave the management cluster in an unrecoverable state.
+upgrade cannot cross more than one Kubernetes minor version. An upgrade that would skip a Kubernetes minor version may
+fail mid-run and leave the management cluster in an unrecoverable state.
 
 The following table lists the Kubernetes version bundled with each recent Palette release.
 
@@ -75,8 +75,8 @@ Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
 
 Before you start any Palette upgrade, compare the Kubernetes version of your current release with that of the target
-release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the missing minor.
-This constraint applies to EC binary and Palette Management Appliance installations. It does not apply to Palette
+release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the missing
+minor. This constraint applies to EC binary and Palette Management Appliance installations. It does not apply to Palette
 installed via Helm on a customer-managed Kubernetes cluster, where your Kubernetes version is managed independently of
 Palette.
 

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -68,8 +68,8 @@ The following table lists the Kubernetes version bundled with each recent Palett
 | 4.9.23 and later               |       1.34.6       |
 
 Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
-`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from `4.8.x`,
-upgrade in two hops.
+`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from
+`4.8.x`, upgrade in two hops.
 
 1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -21,6 +21,24 @@ tags: ["release-notes"]
 
 #### Breaking Changes {#breaking-changes-4.9.c}
 
+#### Upgrade Notes {#upgrade-notes-4.9.c}
+
+<!-- https://spectrocloud.atlassian.net/browse/DOC-2999 -->
+
+- Direct Enterprise Cluster (EC) binary and Palette Management Appliance upgrades from any `4.8.x` release to `4.9.23`
+  or later are not supported. The `4.8.x` series ships Kubernetes `1.32.9`, and `4.9.23` and later ship Kubernetes
+  `1.34.6`; a single Palette upgrade cannot cross more than one Kubernetes minor version. To reach `4.9.23` or later
+  from `4.8.x`, upgrade in two hops.
+
+  1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
+  2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
+
+  Before starting any Palette upgrade, compare the Kubernetes version of your current release with that of the target
+  release. If the delta is two or more minor versions, plan an intermediate hop. This constraint does not apply to
+  Palette installed via Helm on a customer-managed Kubernetes cluster. For the version-to-Kubernetes mapping and full
+  guidance, refer to
+  [Kubernetes Version Constraint](../enterprise-version/upgrade/upgrade.md#kubernetes-version-constraint).
+
 #### Features
 
 <!-- https://spectrocloud.atlassian.net/browse/PCP-6527 -->
@@ -128,6 +146,15 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 - Includes all Palette features, improvements, breaking changes, and deprecations in this release. Refer to the
   [Palette section](#palette-enterprise-4.9.c) for more details.
+
+#### Upgrade Notes {#vertex-upgrade-notes-4.9.c}
+
+<!-- https://spectrocloud.atlassian.net/browse/DOC-2999 -->
+
+- The Kubernetes minor-version constraint on Enterprise Cluster (EC) binary and VerteX Management Appliance upgrades
+  from `4.8.x` to `4.9.23` or later applies to Palette VerteX as well. Refer to the
+  [Palette Enterprise Upgrade Notes](#upgrade-notes-4.9.c) for the two-hop upgrade path, and to
+  [Kubernetes Version Constraint](../vertex/upgrade/upgrade.md#kubernetes-version-constraint) for the full guidance.
 
 ### Automation
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -28,13 +28,13 @@ tags: ["release-notes"]
 - Direct Enterprise Cluster (EC) binary and Palette Management Appliance upgrades from any `4.8.x` release to `4.9.23`
   or later are not supported. The `4.8.x` series ships Kubernetes `1.32.9`, and `4.9.23` and later ship Kubernetes
   `1.34.6`; a single Palette upgrade cannot cross more than one Kubernetes minor version. To reach `4.9.23` or later
-  from `4.8.x`, upgrade in two hops.
+  from `4.8.x`, upgrade in two steps.
 
   1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
   2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
 
   Before starting any Palette upgrade, compare the Kubernetes version of your current release with that of the target
-  release. If the delta is two or more minor versions, plan an intermediate hop. This constraint does not apply to
+  release. If the delta is two or more minor versions, plan an intermediate upgrade. This constraint does not apply to
   Palette installed via Helm on a customer-managed Kubernetes cluster. For the version-to-Kubernetes mapping and full
   guidance, refer to
   [Kubernetes Version Constraint](../enterprise-version/upgrade/upgrade.md#kubernetes-version-constraint).

--- a/docs/docs-content/vertex/upgrade/upgrade-vmware/airgap.md
+++ b/docs/docs-content/vertex/upgrade/upgrade-vmware/airgap.md
@@ -27,6 +27,11 @@ vSphere.
 
 - <PartialsComponent category="self-hosted" name="nginx-traefik-upgrade" edition="Palette VerteX" />
 
+- **(4.8.x to 4.9.23+)** Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported, because they
+  skip a Kubernetes minor version. Upgrade to a `4.9.x` release on Kubernetes `1.33.10` first (we recommend `4.9.14`),
+  then upgrade to your target `4.9.23` or later release. Refer to the
+  [Kubernetes Version Constraint](../upgrade.md#kubernetes-version-constraint) section for details.
+
 - **(pre-4.6.32 to 4.6.32)** When upgrading airgapped self-hosted Palette VerteX to version 4.6.32, the IPAM controller
   may report an `Exhausted IP Pools` error despite having available IP addresses, preventing the cluster from upgrading.
   This is due to a race condition in CAPV version 1.12.0, which may lead to an orphaned IP claim. To resolve this,

--- a/docs/docs-content/vertex/upgrade/upgrade-vmware/non-airgap.md
+++ b/docs/docs-content/vertex/upgrade/upgrade-vmware/non-airgap.md
@@ -26,6 +26,11 @@ This guide takes you through the process of upgrading a self-hosted Palette Vert
 
 - <PartialsComponent category="self-hosted" name="nginx-traefik-upgrade" edition="Palette VerteX" />
 
+- **(4.8.x to 4.9.23+)** Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported, because they
+  skip a Kubernetes minor version. Upgrade to a `4.9.x` release on Kubernetes `1.33.10` first (we recommend `4.9.14`),
+  then upgrade to your target `4.9.23` or later release. Refer to the
+  [Kubernetes Version Constraint](../upgrade.md#kubernetes-version-constraint) section for details.
+
 - **(pre-4.4.14 to 4.4.14+)** If you are upgrading from a Palette VerteX version that is older than 4.4.14, ensure that
   you have executed the utility script to make the CNS mapping unique for the associated PVC. For more information,
   refer to the

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -75,9 +75,9 @@ Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
 
 Before you start any Palette VerteX upgrade, compare the Kubernetes version of your current release with that of the
-target release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the missing
-minor. This constraint applies to EC binary and VerteX Management Appliance installations. It does not apply to Palette
-VerteX installed via Helm on a customer-managed Kubernetes cluster, where your Kubernetes version is managed
+target release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the
+missing minor. This constraint applies to EC binary and VerteX Management Appliance installations. It does not apply to
+Palette VerteX installed via Helm on a customer-managed Kubernetes cluster, where your Kubernetes version is managed
 independently of Palette VerteX.
 
 <Tabs>

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -68,8 +68,8 @@ The following table lists the Kubernetes version bundled with each recent Palett
 | 4.9.23 and later               |       1.34.6       |
 
 Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
-`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from `4.8.x`,
-upgrade in two hops.
+`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from
+`4.8.x`, upgrade in two hops.
 
 1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -56,7 +56,7 @@ health status of MongoDB ReplicaSet members, refer to our
 Enterprise Cluster (EC) binary and VerteX Management Appliance installations bundle a specific Kubernetes version with
 each Palette VerteX release. Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette
 VerteX upgrade cannot cross more than one Kubernetes minor version in a single hop. An upgrade that would skip a
-Kubernetes minor version fails mid-run and leaves the management cluster in an unrecoverable state.
+Kubernetes minor version may fail mid-run and leave the management cluster in an unrecoverable state.
 
 The following table lists the Kubernetes version bundled with each recent Palette VerteX release.
 
@@ -69,13 +69,13 @@ The following table lists the Kubernetes version bundled with each recent Palett
 
 Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
 `1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from
-`4.8.x`, upgrade in two hops.
+`4.8.x`, upgrade in two steps.
 
 1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
 
 Before you start any Palette VerteX upgrade, compare the Kubernetes version of your current release with that of the
-target release. If the delta is two or more minor versions, plan an intermediate hop through a release on the missing
+target release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the missing
 minor. This constraint applies to EC binary and VerteX Management Appliance installations. It does not apply to Palette
 VerteX installed via Helm on a customer-managed Kubernetes cluster, where your Kubernetes version is managed
 independently of Palette VerteX.

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -51,6 +51,35 @@ health status of MongoDB ReplicaSet members, refer to our
 
 :::
 
+### Kubernetes Version Constraint
+
+Enterprise Cluster (EC) binary and VerteX Management Appliance installations bundle a specific Kubernetes version with
+each Palette VerteX release. Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette
+VerteX upgrade cannot cross more than one Kubernetes minor version in a single hop. An upgrade that would skip a
+Kubernetes minor version fails mid-run and leaves the management cluster in an unrecoverable state.
+
+The following table lists the Kubernetes version bundled with each recent Palette VerteX release.
+
+| Palette VerteX Release         | Kubernetes Version |
+| :----------------------------- | :----------------: |
+| 4.7.40, 4.7.43                 |       1.31.8       |
+| 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
+| 4.9.5, 4.9.8, 4.9.14           |      1.33.10       |
+| 4.9.23 and later               |       1.34.6       |
+
+Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
+`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from `4.8.x`,
+upgrade in two hops.
+
+1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
+2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
+
+Before you start any Palette VerteX upgrade, compare the Kubernetes version of your current release with that of the
+target release. If the delta is two or more minor versions, plan an intermediate hop through a release on the missing
+minor. This constraint applies to EC binary and VerteX Management Appliance installations. It does not apply to Palette
+VerteX installed via Helm on a customer-managed Kubernetes cluster, where your Kubernetes version is managed
+independently of Palette VerteX.
+
 <Tabs>
 <TabItem label="VMware" value="VMware">
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR documents the Kubernetes minor-version skip constraint for Enterprise Cluster (EC) binary and Palette Management Appliance upgrades, adding a new `Kubernetes Version Constraint` reference section to the Palette and VerteX upgrade pages, a bullet note to the VMware upgrade guides, and the shared PMA upgrade-notes partial, and matching `Upgrade Notes` entries in the 4.9.c release notes. Explains the two-hop path (`4.8.x → 4.9.14 → 4.9.23+`) required to cross Kubernetes 1.32.9 → 1.33.10 → 1.34.6.

---

## 💻 Changed Pages


- [Release Notes: Upgrade Notes for Palette Enterprise](https://deploy-preview-11226--docs-spectrocloud.netlify.app/release-notes/#upgrade-notes-4.9.c)


Changed pages: 
- [Palette Management Appliance: Upgrade Notes - 3rd Bullet](https://deploy-preview-11226--docs-spectrocloud.netlify.app/enterprise-version/upgrade/palette-management-appliance/#upgrade-notes)
- [Upgrade Airgap Palette Installed on VMware vSphere: Specific Versions: 2nd Bullet](https://deploy-preview-11226--docs-spectrocloud.netlify.app/enterprise-version/upgrade/upgrade-vmware/airgap/#specific-versions)
- [Upgrade Palette Installed on VMware vSphere: Specific Versions: 2nd Bullet](https://deploy-preview-11226--docs-spectrocloud.netlify.app/enterprise-version/upgrade/upgrade-vmware/non-airgap/#specific-versions)
- [Upgrade Palette Installed with Kubernetes: Specific Versions: last bullet](https://deploy-preview-11226--docs-spectrocloud.netlify.app/enterprise-version/upgrade/upgrade-k8s/non-airgap/#specific-versions)
- [Upgrade Airgap Palette Installed with Kubernetes: Specific Versions: last bullet](https://deploy-preview-11226--docs-spectrocloud.netlify.app/enterprise-version/upgrade/upgrade-k8s/airgap/#specific-versions)
- [Palette Upgrade: Kubernetes Version Constraint](https://deploy-preview-11226--docs-spectrocloud.netlify.app/enterprise-version/upgrade/#kubernetes-version-constraint)
- 

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-2999)
