### PR TITLE
adjusting backup and restore

### DIFF
--- a/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
+++ b/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
@@ -325,7 +325,21 @@ Use the following signals to confirm this workaround applies to your destination
 
 - The response from `<VIP>/v1/auth/org` contains `"appEnv": "enterprise-cli"`.
 
-Apply the workaround with the following steps.
+Apply the workaround with the utility script, or with a direct MongoDB write. The utility script is the recommended path because it handles the port-forward, credential lookup, and document update for you.
+
+**Apply with the utility script**
+
+1. On the jump host, run the `set-installer-mode.sh` script from the working directory. The script sets `installerMode` to `self-hosted` in the `systemconfig` document for you.
+
+    ```shell
+    ./set-installer-mode.sh --kubeconfig dst.kubeconfig
+    ```
+
+2. Clear the Hubble pod cache using the procedure in [Clear the Hubble Pod Cache](#clear-the-hubble-pod-cache).
+
+**Apply directly in MongoDB**
+
+If you prefer to apply the change by hand, use the following steps.
 <!-- vale off -->
 1. On the jump host, port-forward the MongoDB service on the destination cluster.
 <!-- vale on -->
@@ -383,7 +397,7 @@ If the source cluster used an external registry, such as Amazon Elastic Containe
 
 1. In the destination cluster system console, go to **Tenant Settings** > **Registries** > **Pack Registries** and create a new pack registry that points at the destination Zot registry. Give it a distinct name, for example `dst-zot`.
 <!-- vale off -->
-2. On the jump host, port-forward the MongoDB service and connect with `mongosh`, following steps 1 through 3 of the [CLI-Installed Enterprise Cluster Source](#cli-installed-enterprise-cluster-source) workaround.
+2. On the jump host, port-forward the MongoDB service and connect with `mongosh`, following steps 1 through 3 of the **Apply directly in MongoDB** procedure in the [CLI-Installed Enterprise Cluster Source](#cli-installed-enterprise-cluster-source) workaround.
 <!-- vale on -->
 3. Confirm both the current default record and the new record. Replace `<default>` with the name of the current default record.
 

--- a/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
+++ b/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
@@ -167,9 +167,9 @@ Synchronize the internal Zot registry on the destination cluster with the intern
 If both clusters share a common external registry, you can skip this section.
 
 :::
-
-1. On the jump host, open the `zot-sync.sh` script for editing.
 <!-- vale off -->
+1. On the jump host, open the `zot-sync.sh` script for editing.
+    
     ```shell
     vi ./zot-sync.sh
     ```

--- a/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
+++ b/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
@@ -41,13 +41,15 @@ For example, a source cluster at 4.7.x can be restored to a destination cluster 
 
 - Administrative access to the {props.version} system console for the source cluster.
 
-- The system address for the source cluster is configured with a Fully Qualified Domain Name (FQDN) instead of an IP address. Workload cluster edge hosts must also reference the FQDN as the `PaletteEndpoint` value in their userdata.
+- The system address for the source cluster is configured with a Fully Qualified Domain Name (FQDN) instead of an IP address.
 
   :::warning
 
   If your source cluster uses an IP address instead of an FQDN for the system address, a config map on each workload cluster must be updated manually to point to the destination cluster's IP address. Contact Spectro Cloud support for guidance.
 
   :::
+
+- Every Edge host used to launch a Connected Edge Native workload cluster from the source cluster references the {props.version} FQDN, and not an IP address, as the `PaletteEndpoint` value in its user data ISO. This is required so that the DNS cutover in [Update DNS and Re-Register Workload Clusters](#update-dns-and-re-register-workload-clusters) reaches every edge host.
 
 - On the jump host, install the following packages. Skopeo mirrors the internal Zot registry, and `jq` parses the registry catalog response.
 
@@ -208,11 +210,19 @@ If both clusters share a common external registry, you can skip this section.
 
     The output contains a namespace in the format `cluster-<uid>`. Record the `<uid>` value for the next step.
 
-4. Run the restore script. Replace `<uid>` with the value from the previous step.
+4. Run the restore script.
 
-    ```shell
-    ./edge-restore.sh --uid <uid> --kubeconfig dst.kubeconfig --backup-dir source-backup
-    ```
+    - For a destination cluster installed with the Management Appliance or the Palette CLI, replace `<uid>` with the value from the previous step and run the following command.
+
+      ```shell
+      ./edge-restore.sh --uid <uid> --kubeconfig dst.kubeconfig --backup-dir source-backup
+      ```
+
+    - For a destination cluster installed with the Helm chart, pass `--is-helm` and omit `--uid`. The script derives the namespace from the Helm release.
+
+      ```shell
+      ./edge-restore.sh --is-helm --kubeconfig dst.kubeconfig --backup-dir source-backup
+      ```
 
 5. Wait for the restore to complete.
 
@@ -230,7 +240,15 @@ After the restore, workload clusters may temporarily show as unhealthy because t
 
     :::
 
-3. Wait for workload clusters to reconnect and report a **Healthy** status.
+3. For each Connected Edge Native workload cluster, SSH into every edge host and reload the Stylus services so that they pick up the new destination cluster. The `daemon-reload` re-reads the unit files, and the two restarts drop any in-memory connection state that still points at the source cluster.
+
+    ```shell
+    systemctl daemon-reload
+    systemctl restart stylus-operator
+    systemctl restart stylus-agent
+    ```
+
+4. Wait for workload clusters to reconnect and report a **Healthy** status.
 
 ## Resume Agent Upgrade in Stages
 
@@ -260,10 +278,185 @@ Enable agent upgrades in stages so that you can validate the restore against a s
 
 ## Post-Restore Workarounds
 
-Depending on how you originally installed the source cluster, you may need to run further manual steps after the restore. Spectro Cloud is finalizing these workarounds as part of the release validation. Review the following list of scenarios that may apply to your environment, and contact Spectro Cloud support for the current steps.
+Depending on how you originally installed the source cluster, and which workload cluster types are re-pointed to the destination cluster, you may need to run further manual steps after the restore. Review the following scenarios and apply the workarounds that fit your environment.
 
-- **CLI-installed Enterprise Cluster source:** If the source cluster was installed using the Palette CLI in Enterprise Cluster mode, the `installerMode` field in the `SystemInstallerConfig` document in the `hubbledb.systems` collection must be updated to `self-hosted` on the destination cluster. This document is immutable through the Palette API, so the update must be applied with a direct MongoDB write.
+Several of the workarounds finish by clearing the cache in the Hubble pods on the destination cluster. Use the procedure in [Clear the Hubble Pod Cache](#clear-the-hubble-pod-cache) whenever it is referenced.
 
-- **Default pack registry conflict:** If the source cluster used an external registry, such as Amazon Elastic Container Registry (ECR), as the default pack registry, the default record on the destination cluster must be reconciled with the destination Zot registry.
+### Clear the Hubble Pod Cache
 
-- **Stale cache in Hubble pods:** If workload clusters continue to report `Resource Not Found` errors against a Cluster UID after the restore, the Hubble pods on the destination cluster may need to be restarted to clear the cache.
+The utility archive includes helper scripts that shut down and start up the Hubble system deployments for a cluster namespace. Running them in sequence forces the Hubble pods to reload their in-memory state.
+
+1. Shut down the Hubble system deployments. Replace `<uid>` with the cluster UID retrieved in [Restore the Database Backup](#restore-the-database-backup).
+
+    ```shell
+    ./k8s-shutdown-edge.sh --uid <uid> --kubeconfig dst.kubeconfig
+    ```
+
+2. Wait one to two minutes for the pods to fully terminate.
+
+3. Start the Hubble system deployments back up.
+
+    ```shell
+    ./k8s-startup-edge.sh --uid <uid> --kubeconfig dst.kubeconfig
+    ```
+
+4. Confirm the Hubble pods return to a `Running` status before continuing.
+
+    ```shell
+    kubectl --kubeconfig dst.kubeconfig get pods --namespace hubble-system
+    ```
+
+If workload clusters continue to report `Resource Not Found` errors against a Cluster UID after the restore, the Hubble pods on the destination cluster may still be caching stale data. Repeat this procedure to clear the cache.
+
+### CLI-Installed Enterprise Cluster Source
+
+If the source cluster was installed using the Palette CLI in Enterprise Cluster mode, the `installerMode` field in the `systemconfig` document in the `hubbledb.config` collection must be updated to `self-hosted` on the destination cluster. This document is immutable through the Palette API, so the update must be applied with a direct MongoDB write.
+
+Use the following signals to confirm this workaround applies to your destination cluster.
+
+- The destination cluster system console displays a **System Cluster** section, which is only present on CLI-installed Enterprise Cluster environments.
+
+- The response from `<VIP>/v1/auth/org` contains `"appEnv": "enterprise-cli"`.
+
+Apply the workaround with the following steps.
+
+1. On the jump host, port-forward the MongoDB service on the destination cluster.
+
+    ```shell
+    kubectl --kubeconfig dst.kubeconfig port-forward --namespace hubble-system svc/mongo 27017:27017
+    ```
+
+2. In a new terminal, retrieve the MongoDB root password.
+
+    ```shell
+    kubectl --kubeconfig dst.kubeconfig get secret spectromongosecret --namespace hubble-system \
+      --output jsonpath='{.data.mongoRootPassword}' | base64 --decode
+    ```
+
+3. Connect to MongoDB with `mongosh`. Replace `<password>` with the value from the previous step.
+
+    ```shell
+    mongosh "mongodb://root:<password>@127.0.0.1:27017/hubbledb?authSource=admin&directConnection=true"
+    ```
+
+4. Locate the `systemconfig` document and record its `_id` value.
+
+    ```javascript
+    db.config.find({ kind: "systemconfig" })
+    ```
+
+5. Update the document to set `installerMode` to `self-hosted`. Replace `<doc_id>` with the `_id` from the previous step.
+
+    ```javascript
+    db.config.updateOne(
+      { kind: "systemconfig", _id: "<doc_id>" },
+      { $set: { "spec.installerMode": "self-hosted", "status.updateTime": new Date() } }
+    )
+    ```
+
+6. Confirm the update.
+
+    ```javascript
+    db.config.find({ kind: "systemconfig" })
+    ```
+
+7. Exit `mongosh` and stop the port-forward.
+
+8. Clear the Hubble pod cache using the procedure in [Clear the Hubble Pod Cache](#clear-the-hubble-pod-cache).
+
+Validate the workaround with the following checks.
+
+- The **System Cluster** section is no longer shown in the destination system console. Compare it against a system console from a fresh appliance environment if needed.
+
+- The response from `<VIP>/v1/auth/org` no longer contains `"appEnv": "enterprise-cli"`.
+
+### Default Pack Registry Conflict
+
+If the source cluster used an external registry, such as Amazon Elastic Container Registry (ECR), as the default pack registry, the destination cluster inherits that record after the restore, replacing the internal Zot registry that the destination cluster was installed with. The Palette UI blocks editing the default record to point to a Zot registry because of the registry type conflict, so the reconciliation must be applied directly in MongoDB.
+
+1. In the destination cluster system console, go to **Tenant Settings** > **Registries** > **Pack Registries** and create a new pack registry that points at the destination Zot registry. Give it a distinct name, for example `dst-zot`.
+
+2. On the jump host, port-forward the MongoDB service and connect with `mongosh`, following steps 1 through 3 of the [CLI-Installed Enterprise Cluster Source](#cli-installed-enterprise-cluster-source) workaround.
+
+3. Confirm both the current default record and the new record. Replace `<default>` with the name of the current default record.
+
+    ```javascript
+    db.registries.findOne({ "metadata.name": "<default>" })
+    db.registries.findOne({ "metadata.name": "dst-zot" })
+    ```
+
+4. Mark the new `dst-zot` record as the default in metadata so that the `spec` copy in the next step passes UI validation.
+
+    ```javascript
+    db.registries.updateOne(
+      { "metadata.name": "dst-zot" },
+      {
+        $set: {
+          "metadata.annotations.isDefault": "true",
+          "spec.registryMeta.isDefault": true,
+          "spec.registryMeta.containsSpectroManifest": true
+        }
+      }
+    )
+    ```
+
+5. Copy the `dst-zot` spec and status into the existing default record. Replace `<default>` with the same name used in step 3.
+
+    ```javascript
+    const zot = db.registries.findOne({ "metadata.name": "dst-zot" });
+
+    db.registries.updateOne(
+      { "metadata.name": "<default>" },
+      {
+        $set: {
+          spec: zot.spec,
+          status: zot.status
+        }
+      }
+    );
+    ```
+
+6. Confirm both records reflect the intended Zot values.
+
+    ```javascript
+    db.registries.findOne({ "metadata.name": "<default>" })
+    db.registries.findOne({ "metadata.name": "dst-zot" })
+    ```
+
+7. In the {props.version} system console, confirm that the default pack registry details now show the destination Zot registry, then sync the registry. After the sync completes, review cluster profiles for any errors or warnings.
+
+8. Remove the temporary record.
+
+    ```javascript
+    db.registries.deleteOne({ "metadata.name": "dst-zot" })
+    ```
+
+9. Exit `mongosh` and stop the port-forward.
+
+10. Clear the Hubble pod cache using the procedure in [Clear the Hubble Pod Cache](#clear-the-hubble-pod-cache).
+
+### Private Cloud Gateway Workload Clusters
+
+Workload clusters deployed through a Private Cloud Gateway (PCG) may continue to reconcile against stale controller state on the destination cluster, even when the source cluster used an FQDN for the system address. Restart the affected controllers on the destination cluster so that they shed the stale caches.
+
+:::warning
+
+Confirm the exact deployment names and namespaces with Spectro Cloud engineering before applying this workaround in production. The list below is based on field observations and may need to be adjusted for your PCG topology and enabled infrastructure providers.
+
+:::
+
+Restart the following deployments on the destination cluster.
+
+- `cluster-management-agent`
+- `palette-controller-manager`
+- `jet`
+- `spectro-cloud-driver`
+- The CAPI controller and each active CAPI infrastructure provider, for example `capv-controller-manager` for VMware.
+
+For each deployment, run the following command. Replace `<name>` with the deployment name and `<ns>` with its namespace.
+
+```shell
+kubectl --kubeconfig dst.kubeconfig rollout restart deployment <name> --namespace <ns>
+```
+
+Wait for each rollout to report all replicas ready, then verify that PCG workload clusters return to a **Healthy** status.

--- a/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
+++ b/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
@@ -9,7 +9,9 @@ You can also use this procedure to back up a cluster and restore to the same clu
 
 :::info
 
-The utility archive referenced throughout this guide contains the scripts you need to complete the backup and restore. Download it from [https://software.spectrocloud.com/scripts/backup-restore/Palette-Backup-Restore-v4.9.0.tar.gz](https://software.spectrocloud.com/scripts/backup-restore/Palette-Backup-Restore-v4.9.0.tar.gz) to your Linux jump host before you begin.
+The utility archive referenced throughout this guide contains the scripts you need to complete the backup and restore. Download the scripts linked below to your Linux jump host before you begin.
+
+[Palette Backup and Restore Scripts](https://software.spectrocloud.com/scripts/backup-restore/Palette-Backup-Restore-v4.9.0.tar.gz)
 
 :::
 
@@ -31,7 +33,7 @@ For example, a source cluster at 4.7.x can be restored to a destination cluster 
 
 - A Linux jump host running Ubuntu 24.04 with network access to both the source and destination clusters. This host is used to run the backup and restore scripts, including the Zot registry sync, which requires Ubuntu 24.04.
 
-- The [`Palette-Backup-Restore-v4.9.0.tar.gz`](https://software.spectrocloud.com/scripts/backup-restore/Palette-Backup-Restore-v4.9.0.tar.gz) utility archive downloaded to your Linux jump host.
+- The [Palette Backup and Restore Scripts](https://software.spectrocloud.com/scripts/backup-restore/Palette-Backup-Restore-v4.9.0.tar.gz) utility archive downloaded to your Linux jump host.
 
 - The source cluster and destination cluster meet the requirements listed in [Supported Scenarios](#supported-scenarios).
 
@@ -45,7 +47,7 @@ For example, a source cluster at 4.7.x can be restored to a destination cluster 
 
   :::warning
 
-  If your source cluster uses an IP address instead of an FQDN for the system address, a config map on each workload cluster must be updated manually to point to the destination cluster's IP address. Contact Spectro Cloud support for guidance.
+  If your source cluster uses an IP address instead of an FQDN for the system address, a config map on each workload cluster must be updated manually to point to the destination cluster's IP address. Contact [Spectro Cloud Support](https://spectrocloud.atlassian.net/servicedesk/customer/portal/6) for guidance.
 
   :::
 
@@ -120,7 +122,7 @@ Pause the agent upgrade on all workload clusters before you take a backup. This 
 2. Place the utility archive downloaded in the [Prerequisites](#prerequisites) into this directory, then extract it. The scripts extract into the current directory.
 
     ```shell
-    tar --extract --verbose --file=Palette-Backup-Restore-v4.9.0.tar.gz
+    tar --extract --verbose --file=Palette-Backup-Restore-*.tar.gz
     ```
 
 3. Copy the source cluster `kubeconfig` file into this directory and name it `source.kubeconfig`.
@@ -174,8 +176,8 @@ If both clusters share a common external registry, you can skip this section.
     ```shell
     SRC=192.0.2.10:30003
     DST=198.51.100.10:30003
-    SRC_CREDS="admin:password"
-    DST_CREDS="admin:password"
+    SRC_CREDS="<username>:<password>"
+    DST_CREDS="<username>:<password>"
     ```
 
 3. Save the file and close the editor.
@@ -311,6 +313,8 @@ If workload clusters continue to report `Resource Not Found` errors against a Cl
 ### CLI-Installed Enterprise Cluster Source
 
 If the source cluster was installed using the Palette CLI in Enterprise Cluster mode, the `installerMode` field in the `systemconfig` document in the `hubbledb.config` collection must be updated to `self-hosted` on the destination cluster. This document is immutable through the Palette API, so the update must be applied with a direct MongoDB write.
+
+Contact [Spectro Cloud Support](https://spectrocloud.atlassian.net/servicedesk/customer/portal/6) for assistance before applying this workaround.
 
 Use the following signals to confirm this workaround applies to your destination cluster.
 

--- a/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
+++ b/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
@@ -236,19 +236,27 @@ After the restore, workload clusters may temporarily show as unhealthy because t
 
 Enable agent upgrades in stages so that you can validate the restore against a small number of workload clusters before applying it broadly.
 
-1. Select one or two workload clusters to use as test clusters.
+1. Log in to the {props.version} tenant console for the destination cluster.
 
-2. In the cluster settings for each test cluster, enable **Agent Upgrade**.
+2. From the left main menu, select **Tenant Settings**.
 
-3. Wait for the agent upgrade to complete. On the cluster **Overview** tab, confirm the following.
+3. Select **Platform Settings**.
+
+4. Disable **Pause Agent Upgrade** so that per-cluster Agent Upgrade toggles take effect.
+
+5. Select one or two workload clusters to use as test clusters.
+
+6. In the cluster settings for each test cluster, enable **Agent Upgrade**.
+
+7. Wait for the agent upgrade to complete. On the cluster **Overview** tab, confirm the following.
 
     - The **Cluster Management Agent** version shows the new version.
 
-    - On the **Edge Hosts** tab, the Stylus Agent version on each edge host shows the new version.
+    - For Edge clusters, on the **Edge Hosts** tab, the Stylus Agent version on each edge host shows the new version. Controller mode clusters do not have this tab.
 
-4. Deploy a new test cluster from the destination cluster to further validate that the environment is stable.
+8. Deploy a new test cluster from the destination cluster to further validate that the environment is stable.
 
-5. Once the test clusters are healthy and running the new agent, enable **Agent Upgrade** for the remaining workload clusters.
+9. Once the test clusters are healthy and running the new agent, enable **Agent Upgrade** for the remaining workload clusters.
 
 ## Post-Restore Workarounds
 

--- a/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
+++ b/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
@@ -81,7 +81,7 @@ For example, a source cluster at 4.7.x can be restored to a destination cluster 
   sudo apt-get install --yes kubectl
   ```
 
-- Add the MongoDB apt repository and install MongoDB Database Tools. The backup and restore scripts call `mongodump` and `mongorestore` from this package.
+- Add the MongoDB apt repository and install MongoDB Database Tools and the MongoDB Shell. The backup and restore scripts call `mongodump` and `mongorestore` from the Database Tools package. The [Post-Restore Workarounds](#post-restore-workarounds) use `mongosh` from the MongoDB Shell package.
 
   ```shell
   curl --fail --silent --show-error --location https://www.mongodb.org/static/pgp/server-8.0.asc | \
@@ -95,7 +95,7 @@ For example, a source cluster at 4.7.x can be restored to a destination cluster 
 
   ```shell
   sudo apt-get update
-  sudo apt-get install --yes mongodb-database-tools
+  sudo apt-get install --yes mongodb-database-tools mongodb-mongosh
   ```
 
 ## Back Up the Source Cluster

--- a/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
+++ b/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
@@ -30,10 +30,13 @@ The following combinations are supported.
 For example, a source cluster at 4.7.x can be restored to a destination cluster at 4.7.x or 4.8.x, but not to a destination cluster at 4.6.x. Both clusters must be the same edition, either Palette or VerteX.
 
 ## Prerequisites
+<!-- vale off -->
 
 - A Linux jump host running Ubuntu 24.04 with network access to both the source and destination clusters. This host is used to run the backup and restore scripts, including the Zot registry sync, which requires Ubuntu 24.04.
 
 - The [Palette Backup and Restore Scripts](https://software.spectrocloud.com/scripts/backup-restore/Palette-Backup-Restore-v4.9.0.tar.gz) utility archive downloaded to your Linux jump host.
+
+<!-- vale on -->
 
 - The source cluster and destination cluster meet the requirements listed in [Supported Scenarios](#supported-scenarios).
 
@@ -112,13 +115,13 @@ Pause the agent upgrade on all workload clusters before you take a backup. This 
 4. Enable **Pause Agent Upgrade**.
 
 ### Take a Database Backup
-
+<!-- vale off -->
 1. On the jump host, create a working directory and change into it.
 
     ```shell
     mkdir --parents palette-backup-restore && cd palette-backup-restore
     ```
-
+<!-- vale on -->
 2. Place the utility archive downloaded in the [Prerequisites](#prerequisites) into this directory, then extract it. The scripts extract into the current directory.
 
     ```shell
@@ -166,11 +169,11 @@ If both clusters share a common external registry, you can skip this section.
 :::
 
 1. On the jump host, open the `zot-sync.sh` script for editing.
-
+<!-- vale off -->
     ```shell
     vi ./zot-sync.sh
     ```
-
+<!-- vale on -->
 2. Update the four values at the top of the script to match your environment. The `SRC` and `DST` values can be the Virtual IP Address (VIP) or the IP address of any node in the corresponding cluster. The credentials must match the ones you set during installation.
 
     ```shell
@@ -197,9 +200,9 @@ If both clusters share a common external registry, you can skip this section.
 ### Restore the Database Backup
 
 1. Copy the destination cluster `kubeconfig` file into the working directory and name it `dst.kubeconfig`.
-
+<!-- vale off -->
 2. On the jump host, set the `KUBECONFIG` environment variable to point to the destination cluster.
-
+<!-- vale on -->
     ```shell
     export KUBECONFIG=dst.kubeconfig
     ```
@@ -323,9 +326,9 @@ Use the following signals to confirm this workaround applies to your destination
 - The response from `<VIP>/v1/auth/org` contains `"appEnv": "enterprise-cli"`.
 
 Apply the workaround with the following steps.
-
+<!-- vale off -->
 1. On the jump host, port-forward the MongoDB service on the destination cluster.
-
+<!-- vale on -->
     ```shell
     kubectl --kubeconfig dst.kubeconfig port-forward --namespace hubble-system svc/mongo 27017:27017
     ```
@@ -379,9 +382,9 @@ Validate the workaround with the following checks.
 If the source cluster used an external registry, such as Amazon Elastic Container Registry (ECR), as the default pack registry, the destination cluster inherits that record after the restore, replacing the internal Zot registry that the destination cluster was installed with. The Palette UI blocks editing the default record to point to a Zot registry because of the registry type conflict, so the reconciliation must be applied directly in MongoDB.
 
 1. In the destination cluster system console, go to **Tenant Settings** > **Registries** > **Pack Registries** and create a new pack registry that points at the destination Zot registry. Give it a distinct name, for example `dst-zot`.
-
+<!-- vale off -->
 2. On the jump host, port-forward the MongoDB service and connect with `mongosh`, following steps 1 through 3 of the [CLI-Installed Enterprise Cluster Source](#cli-installed-enterprise-cluster-source) workaround.
-
+<!-- vale on -->
 3. Confirm both the current default record and the new record. Replace `<default>` with the name of the current default record.
 
     ```javascript

--- a/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
+++ b/_partials/self-hosted/management-appliance/_backup-restore-procedure.mdx
@@ -97,7 +97,7 @@ Use the following steps to pause agent upgrades on workload clusters and take a 
 
 ### Pause Agent Upgrade on the Source Cluster
 
-Pause the agent upgrade on all workload clusters before you take a backup. This prevents workload clusters from receiving an agent upgrade during the backup and cutover, before the destination cluster takes over.
+Pause the agent upgrade on all workload clusters before you take a backup. This helps ensure a controlled agent upgrade of workload clusters during the restore step if the destination cluster is at a newer version than the source cluster.
 
 1. Log in to the {props.version} tenant console for the source cluster.
 
@@ -121,17 +121,15 @@ Pause the agent upgrade on all workload clusters before you take a backup. This 
     tar --extract --verbose --file=Palette-Backup-Restore-v4.9.0.tar.gz
     ```
 
-4. Copy the source cluster `kubeconfig` file into this directory and name it `source.kubeconfig`.
+3. Copy the source cluster `kubeconfig` file into this directory and name it `source.kubeconfig`.
 
-5. Copy the destination cluster `kubeconfig` file into this directory and name it `dst.kubeconfig`.
-
-6. Run the backup script. The script creates the backup directory automatically. If you omit `--backup-dir`, the script generates a timestamped directory named `mongo_hubble_backup_<YYYYMMDD-HHMMSS>`.
+4. Run the backup script. The script creates the backup directory automatically. If you omit `--backup-dir`, the script generates a timestamped directory named `mongo_hubble_backup_<YYYYMMDD-HHMMSS>`.
 
     ```shell
     ./edge-backup.sh --kubeconfig source.kubeconfig --backup-dir source-backup
     ```
 
-7. Confirm that the backup directory contains the expected artifacts.
+5. Confirm that the backup directory contains the expected artifacts.
 
     ```shell
     tree --level 1 source-backup
@@ -149,9 +147,13 @@ Pause the agent upgrade on all workload clusters before you take a backup. This 
     └── mongo-tls
     ```
 
-## Synchronize the Zot Registry
+## Restore to the Destination Cluster
 
-Synchronize the internal Zot registry on the source cluster with the internal Zot registry on the destination cluster so that the destination has the packs and images required by the workload clusters.
+Use the following steps to synchronize the internal Zot registry with the source cluster and then restore the database backup to the destination cluster.
+
+### Synchronize the Zot Registry
+
+Synchronize the internal Zot registry on the destination cluster with the internal Zot registry on the source cluster so that the destination has the packs and images required by the workload clusters.
 
 :::info
 
@@ -188,17 +190,17 @@ If both clusters share a common external registry, you can skip this section.
 
 5. Log in to the destination cluster Zot registry and confirm that the packs are synchronized and that the image checksums match the source registry.
 
-## Restore to the Destination Cluster
+### Restore the Database Backup
 
-Use the following steps to restore the database backup to the destination cluster.
+1. Copy the destination cluster `kubeconfig` file into the working directory and name it `dst.kubeconfig`.
 
-1. On the jump host, set the `KUBECONFIG` environment variable to point to the destination cluster.
+2. On the jump host, set the `KUBECONFIG` environment variable to point to the destination cluster.
 
     ```shell
     export KUBECONFIG=dst.kubeconfig
     ```
 
-2. Retrieve the cluster namespace for the destination cluster.
+3. Retrieve the cluster namespace for the destination cluster.
 
     ```shell
     kubectl --kubeconfig dst.kubeconfig get ns | grep cluster-
@@ -206,13 +208,13 @@ Use the following steps to restore the database backup to the destination cluste
 
     The output contains a namespace in the format `cluster-<uid>`. Record the `<uid>` value for the next step.
 
-3. Run the restore script. Replace `<uid>` with the value from the previous step.
+4. Run the restore script. Replace `<uid>` with the value from the previous step.
 
     ```shell
     ./edge-restore.sh --uid <uid> --kubeconfig dst.kubeconfig --backup-dir source-backup
     ```
 
-4. Wait for the restore to complete.
+5. Wait for the restore to complete.
 
 ## Update DNS and Re-Register Workload Clusters
 
@@ -252,7 +254,7 @@ Enable agent upgrades in stages so that you can validate the restore against a s
 
 Depending on how you originally installed the source cluster, you may need to run further manual steps after the restore. Spectro Cloud is finalizing these workarounds as part of the release validation. Review the following list of scenarios that may apply to your environment, and contact Spectro Cloud support for the current steps.
 
-- **CLI-installed Enterprise Cluster source:** If the source cluster was installed using the Palette CLI in Enterprise Cluster mode, the `installerMode` value in the MongoDB `systemconfig` document must be updated to `self-hosted` on the destination cluster.
+- **CLI-installed Enterprise Cluster source:** If the source cluster was installed using the Palette CLI in Enterprise Cluster mode, the `installerMode` field in the `SystemInstallerConfig` document in the `hubbledb.systems` collection must be updated to `self-hosted` on the destination cluster. This document is immutable through the Palette API, so the update must be applied with a direct MongoDB write.
 
 - **Default pack registry conflict:** If the source cluster used an external registry, such as Amazon Elastic Container Registry (ECR), as the default pack registry, the default record on the destination cluster must be reconciled with the destination Zot registry.
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adjusts the backup_restore partial by splitting the flow into a dedicated Restore to the Destination Cluster section (wrapping Zot sync and the database restore), moving the `dst.kubeconfig` copy into that section, swapping source/destination in the Zot sync description, and rewording the pause-agent-upgrade rationale. Also tightens the installerMode post-restore workaround to name the correct SystemInstallerConfig document in `hubbledb.systems` and note that a direct MongoDB write is required because the field is immutable through the Palette API.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [Backup and Restore the Palette Management Appliance](https://deploy-preview-11271--docs-spectrocloud.netlify.app/enterprise-version/install-palette/palette-management-appliance-backup-restore/)
- [Backup and Restore the VerteX Management Appliance](https://deploy-preview-11271--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/vertex-management-appliance-backup-restore/)

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-3027)
