### PR TITLE
docs: correct PaletteAI Inference Launchpad example server configurations (DOC-3039)

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/reference/server-configurations.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/server-configurations.md
@@ -25,14 +25,13 @@ specifications in [Suggested Hardware](./hardware-requirements.md).
 
 <!-- vale Vale.Terms = NO -->
 
-| **Server vendor**        | **Server model**                                   | **GPU vendor** | **GPU**                                           | **CPU**                                            |
-| ------------------------ | -------------------------------------------------- | -------------- | ------------------------------------------------- | -------------------------------------------------- |
-| Supermicro               | SYS-421GE-TNHR-LC1 (liquid-cooled)                 | NVIDIA         | 8x H100 SXM                                       | Intel Xeon Platinum 8570                           |
-| Supermicro               | Contact your Supermicro representative for details | AMD            | 8x Instinct MI350X                                | Contact your Supermicro representative for details |
-| HPE                      | ProLiant Compute DL380a Gen12                      | NVIDIA         | 8x L40S                                           | Intel Xeon 6710E                                   |
-| Dell                     | PowerEdge XE9680                                   | NVIDIA         | 8x H100 80 GB SXM5                                | 2x Intel Xeon Platinum 8570                        |
-| Dell                     | PowerEdge XE7740                                   | NVIDIA         | 8x RTX PRO 6000 Blackwell Server Edition 96 GB/ea | 2x Intel Xeon 6                                    |
-| Vultr (bare metal cloud) | vbm-256c-3072gb-8-mi325x-gpu                       | AMD            | 8x Instinct MI325X 256 GB/ea                      | Contact your Vultr representative for details      |
+| **Server vendor**        | **Server model**                                   | **GPU vendor** | **GPU**                      | **CPU**                                            |
+| ------------------------ | -------------------------------------------------- | -------------- | ---------------------------- | -------------------------------------------------- |
+| Dell                     | PowerEdge XE9680                                   | NVIDIA         | 8x H200 141 GB SXM5          | 2x Intel Xeon Platinum 8570                        |
+| Supermicro               | SYS-A21GE-NBRT                                     | NVIDIA         | 8x B200 180 GB SXM           | 2x Intel Xeon Platinum 8570                        |
+| Supermicro               | Contact your Supermicro representative for details | NVIDIA         | 8x B300 288 GB SXM           | Contact your Supermicro representative for details |
+| Supermicro               | Contact your Supermicro representative for details | AMD            | 8x Instinct MI350X 288 GB/ea | Contact your Supermicro representative for details |
+| Vultr (bare metal cloud) | vbm-256c-3072gb-8-mi325x-gpu                       | AMD            | 8x Instinct MI325X 256 GB/ea | Contact your Vultr representative for details      |
 
 <!-- vale Vale.Terms = YES -->
 


### PR DESCRIPTION
## 📝 Describe the Change

Fixes the **Example Server Configurations** reference page for PaletteAI Inference Launchpad ([DOC-3039](https://spectrocloud.atlassian.net/browse/DOC-3039)). The previous table listed GPU/server configurations that are not viable target configs for the appliance, which undermined credibility with technical audiences.

Changes to the table, mapped to the ticket's acceptance criteria:

- **Removed the NVIDIA L40S row** (HPE ProLiant DL380a). L40S is an older, small GPU and is never used for AIL inference.
- **Removed the non-viable 8x RTX PRO 6000 row** (Dell PowerEdge XE7740). An 8x RTX PRO 6000 server is not a proposed AIL configuration.
- **Removed all liquid-cooling references** (the `SYS-421GE-TNHR-LC1 (liquid-cooled)` annotation is gone). Cooling is a vendor detail and is no longer stated in the table.
- **Replaced the 8x H100 entries** with the actual target NVIDIA GPU classes.
- **Added 8x H200, 8x B200, and 8x B300 configurations** — the classes targeted for the flagship certified models.
- Kept the valid AMD **MI350X** and **MI325X** rows (not flagged in the ticket).
- Added **per-GPU VRAM** to every row so the configurations are unambiguous.

Sources backing the corrected data (internal Confluence + vendor spec sheets):

- Target NVIDIA classes (H200/B200/B300) for the flagship models — *Launchpad-AI - Model Placement and East-West Networking* and *LLM support for AIL*.
- H200 example server — the internal *8x H200 GLM 5.2 demo runbook* ran on a Dell HGX 8x H200 node (air-cooled); Dell PowerEdge XE9680 supports 8x H200 141 GB SXM5.
- B200 example server — Supermicro SYS-A21GE-NBRT (8x B200 180 GB SXM), air-cooled.
- GPU VRAM figures — *Palette and PaletteAI GPU Lookup Table* (H200 141 GB, B200 180 GB, B300 288 GB).
- B300 uses the page's existing "contact your representative" pattern because no specific B300 server SKU is documented internally yet.

**Follow-up (out of scope here):** the sibling `certified-models-by-hardware.md` NVIDIA tab still lists `H300` and `GB100`, which do not exist in the authoritative GPU Lookup Table, and has no `B200`/`B300` rows. Reconciling that page needs SME confirmation of the exact model-to-B200/B300 certification matrix and should be handled in its own ticket.

---

## 💻 Changed Pages

- `docs/docs-content/paletteai-inference-launchpad/reference/server-configurations.md`
- Preview: _Netlify deploy-preview link to be added once the preview build completes._

This PR makes user-facing changes to one reference page.

---

## 🎫 Jira Tickets

[DOC-3039 — Fix PaletteAI Inference Launchpad Server Configurations Reference Page](https://spectrocloud.atlassian.net/browse/DOC-3039)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-3039]: https://spectrocloud.atlassian.net/browse/DOC-3039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ