### PR TITLE
docs: correct install-the-appliance OS, TUI, network, and storage steps

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
@@ -104,7 +104,6 @@ When you change an existing password, the new password must differ from the old 
 1. On the Palette TUI landing page, no local account exists yet, so press **F2** (**Create login**) to create the
    initial administrator account, then set its username and password. This account signs in to Local UI and accesses the
    node over SSH.
-   {/* NEEDS REVIEW: the F2 "Create login" entry point is from PE-8675, which is not yet merged. QA (2026-07-27) confirmed F2 opens the account-creation screen but saw it labeled "Create User" rather than "Create login"; confirm the final label and flow under PE-8675 before publishing. */}
 2. Move between options with **TAB** or the arrow keys. Press **ENTER** to apply a change, and **ESC** to go back.
    - **Hostname.** Review the hostname and change it if required.
    - **Network adapter.** Each adapter uses Dynamic Host Configuration Protocol (DHCP) by default. For each adapter you

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
@@ -67,26 +67,23 @@ begin. The slim ISO and content bundle must match the target hardware's GPU (NVI
 1. Flash the slim ISO to bootable media, such as a USB drive, with an imaging tool such as balenaEtcher. You can also
    transfer the ISO to the node with `scp` or `rsync`.
 2. Attach the media to the node and set the boot order to boot from it first.
-3. Power on the node. At the GRUB menu, let it select the Palette Edge interactive installer.
+3. Power on the node. At the GRUB menu, let it select the Palette Edge interactive installer. After the selection, the
+   screen can stay blank for several minutes with no output while the installer loads. This is expected, so wait for the
+   interactive installer to appear instead of assuming the boot has stalled.
 4. In the interactive installer:
    - When the installer prompts for the registration option after its first boot, select **Palette eXtended Kubernetes
      (PXK)**. This registers the node with the edge Kubernetes distribution the appliance uses.
+     {/* NEEDS REVIEW: QA (2026-07-27) reports the PXK registration boot option is not applicable at this point and appears later in the flow. Confirm the correct step and timing under PE-8675 before publishing. */}
    - The installer inspects every disk and blocks the install if any disk still holds Kairos partitions from a prior
      install. It reports the offending disks by name.
-   - If needed, use the in-flow wipe option to clear leftover partitions. Refer to
-     [Wipe Non-Empty Disks](#wipe-non-empty-disks).
+   - If a disk still holds Kairos partitions, use the in-flow wipe-all-disks option to clear them, so you do not have to
+     drop to a shell. This action is destructive, so confirm the disk selection before you run it.
    - Select the target disk for the operating system. The installer erases this disk, so do not select the disk you
      intend to use for the Piraeus storage pool.
    - Choose the post-install action (reboot or power off).
    - Review the installation summary and press **ENTER** to start.
 5. Wait for the install to finish. It takes at least 15 minutes, depending on hardware. When it finishes, disconnect the
    ISO. If you chose reboot, the node reboots into the Palette TUI; if you chose power off, power it back on.
-
-### Wipe Non-Empty Disks
-
-The interactive installer detects Kairos partitions on any disk and prevents the install until they are cleared, to
-avoid unpredictable behavior from stale partitions. It provides an in-flow wipe-all-disks option, so you do not have to
-drop to a shell. The action is destructive; confirm before you run it.
 
 ## Configure the Node with the Palette TUI
 
@@ -107,7 +104,7 @@ When you change an existing password, the new password must differ from the old 
 1. On the Palette TUI landing page, no local account exists yet, so press **F2** (**Create login**) to create the
    initial administrator account, then set its username and password. This account signs in to Local UI and accesses the
    node over SSH.
-   {/* NEEDS REVIEW: the F2 "Create login" entry point is from PE-8675, which is not yet merged. Confirm the label and flow before publishing; until then F2 opens node customization and the account is created through the TUI account step. */}
+   {/* NEEDS REVIEW: the F2 "Create login" entry point is from PE-8675, which is not yet merged. QA (2026-07-27) confirmed F2 opens the account-creation screen but saw it labeled "Create User" rather than "Create login"; confirm the final label and flow under PE-8675 before publishing. */}
 2. Move between options with **TAB** or the arrow keys. Press **ENTER** to apply a change, and **ESC** to go back.
    - **Hostname.** Review the hostname and change it if required.
    - **Network adapter.** Each adapter uses Dynamic Host Configuration Protocol (DHCP) by default. For each adapter you
@@ -115,9 +112,9 @@ When you change an existing password, the new password must differ from the old 
      Unit (MTU). Setting a static IP removes the DHCP settings.
    - **DNS.** Set the primary and alternate name servers, and an optional search domain.
    - **NTP.** Set one or more NTP servers, for example `0.pool.ntp.org`.
-3. Navigate to **Quit** and confirm. Quit acts as a logout. It ends your TUI session and returns to the device
-   information screen, which shows the node details and the Local UI address. It does not power off the node. To
-   re-enter the TUI later, run `palette-tui` on the node.
+3. Navigate to **Logout** and confirm. It ends your TUI session and returns to the device information screen, which
+   shows the node details and the Local UI address. It does not power off the node. To re-enter the TUI later, run
+   `palette-tui` on the node.
 4. Repeat the OS install and this TUI configuration on every node. On a multi-node cluster, also complete the network
    bond on every node before you link them.
 
@@ -128,21 +125,23 @@ Once the node has an IP address, you can leave the console and reach the node's 
 1. In a browser, go to `https://<node-ip>:5080`, using the IP you set in the Palette TUI. Local UI uses a self-signed
    certificate, so proceed past the browser warning.
 2. Sign in with the credentials you created in the Palette TUI.
-3. Confirm the node reports a pre-cluster state, ready to build or join a cluster.
+3. Confirm the node reports a pre-cluster state. The node has an IP address but is not yet part of a cluster, so Local
+   UI shows it as ready to build a new cluster or join an existing one rather than reporting a running cluster.
 
 ### Create a Bond
 
-1. In Local UI, open **Network Interfaces**.
-2. Under **Bonds**, select **Create**.
-3. Fill in the bond form. The **Name** field shows `bond0` as placeholder text, not a saved value, so click into it and
-   type the name before you continue. Set **Bond type** to `static` so the bond keeps a fixed IP, select the member NICs
-   manually, and set the **Bonding mode** to `802.3ad`. Bond type (the IP method) and bonding mode (the link-aggregation
-   algorithm) are separate fields. For each field's recommended value, meaning, and when to deviate, refer to
+The **Network Interfaces** view is already open in Local UI, so you do not need to navigate to it separately.
+
+1. Under **Bonds**, select **Create**.
+2. Fill in the bond form. The **Name** field shows `bond0` as placeholder text, not a saved value, so click into it and
+   type the name before you continue. Set **Bond type** to `static` so the bond keeps a fixed IP, then enter the **IP
+   Address** and **Subnet mask**, which are both required. **Gateway** is optional. Select the member NICs manually, and
+   set the **Bonding mode** to `802.3ad`. Bond type (the IP method) and bonding mode (the link-aggregation algorithm)
+   are separate fields. For each field's recommended value, meaning, and when to deviate, refer to
    [Bond Configuration Reference](../reference/bond-configuration.md). The values must match how your data-center switch
    is configured on the ports the appliance is plugged into, so coordinate with your network administrator before you
    apply.
-
-4. Select **Apply**. If Local UI is briefly unreachable, reload the same address after a few seconds. The IP moves from
+3. Select **Apply**. If Local UI is briefly unreachable, reload the same address after a few seconds. The IP moves from
    the network interface card (NIC) to the bond.
 
 ## Configure the Storage
@@ -162,11 +161,12 @@ creation, the group becomes read-only. Confirm the disk selection before you con
 :::
 
 1. In Local UI, open the **Edgehost** tab.
-2. Under **Hardware**, select **Disks**. A side pane opens listing every disk on the host.
-3. Under **Data volume group**, select **Create volume** to open the wizard.
+2. Under **Hardware**, select the disks link. This link is labeled with the number of disks on the host, for example **5
+   disks**, rather than the word **Disks**. A side pane opens listing every disk on the host.
+3. Under **Data volume group**, select **Create data volume group** to open the wizard.
 4. Review the disk selection. By default, the wizard selects every data disk on the host and automatically excludes the
    operating system disk, so you cannot add it to the volume group by mistake. Deselect any data disk you want to keep
-   out of the volume group.
+   out of the volume group. You can leave the wizard's other settings at their defaults for a standard installation.
 5. Select **Create** to apply. The new entry appears under **Data volume group**.
 
 ## Link Hosts (Multi-Node Only)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
@@ -522,7 +522,6 @@ For the full flag list, the metadata file schema, the on-appliance layout, and t
 After the model is uploaded, the remaining tasks are day-two product usage, covered by the existing how-to guides:
 
 - **Deploy a model**. [Deploy a Model](./deploy-a-model.md).
-- **Set the default model**. [Set the Default Model](./set-the-default-model.md).
 - **Generate an API token**. [Generate an API Token](./generate-an-api-token.md).
 - **Connect a coding tool**. [Claude Code](./use-claude-code.md), [Cursor](./use-cursor.md),
   [OpenAI Codex](./use-codex.md), or [OpenCode](./use-opencode.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
@@ -161,8 +161,8 @@ creation, the group becomes read-only. Confirm the disk selection before you con
 :::
 
 1. In Local UI, open the **Edgehost** tab.
-2. Under **Hardware**, select the disks link. This link is labeled with the number of disks on the host, for example **5
-   disks**, rather than the word **Disks**. A side pane opens listing every disk on the host.
+2. Under **Hardware**, select the disks link. This link is labeled with the number of disks on the host (for example,
+   **5 disks**) rather than the word **Disks**. A side pane opens listing every disk on the host.
 3. Under **Data volume group**, select **Create data volume group** to open the wizard.
 4. Review the disk selection. By default, the wizard selects every data disk on the host and automatically excludes the
    operating system disk, so you cannot add it to the volume group by mistake. Deselect any data disk you want to keep


### PR DESCRIPTION
## Summary

Applies the [DOC-3045](https://spectrocloud.atlassian.net/browse/DOC-3045) walkthrough corrections (child of epic
[DOC-3044](https://spectrocloud.atlassian.net/browse/DOC-3044)) to the OS install → storage phase of the PaletteAI
Inference Launchpad installation guide. [Source: Jon Bergfeld's end-to-end install test pass (27 Jul 2026)](https://docs.google.com/document/d/1Jt7hjjYqebKajk5Ag_79GAy0MLoNU8lM4FTJz8QDuU4/edit?usp=drive_link).

Scope is limited to `install-the-appliance.md`; product/UI bugs from the same test pass are out of scope.

## Changes

**Label corrections QA confirmed**

- Palette TUI step 3: **Quit** → **Logout** (and dropped the now-redundant "Quit acts as a logout" phrasing).
- Storage step 3: **Create volume** → **Create data volume group**.
- Storage step 2: the disks link is labeled with the disk count (for example **5 disks**), not the word **Disks**.

**Removed / relocated**

- Removed the redundant "open Network Interfaces" step in Create a Bond (the view is already shown).
- Inlined the disk-wipe guidance at the disk-inspection step where the wipe happens, and removed the standalone
  **Wipe Non-Empty Disks** subsection (its only reference was its own link, now inlined).

**Gaps filled**

- Documented the required **IP Address** and **Subnet mask** bond fields (with **Gateway** noted as optional).
- Added an expected-behavior note that the screen can stay blank for a few minutes after the GRUB selection.
- Clarified what the "pre-cluster state" means for a first-time user.
- Noted the volume-group wizard defaults suit a standard install.

## Flagged / deferred (not silently changed)

- **PE-8675 (blocked, unmerged):** the Step 4 **PXK registration** wording and the TUI **Create login / Create User**
  label are flagged with inline `NEEDS REVIEW` comments rather than rewritten, because the correct label/flow depends on
  PE-8675. QA's 27 Jul observations are recorded in those comments.
- **SME decision (deferred):** whether the essential bond values should be inlined vs. kept only in the Bond
  Configuration Reference. Left as-is (reference link) pending an SME call.

## Validation

- `prettier --check` — passes.
- `vale` — no errors on the changed lines. (The pre-existing `repos` spelling error on an unchanged line is not part of
  this diff.)

Refs DOC-3045.


[DOC-3045]: https://spectrocloud.atlassian.net/browse/DOC-3045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-3044]: https://spectrocloud.atlassian.net/browse/DOC-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ