### PR TITLE
docs: clarify Create a Client Egress and Routing steps and fix the token label (DOC-3051)

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/create-a-client.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/create-a-client.md
@@ -39,14 +39,17 @@ grants model access, and optionally issues the client's first API token.
 5. _(Optional)_ On the **Quotas** step, add usage limits for the client, and then select **Next step**. For details,
    refer to [Set and Manage Client Quotas](./manage-client-quotas.md).
 
-6. _(Optional)_ On the **Egress** step, allow the client to reach external models, and then select **Next step**. For
-   details, refer to [Manage a Client's Model Access](./manage-client-model-access.md).
+6. _(Optional)_ On the **Egress** step, select **Enable egress** to let the client reach external, or frontier, models,
+   and then select **Next step**. External access is denied by default. To add a provider key and set a daily spend cap,
+   refer to [Manage a Client's Model Access](./manage-client-model-access.md#allow-a-client-to-reach-external-models).
 
-7. _(Optional)_ On the **Routing** step, route the client to specific models, and then select **Next step**. For
-   details, refer to [Manage a Client's Model Access](./manage-client-model-access.md).
+7. _(Optional)_ On the **Routing** step, leave the **Tier map** unchanged to route the client with the appliance's
+   default model routing, or edit the **Tier map** to route the client's model aliases to specific models. Then select
+   **Next step**. For details, refer to
+   [Manage a Client's Model Access](./manage-client-model-access.md#route-a-client-to-specific-models).
 
-8. On the **API tokens** step, select **Mint an API token** to issue the client's first token. Optionally enter a
-   **Label** and an **Expires** date. Leave **Expires** blank for a token that never expires.
+8. On the **API tokens** step, select **Add API Token**. In the **Add API token** dialog, optionally enter a **Label**
+   and an **Expires** date, and then select **Add Token**. Leave **Expires** blank for a token that never expires.
 
 9. Select **Create client**.
 
@@ -72,7 +75,7 @@ Confirm that the appliance registered the client and its API token.
 
 3. Select the client to open its detail panel, and then select the **API tokens** section.
 
-4. Confirm the token you minted appears with a state of **active**.
+4. Confirm the token you added appears with a state of **active**.
 
 The client is ready to use once its token is active. To confirm the token works from end to end, connect a coding
 assistant to the appliance with it, as described in [Use Claude Code](./use-claude-code.md).


### PR DESCRIPTION
## What

Sharpens the **Egress** and **Routing** steps of the **Add client** wizard and corrects the API-token button label in the Create a Client how-to.

Addresses [DOC-3051](https://spectrocloud.atlassian.net/browse/DOC-3051), a child of the install-flow QA epic [DOC-3044](https://spectrocloud.atlassian.net/browse/DOC-3044).

## Changes

- **Egress step** — replaces the vague "allow the client to reach external models" with the actual **Enable egress** checkbox, notes that external access is denied by default, and links to the detailed Egress section.
- **Routing step** — describes the default behavior (leave the **Tier map** unchanged to route with the appliance default) and how to edit the tier map, and links to the detailed Routing section.
- **API token button** — renames **Mint an API token** to **Add API Token** to match the console, and documents the **Add API token** dialog and its **Add Token** confirmation. Also updates the verification step from "the token you minted" to "the token you added" for consistency.

## Source of truth

UI labels and behavior verified against the `launchpad-ai` console source (`ui/src/ClientCreateWizard.tsx`): the token button literal is `Add API Token`, the Egress control is an `Enable egress` checkbox, and an unedited Routing tier map is skipped so the client inherits the appliance default routing. Where the ticket and product wording differed, the ticket was treated as the source of truth for intent while exact UI labels were taken from the console.

## Notes

- Scoped to `create-a-client.md` only. `generate-an-api-token.md` still uses "Mint an API token"; that file is owned by DOC-3050, and the shared terminology cleanup is tracked by the C12 consistency card. Coordinated per the DOC-3051 "coordinate with C12 terminology" note.
- Prettier and Vale (`--minAlertLevel=error`) are clean on the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-3051]: https://spectrocloud.atlassian.net/browse/DOC-3051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-3044]: https://spectrocloud.atlassian.net/browse/DOC-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ