### PR TITLE
4.9.c - adding Launchpad for VMs 4.9.13 component updates

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -209,7 +209,8 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 <!-- https://spectrocloud.atlassian.net/browse/PVM-509 -->
 
-- [Launchpad for VMs Appliance](../vm-management/launchpad-for-vms/launchpad-for-vms.md) version 4.9.13 is now available.
+- [Launchpad for VMs Appliance](../vm-management/launchpad-for-vms/launchpad-for-vms.md) version 4.9.13 is now
+  available.
 
 - The appliance now supports a custom UI framework for profile variables. Operators can define and expose appliance
   variables through a dedicated, pluggable profile variable page in Local UI, so each appliance can surface the
@@ -219,8 +220,8 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 <!-- https://spectrocloud.atlassian.net/browse/PVM-805 -->
 
-- The Traefik ingress controller on the appliance now scales to multiple replicas, removing the previous single point
-  of failure in the appliance ingress path.
+- The Traefik ingress controller on the appliance now scales to multiple replicas, removing the previous single point of
+  failure in the appliance ingress path.
 
 #### Bug Fixes
 
@@ -230,8 +231,8 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 <!-- https://spectrocloud.atlassian.net/browse/PVM-839 -->
 
 - Fixed round-trip mutations in the Preferences editor. CPU topology values, grace period serialization, and EFI and
-  Secure Boot display are now preserved correctly on save, and the deprecated `preferThreads` field is no longer
-  written back to the resource.
+  Secure Boot display are now preserved correctly on save, and the deprecated `preferThreads` field is no longer written
+  back to the resource.
 
 <!-- https://spectrocloud.atlassian.net/browse/PVM-633 -->
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -203,6 +203,49 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 #### Bug Fixes
 
+### Launchpad for VMs
+
+#### Features
+
+<!-- https://spectrocloud.atlassian.net/browse/PVM-509 -->
+
+- [Launchpad for VMs Appliance](../vm-management/launchpad-for-vms/launchpad-for-vms.md) version 4.9.13 is now available.
+
+- The appliance now supports a custom UI framework for profile variables. Operators can define and expose appliance
+  variables through a dedicated, pluggable profile variable page in Local UI, so each appliance can surface the
+  variables that matter for its role.
+
+#### Improvements
+
+<!-- https://spectrocloud.atlassian.net/browse/PVM-805 -->
+
+- The Traefik ingress controller on the appliance now scales to multiple replicas, removing the previous single point
+  of failure in the appliance ingress path.
+
+#### Bug Fixes
+
+<!-- https://spectrocloud.atlassian.net/browse/PVM-751 -->
+<!-- https://spectrocloud.atlassian.net/browse/PVM-755 -->
+<!-- https://spectrocloud.atlassian.net/browse/PVM-741 -->
+<!-- https://spectrocloud.atlassian.net/browse/PVM-839 -->
+
+- Fixed round-trip mutations in the Preferences editor. CPU topology values, grace period serialization, and EFI and
+  Secure Boot display are now preserved correctly on save, and the deprecated `preferThreads` field is no longer
+  written back to the resource.
+
+<!-- https://spectrocloud.atlassian.net/browse/PVM-633 -->
+
+- Fixed an issue where VM cloning did not stop the source VM first, which could produce inconsistent clones.
+
+<!-- https://spectrocloud.atlassian.net/browse/PVM-835 -->
+
+- Fixed namespace quota miscalculations that could cause VM deployment failures even when the namespace had enough
+  remaining quota.
+
+<!-- https://spectrocloud.atlassian.net/browse/PVM-727 -->
+
+- Fixed an issue where clones of VMs with hotplug disks did not boot correctly.
+
 ### VerteX
 
 #### Features


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
  
   Info was provided from Sumit as the following:
   

>    we would be having one drop this week 4.9.13
> 
> *VMO 4.9.13 - Release Highlights* :rocket:
> 
> 1. :jigsaw: *Custom UI framework for profile variables* - operators can now define and expose appliance variables through a dedicated pluggable profile variable page
> 2. :broom: *`wipefs` support* — drives can be cleanly wiped before reuse, eliminating leftover filesystem signatures that caused silent provisioning failures
> 3. :electric_plug: *udev* — udev rules are correctly applied on node boot
> 4. :gear: *CDI updated to v1.64 + KubeVirt to v1.8.4* — both core virtualization components bumped to latest stable, picking up upstream bug fixes and improved import/clone pipeline reliability
> 5. :memo: *Preferences fidelity fixes* — resolved round-trip mutations in the Preferences editor: CPU topology values, grace period serialization, EFI/Secure Boot display, and deprecated `preferThreads` writes all corrected
> 6. :lock: *Session and access management hardening* — revoked RBAC sessions are immediately invalidated; local-admin API keys correctly inherit cluster-scope permissions; `/config` endpoint hardened against plaintext password exposure
> 7. :scales: *Traefik HA scaling* — ingress controller now scales to multiple replicas, eliminating the single point of failure on the appliance
> 8. :floppy_disk: *VM cloning and storage fixes* — cloning correctly stops the source VM before proceeding; namespace quota miscalculations causing deployment failures resolved; hotplug disk clones boot correctly

- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR relevant features being added as part of the Launchpad for VMs component release this Friday. 

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Launchpad for VMs Release Notes section](https://deploy-preview-11247--docs-spectrocloud.netlify.app/release-notes/#launchpad-for-vms)


