### PR TITLE
docs(paletteai-inference-launchpad): reword appliance section for on-demand model download

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/docs-content/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -56,9 +56,9 @@ read-only runtime prevents configuration drift and keeps the appliance in a know
 manages the lifecycle of containerized workloads on top, handling scheduling, scaling, and health recovery.
 
 vLLM serves language models with high GPU throughput and handles concurrent requests from many users. The appliance
-ships GLM, DeepSeek, Kimi, and Gemma as local open-weight models that run entirely on your hardware with no external API
-calls. NVIDIA and AMD GPU support provides the parallel processing that large language models require to respond at
-production speed.
+ships with the ability to download one of these flagship open-weight models (GLM, DeepSeek, Kimi, or Gemma) and run it
+entirely on your hardware with no external API calls. NVIDIA and AMD GPU support provides the parallel processing that
+large language models require to respond at production speed.
 
 Intelligent routing directs each request to the most appropriate model. Requests that involve private data or require
 low latency stay local. Other requests can route outbound when the network allows.


### PR DESCRIPTION
## Intent

Reword the 'What Is Inside the Appliance' section of the PaletteAI Inference Launchpad overview so it states the appliance ships with the ability to download one of the flagship open-weight models (GLM, DeepSeek, Kimi, or Gemma) and run it locally, rather than saying it ships all four as bundled local models. This is a deliberate factual correction: the appliance does not bundle all four models; the operator downloads one. The existing value props were intentionally preserved (open-weight, runs entirely on your hardware, no external API calls). Only the single sentence in the vLLM paragraph changed; the 'Local models' table row listing GLM, DeepSeek, Kimi, Gemma was intentionally left as the set of available models. Em-dashes were deliberately avoided to satisfy the repository's Vale rules, and the paragraph was reflowed to prettier proseWrap:always. This is a docs-only prose change with no code, so the test step is intentionally skipped.

## What Changed

- Reworded the single vLLM sentence in the "What Is Inside the Appliance" section so it states the appliance ships with the ability to download one of the flagship open-weight models (GLM, DeepSeek, Kimi, or Gemma) and run it locally, instead of claiming all four ship as bundled local models.
- Preserved the existing value props (open-weight, runs entirely on your hardware, no external API calls) and left the "Local models" table row listing GLM, DeepSeek, Kimi, and Gemma unchanged as the set of available models.
- Kept the prose Vale-clean (no em-dashes) and reflowed the paragraph to the `proseWrap: always` format; docs-only change, so the Test step was skipped.

## Risk Assessment

✅ Low: This is a well-bounded, docs-only single-sentence prose correction that fully conforms to the authoritative intent, introduces no code, links, or factual inconsistencies, and preserves the intentionally-retained table row.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
