### PR TITLE
docs: standardize the how-to sign-in assumption and reorder the client and token guides (DOC-3056)

### DIFF
--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/create-a-client.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/create-a-client.md
@@ -5,7 +5,7 @@ description:
   "Step-by-step guidance for platform administrators on how to create a client on a PaletteAI Inference Launchpad
   appliance by stepping through the Add client wizard and issuing the client's first API token."
 hide_table_of_contents: false
-sidebar_position: 4
+sidebar_position: 3
 tags: ["paletteai-inference-launchpad", "clients", "how-to"]
 keywords: ["launchpad", "ai", "clients", "add client", "api token", "lpai"]
 ---
@@ -27,33 +27,31 @@ To generate an API token by itself, without stepping through the full client set
 Create a client through the **Add client** wizard. The wizard names the client, optionally sets a quota, optionally
 grants model access, and optionally issues the client's first API token.
 
-1. Open the appliance console in a browser and sign in.
+1. From the left main menu, select **Access & Policy**. The **Clients & API tokens** page opens.
 
-2. From the left main menu, select **Access & Policy**. The **Clients & API tokens** page opens.
+2. Select **Add client**. The **Add client** wizard opens on the **Overview** step.
 
-3. Select **Add client**. The **Add client** wizard opens on the **Overview** step.
-
-4. On the **Overview** step, enter a **Client name**, and then select **Next step**. The appliance assigns the client an
+3. On the **Overview** step, enter a **Client name**, and then select **Next step**. The appliance assigns the client an
    immutable identifier and registers it as active.
 
-5. _(Optional)_ On the **Quotas** step, add usage limits for the client, and then select **Next step**. For details,
+4. _(Optional)_ On the **Quotas** step, add usage limits for the client, and then select **Next step**. For details,
    refer to [Set and Manage Client Quotas](./manage-client-quotas.md).
 
-6. _(Optional)_ On the **Egress** step, select **Enable egress** to let the client reach external, or frontier, models,
+5. _(Optional)_ On the **Egress** step, select **Enable egress** to let the client reach external, or frontier, models,
    and then select **Next step**. External access is denied by default. To add a provider key and set a daily spend cap,
    refer to [Manage a Client's Model Access](./manage-client-model-access.md#allow-a-client-to-reach-external-models).
 
-7. _(Optional)_ On the **Routing** step, leave the **Tier map** unchanged to route the client with the appliance's
+6. _(Optional)_ On the **Routing** step, leave the **Tier map** unchanged to route the client with the appliance's
    default model routing, or edit the **Tier map** to route the client's model aliases to specific models. Then select
    **Next step**. For details, refer to
    [Manage a Client's Model Access](./manage-client-model-access.md#route-a-client-to-specific-models).
 
-8. On the **API tokens** step, select **Add API Token**. In the **Add API token** dialog, optionally enter a **Label**
+7. On the **API tokens** step, select **Add API Token**. In the **Add API token** dialog, optionally enter a **Label**
    and an **Expires** date, and then select **Add Token**. Leave **Expires** blank for a token that never expires.
 
-9. Select **Create client**.
+8. Select **Create client**.
 
-10. When the console reveals the token, select **Copy**. The token begins with `lpai_`.
+9. When the console reveals the token, select **Copy**. The token begins with `lpai_`.
 
 :::warning
 

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/generate-an-api-token.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/generate-an-api-token.md
@@ -5,7 +5,7 @@ description:
   "Step-by-step guidance on how to generate an API token in the PaletteAI Inference Launchpad console so that coding
   assistants and other clients can authenticate to the appliance."
 hide_table_of_contents: false
-sidebar_position: 3
+sidebar_position: 4
 tags: ["paletteai-inference-launchpad", "api-token", "how-to"]
 keywords: ["launchpad", "ai", "api token", "authentication", "lpai", "coding agent"]
 ---
@@ -25,24 +25,22 @@ and model access, start with [Create a Client](./create-a-client.md).
 
 If an administrator already gave you an API token, you can use it and skip the following steps.
 
-1. Open the appliance console in a browser and sign in.
+1. From the left main menu, select **Access & Policy**. The **Clients & API tokens** page opens.
 
-2. From the left main menu, select **Access & Policy**. The **Clients & API tokens** page opens.
-
-3. In the client's row, open the three-dot menu and select **Manage Client**. The client's detail panel opens to the
+2. In the client's row, open the three-dot menu and select **Manage Client**. The client's detail panel opens to the
    **Overview** section.
 
-4. Select the **API tokens** section, and then select **Create Token**. The **Create API token** dialog opens.
+3. Select the **API tokens** section, and then select **Create Token**. The **Create API token** dialog opens.
 
-5. _(Optional)_ In the **Label** field, enter a name that identifies the token, such as the coding assistant that uses
+4. _(Optional)_ In the **Label** field, enter a name that identifies the token, such as the coding assistant that uses
    it.
 
-6. _(Optional)_ To set an expiration date, clear **Never expires**, and then choose an **Expires** date. By default, the
+5. _(Optional)_ To set an expiration date, clear **Never expires**, and then choose an **Expires** date. By default, the
    token does not expire.
 
-7. Select **Create Token**.
+6. Select **Create Token**.
 
-8. When the console reveals the token, select **Copy**. The token begins with `lpai_`.
+7. When the console reveals the token, select **Copy**. The token begins with `lpai_`.
 
 :::warning
 

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -19,8 +19,8 @@ you the steps to do it without teaching background concepts.
 | [Deploy a Model](./deploy-a-model.md)                             | Deploy an LLM to the cluster and verify it is serving.                           |
 | [Upload a Model](./upload-a-model.md)                             | Download a model on a jumpbox and upload it to the appliance.                    |
 | [Switch the Default Model](./set-the-default-model.md)            | Switch the default model when the current default becomes unavailable.           |
-| [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.           |
 | [Create a Client](./create-a-client.md)                           | Create a client and issue its first API token.                                   |
+| [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.           |
 | [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, and remove a client's request, token, and cost limits.                |
 | [Manage a Client's Model Access](./manage-client-model-access.md) | Route a client to models and allow it to reach external models.                  |
 | [View Client Usage](./view-client-usage.md)                       | View a client's per-token consumption, requests, and cost.                       |


### PR DESCRIPTION
## What

Applies the cross-cutting consistency fixes Jon raised across the PaletteAI Inference Launchpad how-to set, rather than per guide.

Addresses [DOC-3056](https://spectrocloud.atlassian.net/browse/DOC-3056), the C12 consistency card of the install-flow QA epic [DOC-3044](https://spectrocloud.atlassian.net/browse/DOC-3044).

## Changes

- **Sign-in assumption** — removes the redundant "Open the appliance console in a browser and sign in" first step from `create-a-client.md` and `generate-an-api-token.md`. These were the only two of eight console how-tos that carried it; the rest already assume the console is open and rely on the "console reachable" prerequisite. Every console guide now opens consistently on the first real action. Remaining steps are renumbered.
- **Guide ordering** — `generate-an-api-token.md` lists an existing client as a prerequisite but sat before `create-a-client.md`. Swaps their `sidebar_position` (Create a Client → 3, Generate an API Token → 4) and swaps the matching rows in the how-to index (`how-to-guides.md`) so the client guide precedes the token guide.

## Terminology (item 1) — already done

The ticket's "replace mint with create for tokens" item coordinates with the C6 (DOC-3051) and C7 (DOC-3050) button-label renames, which already shipped. A repo-wide search confirms **zero** remaining "mint"/"minted" occurrences under `paletteai-inference-launchpad/` (how-to, reference/glossary, and explanation). The two token buttons legitimately read **Add API Token** (Add client wizard) and **Create Token** (standalone flow) because they are different console components; both are verified against `launchpad-ai` source. No wording remained to change.

## Checks

- Prettier clean on all three files.
- Vale `--minAlertLevel=error` clean (0 errors); the only alerts are pre-existing suggestions/warnings on unchanged text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-3056]: https://spectrocloud.atlassian.net/browse/DOC-3056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-3044]: https://spectrocloud.atlassian.net/browse/DOC-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ