### PR TITLE
docs(palette-mcp): point MCP server links to the public toolkit repo

### DIFF
--- a/docs/docs-content/automation/palette-mcp/architecture.md
+++ b/docs/docs-content/automation/palette-mcp/architecture.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 tags: ["ai", "mcp", "automation"]
 ---
 
-The [Palette MCP server](https://github.com/spectrocloud/palette-mcp-server) is a local-first Model Context Protocol
+The [Palette MCP server](https://github.com/spectrocloud/palette-agent-toolkit) is a local-first Model Context Protocol
 (MCP) server that runs on your machine or environment as a container or a native binary. The server communicates with
 the configured Palette instance and performs the required API operations.
 

--- a/docs/docs-content/automation/palette-mcp/palette-mcp.md
+++ b/docs/docs-content/automation/palette-mcp/palette-mcp.md
@@ -13,9 +13,9 @@ databases, or call APIs; they do not have to rely on custom logic authored by yo
 (Large Language Model) LLM itself. AI tools connected to MCP servers are useful in practical applications because they
 become active assistants, with capabilities far beyond generating text.
 
-The [Palette MCP Server](https://github.com/spectrocloud/palette-mcp-server) wraps around the Palette API, allowing you
-to use natural language to perform actions on resources. The MCP server is a powerful automation tool that enables LLMs
-to interact with Palette consistently without having to understand the complete Palette API.
+The [Palette MCP Server](https://github.com/spectrocloud/palette-agent-toolkit) wraps around the Palette API, allowing
+you to use natural language to perform actions on resources. The MCP server is a powerful automation tool that enables
+LLMs to interact with Palette consistently without having to understand the complete Palette API.
 
 The Palette MCP server ships as a container image and as a native binary for macOS and Linux, and lets you interact with
 the following Palette resources:

--- a/docs/docs-content/automation/palette-mcp/setup/mcp-setup-claude.md
+++ b/docs/docs-content/automation/palette-mcp/setup/mcp-setup-claude.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 tags: ["ai", "mcp", "automation"]
 ---
 
-This guide covers how to set up the [Palette MCP server](https://github.com/spectrocloud/palette-mcp-server) with
+This guide covers how to set up the [Palette MCP server](https://github.com/spectrocloud/palette-agent-toolkit) with
 [Claude Code](https://code.claude.com/docs/en/overview). You can install the server through the Palette Agent Toolkit
 plugin, which bundles the MCP server configuration and four diagnostic skills in a single install, or configure the
 server manually as a container. We recommend the plugin install for most Claude Code users.

--- a/docs/docs-content/automation/palette-mcp/setup/mcp-setup-cursor.md
+++ b/docs/docs-content/automation/palette-mcp/setup/mcp-setup-cursor.md
@@ -7,7 +7,7 @@ sidebar_position: 20
 tags: ["ai", "mcp", "automation"]
 ---
 
-This guide covers how to setup the [Palette MCP server](https://github.com/spectrocloud/palette-mcp-server) with
+This guide covers how to setup the [Palette MCP server](https://github.com/spectrocloud/palette-agent-toolkit) with
 [Cursor](https://cursor.com/get-started).
 
 ## Prerequisites

--- a/docs/docs-content/automation/palette-mcp/setup/mcp-setup-gemini.md
+++ b/docs/docs-content/automation/palette-mcp/setup/mcp-setup-gemini.md
@@ -7,7 +7,7 @@ sidebar_position: 30
 tags: ["ai", "mcp", "automation"]
 ---
 
-This guide covers how to setup the [Palette MCP server](https://github.com/spectrocloud/palette-mcp-server) with the
+This guide covers how to setup the [Palette MCP server](https://github.com/spectrocloud/palette-agent-toolkit) with the
 [Gemini CLI](https://geminicli.com/).
 
 ## Prerequisites

--- a/docs/docs-content/tutorials/ai/palette-mcp/get-started-palette-mcp.md
+++ b/docs/docs-content/tutorials/ai/palette-mcp/get-started-palette-mcp.md
@@ -8,7 +8,7 @@ toc_max_heading_level: 2
 category: ["tutorial"]
 ---
 
-The [Palette MCP Server](https://github.com/spectrocloud/palette-mcp-server) provides an abstraction layer over the
+The [Palette MCP Server](https://github.com/spectrocloud/palette-agent-toolkit) provides an abstraction layer over the
 Palette API, allowing you to interact with Palette resources through natural language. It interprets user intent,
 translates it into appropriate API requests, and returns structured responses for Large Language Models (LLMs) to
 process. By handling the complexity of the underlying API, it allows LLMs to interact with Palette in a consistent and


### PR DESCRIPTION
Point the Palette MCP server doc links from the private repo (404 for external readers) to the public `palette-agent-toolkit` — 6 pages, links only, container-image (ECR) references unchanged. No Jira ticket (link-only doc fix).