### PR TITLE
fix: restore dynamicFontAwesomeImports.ts on version-4-7

### DIFF
--- a/src/components/IconMapper/dynamicFontAwesomeImports.ts
+++ b/src/components/IconMapper/dynamicFontAwesomeImports.ts
@@ -1,0 +1,57 @@
+import { faCubes } from '@fortawesome/free-solid-svg-icons';
+import { faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { faPersonWalkingLuggage } from '@fortawesome/free-solid-svg-icons';
+import { faObjectUngroup } from '@fortawesome/free-solid-svg-icons';
+import { faObjectGroup } from '@fortawesome/free-solid-svg-icons';
+import { faEnvelopeOpenText } from '@fortawesome/free-solid-svg-icons';
+import { faDatabase } from '@fortawesome/free-solid-svg-icons';
+import { faHdd } from '@fortawesome/free-solid-svg-icons';
+import { faCloudArrowDown } from '@fortawesome/free-solid-svg-icons';
+import { faNetworkWired } from '@fortawesome/free-solid-svg-icons';
+import { faServer } from '@fortawesome/free-solid-svg-icons';
+import { faRoad } from '@fortawesome/free-solid-svg-icons';
+import { faUsers } from '@fortawesome/free-solid-svg-icons';
+import { faLayerGroup } from '@fortawesome/free-solid-svg-icons';
+import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { faShield } from '@fortawesome/free-solid-svg-icons';
+import { faWarehouse } from '@fortawesome/free-solid-svg-icons';
+import { faFlagCheckered } from '@fortawesome/free-solid-svg-icons';
+import { faPalette } from '@fortawesome/free-solid-svg-icons';
+import { faGavel } from '@fortawesome/free-solid-svg-icons';
+import { faTowerObservation } from '@fortawesome/free-solid-svg-icons';
+import { faLock } from '@fortawesome/free-solid-svg-icons';
+import { faGears } from '@fortawesome/free-solid-svg-icons';
+import { faScrewdriverWrench } from '@fortawesome/free-solid-svg-icons';
+import { faBrain } from '@fortawesome/free-solid-svg-icons';
+import { faFlag } from '@fortawesome/free-solid-svg-icons';
+import { faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+
+export const fontAwesomeIcons = {
+  "cubes": faCubes,
+  "terminal": faTerminal,
+  "person-walking-luggage": faPersonWalkingLuggage,
+  "object-ungroup": faObjectUngroup,
+  "object-group": faObjectGroup,
+  "envelope-open-text": faEnvelopeOpenText,
+  "database": faDatabase,
+  "hdd": faHdd,
+  "cloud-arrow-down": faCloudArrowDown,
+  "network-wired": faNetworkWired,
+  "server": faServer,
+  "road": faRoad,
+  "users": faUsers,
+  "layer-group": faLayerGroup,
+  "book": faBook,
+  "shield": faShield,
+  "warehouse": faWarehouse,
+  "flag-checkered": faFlagCheckered,
+  "palette": faPalette,
+  "gavel": faGavel,
+  "tower-observation": faTowerObservation,
+  "lock": faLock,
+  "gears": faGears,
+  "screwdriver-wrench": faScrewdriverWrench,
+  "brain": faBrain,
+  "flag": faFlag,
+  "eye-slash": faEyeSlash
+};


### PR DESCRIPTION
The file was truncated to 0 bytes on version-4-7, breaking @typescript-eslint/no-unsafe-member-access in IconMapper.tsx (surfaced by PR #11405). Restored from version-4-8.