### PR TITLE
docs: document the revoke icon and the Suspend client action (DOC-3055)

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/explanation/clients-and-quotas.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/clients-and-quotas.md
@@ -60,6 +60,19 @@ A client can hold more than one API token. When each developer or coding tool th
 token, revoking one token (for example, after a developer leaves the team) does not disturb the others. Revoking the
 client itself revokes every token that belongs to it.
 
+## Client Lifecycle
+
+A client is active by default. You can suspend it, delete it, or revoke its individual API tokens without changing the
+client itself.
+
+- **Suspend** blocks a client's requests but keeps its API tokens, quotas, and routing settings in place. A suspended
+  client can be resumed at any time, so suspension is reversible.
+- **Delete** permanently retires a client and removes its quota, egress, and routing settings. It revokes every API
+  token the client owns. The client's audit history is preserved, and a delete cannot be undone.
+
+An API token has its own state. A token stays active until it is revoked or passes its expiration date. The appliance
+rejects any request that presents a revoked or expired token, fail-closed.
+
 ## Quotas
 
 A quota is a consumption limit attached to a client. The appliance enforces quotas across three dimensions:

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/revoke-or-delete-a-client.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/revoke-or-delete-a-client.md
@@ -11,8 +11,8 @@ keywords: ["launchpad", "ai", "clients", "revoke", "delete", "expired", "api tok
 ---
 
 This guide explains how a platform administrator ends a client's access on a PaletteAI Inference Launchpad appliance:
-finding expired or revoked tokens, revoking a single API token, and deleting a client. To understand how clients and API
-tokens relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+finding expired or revoked tokens, revoking a single API token, and suspending or deleting a client. To understand how
+clients and API tokens relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
 
 ## Prerequisites
 
@@ -44,18 +44,27 @@ The **Usage** page also shows a token's state in its per-token detail. For usage
 
 3. Select the **API tokens** section.
 
-4. Find the token, and then select **Revoke**.
+4. Find the token, then select the **Revoke access** icon (a prohibit symbol) at the end of its row, and confirm in the
+   **Revoke token** dialog.
 
 Revoking a token is immediate and cannot be undone.
 
-## Delete a Client
+## Suspend or Delete a Client
+
+The **Overview** section of a client's detail panel offers two lifecycle actions, each behind a confirmation:
+
+- **Suspend** blocks the client's requests but keeps its API tokens, quotas, and routing settings in place, so you can
+  resume it later. Suspending is reversible.
+- **Delete** permanently retires the client, removes its quota, egress, and routing settings, and revokes every API
+  token the client owns. The client's audit history is preserved, and you cannot undo a delete.
 
 1. From the left main menu, select **Access & Policy**.
 
-2. On the **Clients & API tokens** page, select the client's delete action, and then confirm.
-   {/* NEEDS REVIEW: exact delete control and confirmation wording. */}
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
 
-Deleting a client revokes every API token that belongs to it.
+3. Select the **Overview** section, then select **Suspend** or **Delete**, and then confirm.
+
+To restore a suspended client, select **Resume** in the **Overview** section.
 
 ## Next Steps
 

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/revoke-or-delete-a-client.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/revoke-or-delete-a-client.md
@@ -22,8 +22,8 @@ clients and API tokens relate, refer to [Clients and Quotas](../explanation/clie
 
 ## Find Expired or Revoked Keys
 
-An API token that passes its expiration date becomes expired, and the appliance rejects any request that presents it,
-fail-closed. The console shows each token's state so you can find expired tokens.
+The console shows each token's state, so you can find expired or revoked tokens. For how the appliance enforces token
+expiry and revocation, refer to [Client Lifecycle](../explanation/clients-and-quotas.md#client-lifecycle).
 
 1. From the left main menu, select **Access & Policy**.
 
@@ -51,12 +51,11 @@ Revoking a token is immediate and cannot be undone.
 
 ## Suspend or Delete a Client
 
-The **Overview** section of a client's detail panel offers two lifecycle actions, each behind a confirmation:
+Suspend a client to block its requests temporarily; suspension is reversible. Delete a client to permanently retire it,
+which revokes all its API tokens and cannot be undone. For what each action keeps or removes, refer to
+[Client Lifecycle](../explanation/clients-and-quotas.md#client-lifecycle).
 
-- **Suspend** blocks the client's requests but keeps its API tokens, quotas, and routing settings in place, so you can
-  resume it later. Suspending is reversible.
-- **Delete** permanently retires the client, removes its quota, egress, and routing settings, and revokes every API
-  token the client owns. The client's audit history is preserved, and you cannot undo a delete.
+Both actions are in the **Overview** section of the client's detail panel, each behind a confirmation.
 
 1. From the left main menu, select **Access & Policy**.
 


### PR DESCRIPTION
## Summary

Addresses [DOC-3055](https://spectrocloud.atlassian.net/browse/DOC-3055) (child of epic
[DOC-3044](https://spectrocloud.atlassian.net/browse/DOC-3044)) from Jon Bergfeld's install/first-use test pass. Both
items are reconciled against the `launchpad-ai` UI source, and the how-to is kept as a pure Diátaxis how-to.

## Changes

**`how-to-guides/revoke-or-delete-a-client.md` (how-to — task-only)**

- **Revoke is an icon action.** Select the **Revoke access** icon (a prohibit symbol) in the token's row, which opens a
  **Revoke token** confirmation — not a labeled button. (`tenant/TokenCreate.tsx` `TokenRevokeAction`.)
- **Suspend documented alongside Delete.** New **Suspend or Delete a Client** section with the steps: both actions are
  in the **Overview** section of the client's detail panel, each behind a confirmation, with **Resume** to restore a
  suspended client. (`clients/ClientDrawer.tsx` `OverviewSection` → `LifecycleActions`.)
- Kept only concise decision/warning cues in the how-to (Suspend is reversible; Delete is permanent and revokes all
  tokens); the detailed behavior links out to the explanation. Resolved the stale delete-control `NEEDS REVIEW`.

**`explanation/clients-and-quotas.md` (explanation — the "why/what")**

- New **Client Lifecycle** section: what Suspend and Delete keep vs. remove, reversibility, and how token expiry and
  revocation are enforced (fail-closed). The how-to links here, keeping the how-to/explanation boundary clean.

## Validation

- `style-guide.md` compliance — passes (how-to is mode-pure; behavior lives in the explanation doc).
- `prettier --check` — passes.
- `vale` — 0 errors, 0 warnings on the diff.

Refs DOC-3055.


[DOC-3055]: https://spectrocloud.atlassian.net/browse/DOC-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-3044]: https://spectrocloud.atlassian.net/browse/DOC-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ