### PR TITLE
docs: correct token guide navigation and button label (DOC-3050)

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/generate-an-api-token.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/generate-an-api-token.md
@@ -29,11 +29,20 @@ If an administrator already gave you an API token, you can use it and skip the f
 
 2. From the left main menu, select **Access & Policy**. The **Clients & API tokens** page opens.
 
-3. Select the client to open its detail panel, and then select the **API tokens** section.
+3. In the client's row, open the three-dot menu and select **Manage Client**. The client's detail panel opens to the
+   **Overview** section.
 
-4. Select **Mint an API token**, and optionally set a **Label** and an **Expires** date.
+4. Select the **API tokens** section, and then select **Create Token**. The **Create API token** dialog opens.
 
-5. When the console reveals the token, select **Copy**. The token begins with `lpai_`.
+5. _(Optional)_ In the **Label** field, enter a name that identifies the token, such as the coding assistant that uses
+   it.
+
+6. _(Optional)_ To set an expiration date, clear **Never expires**, and then choose an **Expires** date. By default, the
+   token does not expire.
+
+7. Select **Create Token**.
+
+8. When the console reveals the token, select **Copy**. The token begins with `lpai_`.
 
 :::warning
 


### PR DESCRIPTION
## Summary

Corrects the navigation and button label in the **Generate an API Token** how-to guide, per [DOC-3050](https://spectrocloud.atlassian.net/browse/DOC-3050) (child of the [DOC-3044](https://spectrocloud.atlassian.net/browse/DOC-3044) install-guide QA epic from Jon Bergfeld's end-to-end test pass).

## Changes

- Replaces the ambiguous "Select the client to open its detail panel" step with the actual path: in the client's row, open the three-dot menu and select **Manage Client**, then select the **API tokens** section.
- Renames the **Mint an API token** action to **Create Token** to match the console.
- Splits the label and expiry into clear optional steps, using the real field names (**Label**, **Never expires**, **Expires**) and the **Create API token** dialog title.

## Verification

Every UI string was verified against the Launchpad for AI console source (`ui/src/clients/`):

- Row menu item **Manage Client** — `ClientsTable.tsx`
- Drawer section **API tokens** — `ClientDrawer.tsx` / `sections.ts`
- **Create Token** button and **Create API token** dialog — `ClientDrawer.tsx`, `CreateTokenModal.tsx`
- **Label** / **Never expires** / **Expires** fields — `ApiTokenFormFields.tsx`
- Token `lpai_` prefix — `api.ts`

Prettier and Vale (`--minAlertLevel=error`) both pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-3050]: https://spectrocloud.atlassian.net/browse/DOC-3050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-3044]: https://spectrocloud.atlassian.net/browse/DOC-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ