### PR TITLE
docs: hide PaletteAI Inference Launchpad example server configurations page (DOC-3057)

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/reference/hardware-requirements.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/hardware-requirements.md
@@ -23,10 +23,8 @@ keywords:
 This page lists the hardware requirements for a PaletteAI Inference Launchpad appliance. Requirements are model-driven:
 the target model determines the GPU count, GPU memory, host RAM, and storage.
 
-For example server configurations that meet these requirements, refer to
-[Example Server Configurations](./server-configurations.md). For model-to-hardware mapping, refer to
-[Certified Models by Hardware](./certified-models-by-hardware.md). For the design decisions behind these requirements,
-refer to [Architecture Overview](../explanation/architecture.md).
+For model-to-hardware mapping, refer to [Certified Models by Hardware](./certified-models-by-hardware.md). For the
+design decisions behind these requirements, refer to [Architecture Overview](../explanation/architecture.md).
 
 ## Hardware Requirements
 
@@ -122,6 +120,5 @@ workstation before upload.
 
 ## Resources
 
-- [Example Server Configurations](./server-configurations.md) for example machines that meet these requirements.
 - [Certified Models by Hardware](./certified-models-by-hardware.md) for model-to-hardware mapping.
 - [Architecture Overview](../explanation/architecture.md) for the design decisions behind these requirements.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/reference.md
@@ -18,7 +18,6 @@ is configured, not how to accomplish a task.
 | [Suggested Hardware](./hardware-requirements.md)                  | Compute, GPU, memory, storage, and network requirements for the appliance.                     |
 | [Bond Configuration](./bond-configuration.md)                     | Field-by-field reference for the Local UI bond form used during installation.                  |
 | [Cluster Profile Variables](./profile-variables.md)               | Every variable the Profile Config wizard collects, with types, defaults, and validation rules. |
-| [Example Server Configurations](./server-configurations.md)       | Example AMD and NVIDIA server configurations for the appliance.                                |
 | [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration.                |
 | [Model Upload Reference](./model-upload-reference.md)             | Palette CLI model download and upload flags, and the model metadata file fields.               |
 | [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.                    |

--- a/docs/docs-content/paletteai-inference-launchpad/reference/server-configurations.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/server-configurations.md
@@ -6,6 +6,7 @@ description: >
   from multiple vendors.
 sidebar_label: Example Server Configurations
 sidebar_position: 3
+unlisted: true
 tags:
   - paletteai-inference-launchpad
   - reference

--- a/docs/docs-content/paletteai-inference-launchpad/release-notes.md
+++ b/docs/docs-content/paletteai-inference-launchpad/release-notes.md
@@ -30,8 +30,8 @@ conceptual introduction, refer to [What is PaletteAI Inference Launchpad?](./pal
   [Install the Appliance](./how-to-guides/install-the-appliance.md) for more information.
 
 - Runs on a single high-density GPU server with NVIDIA or AMD GPUs, NVMe storage, and bonded NICs, sized to the target
-  model from a baseline of 4 GPUs. Refer to [Suggested Hardware](./reference/hardware-requirements.md) and
-  [Example Server Configurations](./reference/server-configurations.md) for more information.
+  model from a baseline of 4 GPUs. Refer to [Suggested Hardware](./reference/hardware-requirements.md) for more
+  information.
 
 - Certifies a focused set of LLMs for coding-assistant use, GLM 5.2, DeepSeek v4 Pro, Kimi 2.7, and Gemma 4, and lets
   you load any other model that fits the available GPU memory. Refer to


### PR DESCRIPTION
## 📝 Describe the Change

Takes down the PaletteAI Inference Launchpad **Example Server Configurations** reference page ([DOC-3057](https://spectrocloud.atlassian.net/browse/DOC-3057)). The page's GPU and server data was deemed inaccurate and misleading, so rather than continue correcting it (the abandoned DOC-3039 approach, PR #11412), it is being removed from the published docs.

Changes:

- **Hide the page** — added `unlisted: true` to `reference/server-configurations.md`. This is the repo's established Docusaurus hide convention: the page drops out of the (autogenerated) reference sidebar, the search index, and the sitemap. The URL still resolves, so existing external bookmarks do not hard-404.
- **Removed all four inbound links** so no reader can navigate to the page:
  - `release-notes.md` — dropped the link from the hardware bullet (kept the Suggested Hardware link).
  - `reference/reference.md` — removed the row from the reference index table.
  - `reference/hardware-requirements.md` — removed the inline "example server configurations" sentence and the **Resources** list item.

Verified locally: Prettier and Vale are clean, and no references to `server-configurations` remain anywhere in the docs. The Netlify deploy-preview / Build check on this PR confirms no broken links.

**Follow-up (`[SME]`, not in this PR):** if "unlisted" is not strong enough and the page must be fully removed from the production build, a follow-up can switch to `draft: true` or delete the file (all inbound links are already gone, so a hard removal will not break the build). Also coordinate with **DOC-3042** (PR #11409), which removes the non-existent GPU rows from the sibling `certified-models-by-hardware.md`.

---

## 💻 Changed Pages

- `docs/docs-content/paletteai-inference-launchpad/reference/server-configurations.md` (now unlisted)
- `docs/docs-content/paletteai-inference-launchpad/release-notes.md`
- `docs/docs-content/paletteai-inference-launchpad/reference/reference.md`
- `docs/docs-content/paletteai-inference-launchpad/reference/hardware-requirements.md`
- Preview: _Netlify deploy-preview link added once the preview build completes._

This PR makes user-facing changes (removes a page from navigation and removes inbound links).

---

## 🎫 Jira Tickets

[DOC-3057 — Hide the PaletteAI Inference Launchpad "Example Server Configurations" reference page](https://spectrocloud.atlassian.net/browse/DOC-3057)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-3057]: https://spectrocloud.atlassian.net/browse/DOC-3057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ