### PR TITLE
docs: rewrite and rename the default-model guide to Switch the Default Model (DOC-3049)

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/architecture.md
@@ -76,6 +76,14 @@ already routed continue on their assigned model, and the new default applies onl
 Before it routes a request, the gateway authenticates the calling client from its API token and enforces that client's
 quotas. For how clients, API tokens, and quotas work together, refer to [Clients and Quotas](./clients-and-quotas.md).
 
+### The Default Model
+
+The appliance sets the default model for you. The model you deploy during setup becomes the default, and if only one
+model serves, that model is the default. The appliance does not switch the default to a different model on its own. When
+the current default stops serving, the appliance raises an incident on the **Overview** page and offers a one-step fix
+so you can switch the default to a model that is currently serving. For that procedure, refer to
+[Set the Default Model](../how-to-guides/set-the-default-model.md).
+
 ## Network Topology
 
 ## Data Residency and Isolation

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/architecture.md
@@ -82,7 +82,7 @@ The appliance sets the default model for you. The model you deploy during setup 
 model serves, that model is the default. The appliance does not switch the default to a different model on its own. When
 the current default stops serving, the appliance raises an incident on the **Overview** page and offers a one-step fix
 so you can switch the default to a model that is currently serving. For that procedure, refer to
-[Set the Default Model](../how-to-guides/set-the-default-model.md).
+[Switch the Default Model](../how-to-guides/set-the-default-model.md).
 
 ## Network Topology
 

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
@@ -78,5 +78,5 @@ resolve the unknown allocation on the affected nodes. Then deploy the model agai
 
 ## Next Steps
 
-To configure which model handles requests that do not name a model explicitly, refer to
-[Set the Default Model](./set-the-default-model.md).
+To change which model handles requests that do not name a model explicitly, refer to
+[Switch the Default Model](./set-the-default-model.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -18,7 +18,7 @@ you the steps to do it without teaching background concepts.
 | [Install the Appliance](./install-the-appliance.md)               | Flash the installer ISO, boot the hardware, and bring up the appliance console.  |
 | [Deploy a Model](./deploy-a-model.md)                             | Deploy an LLM to the cluster and verify it is serving.                           |
 | [Upload a Model](./upload-a-model.md)                             | Download a model on a jumpbox and upload it to the appliance.                    |
-| [Set the Default Model](./set-the-default-model.md)               | Configure which model handles requests that do not name a model explicitly.      |
+| [Switch the Default Model](./set-the-default-model.md)            | Switch the default model when the current default becomes unavailable.           |
 | [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.           |
 | [Create a Client](./create-a-client.md)                           | Create a client and issue its first API token.                                   |
 | [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, and remove a client's request, token, and cost limits.                |

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
@@ -23,6 +23,8 @@ not name a model, the appliance routes it to the default model. For how the appl
 
 Set the default model from the _Overview_. You can only select a model that the appliance currently serves.
 
+{/* NEEDS REVIEW: the "switch default model" control was not displayed on Overview during QA testing (2026-07-27). Confirm the exact condition under which it appears (for example, at least one deployed and serving model, or possibly more than one model) and document it here before publishing. */}
+
 1. From the left main menu, select **Overview**.
 
 2. Open the **switch default model** drop-down menu and select the model to make default.
@@ -34,4 +36,6 @@ For what happens to requests that are in progress when you change the default mo
 
 ## Next Steps
 
-To deploy another model to the appliance, refer to [Deploy a Model](./deploy-a-model.md).
+- **Generate an API token** to send requests to the default model. Refer to
+  [Generate an API Token](./generate-an-api-token.md).
+- **Deploy another model** to the appliance. Refer to [Deploy a Model](./deploy-a-model.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
@@ -2,20 +2,16 @@
 sidebar_label: "Set the Default Model"
 title: "Set the Default Model"
 description:
-  "Guidance for platform operators on how a PaletteAI Inference Launchpad appliance sets the default model for unrouted
-  requests, and how to switch it from the Overview page when the current default becomes unavailable."
+  "Task guidance for platform operators on how to switch the default model on a PaletteAI Inference Launchpad appliance
+  from the Overview page when the current default is no longer serving."
 hide_table_of_contents: false
 sidebar_position: 2
 tags: ["paletteai-inference-launchpad", "models", "how-to"]
 ---
 
-This guide explains how the default model is set on a running PaletteAI Inference Launchpad appliance and how to switch
-it. If a request does not name a model, the appliance routes it to the default model. For how the appliance routes
-requests, refer to [Architecture](../explanation/architecture.md).
-
-The appliance sets the default model for you and does not switch it to a different model on its own. As a result, the
-console has no dedicated control to choose the default during normal operation. You change the default from the
-**Overview** page only when the appliance flags the current default as unavailable.
+This guide shows how to switch the default model on a running PaletteAI Inference Launchpad appliance when the current
+default is no longer serving. The appliance sets and maintains the default model for you; for how the default is chosen
+and applied, refer to [The Default Model](../explanation/architecture.md#the-default-model).
 
 ## Prerequisites
 
@@ -23,23 +19,19 @@ console has no dedicated control to choose the default during normal operation. 
 - A model other than the current default already deployed and serving, so that a healthy model is available to switch
   to. To deploy and verify a model, refer to [Deploy a Model](./deploy-a-model.md).
 
-## How the Default Model Is Set
+## Switch the Default Model
 
-- The model you deploy during initial appliance setup becomes the default model.
-- If you deploy only one model, that model serves as the default.
-
-## Switch the Default Model After an Incident
-
-When the current default model stops serving, for example after you remove it or the node hosting it goes down, the
-**Overview** page raises an incident and offers a one-step fix to point the default at a model that is currently
-serving.
+When the current default model stops serving, the **Overview** page raises an incident and offers a one-step fix to
+point the default at a model that is currently serving.
 
 1. From the left main menu, select **Overview**.
 2. In the **Decisions waiting on you** card, locate the active incident for the default model.
 3. Open the **switch default model** drop-down menu and select a model that the appliance currently serves.
 4. Select **Apply Fix**, and then select **Confirm & apply**.
 
-The appliance switches the default model and re-runs its health check to confirm the new default recovers.
+The appliance switches the default model and re-runs its health check to confirm the new default recovers. For what
+happens to requests already in progress when the default changes, refer to
+[Request Routing](../explanation/architecture.md#request-routing).
 
 :::info
 
@@ -47,9 +39,6 @@ If no model is currently serving, the card reports that there is nothing to swit
 **Cluster** tab first, then return to the **Overview** page. Refer to [Deploy a Model](./deploy-a-model.md).
 
 :::
-
-For what happens to requests that are in progress when the default model changes, refer to
-[Architecture](../explanation/architecture.md).
 
 ## Next Steps
 

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
@@ -2,36 +2,53 @@
 sidebar_label: "Set the Default Model"
 title: "Set the Default Model"
 description:
-  "Step-by-step guidance for platform operators on how to set the default model that handles unrouted requests on a
-  running PaletteAI Inference Launchpad appliance."
+  "Guidance for platform operators on how a PaletteAI Inference Launchpad appliance sets the default model for unrouted
+  requests, and how to switch it from the Overview page when the current default becomes unavailable."
 hide_table_of_contents: false
 sidebar_position: 2
 tags: ["paletteai-inference-launchpad", "models", "how-to"]
 ---
 
-This guide explains how to set the default model on a running PaletteAI Inference Launchpad appliance. If a request does
-not name a model, the appliance routes it to the default model. For how the appliance routes requests, refer to
-[Architecture](../explanation/architecture.md).
+This guide explains how the default model is set on a running PaletteAI Inference Launchpad appliance and how to switch
+it. If a request does not name a model, the appliance routes it to the default model. For how the appliance routes
+requests, refer to [Architecture](../explanation/architecture.md).
+
+The appliance sets the default model for you and does not switch it to a different model on its own. As a result, the
+console has no dedicated control to choose the default during normal operation. You change the default from the
+**Overview** page only when the appliance flags the current default as unavailable.
 
 ## Prerequisites
 
 - A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
-- The model you want to make default already deployed and serving. To deploy and verify a model, refer to
-  [Deploy a Model](./deploy-a-model.md).
+- A model other than the current default already deployed and serving, so that a healthy model is available to switch
+  to. To deploy and verify a model, refer to [Deploy a Model](./deploy-a-model.md).
 
-## Set the Default Model
+## How the Default Model Is Set
 
-Set the default model from the _Overview_. You can only select a model that the appliance currently serves.
+- The model you deploy during initial appliance setup becomes the default model.
+- If you deploy only one model, that model serves as the default.
 
-{/* NEEDS REVIEW: the "switch default model" control was not displayed on Overview during QA testing (2026-07-27). Confirm the exact condition under which it appears (for example, at least one deployed and serving model, or possibly more than one model) and document it here before publishing. */}
+## Switch the Default Model After an Incident
+
+When the current default model stops serving, for example after you remove it or the node hosting it goes down, the
+**Overview** page raises an incident and offers a one-step fix to point the default at a model that is currently
+serving.
 
 1. From the left main menu, select **Overview**.
+2. In the **Decisions waiting on you** card, locate the active incident for the default model.
+3. Open the **switch default model** drop-down menu and select a model that the appliance currently serves.
+4. Select **Apply Fix**, and then select **Confirm & apply**.
 
-2. Open the **switch default model** drop-down menu and select the model to make default.
+The appliance switches the default model and re-runs its health check to confirm the new default recovers.
 
-3. Select **Apply fix**, and then confirm.
+:::info
 
-For what happens to requests that are in progress when you change the default model, refer to
+If no model is currently serving, the card reports that there is nothing to switch to. Deploy a model from the
+**Cluster** tab first, then return to the **Overview** page. Refer to [Deploy a Model](./deploy-a-model.md).
+
+:::
+
+For what happens to requests that are in progress when the default model changes, refer to
 [Architecture](../explanation/architecture.md).
 
 ## Next Steps

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: "Set the Default Model"
-title: "Set the Default Model"
+sidebar_label: "Switch the Default Model"
+title: "Switch the Default Model"
 description:
   "Task guidance for platform operators on how to switch the default model on a PaletteAI Inference Launchpad appliance
   from the Overview page when the current default is no longer serving."


### PR DESCRIPTION
## Summary

Corrects and reworks the default-model how-to for [DOC-3049](https://spectrocloud.atlassian.net/browse/DOC-3049)
(child of epic [DOC-3044](https://spectrocloud.atlassian.net/browse/DOC-3044)), from Jon Bergfeld's install/first-use
test pass. The original guide documented a control that does not exist in normal operation; this PR corrects it against
the product UI source, restructures it along Diátaxis lines, and renames it.

## What changed

- **Renamed the guide to "Switch the Default Model"** (title + sidebar label). The old name, "Set the Default Model",
  implied a routine set-the-default task the UI does not provide. Inbound link text is updated in
  `explanation/architecture.md`, `how-to-guides/deploy-a-model.md`, and the how-to index. The filename/slug
  (`set-the-default-model.md`) is unchanged to avoid altering a published URL.
- **Corrected the procedure against the product source.** The guide previously presented "Overview → switch default
  model → Apply fix" as a routine way to set the default. In the current UI that control is an incident-recovery
  affordance: it appears only when the current default model stops serving, and it switches the default to a
  currently-served model. The how-to now documents that accurately, with correct labels (**Decisions waiting on you** →
  **switch default model** → **Apply Fix** → **Confirm & apply**) and the no-model-serving case.
- **Restored a clean Diátaxis boundary.** The how-to is now task-only. The understanding-oriented content (the default
  is set to the model you deploy at setup; a single served model acts as default; the appliance does not switch it on
  its own) moved to a new **"The Default Model"** subsection under Request Routing in `explanation/architecture.md`,
  which the how-to links to.
- **Next Steps** points forward to **Generate an API Token**.

## Left for other PRs (to avoid conflicts)

Two inbound links still read "Set the Default Model" and point at this guide; they live in work owned elsewhere, so they
should be updated there:

- `release-notes.md` → PR #11246 (release notes)
- `reference/glossary.md` → DOC-2929 glossary branch

## Source basis (UI-facing only)

`ui/src/ControlRoom.tsx` (incident-gated `IncidentFix`), `ui/src/App.tsx` (Overview → ControlRoom), `ui/src/FirstBoot.tsx`
(setup records the default). Confirmed no other console control sets the default. Config/CRD/API paths are out of scope
per the UI-facing-only decision.

## Validation

- `style-guide.md` compliance — passes (the how-to is mode-pure; explanation lives in the explanation doc).
- `prettier --check` — passes.
- `vale` — 0 errors, 0 warnings.

Refs DOC-3049.


[DOC-3049]: https://spectrocloud.atlassian.net/browse/DOC-3049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-3044]: https://spectrocloud.atlassian.net/browse/DOC-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ