### PR TITLE
docs: note transient node Degraded state during model deployment

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
@@ -53,6 +53,13 @@ Confirm the model is serving before you route traffic to it.
    `deploying` or `smoke-testing` means the model is still coming online, and a state of `failed` or
    `verification failed` means the model did not come online.
 
+:::info
+
+While a model is deploying, a node hosting it can briefly report a `Degraded` or `Not serving` state. This is expected
+during deployment and clears once the model finishes coming online, at which point the node returns to a healthy state.
+
+:::
+
 For why a model becomes routable only after it passes its smoke test, refer to
 [Model Provisioning Lifecycle](../explanation/architecture.md#model-provisioning-lifecycle).
 


### PR DESCRIPTION
## Summary

Addresses [DOC-3048](https://spectrocloud.atlassian.net/browse/DOC-3048) (child of epic
[DOC-3044](https://spectrocloud.atlassian.net/browse/DOC-3044)) from Jon Bergfeld's install/first-use test pass
(27 Jul 2026). Scope is `deploy-a-model.md` only.

## Change

- Added an `:::info` admonition in **Verify the Model Is Serving** noting that a node hosting a model can briefly report
  a `Degraded` or `Not serving` state during deployment and returns to healthy on its own once the model finishes coming
  online. This sets expectations for a normal transient state Jon observed during deploy.

## Deferred (not in this PR)

- **Item 1 — the "left main menu" navigation.** On review this is a **product visibility bug**, not a docs fix: the
  guide's `left main menu → Cluster` path is correct once the navigation renders (Jon confirmed "Cluster → Models, I see
  the model deploying"), and "left main menu" is the style-guide-approved term for the side navbar. The left navigation
  simply does not render until the user signs out and back in. Documenting a "use the home page instead" workaround would
  bake in buggy behavior, which the epic scope excludes. Recommend tracking the nav-visibility bug as a product ticket,
  or confirming the intended first-load entry point with an SME before any doc change.

## Validation

- `prettier --check` — passes.
- `vale` — 0 errors, 0 warnings on the file.

Refs DOC-3048.


[DOC-3048]: https://spectrocloud.atlassian.net/browse/DOC-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-3044]: https://spectrocloud.atlassian.net/browse/DOC-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ