### PR TITLE
docs(paletteai-inference-launchpad): certify Gemma 4 across all GPU configurations

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/explanation/model-certification.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/model-certification.md
@@ -18,9 +18,9 @@ specific hardware, refer to [Certified Models by Hardware](../reference/certifie
 
 ## Certification Overview
 
-A certified model is a large language model (LLM) that Spectro Cloud has tested on a specific GPU configuration and
-confirmed runs correctly on PaletteAI Inference Launchpad. Spectro Cloud runs each certified model on the hardware it is
-paired with, rather than assuming the model works from public benchmarks. When you deploy a certified model on a
+A certified model is a large language model (LLM) that Spectro Cloud has validated to run correctly on the listed GPU
+configuration for PaletteAI Inference Launchpad. This validation is based on Spectro Cloud's own testing rather than
+public benchmarks, and it can extend across equivalent GPU configurations. When you deploy a certified model on a
 configuration where it is certified, you can be confident it loads and serves requests without hardware surprises.
 
 ## Model Use Cases

--- a/docs/docs-content/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
@@ -14,8 +14,8 @@ tags:
 ---
 
 Spectro Cloud certifies a small set of large language models (LLMs) for the hardware that PaletteAI Inference Launchpad
-supports. A _certified_ model is one that Spectro Cloud has tested on the listed GPU configuration. For what
-certification covers, refer to [Model Certification](../explanation/model-certification.md).
+supports. A _certified_ model is one that Spectro Cloud has validated to run correctly on the listed GPU configuration.
+For what certification covers, refer to [Model Certification](../explanation/model-certification.md).
 
 :::info
 
@@ -29,21 +29,18 @@ discuss your use case.
 
 <TabItem label="NVIDIA" value="nvidia">
 
-| **GPU configuration**   | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** | **Gemma 4** |
-| ----------------------- | :---------: | :-----------------: | :----------: | :---------: |
-| 4 x H100                |     ❌      |         ❌          |      ❌      |     ✅      |
-| 8 x H100                |     ❌      |         ❌          |      ❌      |     ✅      |
-| 4 x H200                |     ❌      |         ❌          |      ❌      |     ✅      |
-| 8 x H200                |     ✅      |         ✅          |      ✅      |     ✅      |
-| 4 x H300 <sup>\*</sup>  |     ❌      |         ❌          |      ❌      |     ❌      |
-| 8 x H300                |     ✅      |         ✅          |      ✅      |     ❌      |
-| 4 x GB100 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |     ❌      |
-| 8 x GB100               |     ✅      |         ✅          |      ✅      |     ❌      |
-| 4 x GB200 <sup>\*</sup> |     ❌      |         ❌          |      ❌      |     ❌      |
-| 8 x GB200               |     ✅      |         ✅          |      ✅      |     ❌      |
-
-<sup>*</sup> No certified model for this configuration. [Contact Spectro Cloud](https://www.spectrocloud.com/contact) to
-discuss your use case.
+| **GPU configuration** | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** | **Gemma 4** |
+| --------------------- | :---------: | :-----------------: | :----------: | :---------: |
+| 4 x H100              |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x H100              |     ❌      |         ❌          |      ❌      |     ✅      |
+| 4 x H200              |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x H200              |     ✅      |         ✅          |      ✅      |     ✅      |
+| 4 x H300              |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x H300              |     ✅      |         ✅          |      ✅      |     ✅      |
+| 4 x GB100             |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x GB100             |     ✅      |         ✅          |      ✅      |     ✅      |
+| 4 x GB200             |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x GB200             |     ✅      |         ✅          |      ✅      |     ✅      |
 
 </TabItem>
 
@@ -51,16 +48,14 @@ discuss your use case.
 
 | **GPU configuration** | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** | **Gemma 4** |
 | --------------------- | :---------: | :-----------------: | :----------: | :---------: |
-| 4 x MI300X            |     ❌      |         ❌          |      ✅      |     ❌      |
-| 8 x MI300X            |     ✅      |         ❌          |      ❌      |     ❌      |
-| 4 x MI325X            |     ✅      |         ❌          |      ✅      |     ⏳      |
-| 8 x MI325X            |     ✅      |         ❌          |      ❌      |     ⏳      |
-| 4 x MI350X            |     ✅      |         ✅          |      ❌      |     ⏳      |
-| 8 x MI350X            |     ✅      |         ✅          |      ❌      |     ⏳      |
-| 4 x MI355X            |     ✅      |         ✅          |      ❌      |     ❌      |
-| 8 x MI355X            |     ✅      |         ✅          |      ❌      |     ❌      |
-
-⏳ Certification in progress.
+| 4 x MI300X            |     ❌      |         ❌          |      ✅      |     ✅      |
+| 8 x MI300X            |     ✅      |         ❌          |      ❌      |     ✅      |
+| 4 x MI325X            |     ✅      |         ❌          |      ✅      |     ✅      |
+| 8 x MI325X            |     ✅      |         ❌          |      ❌      |     ✅      |
+| 4 x MI350X            |     ✅      |         ✅          |      ❌      |     ✅      |
+| 8 x MI350X            |     ✅      |         ✅          |      ❌      |     ✅      |
+| 4 x MI355X            |     ✅      |         ✅          |      ❌      |     ✅      |
+| 8 x MI355X            |     ✅      |         ✅          |      ❌      |     ✅      |
 
 </TabItem>
 

--- a/docs/docs-content/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/glossary.md
@@ -76,8 +76,8 @@ gateway continues to handle routing, [token metering](#token-metering), quota co
 
 ### Certified Model
 
-A model that Spectro Cloud has tested on a specific GPU configuration and confirmed runs correctly on the appliance,
-rather than assuming it works from public benchmarks. Refer to
+A model that Spectro Cloud has validated to run correctly on the listed GPU configuration, based on its own testing
+rather than public benchmarks. Refer to
 [Model Certification](../explanation/model-certification.md) and
 [Certified Models by Hardware](./certified-models-by-hardware.md).
 

--- a/docs/docs-content/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/glossary.md
@@ -77,8 +77,7 @@ gateway continues to handle routing, [token metering](#token-metering), quota co
 ### Certified Model
 
 A model that Spectro Cloud has validated to run correctly on the listed GPU configuration, based on its own testing
-rather than public benchmarks. Refer to
-[Model Certification](../explanation/model-certification.md) and
+rather than public benchmarks. Refer to [Model Certification](../explanation/model-certification.md) and
 [Certified Models by Hardware](./certified-models-by-hardware.md).
 
 ### Chargeback


### PR DESCRIPTION
Gemma 4 is now marked as certified for every listed NVIDIA and AMD GPU configuration because it runs on a single GPU and is supported broadly across the hardware.

Reword the definition of a certified model from "tested on the listed GPU configuration" to "validated to run correctly on the listed GPU configuration" so it no longer implies that every hardware and model combination was individually tested, keeping it aligned with the Model Certification page.

Remove the NVIDIA "no certified model for this configuration" footnote and the AMD "certification in progress" legend, which are no longer accurate now that Gemma 4 covers every configuration.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `docs/docs-content/paletteai-inference-launchpad/reference/certified-models-by-hardware.md:17` - The rewording on line 17 (&#34;validated to run correctly&#34;) intentionally softens the certified-model definition, and the intent states this was done &#34;to stay aligned with the Model Certification explanation page without overclaiming.&#34; However, the linked explanation page (docs/docs-content/paletteai-inference-launchpad/explanation/model-certification.md, Certification Overview) is unchanged and still claims Spectro Cloud &#34;has tested on a specific GPU configuration&#34; and &#34;runs each certified model on the hardware it is paired with, rather than assuming the model works from public benchmarks.&#34; Per the intent, Gemma 4&#39;s all-config certification is based on single-GPU verification plus a 4x/8x equivalence inference — the exact &#34;assumption&#34; the explanation page disclaims — so the two linked pages now diverge and the explanation page overclaims relative to how Gemma 4 was certified. Consider updating the explanation page&#39;s wording as a follow-up so the alignment the intent describes actually holds.

🔧 Fix: align certified-model definition wording across explanation and glossary pages
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
