### PR TITLE
docs: add enable native load balancer to CK8s DOC-3024

### DIFF
--- a/docs/docs-content/integrations/kubernetes-ck8s.mdx
+++ b/docs/docs-content/integrations/kubernetes-ck8s.mdx
@@ -1,0 +1,86 @@
+---
+sidebar_label: "Canonical Kubernetes"
+title: "Canonical Kubernetes"
+description: "Canonical Kubernetes pack in Palette"
+hide_table_of_contents: true
+type: "integration"
+category: ["kubernetes", "amd64"]
+sidebar_class_name: "hide-from-sidebar"
+logoUrl: "https://registry.spectrocloud.com/v1/ubuntu-vsphere/blobs/sha256:09a727f9005b79c69d8e60e12ce130880c63131315b49e7fb4cc44e53d34dc7a?type=image.webp"
+tags: ["packs", "canonical", "kubernetes"]
+---
+
+<RedirectPackPage packName="kubernetes-ck8s" />
+
+## Versions Supported
+
+<Tabs queryString="parent">
+
+<TabItem label="1.35.x" value="1.35.x">
+
+## Native Load Balancer
+
+The Canonical Kubernetes pack includes a built-in load balancer that you can enable directly from the pack
+configuration. When enabled, Kubernetes Services of type `LoadBalancer` receive an external IP address from a Classless
+Inter-Domain Routing (CIDR) block or IP range that you specify in the pack values. This removes the need to install a
+separate load balancer pack, such as MetalLB, to publish services on clusters that use Canonical Kubernetes.
+
+The built-in load balancer runs in Layer 2 (L2) mode. In L2 mode, the load balancer announces the assigned IP address on
+the local network by responding to Address Resolution Protocol (ARP) requests, which makes the service reachable from
+other devices on the same subnet. Choose an address range that belongs to the same Layer 2 network as your cluster hosts
+and that does not overlap with any other allocated IP addresses.
+
+Native load balancer support was introduced in Canonical Kubernetes pack version `1.35.2`.
+
+### Prerequisites
+
+- A cluster profile that uses the Canonical Kubernetes pack version `1.35.2` or later.
+
+- A CIDR block or an IP range on the same Layer 2 network as your cluster hosts. Reserve the addresses for the load
+  balancer, and confirm that no other devices in the network use them.
+
+### Enablement
+
+1. Log in to [Palette](https://console.spectrocloud.com).
+
+2. From the **left main menu**, select **Profiles**.
+
+3. Select the cluster profile that you plan to use, and then select the Canonical Kubernetes layer.
+
+4. In the YAML editor, locate the `cluster-config` section inside the `config` block. Add a `load-balancer` entry with
+   the following parameters. Replace `<load-balancer-range>` with the CIDR block or IP range that the load balancer must
+   use when it assigns external IP addresses.
+
+   ```yaml
+   config: |
+     cluster-config:
+       network:
+         enabled: false
+       ingress:
+         enabled: false
+       metrics-server:
+         enabled: false
+       local-storage:
+         enabled: false
+       load-balancer:
+         enabled: true
+         cidrs:
+           - <load-balancer-range>
+         l2-mode: true
+   ```
+
+   The following table describes each `load-balancer` parameter.
+
+   | **Parameter** | **Description**                                                                                                                                                                                                                                             |
+   | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `enabled`     | Enables the built-in load balancer in the Canonical Kubernetes distribution. Set to `true`.                                                                                                                                                                 |
+   | `cidrs`       | A list of address ranges that the load balancer draws from when it assigns an external IP address to a Service of type `LoadBalancer`. Each list item can be a CIDR block, such as `10.10.177.0/24`, or an IP range, such as `10.10.177.204-10.10.177.208`. |
+   | `l2-mode`     | Enables Layer 2 announcement of the assigned IP addresses through ARP. Set to `true` for environments where Border Gateway Protocol (BGP) is not available.                                                                                                 |
+
+5. Save the changes to the cluster profile.
+
+6. Deploy a cluster with this cluster profile, or update an existing cluster to the new profile version.
+
+</TabItem>
+
+</Tabs>

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -468,6 +468,13 @@ Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible ver
 
 #### Pack Notes
 
+<!-- prettier-ignore-start -->
+<!-- https://spectrocloud.atlassian.net/browse/PAC-4186 -->
+
+- The <VersionedLink text="Canonical Kubernetes" url="/integrations/packs/?pack=kubernetes-ck8s" /> pack now includes a
+  native load balancer that you can enable through the pack configuration, available in version `1.35.2` and later.Refer to <VersionedLink text="Native Load Balancer" url="/integrations/packs/?pack=kubernetes-ck8s&tab=custom" /> for configuration steps.
+<!-- prettier-ignore-end -->
+
 <!-- https://spectrocloud.atlassian.net/browse/PAC-4395 -->
 
 - Fixed an issue where the Traefik pack remained in `PackServiceNotReady` state on Kubernetes distributions that do not


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
- [x] Ensure all **Vale comments** are resolved.
- [x] All **CI jobs** have completed successfully.
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adds native load balance configuration to CK8s additional details page.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Release Notes](https://deploy-preview-11252--docs-spectrocloud.netlify.app/release-notes/#pack-notes)
- [CK8s pack](https://deploy-preview-11252--docs-spectrocloud.netlify.app/integrations/packs/?pack=kubernetes-ck8s)

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[DOC-3024](https://spectrocloud.atlassian.net/browse/DOC-3024)


[DOC-3024]: https://spectrocloud.atlassian.net/browse/DOC-3024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ