### PR TITLE
[version-4-9] docs: Backport PaletteAI Inference Launchpad docs

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -24,3 +24,8 @@ Google.We = NO
 Google.Acronyms = NO
 Alex.Condescending = NO
 Google.OptionalPlurals = NO
+; A glossary legitimately uses single-letter section dividers (## A, ## B ...) and
+; term-name headings that Vale's general heading rules flag. Scope those off here.
+[docs/docs-content/paletteai-inference-launchpad/reference/glossary.md]
+spectrocloud-docs-internal.heading-all-caps = NO
+spectrocloud-docs-internal.headings-title = NO

--- a/_partials/paletteai-inference-launchpad/_request-routing-and-quotas.mdx
+++ b/_partials/paletteai-inference-launchpad/_request-routing-and-quotas.mdx
@@ -1,0 +1,13 @@
+---
+partial_category: paletteai-inference-launchpad
+partial_name: request-routing-and-quotas
+---
+
+Requests you send through the appliance are subject to the routing rule and quota configured for your API token. If an
+operator configured a routing rule for your token, the appliance can redirect a request to a frontier model instead of a
+local one. Token quotas apply per API token, and when a token exhausts its quota, the appliance returns an HTTP `429`
+response.
+
+To understand what a client is and how API keys and quotas govern usage, refer to
+[Clients and Quotas](/paletteai-inference-launchpad/explanation/clients-and-quotas).
+{/* TODO: link to the intelligent routing how-to and the token quotas and metering reference once they exist */}

--- a/docs/docs-content/paletteai-inference-launchpad/_category_.json
+++ b/docs/docs-content/paletteai-inference-launchpad/_category_.json
@@ -1,0 +1,4 @@
+{
+  "position": 1000,
+  "className": "hidden-category"
+}

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/_category_.json
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Explanation",
+  "position": 30,
+  "link": {
+    "type": "doc",
+    "id": "paletteai-inference-launchpad/explanation/explanation"
+  }
+}

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/architecture.md
@@ -1,0 +1,89 @@
+---
+sidebar_label: "Architecture Overview"
+title: "PaletteAI Inference Launchpad Architecture Overview"
+description:
+  "An explanation of the PaletteAI Inference Launchpad architecture, including its component stack, data flow, and
+  network topology."
+hide_table_of_contents: false
+sidebar_position: 1
+tags: ["paletteai-inference-launchpad", "architecture", "explanation"]
+keywords: ["launchpad", "ai", "architecture", "kubernetes", "kairos", "helm", "data flow"]
+---
+
+This page explains how PaletteAI Inference Launchpad works, how its components interact, and what key decisions shaped
+the design. Use this page to build an understanding of the architecture before you deploy or operate PaletteAI Inference
+Launchpad.
+
+## Component Stack
+
+The appliance serves each model through an inference engine, such as vLLM, running on its Kubernetes cluster. Each
+loaded model is exposed as an OpenAI-compatible endpoint, such as `/v1/chat/completions` and `/v1/models`. For the
+engine kinds the appliance supports and how it selects one, refer to [Inference Engines](./inference-engines.md).
+
+## Hardware Sizing
+
+The appliance is designed and tuned for a single high-density GPU server. That shape avoids the storage-replication,
+network-fabric, and scheduling complexity that appears as soon as nodes multiply, and it matches how most deployments
+start. Multi-server clusters are possible but are not tuned for this release.
+
+Sizing follows from the model rather than from a fixed value. The target model sets the GPU count, and the rest of the
+machine scales with it.
+
+The CPU is dual-socket because high-density GPU servers use two sockets, and 128 total cores give Kubernetes, the
+inference server, and system tasks enough headroom while leaving room to reuse the server for other workloads later.
+
+Host RAM is sized as GPU-adjacent memory, which covers host-side buffers and KV cache spill, plus a base for the
+operating system, the Kubernetes control plane, cluster services, and the hot KV cache tier. Undersized RAM forces the
+KV cache to spill to disk sooner, where it is far slower.
+
+Storage is NVMe only because model loading and KV cache I/O exceed what SATA solid-state drives or spinning disks can
+sustain. The disks split into two pools with different lifetimes. A small system pool on the OS disks holds the
+container registry and airgap content that must be available before the cluster builds, and a larger data pool on
+separate NVMe drives is created after the cluster comes up, once Piraeus is available. Piraeus stripes the data pool
+across its drives to combine read and write bandwidth for model loading and KV cache spill.
+
+The network uses bonded NICs so that the ports on a high-density server present one logical interface, which the
+appliance detects and configures automatically.
+
+For the specific values and example server configurations, refer to
+[Suggested Hardware](../reference/hardware-requirements.md).
+
+## Appliance and Cluster Formation
+
+## Model Provisioning Lifecycle
+
+When you deploy a model, you select it for the cluster rather than for a specific node, and the appliance places it
+automatically on the best-fit node. The best-fit node is the node with the most free GPUs that still fit the model. A
+model that does not need a GPU is placed on a CPU-capable node.
+
+The appliance reports each node's free capacity honestly. A node shows either a known free GPU count or an unknown
+allocation when the appliance cannot determine the count. The appliance never treats a node with an unknown allocation
+as free, never selects such a node automatically, and never invents a placement target. When no node can host a model,
+the appliance holds the deployment and reports the reason instead of choosing a node anyway.
+
+The appliance applies a deployment through a guarded sequence. It first previews the change so you can review it, and it
+writes nothing until you confirm. It then brings the model through gate, provision, smoke-test, and ready stages. A
+model becomes routable only after its signature is verified and its smoke test passes, so the appliance never presents a
+model as ready before it can serve requests.
+
+## Request Routing
+
+The gateway routes each request to a model. A request that names a model uses that model, and a request that does not
+name a model falls back to the default model. When you change the default model, the gateway rebuilds its router in
+place. The gateway does not restart, and it does not drain requests that are in progress. Requests that the gateway
+already routed continue on their assigned model, and the new default applies only to later requests.
+
+Before it routes a request, the gateway authenticates the calling client from its API token and enforces that client's
+quotas. For how clients, API tokens, and quotas work together, refer to [Clients and Quotas](./clients-and-quotas.md).
+
+### The Default Model
+
+The appliance sets the default model for you. The model you deploy during setup becomes the default, and if only one
+model serves, that model is the default. The appliance does not switch the default to a different model on its own. When
+the current default stops serving, the appliance raises an incident on the **Overview** page and offers a one-step fix
+so you can switch the default to a model that is currently serving. For that procedure, refer to
+[Switch the Default Model](../how-to-guides/set-the-default-model.md).
+
+## Network Topology
+
+## Data Residency and Isolation

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/clients-and-quotas.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/clients-and-quotas.md
@@ -1,0 +1,128 @@
+---
+sidebar_label: "Clients and Quotas"
+title: "Clients and Quotas"
+description:
+  "An explanation of clients, API tokens, and quotas in PaletteAI Inference Launchpad: what a client is, why the
+  appliance serves many clients such as AI coding assistants, and how it meters and limits their usage."
+hide_table_of_contents: false
+sidebar_position: 2
+tags: ["paletteai-inference-launchpad", "explanation", "clients", "quotas"]
+keywords: ["launchpad", "ai", "clients", "api token", "quota", "rate limit", "coding assistant", "claude code"]
+---
+
+AI coding assistants such as Claude Code, Cursor, OpenAI Codex, and OpenCode make up many of the workloads that connect
+to a PaletteAI Inference Launchpad appliance, sending their requests to the appliance instead of to a cloud provider. A
+single appliance can serve many of these assistants at once, along with other workloads such as an internal chatbot or a
+nightly batch job. This page explains how the appliance tells those workloads apart, and how it meters and limits what
+each one consumes. It covers what a _client_ is, why one appliance serves many of them, and how clients, API tokens, and
+quotas fit together. Read it to understand these ideas before you create clients, issue tokens, or set quotas.
+
+## What a Client Is
+
+A client is the identity the appliance uses to recognize who is sending a request. It is the unit of both access and
+accounting. The appliance attributes every request to exactly one client and measures every quota and usage metric per
+client.
+
+A client is more often a _workload_ than a person. Each AI coding assistant that connects to the appliance is a client.
+A single client might represent one engineering team, with each developer holding a separate API token, or a single
+coding tool. A customer support assistant or a data pipeline also makes a natural client, and most such workloads have
+no human operator at all.
+
+One appliance can serve many clients side by side. They draw on the same loaded models and the same GPU hardware, so the
+appliance needs a way to keep them from interfering with one another. That is what clients, tokens, and quotas provide.
+
+## Why the Appliance Serves Many Clients
+
+The appliance is a single machine with a fixed amount of GPU capacity. Unlike a cloud service, it cannot scale out on
+demand, so its capacity is shared among everything that uses it. Giving every workload the same anonymous access would
+make that shared resource impossible to manage. Distinct clients let you do four things that a single shared credential
+cannot:
+
+- **Protect capacity.** Per-client limits stop one coding assistant, such as an agent working through a large refactor,
+  from consuming all available throughput and starving the others.
+- **Attribute usage.** Per-client metrics show which team or tool consumed what, so you can identify where capacity goes
+  and plan accordingly.
+- **Contain credentials.** A token that a developer commits to a repository by mistake affects only its client. You
+  revoke that one token without disrupting any other workload.
+- **Govern outbound reach.** When the appliance routes to external providers, you can control which clients may send
+  requests off the appliance. For example, you can allow only certain coding assistants to reach a paid frontier model.
+
+Creating separate clients is not about distributing access for its own sake. It is how you keep a shared, finite
+appliance usable by many workloads at once.
+
+## Clients and API Tokens
+
+A client proves its identity with an API token, a bearer credential that begins with the prefix `lpai_`. Every request
+carries its token in the `Authorization` header. The appliance resolves the token to its client, applies that client's
+quotas, and records the request's usage against that client.
+
+A client can hold more than one API token. When each developer or coding tool that shares a client carries its own
+token, revoking one token (for example, after a developer leaves the team) does not disturb the others. Revoking the
+client itself revokes every token that belongs to it.
+
+## Client Lifecycle
+
+A client is active by default. You can suspend it, delete it, or revoke its individual API tokens without changing the
+client itself.
+
+- **Suspend** blocks a client's requests but keeps its API tokens, quotas, and routing settings in place. A suspended
+  client can be resumed at any time, so suspension is reversible.
+- **Delete** permanently retires a client and removes its quota, egress, and routing settings. It revokes every API
+  token the client owns. The client's audit history is preserved, and a delete cannot be undone.
+
+An API token has its own state. A token stays active until it is revoked or passes its expiration date. The appliance
+rejects any request that presents a revoked or expired token, fail-closed.
+
+## Quotas
+
+A quota is a consumption limit attached to a client. The appliance enforces quotas across three dimensions:
+
+- **Requests.** The number of calls a client makes.
+- **Tokens.** The number of tokens a client's requests process.
+- **Cost.** The computed cost of a client's requests.
+
+The appliance measures each dimension over rolling windows of one second, one minute, one hour, and one day. There is no
+monthly or billing-cycle window.
+
+When a client reaches a limit, the appliance rejects further requests with HTTP `429 Too Many Requests` and names the
+dimension and window that tripped. It does not queue or slow the requests. It blocks them until the window rolls over
+and the client is back under the limit.
+
+{/* NEEDS REVIEW: quota enforcement is off by default (global switch) per current working assumption. Confirm with an SME before publishing. */}
+
+{/* TODO: link to the Set and Manage Quotas how-to (DOC-2940) and Quota & Rate Limit reference (DOC-2941) once they exist. */}
+
+## What Clients Can Access
+
+Access to models depends on whether a model runs locally on the appliance or is reached through an external provider.
+
+- **Local models.** Every client can call every model served locally on the appliance. The appliance does not restrict
+  which local models a client may call. It meters and limits how much a client uses through quotas, but it does not gate
+  access to any local model.
+- **External models.** If the appliance is configured to route to external providers, each client's reach is governed by
+  an allow-list that denies by default. A client can call an external provider or model only when that provider or model
+  is explicitly allowed for it.
+
+## How It Fits Together
+
+A single request from a coding assistant ties these ideas together.
+
+1. A code completion request arrives with `Authorization: Bearer lpai_...`.
+2. The appliance resolves the token to its client.
+3. The appliance checks that client's quota for the requested dimension and window.
+4. If the client is within its limits, the appliance routes the request to the model and records the usage against the
+   client. If the client is over a limit, the appliance rejects the request with `429` instead.
+
+Setting up a client builds this same chain ahead of time, starting with the client, then its tokens, and then its
+quotas, so it is ready to run on every request.
+
+## Resources
+
+- [Create a Client](../how-to-guides/create-a-client.md) walks through creating a client and issuing its first API
+  token.
+- [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md) walks through connecting a
+  coding assistant to a client with an API token.
+- [Architecture Overview](./architecture.md) explains how the appliance routes requests and where its components sit.
+- [Model Certification](./model-certification.md) explains which models a client can call and how you choose them.
+- [Glossary](../reference/glossary.md) defines the client, API token, quota, and routing terms used throughout this
+  page.

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/explanation.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/explanation.md
@@ -1,0 +1,21 @@
+---
+sidebar_label: "Explanation"
+title: "PaletteAI Inference Launchpad Explanation"
+description: "Background, context, and design rationale for understanding how PaletteAI Inference Launchpad works."
+hide_table_of_contents: false
+sidebar_position: 0
+tags: ["paletteai-inference-launchpad", "explanation"]
+---
+
+Explanatory and conceptual guides help you understand how and why PaletteAI Inference Launchpad works the way it does.
+They cover design decisions, component relationships, and trade-offs rather than walking you through tasks.
+
+## Contents
+
+| **Topic**                                                   | **What you understand**                                                                                           |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| [Architecture Overview](./architecture.md)                  | The component stack, request routing, model provisioning lifecycle, and data residency model.                     |
+| [Clients and Quotas](./clients-and-quotas.md)               | What a client is, why the appliance serves many clients, and how API tokens and quotas govern usage.              |
+| [Model Certification](./model-certification.md)             | What certified means, how models are certified, and how to choose models for your use case.                       |
+| [Inference Engines](./inference-engines.md)                 | What an inference engine is, automatic engine selection, the supported kinds, and when to override it.            |
+| [Installation Architecture](./installation-architecture.md) | How the appliance installs across two stages, including the roles of the jumpbox and why the network uses a bond. |

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/inference-engines.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/inference-engines.md
@@ -1,0 +1,60 @@
+---
+sidebar_label: "Inference Engines"
+title: "PaletteAI Inference Launchpad Inference Engines"
+description:
+  "An explanation of inference engines in PaletteAI Inference Launchpad, including automatic engine selection, the
+  supported engine kinds, and when to override the automatic choice."
+hide_table_of_contents: false
+sidebar_position: 4
+tags: ["paletteai-inference-launchpad", "models", "explanation"]
+keywords: ["launchpad", "ai", "inference", "engine", "vLLM", "SGLang", "Ollama"]
+---
+
+This page explains what an inference engine is in PaletteAI Inference Launchpad, how the appliance selects one
+automatically, and when you might choose one yourself. It gives you the background to make an informed choice when you
+[deploy a model](../how-to-guides/deploy-a-model.md), where the engine is an optional setting.
+
+## Inference Engine Overview
+
+An inference engine is the runtime that loads a model and serves its requests. The appliance exposes each loaded model
+as an OpenAI-compatible endpoint, but the engine behind that endpoint is what actually runs the model on a node's CPU or
+GPUs. The engine determines how the model runs, which hardware it can use, and which serving features are available.
+
+Each engine has a kind that identifies the underlying runtime, and each engine is either GPU-capable or CPU-only. A GPU
+model can only run on a GPU-capable engine, and a model intended for CPU nodes runs on a CPU-only engine.
+
+## Automatic Engine Selection
+
+When you deploy a model, the engine setting defaults to **engine (auto)**. With the automatic option, the appliance
+selects an engine that fits the model you chose, a GPU-capable engine for a GPU model and a CPU-only engine for a CPU
+model. Leaving the setting on automatic is the recommended choice for most deployments, because the appliance matches
+the engine to the model and the target node for you.
+
+The engines you can choose from depend on how your appliance is configured. The deploy panel lists the automatic option
+first, followed by any named engines the appliance exposes, each labeled with its kind, such as `default · sglang`.
+
+## Supported Engine Kinds
+
+PaletteAI Inference Launchpad supports the following engine kinds.
+
+| **Kind**  | **Hardware** | **Summary**                                                              |
+| --------- | ------------ | ------------------------------------------------------------------------ |
+| vLLM      | GPU          | High-throughput GPU serving for large models.                            |
+| SGLang    | GPU          | High-throughput GPU serving with support for advanced serving features.  |
+| Ollama    | CPU          | CPU-based serving for smaller models on nodes without a GPU.             |
+| llama.cpp | CPU          | Lightweight CPU-based serving for smaller models on nodes without a GPU. |
+
+Serving features can vary by kind. For example, some kinds support reasoning and tool-calling for models that provide
+them, while others do not. The automatic option accounts for these differences when it matches an engine to a model.
+
+## Manual Engine Selection
+
+Leave the engine on the automatic option unless you have a specific reason to pin a model to a particular engine, such
+as a serving feature that a specific kind provides. When you select an engine yourself, the appliance only offers
+engines that fit the model's hardware, so you cannot select a CPU-only engine for a GPU model or the reverse.
+
+## Resources
+
+- [Deploy a Model](../how-to-guides/deploy-a-model.md)
+- [Architecture](./architecture.md)
+- [Certified Models by Hardware](../reference/certified-models-by-hardware.md)

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/installation-architecture.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/installation-architecture.md
@@ -1,0 +1,71 @@
+---
+id: installation-architecture
+title: Installation Architecture
+description: >
+  How the PaletteAI Inference Launchpad appliance installs across two stages, the roles of the jumpbox, slim ISO, and
+  Local UI, and why the network uses a bond rather than a bridge.
+sidebar_label: Installation Architecture
+sidebar_position: 5
+tags:
+  - paletteai-inference-launchpad
+  - explanation
+  - install
+keywords: ["launchpad", "ai", "install", "architecture", "bond", "jumpbox"]
+---
+
+Installing the appliance moves it from bare hardware to a running, reachable console in two stages, driven from a
+separate administrative workstation (a [jumpbox](../reference/glossary.md#jumpbox)). This page explains what happens in
+each stage and why the appliance is put together the way it is. For the ordered procedure, refer to
+[Install the Appliance](../how-to-guides/install-the-appliance.md).
+
+## Two stages, driven from the jumpbox
+
+You install the appliance from a jumpbox because the appliance itself is a self-contained unit with no external
+management plane. The jumpbox holds the Palette CLI and the artifacts you download from Artifact Studio: the
+[slim ISO](../reference/glossary.md#slim-iso), the [content bundle](../reference/glossary.md#content-bundle), and one
+`metadata.yaml` per model. The jumpbox is where you run the CLI commands that put those artifacts on the appliance.
+
+### Stage 1: Operating System and Initial Configuration
+
+You flash the slim ISO (approximately 1.5 GB) to bootable media, or mount it through the server's
+[baseboard management controller (BMC)](../reference/glossary.md#bmc) as
+[virtual media](../reference/glossary.md#virtual-media), and boot the node. The Palette Edge interactive installer
+writes the immutable [Kairos](../reference/glossary.md#kairos)-based operating system to the local disk. The node then
+reboots into the [Palette TUI](../reference/glossary.md#palette-tui), where you set the initial administrator
+credentials, hostname, DNS, NTP, and a static IP.
+
+### Stage 2: Network, Content, and Cluster Deployment
+
+You open [Local UI](../reference/glossary.md#local-ui) at the node's IP address, create a network
+[bond](../reference/glossary.md#bond), link the other nodes (multi-node only), and upload the content bundle (more than
+20 GB) from Local UI or the Palette CLI. You then deploy the cluster with a wizard that builds the Kubernetes cluster
+and installs the platform packs. During or after cluster deployment, the Palette CLI on the jumpbox downloads the model
+from Hugging Face and uploads it to the appliance over SSH. The model then appears in the console, where you deploy it
+to serve requests.
+
+## Bond, not bridge
+
+Networking uses a bond, not a bridge. A bond aggregates two physical NICs into a single logical link (`bond0`), and both
+member NICs are active at once. That matters because two heavy traffic classes share the appliance's data NICs:
+
+- **Cluster traffic**. concurrent client requests, model-weight loads, and container-image pulls.
+- **[Piraeus](../reference/glossary.md#piraeus) storage replication**. continuous, byte-level replication of storage
+  volumes across nodes in a multi-node cluster.
+
+A bond in `802.3ad` mode (Link Aggregation Control Protocol, or LACP) with the `layer3+4` hash policy spreads these
+long-lived flows evenly across both NICs, so cluster and storage traffic share the aggregated bandwidth. A bridge, by
+contrast, is only useful in scenarios where distinct virtual-machine networks must be isolated. PaletteAI Inference
+Launchpad runs containerized workloads and does not need that.
+
+For the exact field values you enter in the bond form, refer to
+[Bond Configuration Reference](../reference/bond-configuration.md).
+
+## GPU memory sizes the model
+
+A model fails to load if the GPUs do not have enough combined memory to hold it. The largest model that fits is
+approximately 85 percent of the combined GPU memory, leaving headroom for the KV cache and runtime overhead. For
+example, four H100 80 GB GPUs provide 320 GB, which holds a model up to roughly 272 GB. A larger model produces a
+[vLLM](../reference/glossary.md#vllm) error such as `No available memory for the cache blocks`.
+
+Confirm the target model fits the GPUs before you install. For model-to-hardware mapping, refer to
+[Certified Models by Hardware](../reference/certified-models-by-hardware.md).

--- a/docs/docs-content/paletteai-inference-launchpad/explanation/model-certification.md
+++ b/docs/docs-content/paletteai-inference-launchpad/explanation/model-certification.md
@@ -1,0 +1,49 @@
+---
+id: model-certification
+title: Model Certification
+description: >
+  What it means for a model to be certified on PaletteAI Inference Launchpad, how models are certified, and how to
+  choose the right models for your use case.
+sidebar_label: Model Certification
+sidebar_position: 3
+tags:
+  - paletteai-inference-launchpad
+  - explanation
+  - models
+keywords: ["launchpad", "ai", "certified models", "certification", "coding assistant"]
+---
+
+This page explains what model certification means and how a model becomes certified. For the models certified on
+specific hardware, refer to [Certified Models by Hardware](../reference/certified-models-by-hardware.md).
+
+## Certification Overview
+
+A certified model is a large language model (LLM) that Spectro Cloud has validated to run correctly on the listed GPU
+configuration for PaletteAI Inference Launchpad. This validation is based on Spectro Cloud's own testing rather than
+public benchmarks, and it can extend across equivalent GPU configurations. When you deploy a certified model on a
+configuration where it is certified, you can be confident it loads and serves requests without hardware surprises.
+
+## Model Use Cases
+
+Spectro Cloud chooses the certified models with coding assistants as the primary use case. If your primary need is a
+coding assistant, start with the certified models.
+
+Other models may serve other use cases better, so if your primary need is not a coding assistant,
+[contact Spectro Cloud](https://www.spectrocloud.com/contact) to discuss the right models for your use case.
+
+:::info
+
+The certified list is not exclusive. You can load models beyond it as long as they fit within the GPU resources
+available on your appliance. If the model you want is not certified for your hardware,
+[contact Spectro Cloud](https://www.spectrocloud.com/contact) to discuss your use case.
+
+:::
+
+For how to add a model to a running appliance, refer to [Deploy a Model](../how-to-guides/deploy-a-model.md).
+
+## How Certification Differs from Model as a Service
+
+PaletteAI Inference Launchpad is not a Model as a Service. Rather than offering the widest possible catalog of models on
+demand, Spectro Cloud certifies a focused set of models for on-premises inference on your own hardware. For multi-tenant
+AI factory use cases, [PaletteAI](https://docs.palette-ai.com) is the better fit. For a full comparison of the two
+products, refer to [What is PaletteAI Inference Launchpad?](../paletteai-inference-launchpad.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/_category_.json
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "How-to Guides",
+  "position": 20,
+  "link": {
+    "type": "doc",
+    "id": "paletteai-inference-launchpad/how-to-guides/how-to-guides"
+  }
+}

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/create-a-client.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/create-a-client.md
@@ -1,0 +1,88 @@
+---
+sidebar_label: "Create a Client"
+title: "Create a Client"
+description:
+  "Step-by-step guidance for platform administrators on how to create a client on a PaletteAI Inference Launchpad
+  appliance by stepping through the Add client wizard and issuing the client's first API token."
+hide_table_of_contents: false
+sidebar_position: 3
+tags: ["paletteai-inference-launchpad", "clients", "how-to"]
+keywords: ["launchpad", "ai", "clients", "add client", "api token", "lpai"]
+---
+
+This guide explains how a platform administrator creates a client on a PaletteAI Inference Launchpad appliance. A client
+is a named team, business unit, or workload, represented by one or more API tokens. To understand what a client is and
+how clients, API tokens, and quotas relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+To generate an API token by itself, without stepping through the full client setup, refer to
+[Generate an API Token](./generate-an-api-token.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- Console access with permission to manage clients. Managing clients can require operator access.
+
+## Create a Client
+
+Create a client through the **Add client** wizard. The wizard names the client, optionally sets a quota, optionally
+grants model access, and optionally issues the client's first API token.
+
+1. From the left main menu, select **Access & Policy**. The **Clients & API tokens** page opens.
+
+2. Select **Add client**. The **Add client** wizard opens on the **Overview** step.
+
+3. On the **Overview** step, enter a **Client name**, and then select **Next step**. The appliance assigns the client an
+   immutable identifier and registers it as active.
+
+4. _(Optional)_ On the **Quotas** step, add usage limits for the client, and then select **Next step**. For details,
+   refer to [Set and Manage Client Quotas](./manage-client-quotas.md).
+
+5. _(Optional)_ On the **Egress** step, select **Enable egress** to let the client reach external, or frontier, models,
+   and then select **Next step**. External access is denied by default. To add a provider key and set a daily spend cap,
+   refer to [Manage a Client's Model Access](./manage-client-model-access.md#allow-a-client-to-reach-external-models).
+
+6. _(Optional)_ On the **Routing** step, leave the **Tier map** unchanged to route the client with the appliance's
+   default model routing, or edit the **Tier map** to route the client's model aliases to specific models. Then select
+   **Next step**. For details, refer to
+   [Manage a Client's Model Access](./manage-client-model-access.md#route-a-client-to-specific-models).
+
+7. On the **API tokens** step, select **Add API Token**. In the **Add API token** dialog, optionally enter a **Label**
+   and an **Expires** date, and then select **Add Token**. Leave **Expires** blank for a token that never expires.
+
+8. Select **Create client**.
+
+9. When the console reveals the token, select **Copy**. The token begins with `lpai_`.
+
+:::warning
+
+The console shows the token only once and stores only a hash of it. Copy it now. If you lose it, revoke the token and
+create a new one.
+
+:::
+
+A client can hold more than one API token. To add another token to a client later, refer to
+[Generate an API Token](./generate-an-api-token.md).
+
+## Verify the Client
+
+Confirm that the appliance registered the client and its API token.
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, confirm the new client appears in the list under the name you gave it.
+
+3. Select the client to open its detail panel, and then select the **API tokens** section.
+
+4. Confirm the token you added appears with a state of **active**.
+
+The client is ready to use once its token is active. To confirm the token works from end to end, connect a coding
+assistant to the appliance with it, as described in [Use Claude Code](./use-claude-code.md).
+
+## Next Steps
+
+After you create a client, configure how much it can consume and which models it can reach.
+
+- [Set and Manage Client Quotas](./manage-client-quotas.md)
+- [Manage a Client's Model Access](./manage-client-model-access.md)
+- [View Client Usage](./view-client-usage.md)
+- [Revoke or Delete a Client](./revoke-or-delete-a-client.md)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
@@ -1,0 +1,82 @@
+---
+sidebar_label: "Deploy a Model"
+title: "Deploy a Model"
+description:
+  "Step-by-step guidance for platform operators on how to deploy an LLM model to a running PaletteAI Inference Launchpad
+  appliance and verify that it is serving."
+hide_table_of_contents: false
+sidebar_position: 1
+tags: ["paletteai-inference-launchpad", "models", "how-to"]
+---
+
+This guide explains how to deploy a model to a running PaletteAI Inference Launchpad appliance and verify that the model
+is serving requests. The appliance places the model automatically on the best-fit node. For how placement and the deploy
+lifecycle work, refer to [Model Provisioning Lifecycle](../explanation/architecture.md#model-provisioning-lifecycle).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
+- At least one node with free capacity for the model you intend to deploy.
+- The model present in the appliance catalog and able to fit the appliance's available GPU resources. To confirm
+  support, refer to [Certified Models by Hardware](../reference/certified-models-by-hardware.md) and
+  [Suggested Hardware](../reference/hardware-requirements.md). To place a model in the appliance catalog, follow
+  [Upload a Model](./upload-a-model.md) first.
+
+## Deploy a Model
+
+1. From the left main menu, select **Cluster**.
+
+2. Select **Deploy model** to open the deploy panel.
+
+3. Review the **cluster capacity** line to find which nodes have free GPUs. Each node shows either a free count, such as
+   `N of T free`, or `allocation unknown`.
+
+4. Open the model drop-down menu and select the model to deploy.
+
+5. _(Optional)_ Open the engine drop-down menu and select an engine. Leave it on **engine (auto)** to let the appliance
+   choose the engine. For what an engine is and when you would override the automatic choice, refer to
+   [Inference Engines](../explanation/inference-engines.md).
+
+6. Confirm that the **will deploy to** line shows a best-fit node. If the panel shows **Deploy held** with a reason, or
+   the **Deploy** button is unavailable, no node currently fits the model. Refer to
+   [Resolve a Blocked Deployment](#resolve-a-blocked-deployment) before you continue.
+
+7. Select **Deploy**, review the deployment preview, and then select **Confirm & apply**.
+
+### Verify the Model Is Serving
+
+Confirm the model is serving before you route traffic to it.
+
+1. Locate the model in the _Model_ table on the **Cluster** page.
+
+2. Confirm that the model health reads `N/N healthy` and that its state reaches `ready` or `serving`. A state of
+   `deploying` or `smoke-testing` means the model is still coming online, and a state of `failed` or
+   `verification failed` means the model did not come online.
+
+:::info
+
+While a model is deploying, a node hosting it can briefly report a `Degraded` or `Not serving` state. This is expected
+during deployment and clears once the model finishes coming online, at which point the node returns to a healthy state.
+
+:::
+
+For why a model becomes routable only after it passes its smoke test, refer to
+[Model Provisioning Lifecycle](../explanation/architecture.md#model-provisioning-lifecycle).
+
+## Resolve a Blocked Deployment
+
+If no node can host the model you selected, the **Deploy** button is unavailable and the panel explains why. The reason
+is one of the following:
+
+- The model is already deployed on every node in the cluster.
+- The model needs GPUs, but no node in the cluster has a GPU.
+- No node has enough free GPUs for the model because every GPU node is full.
+- No node has enough free GPUs for the model, and some nodes report `allocation unknown`.
+
+To resolve the reason, free GPUs on a node by draining or shutting down another model, add capacity to the cluster, or
+resolve the unknown allocation on the affected nodes. Then deploy the model again.
+
+## Next Steps
+
+To change which model handles requests that do not name a model explicitly, refer to
+[Switch the Default Model](./set-the-default-model.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/generate-an-api-token.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/generate-an-api-token.md
@@ -1,0 +1,59 @@
+---
+sidebar_label: "Generate an API Token"
+title: "Generate an API Token"
+description:
+  "Step-by-step guidance on how to generate an API token in the PaletteAI Inference Launchpad console so that coding
+  assistants and other clients can authenticate to the appliance."
+hide_table_of_contents: false
+sidebar_position: 4
+tags: ["paletteai-inference-launchpad", "api-token", "how-to"]
+keywords: ["launchpad", "ai", "api token", "authentication", "lpai", "coding agent"]
+---
+
+This guide explains how to generate an API token in the PaletteAI Inference Launchpad console. Clients such as coding
+assistants use the token to authenticate their requests to the appliance. To understand how tokens, clients, and quotas
+relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md). To create a client and then set its quotas
+and model access, start with [Create a Client](./create-a-client.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- An existing client to issue the token to. To create one, refer to [Create a Client](./create-a-client.md).
+- Console access with permission to create API tokens. Creating a token can require operator access.
+
+## Generate an API Token
+
+If an administrator already gave you an API token, you can use it and skip the following steps.
+
+1. From the left main menu, select **Access & Policy**. The **Clients & API tokens** page opens.
+
+2. In the client's row, open the three-dot menu and select **Manage Client**. The client's detail panel opens to the
+   **Overview** section.
+
+3. Select the **API tokens** section, and then select **Create Token**. The **Create API token** dialog opens.
+
+4. _(Optional)_ In the **Label** field, enter a name that identifies the token, such as the coding assistant that uses
+   it.
+
+5. _(Optional)_ To set an expiration date, clear **Never expires**, and then choose an **Expires** date. By default, the
+   token does not expire.
+
+6. Select **Create Token**.
+
+7. When the console reveals the token, select **Copy**. The token begins with `lpai_`.
+
+:::warning
+
+The console shows the token only once and stores only a hash of it. Copy it now. If you lose it, revoke the token and
+create a new one.
+
+:::
+
+## Next Steps
+
+Use the token to connect a coding assistant to the appliance.
+
+- [Use Claude Code](./use-claude-code.md)
+- [Use Cursor](./use-cursor.md)
+- [Use OpenAI Codex](./use-codex.md)
+- [Use OpenCode](./use-opencode.md)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -1,0 +1,31 @@
+---
+sidebar_label: "How-to Guides"
+title: "PaletteAI Inference Launchpad How-to Guides"
+description:
+  "Step-by-step guides for completing specific operational tasks on a running PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 0
+tags: ["paletteai-inference-launchpad", "how-to"]
+---
+
+How-to guides get a specific job done on a running appliance. They assume you know what you want to accomplish and give
+you the steps to do it without teaching background concepts.
+
+## Contents
+
+| **Guide**                                                         | **What you do**                                                                  |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [Install the Appliance](./install-the-appliance.md)               | Flash the installer ISO, boot the hardware, and bring up the appliance console.  |
+| [Deploy a Model](./deploy-a-model.md)                             | Deploy an LLM to the cluster and verify it is serving.                           |
+| [Upload a Model](./upload-a-model.md)                             | Download a model on a jumpbox and upload it to the appliance.                    |
+| [Switch the Default Model](./set-the-default-model.md)            | Switch the default model when the current default becomes unavailable.           |
+| [Create a Client](./create-a-client.md)                           | Create a client and issue its first API token.                                   |
+| [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.           |
+| [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, and remove a client's request, token, and cost limits.                |
+| [Manage a Client's Model Access](./manage-client-model-access.md) | Route a client to models and allow it to reach external models.                  |
+| [View Client Usage](./view-client-usage.md)                       | View a client's per-token consumption, requests, and cost.                       |
+| [Revoke or Delete a Client](./revoke-or-delete-a-client.md)       | Find expired keys, revoke a token, or delete a client.                           |
+| [Use Claude Code](./use-claude-code.md)                           | Connect Claude Code to the appliance so a local model serves each request.       |
+| [Use Cursor](./use-cursor.md)                                     | Connect Cursor's Ask mode to the appliance through a uniquely named model alias. |
+| [Use OpenAI Codex](./use-codex.md)                                | Connect the OpenAI Codex CLI to the appliance with a custom model provider.      |
+| [Use OpenCode](./use-opencode.md)                                 | Connect the OpenCode terminal agent to the appliance through a custom provider.  |

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
@@ -1,0 +1,540 @@
+---
+sidebar_label: "Install the Appliance"
+title: "Install the PaletteAI Inference Launchpad Appliance"
+description:
+  "Step-by-step guidance for platform operators on how to install the PaletteAI Inference Launchpad appliance from bare
+  hardware to a running, reachable appliance console."
+hide_table_of_contents: false
+sidebar_position: 0
+tags: ["paletteai-inference-launchpad", "install", "how-to"]
+keywords: ["launchpad", "ai", "install", "appliance", "hardware", "iso", "edge", "local ui"]
+---
+
+This guide explains how to install the PaletteAI Inference Launchpad appliance on bare hardware, from an administrative
+workstation (a [jumpbox](../reference/glossary.md#jumpbox)). You download the
+[slim ISO](../reference/glossary.md#slim-iso), [content bundle](../reference/glossary.md#content-bundle), and model
+metadata from Artifact Studio, install the edge OS on the node, configure the network in the Palette text-based user
+interface (TUI) and Local UI, upload the content bundle, deploy the cluster, and upload a model. By the end, you will
+have a running, reachable appliance console with a model ready to deploy. For the two-stage architecture and design
+rationale, refer to [Installation Architecture](../explanation/installation-architecture.md).
+
+:::info
+
+Each terminal command in this guide has a **Linux / macOS** tab (POSIX shell) and a **Windows** tab (PowerShell). Select
+the tab that matches your jumpbox. Your choice applies to every command on the page.
+
+:::
+
+## Before You Begin
+
+Confirm each prerequisite before starting:
+
+- The appliance server and administrative workstation (jumpbox) meet the
+  [Hardware Requirements](../reference/hardware-requirements.md), which covers GPU, CPU, RAM, storage, network, and IP
+  addressing.
+- The Palette CLI is installed and configured on the jumpbox.
+- The hardware supports Ubuntu 24.04.
+- The server has [baseboard management controller (BMC)](../reference/glossary.md#bmc) access available for
+  [virtual media](../reference/glossary.md#virtual-media), as a fallback if USB boot fails.
+- You have a reserved [virtual IP address (VIP)](../reference/glossary.md#vip) for the cluster, and a single unused
+  platform IP address (not a range) for MetalLB to assign to platform services.
+- The target model fits the available GPU memory. Refer to
+  [Certified Models by Hardware](../reference/certified-models-by-hardware.md) for the model-to-hardware mapping, and to
+  [Installation Architecture](../explanation/installation-architecture.md#gpu-memory-sizes-the-model) for the memory
+  ceiling rule.
+- _(External NFS only)_ If the environment uses an external Network File System (NFS) storage network, such as a
+  dedicated storage fabric, have the virtual local area network (VLAN) ID and IP address ready for a tagged VLAN
+  sub-interface on the node's bond, for example `bond0.396` on VLAN 396 with `10.0.22.110/24`. You configure this when
+  you create the bond, because the storage network is otherwise unreachable. This is separate from the appliance's
+  internal Piraeus storage.
+
+## Download the Artifacts
+
+Three artifacts come from Artifact Studio, Spectro Cloud's artifact download portal. Download all three before you
+begin. The slim ISO and content bundle must match the target hardware's GPU (NVIDIA or AMD).
+
+- **Slim ISO (~1.5 GB)**. the bootable installer. You write it to a USB drive, or mount it through the server's BMC, and
+  boot the node from it.
+- **Content bundle (more than 20 GB)**. the platform and application layers. You upload it through the Palette CLI
+  (recommended) or Local UI after the node is on the network.
+- **Model metadata (`metadata.yaml`, a few KB)**. one file per model you intend to deploy. It is a separate download,
+  not part of the ISO or content bundle. You use it later, with the Palette CLI, to download the model weights from
+  Hugging Face and upload them to the appliance. Download it from Artifact Studio, or from the `models/` directory of
+  the `launchpad-ai` repository, for example `models/glm-5.2/1.0.0/metadata.yaml`.
+
+## Install the OS
+
+1. Flash the slim ISO to bootable media, such as a USB drive, with an imaging tool such as balenaEtcher. You can also
+   transfer the ISO to the node with `scp` or `rsync`.
+2. Attach the media to the node and set the boot order to boot from it first.
+3. Power on the node. At the GRUB menu, let it select the Palette Edge interactive installer. After the selection, the
+   screen can stay blank for several minutes with no output while the installer loads. This is expected, so wait for the
+   interactive installer to appear instead of assuming the boot has stalled.
+4. In the interactive installer:
+   - When the installer prompts for the registration option after its first boot, select **Palette eXtended Kubernetes
+     (PXK)**. This registers the node with the edge Kubernetes distribution the appliance uses.
+     {/* NEEDS REVIEW: QA (2026-07-27) reports the PXK registration boot option is not applicable at this point and appears later in the flow. Confirm the correct step and timing under PE-8675 before publishing. */}
+   - The installer inspects every disk and blocks the install if any disk still holds Kairos partitions from a prior
+     install. It reports the offending disks by name.
+   - If a disk still holds Kairos partitions, use the in-flow wipe-all-disks option to clear them, so you do not have to
+     drop to a shell. This action is destructive, so confirm the disk selection before you run it.
+   - Select the target disk for the operating system. The installer erases this disk, so do not select the disk you
+     intend to use for the Piraeus storage pool.
+   - Choose the post-install action (reboot or power off).
+   - Review the installation summary and press **ENTER** to start.
+5. Wait for the install to finish. It takes at least 15 minutes, depending on hardware. When it finishes, disconnect the
+   ISO. If you chose reboot, the node reboots into the Palette TUI; if you chose power off, power it back on.
+
+## Configure the Node with the Palette TUI
+
+After the OS install and reboot, the node comes up in the Palette TUI, where you set the initial credentials and
+network. The hostname, DNS, and NTP settings are configured here in the TUI, not in Local UI.
+
+The appliance enforces a password policy on every account you create in the Palette TUI, including `root`. Each password
+must meet all of the following requirements:
+
+- Be at least 15 characters long.
+- Include at least one lowercase letter, one uppercase letter, one digit, and one special character, such as `!`, `@`,
+  `#`, `$`, `%`, `^`, `&`, or `*`.
+- Not contain the account username.
+- Not contain spaces, a double quote (`"`), a single quote (`'`), or a backslash (`\`).
+
+When you change an existing password, the new password must differ from the old one by at least 5 characters.
+
+1. On the Palette TUI landing page, no local account exists yet, so press **F2** (**Create login**) to create the
+   initial administrator account, then set its username and password. This account signs in to Local UI and accesses the
+   node over SSH.
+2. Move between options with **TAB** or the arrow keys. Press **ENTER** to apply a change, and **ESC** to go back.
+   - **Hostname.** Review the hostname and change it if required.
+   - **Network adapter.** Each adapter uses Dynamic Host Configuration Protocol (DHCP) by default. For each adapter you
+     can switch to a static IP address (with subnet mask and gateway), set a VLAN ID, or set the Maximum Transmission
+     Unit (MTU). Setting a static IP removes the DHCP settings.
+   - **DNS.** Set the primary and alternate name servers, and an optional search domain.
+   - **NTP.** Set one or more NTP servers, for example `0.pool.ntp.org`.
+3. Navigate to **Logout** and confirm. It ends your TUI session and returns to the device information screen, which
+   shows the node details and the Local UI address. It does not power off the node. To re-enter the TUI later, run
+   `palette-tui` on the node.
+4. Repeat the OS install and this TUI configuration on every node. On a multi-node cluster, also complete the network
+   bond on every node before you link them.
+
+## Configure the Network in Local UI
+
+Once the node has an IP address, you can leave the console and reach the node's Local UI from a browser.
+
+1. In a browser, go to `https://<node-ip>:5080`, using the IP you set in the Palette TUI. Local UI uses a self-signed
+   certificate, so proceed past the browser warning.
+2. Sign in with the credentials you created in the Palette TUI.
+3. Confirm the node reports a pre-cluster state. The node has an IP address but is not yet part of a cluster, so Local
+   UI shows it as ready to build a new cluster or join an existing one rather than reporting a running cluster.
+
+### Create a Bond
+
+The **Network Interfaces** view is already open in Local UI, so you do not need to navigate to it separately.
+
+1. Under **Bonds**, select **Create**.
+2. Fill in the bond form. The **Name** field shows `bond0` as placeholder text, not a saved value, so click into it and
+   type the name before you continue. Set **Bond type** to `static` so the bond keeps a fixed IP, then enter the **IP
+   Address** and **Subnet mask**, which are both required. **Gateway** is optional. Select the member NICs manually, and
+   set the **Bonding mode** to `802.3ad`. Bond type (the IP method) and bonding mode (the link-aggregation algorithm)
+   are separate fields. For each field's recommended value, meaning, and when to deviate, refer to
+   [Bond Configuration Reference](../reference/bond-configuration.md). The values must match how your data-center switch
+   is configured on the ports the appliance is plugged into, so coordinate with your network administrator before you
+   apply.
+3. Select **Apply**. If Local UI is briefly unreachable, reload the same address after a few seconds. The IP moves from
+   the network interface card (NIC) to the bond.
+
+## Configure the Storage
+
+If you do not configure storage, Local UI configures it automatically and adds every available data disk on the host to
+the **Data volume group**, always excluding the operating system disk. Configure it manually only when you need to
+control which disks [Piraeus](../reference/glossary.md#piraeus) uses, for example, to keep a data disk out of the
+storage pool. The **Data volume group** tells Piraeus which physical disks to use for cluster storage, and model weights
+and the KV cache live on these disks. Local UI mounts the volume group at `/opt/data/spectrocloud`. Configure the volume
+group after the bond and before you link hosts, and on a multi-node cluster, complete this section on every node.
+
+:::warning Read-only after cluster creation
+
+You can delete or modify the Data volume group any number of times before you deploy the cluster. After cluster
+creation, the group becomes read-only. Confirm the disk selection before you continue.
+
+:::
+
+1. In Local UI, open the **Edgehost** tab.
+2. Under **Hardware**, select the disks link. This link is labeled with the number of disks on the host (for example,
+   **5 disks**) rather than the word **Disks**. A side pane opens listing every disk on the host.
+3. Under **Data volume group**, select **Create data volume group** to open the wizard.
+4. Review the disk selection. By default, the wizard selects every data disk on the host and automatically excludes the
+   operating system disk, so you cannot add it to the volume group by mistake. Deselect any data disk you want to keep
+   out of the volume group. You can leave the wizard's other settings at their defaults for a standard installation.
+5. Select **Create** to apply. The new entry appears under **Data volume group**.
+
+## Link Hosts (Multi-Node Only)
+
+Skip this section for a single-node installation. Link the hosts before you upload the content bundle, so that content
+synchronizes across all linked hosts automatically. Every host must have a static IP, a Local UI login, and its own bond
+before you link them.
+
+1. Decide which host is the leader of the group. The leader coordinates linking. For high availability, use an odd
+   number of control-plane nodes.
+2. In the leader's Local UI, open **[Linked Edge Hosts](../reference/glossary.md#linked-edge-hosts)** > **Generate
+   token**. The leader emits a Base64-encoded token containing its IP address and a
+   [one-time password (OTP)](../reference/glossary.md#otp) valid for two minutes. The token appears with a copy button,
+   not a labeled **Copy** control, so select the copy button to copy the token to your clipboard.
+3. On each other host's Local UI, open **Linked Edge Hosts** > **Link this device to another**. Paste the token from the
+   leader and confirm.
+4. Repeat for every host you want to link.
+5. Confirm all linked hosts appear in the **Linked Edge Hosts** table. Each linked host shows a **Pending** status until
+   you upload the content bundle in the next step, so a **Pending** status here is expected and does not indicate a
+   problem. Content synchronization takes at least five minutes, depending on the network.
+
+## Upload the Content Bundle
+
+Upload the content bundle before you deploy the cluster. On a multi-node cluster, content uploaded on the leader
+synchronizes automatically to every linked host. The model itself is not uploaded here; you upload it separately in
+[Upload Your Model](#upload-your-model).
+
+Two upload paths are available:
+
+- **Palette CLI from the jumpbox (recommended).** Streams the bundle to the node from the command line, so you can
+  script the upload and it does not depend on a browser session. The bundle can sit on the jumpbox filesystem or on an
+  NFS share mounted on the jumpbox.
+- **Local UI browser upload (not recommended).** Uploads through the browser. The content bundle is more than 20 GB, so
+  the browser upload is slow and prone to timeouts. Use it only when the Palette CLI is not available on the jumpbox.
+
+### Upload with the Palette CLI (Recommended)
+
+The Palette CLI runs on your jumpbox and authenticates to the node with a per-node upload token, so you do not sign in
+to Palette SaaS for this step.
+
+Before you start, confirm the jumpbox has everything the upload needs:
+
+- **The Palette CLI installed and on your `PATH`.** Download the Linux binary from the Downloads page and move it to
+  `/usr/local/bin/palette` so the `palette` command resolves from any directory. For step-by-step instructions, refer to
+  [Install Palette CLI](../../automation/palette-cli/install-palette-cli.md). You do not need to run `palette login` for
+  this workflow, because the content-upload command uses a node-issued token, not your Palette API key.
+- **The content bundle reachable on the jumpbox.** The `.tar.zst` file must be on the jumpbox filesystem or on an NFS
+  share mounted on the jumpbox. If you downloaded it on another machine, copy it to the jumpbox first with `scp` or
+  `rsync`.
+- **SSH access to the node** using the administrator account you created in the Palette TUI. You use SSH once, to read
+  the token off the node.
+- **Network reachability from the jumpbox to the node on TCP port `5082`.** The Palette CLI posts the bundle to the
+  node's Local UI API on port `5082`, which is separate from the Local UI web address on port `5080`. If the jumpbox
+  cannot reach the bond IP on port `5082`, the upload fails.
+
+#### (Optional) Locate the bundle on an NFS share
+
+If the content bundle is on an NFS share rather than the jumpbox's local disk, mount the share on the jumpbox and note
+the bundle's full path. You upload it directly from the mount, so no local copy is needed. These commands assume a POSIX
+shell on the Linux jumpbox.
+
+1. List the NFS mounts on the jumpbox to find the share.
+
+   ```bash
+   df --human-readable --type=nfs --type=nfs4
+   ```
+
+   ```bash hideClipboard title="Expected output"
+   Filesystem             Size  Used Avail Use% Mounted on
+   10.0.19.10:/data/ipmi  7.0T   52G  6.6T   1% /mnt/nfs/ipmi
+   ```
+
+   The path in the **Mounted on** column is the mount point. In this example the share is mounted at `/mnt/nfs/ipmi`.
+
+2. List the bundle on the mount and note the full path to the `.tar.zst` file.
+
+   ```bash
+   ls --format=long --human-readable /mnt/nfs/ipmi/
+   ```
+
+   ```bash hideClipboard title="Expected output"
+   -rw-r--r-- 1 root root 22G Jul 21 10:00 launchpad-ai-content.tar.zst
+   ```
+
+   Use the full mount path, for example `/mnt/nfs/ipmi/<content-bundle>.tar.zst`, as the `--file` value in the upload
+   command below.
+
+#### Upload steps
+
+1. From the jumpbox, read the per-node upload token from the node and store it in an environment variable. Local UI
+   writes this token to a file on the node when it first comes up, so the token already exists and you do not generate
+   or request one. Replace `<user>` with the administrator username you set in the Palette TUI and `<node-ip>` with the
+   bond IP.
+
+   <Tabs groupId="os">
+
+   <TabItem label="Linux / macOS" value="unix">
+
+   ```bash
+   export AIL_NODE_TOKEN=$(ssh <user>@<node-ip> sudo cat /opt/spectrocloud/.upload-auth-token)
+   ```
+
+   </TabItem>
+
+   <TabItem label="Windows" value="windows">
+
+   ```powershell
+   $env:AIL_NODE_TOKEN = ssh <user>@<node-ip> sudo cat /opt/spectrocloud/.upload-auth-token
+   ```
+
+   </TabItem>
+
+   </Tabs>
+
+2. Run the upload from the jumpbox. Replace `<content-bundle>` with the path to the bundle, on the jumpbox filesystem or
+   on the NFS mount (for example `./launchpad-ai-content.tar.zst` or `/mnt/nfs/ipmi/launchpad-ai-content.tar.zst`), and
+   `<node-ip>` with the bond IP. The default target port is `5082`; if the Local UI API uses a different port, add
+   `-p <port>`.
+
+   <Tabs groupId="os">
+
+   <TabItem label="Linux / macOS" value="unix">
+
+   ```bash
+   palette content upload \
+     --file <content-bundle> \
+     --token "$AIL_NODE_TOKEN" \
+     <node-ip>
+   ```
+
+   </TabItem>
+
+   <TabItem label="Windows" value="windows">
+
+   ```powershell
+   palette content upload `
+     --file <content-bundle> `
+     --token $env:AIL_NODE_TOKEN `
+     <node-ip>
+   ```
+
+   </TabItem>
+
+   </Tabs>
+
+   ```bash hideClipboard title="Expected output"
+   response: Uploaded content successfully
+   ```
+
+   A progress bar tracks the transfer. After it reaches 100 percent, the node decompresses the archive and imports its
+   images into the local registry. For a bundle of 20 GB or more, this server-side phase can take 15 to 30 minutes with
+   no visible progress. Use a wired connection, keep the terminal open, do not interrupt the CLI, and wait for the node
+   to finish before you continue.
+
+### Upload from Local UI (Not Recommended)
+
+The content bundle is more than 20 GB, so the browser upload is slow and can time out. Use this path only when the
+Palette CLI is not available on the jumpbox.
+
+1. From the left main menu, select **Content** > **Actions** > **Upload Content**.
+2. Select the content bundle and start the upload.
+3. After the upload reaches 100 percent, wait for the node to finish unpacking the bundle before continuing.
+
+## Deploy the Cluster
+
+:::warning HPE hardware
+
+On HPE servers, confirm the GPUs are visible to the operating system before you deploy. The cluster installs the GPU
+driver pack during deployment, so if the GPUs do not enumerate on the PCI bus, apply the PCI workaround first. Refer to
+[Known Issues: GPUs do not enumerate on HPE servers](../reference/known-issues.md#gpus-do-not-enumerate-on-hpe-servers).
+
+:::
+
+1. From the left main menu, select **Cluster** > **Create cluster**.
+2. Complete **Basic Information** (cluster name and tags), then select **Next**.
+3. In **Cluster Profile**, review the default PaletteAI Inference Launchpad profile. It bundles the edge OS, Kubernetes,
+   storage, networking, ingress, observability, and the PaletteAI Inference Launchpad application. The exact packs are
+   defined by the profile and can change between releases, so review the profile in Local UI for the current list.
+   Select **Next**.
+4. In **Profile Config**, complete the PaletteAI Inference Launchpad custom wizard. The wizard collects the settings the
+   platform packs need to install correctly on your hardware and network, in six sections: Networking, OS and metrics,
+   Container registry, Local admin, Storage, and Certificates. In Networking, the **Platform IP Address** is a single
+   unused IP address (not a range) that MetalLB assigns to the appliance console and API. In Certificates, provide the
+   CA certificate for the appliance's OIDC endpoint. The two certificate fields are labeled **OIDC CA cert** and **OIDC
+   CA key**, so look for the **OIDC** labels. To create a self-signed certificate, select the **OIDC CA cert** field
+   first, then select **Generate**, which fills in both the certificate and the key. To provide your own certificate
+   instead, paste your base64-encoded CA certificate and its private key. For every field's type, default, and
+   validation rules, including the password complexity requirements for the Registry and Local Admin passwords, refer to
+   [Cluster Profile Variables](../reference/profile-variables.md). Then select **Next**.
+
+5. In **Cluster Config**, configure the cluster settings, including the cluster **VIP**. Enter the VIP you reserved in
+   [Before You Begin](#before-you-begin). The VIP is a single IP address that always resolves to whichever node
+   currently holds the control-plane role, so the cluster keeps one stable endpoint even as individual nodes fail over.
+6. In **Node Config**, assign hosts to the control-plane and worker node pools.
+   {/* NEEDS REVIEW: QA's end-to-end install pass (2026-07-27) confirms a step is needed here to select the bond interface for the CNI during node config, but the exact field label and its section are still unconfirmed. Remains SME-blocked before publishing. */}
+   - Single node: no host selection is needed. Remove the worker pool and ensure **Allow worker capability** is enabled
+     on the control-plane pool so the sole node acts as both the control plane and the worker.
+   - Multi-node: assign the hosts you linked previously. Keep the leader in the control-plane pool and use an odd number
+     of control-plane nodes. You can remove the worker pool if it is not required, but ensure **Allow worker
+     capability** is enabled on the control-plane pool.
+7. Review the configuration and deploy. The nodes reboot as part of the build, and deployment can take up to
+   approximately 45 minutes; GPU driver installation adds time on first boot. During deployment, Traefik and Local UI
+   restart alongside the packs, so the browser may display a **"Your service is temporarily unavailable"** page more
+   than once. Refresh the browser to resume, and do not close the wizard or restart the deployment.
+
+   :::warning Extended pause during the node reboot
+
+   The deployment includes a node reboot during which the browser displays no progress for approximately 10 minutes.
+   This pause is expected. Wait for the browser to reconnect automatically; do not power-cycle the node or close the
+   wizard.
+
+   :::
+
+## Validate the Installation
+
+1. On the **Cluster** page, confirm the cluster reaches a **Running** and **Healthy** state and that all packs install.
+2. Confirm that all pods are running. SSH to the node and run `kubectl` against the node's admin kubeconfig.
+
+   ```bash
+   sudo kubectl --kubeconfig /etc/kubernetes/admin.conf get pods --all-namespaces
+   ```
+
+   ```bash hideClipboard title="Expected output"
+   NAMESPACE     NAME                        READY   STATUS    RESTARTS   AGE
+   kube-system   coredns-6f9b7c9d8-abcde     1/1     Running   0          12m
+   ```
+
+   The output lists pods across namespaces in the `Running` state.
+
+   To run `kubectl`, or a tool such as K9s, from the jumpbox instead, copy the node's kubeconfig off the node. It lives
+   at `/etc/kubernetes/admin.conf` and is readable only by `root`, so read it with `sudo`. Replace `<user>` with the
+   administrator username you set in the Palette TUI and `<node-ip>` with the node's IP.
+
+   <Tabs groupId="os">
+
+   <TabItem label="Linux / macOS" value="unix">
+
+   ```bash
+   ssh <user>@<node-ip> "sudo cat /etc/kubernetes/admin.conf" > appliance.kubeconfig
+   ```
+
+   </TabItem>
+
+   <TabItem label="Windows" value="windows">
+
+   ```powershell
+   ssh <user>@<node-ip> "sudo cat /etc/kubernetes/admin.conf" | Out-File -Encoding ascii appliance.kubeconfig
+   ```
+
+   </TabItem>
+
+   </Tabs>
+
+   The kubeconfig grants cluster-admin access, so store it like a root credential. If its `server` address is
+   `127.0.0.1` or an internal VIP the jumpbox cannot reach, replace it with the node's reachable IP or the cluster VIP.
+   Then point `kubectl` at it.
+
+   ```bash
+   kubectl --kubeconfig appliance.kubeconfig get pods --all-namespaces
+   ```
+
+3. After deployment completes, additional items appear in the Local UI left main menu. Use them to reach the PaletteAI
+   Inference Launchpad platform and confirm that GPU nodes are schedulable.
+
+:::info Log in to the console
+
+The cluster is now running. Open the PaletteAI Inference Launchpad console from the custom link that appears in the
+Local UI left main menu after deployment completes, rather than typing the platform IP address by hand. The console is
+served at `https://<platform-ip>`, the single Platform IP Address that Traefik fronts (the one you set in the cluster
+profile). Sign in with the **Local Admin** username and password you set in the Profile Config wizard during cluster
+creation. This is deliberately a different account from the Palette TUI account you created earlier: the Palette TUI
+account manages the node, signing in to Local UI and connecting over SSH, while the Local Admin account signs in to the
+appliance console and the Grafana dashboard, which share this one login. You set the Local Admin password during cluster
+creation because the console and Grafana do not exist until the cluster is deployed.
+
+:::
+
+If the cluster does not reach a **Running** and **Healthy** state, or if the GPUs do not enumerate as expected, refer to
+[Known Issues](../reference/known-issues.md).
+
+## Upload Your Model
+
+Uploading a model is a day-two operation, separate from the day-zero appliance install. You can run it in parallel with
+cluster deployment; it does not need to wait for validation. Models are uploaded separately from the content bundle,
+from the jumpbox to an appliance node, using the Palette CLI. The jumpbox needs `rsync` 3.2.3 or later and OpenSSH 8.4
+or later.
+
+For the full flag list, the metadata file schema, the on-appliance layout, and the deploy-catalog states, refer to
+[Model Upload Reference](../reference/model-upload-reference.md).
+
+1. Download the model metadata (`metadata.yaml`) from Artifact Studio.
+2. On the jumpbox, download the model to a writable local directory, for example `/home/ubuntu/downloads`. Do not use an
+   NFS share, which may be mounted read-only. The model lands at `<model-dir>/<name>/<version>/`.
+
+   <Tabs groupId="os">
+
+   <TabItem label="Linux / macOS" value="unix">
+
+   ```bash
+   palette content model download \
+     --metadata model.yaml \
+     --model-dir ./models
+   ```
+
+   </TabItem>
+
+   <TabItem label="Windows" value="windows">
+
+   ```powershell
+   palette content model download `
+     --metadata model.yaml `
+     --model-dir .\models
+   ```
+
+   </TabItem>
+
+   </Tabs>
+
+   For gated or private Hugging Face repos, set `HF_TOKEN`.
+
+3. Upload the model to an appliance node. We recommend using SSH key authentication (`--ssh-key`). If you do not have a
+   key on the node, use `--ssh-password` for password authentication (supported on a Unix jumpbox only), and add
+   `--insecure-skip-host-key-check` if the node's host key is not yet known.
+
+   <Tabs groupId="os">
+
+   <TabItem label="Linux / macOS" value="unix">
+
+   ```bash
+   palette content model upload \
+     --metadata model.yaml \
+     --model-dir ./models \
+     --ssh-user <user> \
+     --ssh-host <node-ip> \
+     --ssh-key ~/.ssh/id_ed25519
+   ```
+
+   </TabItem>
+
+   <TabItem label="Windows" value="windows">
+
+   ```powershell
+   palette content model upload `
+     --metadata model.yaml `
+     --model-dir .\models `
+     --ssh-user <user> `
+     --ssh-host <node-ip> `
+     --ssh-key ~\.ssh\id_ed25519
+   ```
+
+   </TabItem>
+
+   </Tabs>
+
+4. Confirm the model is ready to deploy. In the appliance console, select **Cluster** from the left main menu, then
+   select **Deploy model** to open the deploy panel, and open the model drop-down menu. On a single-node appliance, the
+   model appears in the drop-down on the next catalog scan after the upload finishes. On a multi-node appliance, the
+   drop-down shows the model's cluster-wide state: **Available** when the model is ready on every node and can be
+   deployed, **Pending** while the appliance is still synchronizing it across nodes, or **Missing** when the appliance
+   has the model's metadata but not yet its weights. Only an **Available** model can be deployed.
+
+## Next Steps
+
+After the model is uploaded, the remaining tasks are day-two product usage, covered by the existing how-to guides:
+
+- **Deploy a model**. [Deploy a Model](./deploy-a-model.md).
+- **Generate an API token**. [Generate an API Token](./generate-an-api-token.md).
+- **Connect a coding tool**. [Claude Code](./use-claude-code.md), [Cursor](./use-cursor.md),
+  [OpenAI Codex](./use-codex.md), or [OpenCode](./use-opencode.md).
+
+For definitions of the terms used in this guide, such as slim ISO, content bundle, jumpbox, bond, leader, follower,
+Palette TUI, Local UI, and OTP, refer to the [Glossary](../reference/glossary.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
@@ -1,0 +1,80 @@
+---
+sidebar_label: "Manage a Client's Model Access"
+title: "Manage a Client's Model Access"
+description:
+  "Step-by-step guidance for platform administrators on how to route a client to specific models and allow a client to
+  reach external models on a PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 6
+tags: ["paletteai-inference-launchpad", "clients", "models", "how-to"]
+keywords: ["launchpad", "ai", "clients", "model access", "routing", "tier map", "egress", "frontier"]
+---
+
+This guide explains how a platform administrator controls which models a client uses on a PaletteAI Inference Launchpad
+appliance. Model access depends on whether a model runs locally on the appliance or is reached through an external
+provider.
+
+- **Local models.** Every client with a valid API token can call every model served locally on the appliance. You do not
+  grant access to local models. To choose which local model handles a client's requests, route the client with a tier
+  map.
+- **External models.** A new client cannot reach external, or frontier, models until you enable egress for it. External
+  access is denied by default and is granted per client.
+
+To understand how clients and models relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- An existing client. To create one, refer to [Create a Client](./create-a-client.md).
+- Console access with permission to manage clients. Managing clients can require operator access.
+- _(External models only)_ A provider key for the external provider.
+
+## Route a Client to Specific Models
+
+Use a client's tier map to route the client's model aliases to the models you choose.
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Routing** section.
+
+4. In the **Tier map**, select **Add alias rule**, or edit an existing row.
+
+5. Set the **Alias prefix**, such as `claude-opus-`, and the **Model** it routes to.
+
+6. Save the client.
+
+The tier map applies to the selected client. Requests from other clients follow their own tier maps, so they are not
+routed to that model unless you configure their tier maps as well.
+
+<!--TODO: once published, add a sentence here linking to Configure Intelligent Routing and Semantic Domains (DOC-2926) for routing that goes beyond client-level model selection, such as semantic domains.-->
+
+{/* NEEDS REVIEW: the tier map governs which model handles a client's requests by default. It is a routing overlay, not a hard access gate for local models. Confirm the operator-facing framing with an SME. */}
+
+## Allow a Client to Reach External Models
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Egress** section.
+
+4. Select **Enable egress**.
+
+5. Add a provider key for the external provider.
+
+6. Set a daily spend cap for the client. Egress is fail-closed on the cap, so a cap of `0` blocks egress.
+
+7. _(Optional)_ List the provider models the client may reach. Leave the list empty to allow every model from that
+   provider.
+
+8. Save the client.
+
+Frontier-model bursting is configured separately and is out of scope for this guide.
+{/* TODO: link to the frontier-model bursting guide once published. */}
+
+## Next Steps
+
+- [Set and Manage Client Quotas](./manage-client-quotas.md)
+- [View Client Usage](./view-client-usage.md)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/manage-client-quotas.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/manage-client-quotas.md
@@ -1,0 +1,62 @@
+---
+sidebar_label: "Set and Manage Client Quotas"
+title: "Set and Manage Client Quotas"
+description:
+  "Step-by-step guidance for platform administrators on how to set, edit, and remove usage quotas on a client on a
+  PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 5
+tags: ["paletteai-inference-launchpad", "clients", "quotas", "how-to"]
+keywords: ["launchpad", "ai", "clients", "quota", "rate limit", "requests", "tokens", "cost", "429"]
+---
+
+This guide explains how a platform administrator sets and manages usage quotas on a client on a PaletteAI Inference
+Launchpad appliance. A quota limits how much a client consumes. A quota applies to the client, so every API token that
+belongs to the client draws on the same limits. To understand how quotas fit with clients and API tokens, refer to
+[Clients and Quotas](../explanation/clients-and-quotas.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- An existing client. To create one, refer to [Create a Client](./create-a-client.md).
+- Console access with permission to manage clients. Managing clients can require operator access.
+
+## Set a Client Quota
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Quotas** section.
+
+4. Select **Add window limit**.
+
+5. Choose the dimension to limit: **requests**, **tokens**, or **cost**.
+
+6. Choose the window the limit applies over: **second**, **minute**, **hour**, or **day**.
+
+7. Enter the limit for that dimension and window.
+
+8. Repeat the previous steps for each limit you want. For example, add a requests-per-minute limit, a tokens-per-day
+   limit, and a cost-per-day limit.
+
+9. Save the client.
+
+Each row limits one dimension over one window. A window with no row stays uncapped.
+
+## Edit or Remove a Quota
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Quotas** section.
+
+4. Change a limit, or remove a window-limit row.
+
+5. Save the client.
+
+## Next Steps
+
+- [Manage a Client's Model Access](./manage-client-model-access.md)
+- [View Client Usage](./view-client-usage.md)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/revoke-or-delete-a-client.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/revoke-or-delete-a-client.md
@@ -1,0 +1,71 @@
+---
+sidebar_label: "Revoke or Delete a Client"
+title: "Revoke or Delete a Client"
+description:
+  "Step-by-step guidance for platform administrators on how to find expired keys, revoke an API token, and delete a
+  client on a PaletteAI Inference Launchpad appliance, and what happens to in-flight requests."
+hide_table_of_contents: false
+sidebar_position: 8
+tags: ["paletteai-inference-launchpad", "clients", "api token", "how-to"]
+keywords: ["launchpad", "ai", "clients", "revoke", "delete", "expired", "api token", "in-flight"]
+---
+
+This guide explains how a platform administrator ends a client's access on a PaletteAI Inference Launchpad appliance:
+finding expired or revoked tokens, revoking a single API token, and suspending or deleting a client. To understand how
+clients and API tokens relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- An existing client. To create one, refer to [Create a Client](./create-a-client.md).
+- Console access with permission to manage clients. Managing clients can require operator access.
+
+## Find Expired or Revoked Keys
+
+The console shows each token's state, so you can find expired or revoked tokens. For how the appliance enforces token
+expiry and revocation, refer to [Client Lifecycle](../explanation/clients-and-quotas.md#client-lifecycle).
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **API tokens** section. Each token shows a state of **active**, **expired**, or **revoked**.
+
+The **Usage** page also shows a token's state in its per-token detail. For usage, refer to
+[View Client Usage](./view-client-usage.md).
+
+{/* NEEDS REVIEW: the ticket (DOC-2927) also asks for expired keys to be flagged on an overview page, but the appliance Overview dashboard, the client Overview section, and the client list do not flag expired tokens. Expired state appears only in a client's API tokens section and in the Usage per-token detail. Confirm the intended surface with the ticket owner. */}
+
+## Revoke an API Token
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **API tokens** section.
+
+4. Find the token, then select the **Revoke access** icon (a prohibit symbol) at the end of its row, and confirm in the
+   **Revoke token** dialog.
+
+Revoking a token is immediate and cannot be undone.
+
+## Suspend or Delete a Client
+
+Suspend a client to block its requests temporarily; suspension is reversible. Delete a client to permanently retire it,
+which revokes all its API tokens and cannot be undone. For what each action keeps or removes, refer to
+[Client Lifecycle](../explanation/clients-and-quotas.md#client-lifecycle).
+
+Both actions are in the **Overview** section of the client's detail panel, each behind a confirmation.
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Overview** section, then select **Suspend** or **Delete**, and then confirm.
+
+To restore a suspended client, select **Resume** in the **Overview** section.
+
+## Next Steps
+
+- [Create a Client](./create-a-client.md)
+- [Generate an API Token](./generate-an-api-token.md)

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
@@ -1,0 +1,47 @@
+---
+sidebar_label: "Switch the Default Model"
+title: "Switch the Default Model"
+description:
+  "Task guidance for platform operators on how to switch the default model on a PaletteAI Inference Launchpad appliance
+  from the Overview page when the current default is no longer serving."
+hide_table_of_contents: false
+sidebar_position: 2
+tags: ["paletteai-inference-launchpad", "models", "how-to"]
+---
+
+This guide shows how to switch the default model on a running PaletteAI Inference Launchpad appliance when the current
+default is no longer serving. The appliance sets and maintains the default model for you; for how the default is chosen
+and applied, refer to [The Default Model](../explanation/architecture.md#the-default-model).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
+- A model other than the current default already deployed and serving, so that a healthy model is available to switch
+  to. To deploy and verify a model, refer to [Deploy a Model](./deploy-a-model.md).
+
+## Switch the Default Model
+
+When the current default model stops serving, the **Overview** page raises an incident and offers a one-step fix to
+point the default at a model that is currently serving.
+
+1. From the left main menu, select **Overview**.
+2. In the **Decisions waiting on you** card, locate the active incident for the default model.
+3. Open the **switch default model** drop-down menu and select a model that the appliance currently serves.
+4. Select **Apply Fix**, and then select **Confirm & apply**.
+
+The appliance switches the default model and re-runs its health check to confirm the new default recovers. For what
+happens to requests already in progress when the default changes, refer to
+[Request Routing](../explanation/architecture.md#request-routing).
+
+:::info
+
+If no model is currently serving, the card reports that there is nothing to switch to. Deploy a model from the
+**Cluster** tab first, then return to the **Overview** page. Refer to [Deploy a Model](./deploy-a-model.md).
+
+:::
+
+## Next Steps
+
+- **Generate an API token** to send requests to the default model. Refer to
+  [Generate an API Token](./generate-an-api-token.md).
+- **Deploy another model** to the appliance. Refer to [Deploy a Model](./deploy-a-model.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/upload-a-model.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/upload-a-model.md
@@ -1,0 +1,123 @@
+---
+sidebar_label: "Upload a Model"
+title: "Upload a Model"
+description:
+  "Step-by-step guidance for platform operators on how to download a model on a jumpbox and upload it to a PaletteAI
+  Inference Launchpad appliance with the Palette CLI over SSH."
+hide_table_of_contents: false
+sidebar_position: 1.5
+tags: ["paletteai-inference-launchpad", "models", "how-to"]
+keywords: ["launchpad", "ai", "model upload", "jumpbox", "palette cli", "huggingface", "rsync", "ssh", "air-gapped"]
+---
+
+{/* NEEDS REVIEW: per SME review, the model-upload flow is expected to change due to storage constraints and requirements. Revisit this guide when the new flow lands. */}
+
+PaletteAI Inference Launchpad is a self-contained appliance with no outbound internet access, so you bring models to it
+rather than having the appliance pull them at deploy time. You download a model onto a jumpbox and transfer it to the
+appliance over SSH, after which the model appears in the appliance's deploy catalog.
+
+This guide comes before [Deploy a Model](./deploy-a-model.md): the upload puts the model in the catalog, and the deploy
+serves it. For the full command flags and metadata file fields, refer to
+[Model Upload Reference](../reference/model-upload-reference.md).
+
+:::info
+
+You run every step in this guide from a **jumpbox**: a separate machine (also called the administrative workstation)
+with network access to your model source, such as Hugging Face, and SSH access to the appliance. The appliance never
+downloads models itself. For how to provision the jumpbox, refer to
+[Administrative Workstation](../reference/hardware-requirements.md#administrative-workstation).
+
+:::
+
+## Prerequisites
+
+- A **jumpbox** (administrative workstation) on the appliance network, provisioned with the Palette CLI, an SSH client
+  and key pair (or password authentication), enough local disk to stage model downloads, and network access to your
+  model source, such as Hugging Face. For details, refer to
+  [Administrative Workstation](../reference/hardware-requirements.md#administrative-workstation) and
+  [Model Download Access](../reference/hardware-requirements.md#model-download-access-recommended).
+- `rsync` on the jumpbox. The Palette CLI uses it to transfer the model to the appliance over SSH.
+- The metadata YAML for the model you intend to upload, obtained from Artifact Studio. For its fields, refer to
+  [Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
+- The appliance's SSH host address (IP or DNS name) and an SSH user.
+- _(Gated or private Hugging Face repositories)_ A Hugging Face access token.
+
+{/* NEEDS REVIEW: the source specifies rsync 3.2.3+ and OpenSSH 8.4+ on the jumpbox. Confirm the minimum versions before publishing. */}
+
+## Download the Model
+
+On the jumpbox, download the model from Hugging Face into a writable local directory. Do not use a read-only NFS mount.
+
+1. Run the download command, using the path to your metadata file and the directory to download into.
+
+   ```bash
+   palette content model download \
+       --metadata model.yaml \
+       --model-dir ./models
+   ```
+
+   The model downloads to `<model-dir>/<name>/<version>/`, where `<name>` and `<version>` come from the metadata file.
+
+2. _(Gated or private Hugging Face repositories)_ Provide a Hugging Face token through the `HF_TOKEN` environment
+   variable.
+
+   ```bash
+   HF_TOKEN=<hugging-face-token> palette content model download \
+       --metadata model.yaml \
+       --model-dir ./models
+   ```
+
+## Upload the Model to the Appliance
+
+Ship the downloaded directory from the jumpbox to the appliance over SSH. On a multi-node appliance, upload to a single
+node; the appliance syncs the model to the remaining nodes automatically.
+
+1. Run the upload command with the model directory and the appliance's SSH details.
+
+   ```bash
+   palette content model upload \
+       --metadata model.yaml \
+       --model-dir ./models \
+       --ssh-user <ssh-user> \
+       --ssh-host <appliance-host> \
+       --ssh-key <private-key-path>
+   ```
+
+   Replace `<ssh-user>` and `<appliance-host>` with the appliance's SSH user and address, and `<private-key-path>` with
+   the path to your private key, such as `~/.ssh/id_ed25519`.
+
+The upload command accepts other flags, including password authentication (`--ssh-password`, optionally with
+`--insecure-skip-host-key-check`), one-step download and upload (`--download`), and metadata-only sync
+(`--metadata-only`). For the full list, refer to
+[Model Upload Reference](../reference/model-upload-reference.md#palette-content-model-upload).
+
+## Verify the Model and Deploy It
+
+:::warning
+
+The appliance surfaces an uploaded model only when it matches an entry in the appliance's curated model catalog. If you
+upload a model that is not in the curated catalog, the upload succeeds but the model does not appear in the deploy
+catalog.
+
+:::
+
+{/* NEEDS REVIEW: per the source, an uploaded model that does not match a curated catalog entry is logged but not surfaced today, with a schema-gap follow-up planned. Confirm current behavior before publishing. */}
+
+{/* NEEDS REVIEW: multi-node catalog states and automatic peer sync are from the engineering source. Confirm the labels and behavior before publishing. */}
+
+1. In the appliance console, select **Cluster** from the left main menu, then select **Deploy model** to open the deploy
+   panel.
+
+2. Open the model drop-down menu and confirm the model you uploaded is listed. On a single-node appliance, the model
+   appears on the next catalog scan after the upload finishes. On a multi-node appliance, the catalog shows the model's
+   cluster-wide state: `Available` when the model is ready on every node, `Pending N/M` while nodes are still syncing,
+   or `Missing`. Only an `Available` model can be deployed.
+
+3. Deploy the model by following [Deploy a Model](./deploy-a-model.md).
+
+## Next Steps
+
+- **Deploy the model:** Follow [Deploy a Model](./deploy-a-model.md) to deploy the uploaded model and verify it is
+  serving.
+- **Review the reference:** Refer to [Model Upload Reference](../reference/model-upload-reference.md) for the full
+  command flags and metadata file fields.

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-claude-code.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-claude-code.md
@@ -1,0 +1,101 @@
+---
+sidebar_label: "Use Claude Code"
+title: "Use PaletteAI Inference Launchpad with Claude Code"
+description:
+  "Connect Anthropic's Claude Code coding agent to a PaletteAI Inference Launchpad appliance so that a model on the
+  appliance serves every request."
+hide_table_of_contents: false
+sidebar_position: 9
+tags: ["paletteai-inference-launchpad", "claude-code", "how-to"]
+keywords: ["launchpad", "ai", "claude code", "anthropic", "coding agent", "api token"]
+---
+
+This guide explains how to connect Claude Code to a PaletteAI Inference Launchpad appliance so that a model running on
+the appliance serves every request instead of Anthropic's hosted API. You point Claude Code at the appliance with two
+environment variables and confirm the connection.
+
+## Prerequisites
+
+- Claude Code installed and already working against Anthropic's hosted API. For installation, refer to the
+  [Claude Code documentation](https://docs.claude.com/en/docs/claude-code).
+- A running PaletteAI Inference Launchpad appliance with at least one model deployed and serving. To deploy a model,
+  refer to [Deploy a Model](./deploy-a-model.md).
+- An API token for the appliance. To create one, refer to [Generate an API Token](./generate-an-api-token.md), or use a
+  token an administrator generated for you.
+
+## Configure Claude Code
+
+On the machine where you run Claude Code, set the following environment variables.
+
+:::tip
+
+You do not have to assemble these variables by hand. In the console, select **Connect coding agent** and open the
+**Claude Code** tab to generate a ready-to-paste configuration snippet. The snippet can also set optional per-tier model
+aliases and a reasoning-effort level. For the full list of values it can set, refer to
+[Claude Code Configuration](../reference/claude-code-reference.md).
+
+:::
+
+```bash
+export ANTHROPIC_BASE_URL=https://<appliance-host>
+export ANTHROPIC_AUTH_TOKEN=<lpai-token>
+```
+
+Set `ANTHROPIC_BASE_URL` to your appliance's address with no path. Do not append `/v1`. Claude Code adds the API path
+itself. Use `ANTHROPIC_AUTH_TOKEN` for the token. `ANTHROPIC_API_KEY` also works, but do not set it globally if you also
+sign in to Claude Code with an Anthropic account.
+
+To persist the settings instead of exporting them each session, add them to the `~/.claude/settings.json` file.
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://<appliance-host>",
+    "ANTHROPIC_AUTH_TOKEN": "<lpai-token>"
+  }
+}
+```
+
+Claude Code requests a Claude alias, such as `claude-opus-4-8`. To pin every request to one alias, set `ANTHROPIC_MODEL`
+to it. For the aliases the appliance accepts, refer to
+[Claude Code Configuration](../reference/claude-code-reference.md).
+
+```bash
+export ANTHROPIC_MODEL=claude-opus-4-8
+```
+
+We strongly recommend giving the appliance a DNS name and a valid, publicly trusted TLS certificate. The connection uses
+HTTPS, so a valid certificate protects your token in transit.
+
+:::warning
+
+If the appliance uses a self-signed certificate, Claude Code rejects the connection by default. As a temporary measure
+for testing, set `NODE_TLS_REJECT_UNAUTHORIZED=0` before you start Claude Code. This disables certificate verification,
+so do not use it outside short-lived testing.
+
+:::
+
+## Verify the Connection
+
+Run a single prompt to confirm the appliance answers.
+
+```bash
+claude --print "reply with exactly CC_OK and nothing else"
+```
+
+```bash hideClipboard title="Expected output"
+CC_OK
+```
+
+A reply confirms that the base URL, token, and model routing all work. To confirm which endpoint and credential the
+session uses, run the `/status` command in Claude Code and review the **Anthropic base URL** and **Auth token** lines.
+
+## Request Routing and Quotas
+
+<PartialsComponent category="paletteai-inference-launchpad" name="request-routing-and-quotas" />
+
+## Next Steps
+
+To look up any configuration value, refer to [Claude Code Configuration](../reference/claude-code-reference.md). To
+deploy another model to the appliance, refer to [Deploy a Model](./deploy-a-model.md).
+{/* TODO: add direction to the client and API token management, token quotas and metering, and intelligent routing pages once they exist */}

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-codex.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-codex.md
@@ -1,0 +1,97 @@
+---
+sidebar_label: "Use OpenAI Codex"
+title: "Use PaletteAI Inference Launchpad with OpenAI Codex"
+description:
+  "Connect the OpenAI Codex CLI to a PaletteAI Inference Launchpad appliance so that a model on the appliance serves
+  every request."
+hide_table_of_contents: false
+sidebar_position: 11
+tags: ["paletteai-inference-launchpad", "codex", "how-to"]
+keywords: ["launchpad", "ai", "openai codex", "codex cli", "responses api", "config.toml", "api token"]
+---
+
+This guide explains how to connect the OpenAI Codex CLI to a PaletteAI Inference Launchpad appliance so that a model
+running on the appliance serves every request instead of OpenAI's hosted API. You add a custom model provider to the
+Codex configuration file and confirm the connection.
+
+## Prerequisites
+
+- The OpenAI Codex CLI installed and already working. For installation, refer to the
+  [OpenAI Codex website](https://github.com/openai/codex).
+- A running PaletteAI Inference Launchpad appliance with at least one model deployed and serving. To deploy a model,
+  refer to [Deploy a Model](./deploy-a-model.md).
+- An API token for the appliance. To create one, refer to [Generate an API Token](./generate-an-api-token.md), or use a
+  token an administrator generated for you.
+- The appliance reachable at a DNS hostname with a valid, publicly trusted TLS certificate. Codex validates TLS strictly
+  and cannot skip certificate verification, so a self-signed certificate does not work.
+
+## Configure Codex
+
+Codex uses the Responses API, so you add a custom model provider that points at the appliance. For a description of each
+field, refer to [OpenAI Codex Configuration](../reference/codex-reference.md).
+
+:::tip
+
+The console can generate a starter version of this configuration for you. Select **Connect coding agent** and open the
+**Codex** tab to copy a `config.toml` snippet pre-filled with your appliance's endpoint. Review the model and provider
+values against the steps below before you save it.
+
+:::
+
+1. Add the following custom provider to the Codex configuration file at `~/.codex/config.toml`. Replace
+   `<appliance-host>` with your appliance address.
+
+   ```toml
+   model = "glm-5.2"            # a model the appliance serves, not "auto"
+   model_provider = "lpai"
+
+   [model_providers.lpai]
+   name = "Launchpad"
+   base_url = "https://<appliance-host>/v1"
+   env_key = "LPAI_KEY"
+   wire_api = "responses"       # Codex uses the Responses API
+   ```
+
+   Set `model` to a model the appliance serves, such as `glm-5.2`. Do not use `auto`, because the Responses API passes
+   the model straight to the engine. Set `base_url` to your appliance address with the `/v1` path appended.
+
+2. Set the environment variable named in `env_key` to your API token so that Codex can authenticate. In this example,
+   `env_key` is `LPAI_KEY`. Replace `<lpai-token>` with the token you copied.
+
+   ```bash
+   export LPAI_KEY=<lpai-token>
+   ```
+
+{/* NEEDS REVIEW: this guide says `model` must be a real served id (not an alias) because the Responses API passes the model straight to the engine, but the console's "Connect coding agent" > Codex snippet sets `model = "claude-opus-4-8"`, a tier-map alias. Confirm with an SME whether the tier map resolves aliases over the Responses API. */}
+
+## Verify the Connection
+
+Run a single prompt to confirm the appliance answers.
+
+```bash
+codex exec --skip-git-repo-check "reply with exactly CODEX_OK and nothing else"
+```
+
+```bash hideClipboard title="Expected output"
+CODEX_OK
+```
+
+A reply confirms that the base URL, token, provider, and model routing all work. The `--skip-git-repo-check` flag lets
+you run the test outside a git repository.
+
+:::info
+
+Codex may print a `Model metadata for glm-5.2 not found` warning. This warning is cosmetic and does not affect the
+request.
+
+:::
+
+## Request Routing and Quotas
+
+<PartialsComponent category="paletteai-inference-launchpad" name="request-routing-and-quotas" />
+
+## Next Steps
+
+To look up each configuration value, refer to [OpenAI Codex Configuration](../reference/codex-reference.md). To connect
+a different coding tool, refer to [Use PaletteAI Inference Launchpad with Claude Code](./use-claude-code.md) or
+[Use PaletteAI Inference Launchpad with Cursor](./use-cursor.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-cursor.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-cursor.md
@@ -1,0 +1,127 @@
+---
+sidebar_label: "Use Cursor"
+title: "Use PaletteAI Inference Launchpad with Cursor"
+description:
+  "Connect the Cursor code editor to a PaletteAI Inference Launchpad appliance so that a model on the appliance serves
+  your requests in Cursor's Ask mode."
+hide_table_of_contents: false
+sidebar_position: 10
+tags: ["paletteai-inference-launchpad", "cursor", "how-to"]
+keywords: ["launchpad", "ai", "cursor", "openai-compatible", "model alias", "ask mode", "api token"]
+---
+
+This guide explains how to connect Cursor to a PaletteAI Inference Launchpad appliance so that a model running on the
+appliance serves your requests instead of a cloud provider. You create a uniquely named model alias on the appliance,
+point Cursor at the appliance, and confirm that requests route through the appliance.
+
+:::warning
+
+Cursor routes only **Ask** mode (chat) requests to a custom endpoint. Agent, Edit, and Tab remain locked to Cursor's own
+models. This is a limitation of Cursor's bring-your-own-key support, not of the appliance, so those modes do not use the
+appliance even after you complete this guide.
+
+:::
+
+## Prerequisites
+
+- Cursor installed and already working. For installation, refer to the [Cursor documentation](https://docs.cursor.com).
+- A running PaletteAI Inference Launchpad appliance with at least one model deployed and serving. To deploy a model,
+  refer to [Deploy a Model](./deploy-a-model.md).
+- An API token for the appliance. To create one, refer to [Generate an API Token](./generate-an-api-token.md).
+  Generating the token and creating the model alias later in this guide can require operator access.
+- The appliance reachable at a DNS name with a valid, publicly trusted TLS certificate. Cursor sends requests from its
+  own cloud servers, so a self-signed certificate does not work and there is no client-side workaround.
+
+## Create a Model Alias
+
+Cursor sends model requests from its own cloud servers and decides where to route each request by the model name. If the
+name matches a model already in Cursor's catalog, such as `glm-5.2` or `gpt-4o`, Cursor routes the request to its own
+backend and never contacts your appliance. To force Cursor to use the appliance, serve the model under a unique alias
+name that does not exist in Cursor's catalog.
+
+{/* NEEDS REVIEW: the console's "Connect coding agent" > Cursor tab suggests adding the model `claude-opus-4-8`. That name likely matches Cursor's built-in catalog, so it would route to Cursor's own backend rather than the appliance, the problem this section prevents. Confirm with an SME; the unique-alias approach in this section is what reliably reaches the appliance. */}
+
+Creating an alias is an operator task. If you do not have operator access, ask an administrator to create the alias and
+give you its name, then continue to [Configure Cursor](#configure-cursor).
+
+The appliance can serve any model id as an alias of a model it already runs. On the appliance, alias a unique name to a
+served model. Replace `<appliance-host>` with your appliance address and `<admin-session-token>` with an operator
+session token.
+
+```bash
+curl --silent "https://<appliance-host>/admin/apply" \
+  --header "Authorization: Bearer <admin-session-token>" \
+  --header "Content-Type: application/json" \
+  --data '{"proposed_op":{"op":"set_tier","alias_prefix":"launchpad-glm52","model":"zai-org/GLM-5.2","thinking":"off","confirmed":true}}'
+```
+
+Set `alias_prefix` to the unique name Cursor requests, and set `model` to the id of a model the appliance already
+serves, such as `zai-org/GLM-5.2`. To find the served model id, check the appliance's `/v1/models` endpoint or the admin
+view in the console.
+
+The alias then appears in the appliance's `/v1/models` response and routes to the real model. The `alias_prefix` value,
+such as `launchpad-glm52`, is the name you enter in Cursor.
+
+{/* NEEDS REVIEW: the alias command and its admin-session bearer token ($ADMIN_SESSION) come verbatim from the connect guide; confirm how an operator obtains that session token. */}
+
+## Configure Cursor
+
+Point Cursor at the appliance in Cursor's settings. For the full list of settings and their example values, refer to
+[Cursor Configuration](../reference/cursor-reference.md).
+
+:::tip
+
+The console lists these same steps for you. Select **Connect coding agent** and open the **Cursor** tab for the base URL
+and key to enter. Use the unique alias from [Create a Model Alias](#create-a-model-alias) as the model name, not a
+built-in model name that Cursor already knows.
+
+:::
+
+1. In Cursor, open **Settings** > **Models**.
+
+2. Enable **Override OpenAI Base URL**, and enter your appliance address with the `/v1` path appended, such as
+   `https://<appliance-host>/v1`.
+
+3. In the **OpenAI API Key** field, enter your `lpai_` token.
+
+4. Under **OpenAI API Key**, select **Add model**, and enter the unique alias name, such as `launchpad-glm52`. A unique
+   name forces Cursor to treat the model as your custom model and send the request to your endpoint.
+
+5. Turn off Cursor's built-in models so that only your alias is active.
+
+## Verify the Connection
+
+Confirm that Cursor routes a request to the appliance instead of to its own backend.
+
+1. In Cursor, open a chat and set the mode to **Ask**.
+
+2. In the model picker, select your alias, such as `launchpad-glm52`.
+
+3. Send a test prompt.
+
+   ```text
+   reply with exactly CURSOR_OK and nothing else
+   ```
+
+4. Confirm that Cursor displays the reply `CURSOR_OK`.
+
+Because the alias name exists only on your appliance, Cursor cannot serve it from its own backend. A reply confirms that
+the chat request reached the appliance, that a model there served it, and that the base URL, token, alias, and routing
+all work.
+
+:::warning
+
+If Cursor returns `We're having trouble finding the resource you requested`, the alias name matches a model in Cursor's
+catalog, so Cursor routed the request to its own backend and never contacted the appliance. Create the alias again with
+a more unique name, and select the new name in Cursor.
+
+:::
+
+## Request Routing and Quotas
+
+<PartialsComponent category="paletteai-inference-launchpad" name="request-routing-and-quotas" />
+
+## Next Steps
+
+To look up the base URL, alias, and the Cursor modes the appliance supports, refer to
+[Cursor Configuration](../reference/cursor-reference.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-opencode.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/use-opencode.md
@@ -1,0 +1,114 @@
+---
+sidebar_label: "Use OpenCode"
+title: "Use PaletteAI Inference Launchpad with OpenCode"
+description:
+  "Connect the OpenCode terminal coding agent to a PaletteAI Inference Launchpad appliance so that a model on the
+  appliance serves every request."
+hide_table_of_contents: false
+sidebar_position: 12
+tags: ["paletteai-inference-launchpad", "opencode", "how-to"]
+keywords: ["launchpad", "ai", "opencode", "openai-compatible", "custom provider", "opencode.json", "api token"]
+---
+
+This guide explains how to connect OpenCode to a PaletteAI Inference Launchpad appliance so that a model running on the
+appliance serves every request instead of a cloud provider. You add a custom provider to the OpenCode configuration file
+and confirm the connection.
+
+## Prerequisites
+
+- OpenCode installed and already working. For installation details, refer to the
+  [OpenCode website](https://opencode.ai).
+- A running PaletteAI Inference Launchpad appliance with at least one model deployed and serving. To deploy a model,
+  refer to [Deploy a Model](./deploy-a-model.md).
+- An API token for the appliance. To create one, refer to [Generate an API Token](./generate-an-api-token.md), or use a
+  token an administrator generated for you.
+
+## Configure OpenCode
+
+OpenCode connects to any OpenAI-compatible endpoint through a custom provider. Add a provider for the appliance to the
+OpenCode configuration file. For a description of each field, refer to
+[OpenCode Configuration](../reference/opencode-reference.md).
+
+:::tip
+
+The console can generate a starter version of this file for you. Select **Connect coding agent** and open the
+**OpenCode** tab to copy an `opencode.json` snippet pre-filled with your appliance's endpoint. Review the `baseURL` and
+`models` values against the steps below before you save it.
+
+:::
+
+1. Add the following provider to the OpenCode configuration file at `~/.config/opencode/opencode.json`. Replace
+   `<appliance-host>` with your appliance address and `<lpai-token>` with the token you copied.
+
+   ```json
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "provider": {
+       "launchpad": {
+         "npm": "@ai-sdk/openai-compatible",
+         "name": "Launchpad",
+         "options": {
+           "baseURL": "https://<appliance-host>/v1",
+           "apiKey": "<lpai-token>"
+         },
+         "models": {
+           "glm-5.2": { "name": "GLM-5.2 (Launchpad)" }
+         }
+       }
+     }
+   }
+   ```
+
+2. Set `baseURL` to your appliance address with the `/v1` path appended.
+
+3. Set `apiKey` to your `lpai_` token.
+
+4. Under `models`, list each model id the appliance serves that you want to use, such as `glm-5.2`. The `launchpad` key
+   is a name you choose for the provider. OpenCode identifies a model by that provider name and a model id joined with a
+   slash, such as `launchpad/glm-5.2`, which you pass to the `--model` flag when you run OpenCode in the next section.
+
+5. We strongly recommend giving the appliance a DNS name and a valid, publicly trusted TLS certificate. The connection
+   uses HTTPS, so a valid certificate protects your token in transit.
+
+   :::warning
+
+   If the appliance uses a self-signed certificate, OpenCode rejects the connection by default because it runs on
+   Node.js. As a temporary measure for testing, set `NODE_TLS_REJECT_UNAUTHORIZED=0` before you start OpenCode. This
+   disables certificate verification, so do not use it outside short-lived testing.
+
+   :::
+
+## Verify the Connection
+
+Run a single prompt to confirm the appliance answers. The `--model` flag takes a `provider/model` value that combines
+the provider key from your configuration file with a model id.
+
+```bash
+opencode run --model launchpad/glm-5.2 "reply with exactly OPENCODE_OK"
+```
+
+```bash hideClipboard title="Expected output"
+OPENCODE_OK
+```
+
+A reply confirms that the base URL, token, provider, and model routing all work. OpenCode splits the `--model` value on
+the first slash, so `launchpad/glm-5.2` selects the `glm-5.2` model from the `launchpad` provider.
+
+:::tip
+
+If you use a reasoning model and the reply comes back empty, raise the output limit. Hidden reasoning tokens can consume
+a small output budget entirely, which leaves no room for the visible reply.
+
+:::
+
+## Request Routing and Quotas
+
+<PartialsComponent category="paletteai-inference-launchpad" name="request-routing-and-quotas" />
+
+## Next Steps
+
+To look up each configuration value, refer to [OpenCode Configuration](../reference/opencode-reference.md). To connect a
+different coding tool, refer to [Use PaletteAI Inference Launchpad with Claude Code](./use-claude-code.md),
+[Use PaletteAI Inference Launchpad with Cursor](./use-cursor.md), or
+[Use PaletteAI Inference Launchpad with OpenAI Codex](./use-codex.md). To deploy another model to the appliance, refer
+to [Deploy a Model](./deploy-a-model.md).

--- a/docs/docs-content/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
+++ b/docs/docs-content/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
@@ -1,0 +1,50 @@
+---
+sidebar_label: "View Client Usage"
+title: "View Client Usage"
+description:
+  "Step-by-step guidance for platform administrators on how to view per-client and per-token consumption on a PaletteAI
+  Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 7
+tags: ["paletteai-inference-launchpad", "clients", "usage", "how-to"]
+keywords: ["launchpad", "ai", "clients", "usage", "tokens", "requests", "cost", "metrics"]
+---
+
+This guide explains how a platform administrator views consumption per client and per API token on a PaletteAI Inference
+Launchpad appliance. To understand how usage relates to clients and quotas, refer to
+[Clients and Quotas](../explanation/clients-and-quotas.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- One or more clients with API tokens. To create a client, refer to [Create a Client](./create-a-client.md).
+- Console access with permission to view usage.
+
+## View Usage by Client
+
+1. From the left main menu, select **Usage**.
+
+2. Select the **By client** tab.
+
+3. Select a client.
+
+The client view shows:
+
+- Per-client totals for local input tokens, local output tokens, egress tokens, and egress cost.
+- A per-token table with each token's label, prefix, status, last-used time, creation time, expiration, request count,
+  input tokens, output tokens, total tokens, and cost.
+- The percentage of each quota used, which indicates how much of each limit is still available.
+- A conversation-routing breakdown that shows which models handled the client's requests.
+
+:::info
+
+Usage counts reflect activity since the appliance gateway last restarted.
+
+:::
+
+<!--TODO: once these sibling pages publish, add a "Further reading" list here linking to: View Token Usage and Consumption Metrics (DOC-2925) for more detail on usage metrics; and the Usage Metrics Reference (DOC-2942) for every metric and field. -->
+
+## Next Steps
+
+- [Set and Manage Client Quotas](./manage-client-quotas.md)
+- [Revoke or Delete a Client](./revoke-or-delete-a-client.md)

--- a/docs/docs-content/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/docs-content/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -1,0 +1,141 @@
+---
+id: overview
+title: What is PaletteAI Inference Launchpad?
+description: >
+  PaletteAI Inference Launchpad is a standalone, turnkey AI appliance that lets enterprises run large language models on
+  their own hardware without cloud dependency, AI consulting, or complex infrastructure setup.
+sidebar_label: Overview
+sidebar_position: 1
+tags:
+  - paletteai-inference-launchpad
+  - overview
+  - explanation
+---
+
+PaletteAI Inference Launchpad turns your own hardware into a private AI platform. Boot the image, load a model, and you
+are serving large language models (LLMs) in your own environment, with no cloud dependency, no AI consulting engagement,
+and no weeks spent wiring together an inference stack.
+
+Because inference runs on the appliance, your data never leaves your environment, and unpredictable per-token API bills
+become a fixed, predictable infrastructure cost. The appliance deploys as a single bootable image with no Palette or
+PaletteAI dependency.
+
+## The Problem It Solves
+
+Cloud-hosted AI is not the right fit for every enterprise. Data residency rules, regulatory compliance, air-gapped
+networks, latency targets, and per-token API costs can all push inference back inside your own walls.
+
+The catch is that building an on-prem AI stack from scratch means assembling GPU compute, an operating system,
+Kubernetes, an LLM inference runtime, authentication, Role-Based Access Control (RBAC), and observability, and then
+keeping it all working together. PaletteAI Inference Launchpad delivers the whole stack, pre-integrated, as a single
+bootable artifact.
+
+## Predictable AI Costs
+
+Cloud AI services bill per token, so costs scale directly with usage and become difficult to budget at enterprise scale.
+Running inference on your own hardware changes that billing model. Once the hardware is provisioned, inference cost is a
+fixed infrastructure line item regardless of token volume, making AI spend predictable and independent of how heavily
+the system is used.
+
+## What Is Inside the Appliance
+
+The appliance ships with the following pre-integrated components.
+
+| **Layer**             | **Technology**                                  |
+| --------------------- | ----------------------------------------------- |
+| Operating system      | [Kairos](https://kairos.io) on Ubuntu 24.04     |
+| Orchestration         | Kubernetes                                      |
+| LLM inference runtime | vLLM                                            |
+| Intelligent routing   | Routing by task type and data sensitivity       |
+| Local models          | GLM, DeepSeek, Kimi, Gemma                      |
+| Platform services     | Authentication, RBAC, monitoring, observability |
+| GPU support           | NVIDIA, AMD                                     |
+
+The OS layer runs Kairos on Ubuntu 24.04, an immutable Linux distribution designed for appliance deployments. Its
+read-only runtime prevents configuration drift and keeps the appliance in a known, reproducible state. Kubernetes
+manages the lifecycle of containerized workloads on top, handling scheduling, scaling, and health recovery.
+
+vLLM serves language models with high GPU throughput and handles concurrent requests from many users. The appliance
+ships with the ability to download one of these flagship open-weight models (GLM, DeepSeek, Kimi, or Gemma) and run it
+entirely on your hardware with no external API calls. NVIDIA and AMD GPU support provides the parallel processing that
+large language models require to respond at production speed.
+
+Intelligent routing directs each request to the most appropriate model. Requests that involve private data or require
+low latency stay local. Other requests can route outbound when the network allows.
+
+Platform services cover authentication, RBAC, monitoring, and observability. These surface health and usage data and
+ensure the appliance behaves as a managed enterprise system rather than a raw inference server. To understand how the
+appliance identifies callers and meters their usage, refer to [Clients and Quotas](./explanation/clients-and-quotas.md).
+
+The stack is packaged as Helm charts, which bundle each component as a versioned unit. You can update individual layers
+independently without replacing the entire appliance image.
+
+## PaletteAI Inference Launchpad or PaletteAI
+
+PaletteAI Inference Launchpad and [PaletteAI](https://docs.palette-ai.com) are related but distinct products that serve
+different scales and deployment models.
+
+|                       | **PaletteAI Inference Launchpad**               | **PaletteAI**                                                           |
+| --------------------- | ----------------------------------------------- | ----------------------------------------------------------------------- |
+| **Form factor**       | Standalone appliance (bootable ISO)             | Software platform (Helm chart or All-in-One ISO on existing Kubernetes) |
+| **Requires Palette?** | No                                              | Only if Palette also manages the underlying cluster                     |
+| **Primary users**     | Platform engineering and IT teams               | Platform engineering teams                                              |
+| **Scale**             | Single-site, on-prem, air-gapped                | Multi-cluster, multi-tenant, cloud and data center                      |
+| **AI workload model** | Local LLM inference with optional cloud routing | Full AI factory: GPU-as-a-Service, Model-as-a-Service, AI Studio        |
+
+## What PaletteAI Inference Launchpad Is Not
+
+- Not a managed cloud service. You own and operate the appliance.
+- Not a Palette add-on. No Palette tenant or license required.
+- Not a general-purpose Kubernetes platform. It is for LLM inference only.
+
+## Explore the Documentation
+
+Whatever brought you here, these are the fastest paths in.
+
+- **Get started**: [Suggested Hardware](./reference/hardware-requirements.md) •
+  [Install the appliance](./how-to-guides/install-the-appliance.md) •
+  [Deploy your first model](./how-to-guides/deploy-a-model.md)
+- **Understand the product**: [Architecture](./explanation/architecture.md) •
+  [Clients and Quotas](./explanation/clients-and-quotas.md) •
+  [Model Certification](./explanation/model-certification.md) • [Inference Engines](./explanation/inference-engines.md)
+- **Connect your coding tools**: [Claude Code](./how-to-guides/use-claude-code.md) •
+  [Cursor](./how-to-guides/use-cursor.md) • [OpenAI Codex](./how-to-guides/use-codex.md) •
+  [OpenCode](./how-to-guides/use-opencode.md)
+- **Operate day to day**: [Create a client](./how-to-guides/create-a-client.md) •
+  [Set client quotas](./how-to-guides/manage-client-quotas.md) •
+  [View client usage](./how-to-guides/view-client-usage.md) •
+  [Revoke or delete a client](./how-to-guides/revoke-or-delete-a-client.md)
+- **Look something up**: [Glossary](./reference/glossary.md) •
+  [Certified models by hardware](./reference/certified-models-by-hardware.md) •
+  [Known issues](./reference/known-issues.md) • [Release notes](./release-notes.md)
+
+## How This Documentation Is Organized
+
+- **[Tutorials](./tutorials/tutorials.md)** are learning-oriented lessons that guide you through a complete, working
+  example from start to finish.
+- **[How-to guides](./how-to-guides/how-to-guides.md)** are task-oriented and assume you know what you want to do, then
+  give you the steps to get there.
+- **[Reference](./reference/reference.md)** is information-oriented. It describes what exists and how it is configured
+  when you need to look something up.
+- **[Explanation](./explanation/explanation.md)** is understanding-oriented. It covers design decisions, component
+  relationships, and trade-offs.
+
+## Project and Community
+
+PaletteAI Inference Launchpad is built by [Spectro Cloud](https://www.spectrocloud.com), and there is a friendly
+community around it that we would love you to be part of. Share what you are building, ask questions, and swap tips with
+other builders and the people who make the product.
+
+:::info
+
+Visit the [Spectro Cloud community](https://www.spectrocloud.com/community) to connect with fellow users, follow the
+open source projects behind the appliance, and stay in the loop on what is next.
+
+:::
+
+## Commercial Support
+
+Planning a production rollout, or want to talk through your hardware and model choices with an expert? Learn more about
+plans and support on the [PaletteAI Inference Launchpad](https://www.spectrocloud.com/platform/inference-launchpad)
+product page.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/_category_.json
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Reference",
+  "position": 40,
+  "link": {
+    "type": "doc",
+    "id": "paletteai-inference-launchpad/reference/reference"
+  }
+}

--- a/docs/docs-content/paletteai-inference-launchpad/reference/bond-configuration.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/bond-configuration.md
@@ -1,0 +1,145 @@
+---
+id: bond-configuration
+title: Bond Configuration Reference
+description: >
+  Field-by-field reference for the bond form in Local UI: bond name, bond type, members, bonding mode, hash policy, link
+  monitoring interval, LACP rate, MTU, IP, gateway and DNS, optional VLAN sub-interface, and Cilium interface selection.
+sidebar_label: Bond Configuration
+sidebar_position: 2.5
+tags:
+  - paletteai-inference-launchpad
+  - reference
+  - install
+  - network
+keywords: ["launchpad", "ai", "bond", "802.3ad", "LACP", "MIIMonitorSec", "VLAN", "network"]
+---
+
+The appliance carries cluster traffic and [Piraeus](./glossary.md#piraeus) storage replication over a bonded interface,
+`bond0`, that aggregates two physical NICs into one logical link. This page documents each field of the Local UI
+**Network Interfaces > Bonds > Create** form. The values must match how your data-center switch is configured on the
+ports the appliance is plugged into; confirm them with your network administrator before you apply them.
+
+For the step-by-step procedure, refer to
+[Install the Appliance](../how-to-guides/install-the-appliance.md#create-a-bond). For the rationale for using a bond
+rather than a bridge, refer to [Installation Architecture](../explanation/installation-architecture.md#bond-not-bridge).
+
+## Fields
+
+Two fields are often confused. The **Bond type** sets how the bond gets its IP address (`static`, `dhcp`, or `none`),
+while the **Bonding mode** sets the link-aggregation algorithm (`802.3ad`). They are separate settings. Set the bond
+type to `static` and the bonding mode to `802.3ad`.
+
+### Bond name
+
+Recommended value: a name you type yourself, for example `bond0`.
+
+The name field shows `bond0` as grayed-out placeholder text, not a saved value. Click into the field and type the name
+before you continue; otherwise, the bond can be submitted without a name. Use `bond0` unless you already have a bond of
+that name.
+
+### Bond type
+
+Recommended value: `static`.
+
+Sets how the bond obtains its IP address: `static` (you enter the IP, subnet, and gateway), `dhcp` (the bond requests an
+address), or `none` (no IP, Layer 2 only). Choose `static` so the appliance keeps a fixed address. The IP, gateway, and
+DNS fields appear only when the type is `static` or `dhcp`.
+
+### Members
+
+Recommended value: the two data NICs, for example `enP1s3f0np0` and `enP1s3f1np1`.
+
+Select the member NICs manually from the list of physical interfaces. These are the NICs the Palette TUI showed during
+initial configuration. Do not include the out-of-band management NIC. Both member NICs must be cabled to switch ports
+that belong to the same LAG group.
+
+### Bond mode
+
+Recommended value: `802.3ad`.
+
+Selects dynamic Link Aggregation (LAG), the industry-standard bonding mode negotiated with the switch by the Link
+Aggregation Control Protocol (LACP). Both NICs are active at the same time, and the switch treats the pair as one
+logical port. This mode requires the switch to be configured with a matching LAG group with LACP enabled on the two
+switch ports.
+
+Do not select `active-backup` (uses only one NIC at a time) or `balance-alb` (works without switch configuration but
+interacts poorly with Piraeus's continuous replication traffic).
+
+### Hash policy
+
+Recommended value: `layer3+4`.
+
+The rule the bond uses to decide which of the two NICs sends any given outbound packet. `layer3+4` hashes on the source
+and destination IP address plus the TCP or UDP port, so many long-lived flows spread evenly across both NICs. The
+simpler `layer2` policy (MAC-only) sends all traffic through one NIC when the peer is a single router, which caps the
+bond at one NIC's bandwidth. Confirm the switch is set to the same hash policy. This field applies only to the `802.3ad`
+bonding mode.
+
+### Link monitoring interval
+
+Recommended value: `100`.
+
+The interval, in milliseconds, at which the bond driver checks each member NIC's link state, set through the
+`MIIMonitorSec` option. Local UI populates this field with a default of `100`. Keep the default unless your network team
+requires a different value.
+
+### LACP transmit rate
+
+Recommended value: `fast`.
+
+The rate at which the appliance exchanges LACP heartbeat frames with the switch. `fast` sends one heartbeat per second,
+so a failed link is detected within a few seconds. `slow` (the LACP default) sends one every 30 seconds; use it only if
+your switch team requires it. The overhead of `fast` is negligible. This field applies only to the `802.3ad` bonding
+mode.
+
+### Maximum Transmission Unit (MTU)
+
+Recommended value: your network's MTU, for example `1500`, or `9000` for jumbo frames.
+
+The maximum transmission unit applied to the bond interface. Match the value your data-center switch uses on the same
+ports. Jumbo frames are optional and are not required for the appliance.
+
+### IP address (static bonds)
+
+Recommended value: the host IP on the bond, as CIDR, for example `10.0.21.106/24`.
+
+The address the node uses on the untagged (native) VLAN, shown only when the bond type is `static`. Local UI moves the
+IP you set on the individual NIC in the Palette TUI onto the bond when you apply the form, so the node keeps the same
+address, only on a different interface.
+
+### Gateway and DNS servers
+
+Recommended value: the default gateway and DNS servers you set in the Palette TUI.
+
+Local UI carries these over so the node keeps outbound connectivity and name resolution once the bond takes over.
+
+### VLAN sub-interface (optional)
+
+Recommended value (when needed): `bond0.<vlan-id>` with its own CIDR, for example `bond0.393` with `10.0.22.110/24`.
+
+Add one only if you need to reach a tagged VLAN, such as an external NFS storage network. The switch ports that carry
+the bond must be configured to trunk the tagged VLAN through to the appliance.
+
+### Cilium interface selection
+
+Recommended value: leave empty.
+
+Cilium is the Kubernetes networking layer the cluster installs later. It auto-detects the interface that owns the
+default gateway (the bond) and uses it, so no explicit selection is needed. Only override this if Spectro Cloud support
+directs you to.
+
+## Quick reference
+
+```text
+Bond name    : type it yourself, for example bond0 (the field shows bond0 as a placeholder)
+Bond type    : static
+Members      : the data NICs, selected manually, for example enP1s3f0np0 and enP1s3f1np1
+Bonding mode : 802.3ad
+Hash policy  : layer3+4
+Link monitor : 100 (MIIMonitorSec, milliseconds)
+LACP rate    : fast
+MTU          : your network MTU, for example 1500
+IP           : the host IP on the bond, for example 10.0.21.106/24 (untagged, static bonds)
+Gateway/DNS  : the default gateway and DNS servers
+VLAN (opt.)  : bond0.<vlan-id>, for example bond0.393 with 10.0.22.110/24
+```

--- a/docs/docs-content/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
@@ -1,0 +1,58 @@
+---
+id: certified-models-by-hardware
+title: Certified Models by Hardware
+description: >
+  Reference table that maps each supported NVIDIA and AMD GPU configuration to the LLM models certified for PaletteAI
+  Inference Launchpad.
+sidebar_label: Certified Models by Hardware
+sidebar_position: 4
+tags:
+  - paletteai-inference-launchpad
+  - reference
+  - models
+  - hardware
+---
+
+Spectro Cloud certifies a small set of large language models (LLMs) for the hardware that PaletteAI Inference Launchpad
+supports. A _certified_ model is one that Spectro Cloud has validated to run correctly on the listed GPU configuration.
+For what certification covers, refer to [Model Certification](../explanation/model-certification.md).
+
+:::info
+
+This is not an exclusive list. You can load other models on the appliance as long as they fit within the available GPU
+resources. If the model you want does not appear here, [contact Spectro Cloud](https://www.spectrocloud.com/contact) to
+discuss your use case.
+
+:::
+
+<Tabs queryString="vendor">
+
+<TabItem label="NVIDIA" value="nvidia">
+
+| **GPU configuration** | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** | **Gemma 4** |
+| --------------------- | :---------: | :-----------------: | :----------: | :---------: |
+| 4 x H100              |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x H100              |     ❌      |         ❌          |      ❌      |     ✅      |
+| 4 x H200              |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x H200              |     ✅      |         ✅          |      ✅      |     ✅      |
+| 4 x B200              |     ❌      |         ❌          |      ❌      |     ✅      |
+| 8 x B200              |     ✅      |         ✅          |      ✅      |     ✅      |
+
+</TabItem>
+
+<TabItem label="AMD" value="amd">
+
+| **GPU configuration** | **GLM 5.2** | **DeepSeek v4 Pro** | **Kimi 2.7** | **Gemma 4** |
+| --------------------- | :---------: | :-----------------: | :----------: | :---------: |
+| 4 x MI300X            |     ❌      |         ❌          |      ✅      |     ✅      |
+| 8 x MI300X            |     ✅      |         ❌          |      ✅      |     ✅      |
+| 4 x MI325X            |     ✅      |         ❌          |      ✅      |     ✅      |
+| 8 x MI325X            |     ✅      |         ❌          |      ❌      |     ✅      |
+| 4 x MI350X            |     ✅      |         ✅          |      ❌      |     ✅      |
+| 8 x MI350X            |     ✅      |         ✅          |      ❌      |     ✅      |
+| 4 x MI355X            |     ✅      |         ✅          |      ❌      |     ✅      |
+| 8 x MI355X            |     ✅      |         ✅          |      ❌      |     ✅      |
+
+</TabItem>
+
+</Tabs>

--- a/docs/docs-content/paletteai-inference-launchpad/reference/claude-code-reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/claude-code-reference.md
@@ -1,0 +1,54 @@
+---
+sidebar_label: "Claude Code Configuration"
+title: "PaletteAI Inference Launchpad Claude Code Configuration"
+description:
+  "Reference for the environment variables and values used to connect Claude Code to a PaletteAI Inference Launchpad
+  appliance."
+hide_table_of_contents: false
+sidebar_position: 5
+tags: ["paletteai-inference-launchpad", "claude-code", "reference"]
+keywords: ["launchpad", "ai", "claude code", "anthropic", "environment variables", "api token", "model"]
+---
+
+This page lists the configuration values Claude Code uses to connect to a PaletteAI Inference Launchpad appliance. For
+the steps to set them, refer to
+[Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md).
+
+## Environment Variables
+
+| **Variable**                     | **Description**                                                                                                                             | **Example value**                   |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `ANTHROPIC_BASE_URL`             | The PaletteAI Inference Launchpad inference endpoint. Use the appliance address with no path. Claude Code appends `/v1/messages`.           | `https://amd.spectrocloud.com:8443` |
+| `ANTHROPIC_AUTH_TOKEN`           | The API token generated in the console. It begins with `lpai_`. `ANTHROPIC_API_KEY` is also accepted.                                       | `lpai_YOUR_TOKEN`                   |
+| `ANTHROPIC_MODEL`                | Optional. The Claude alias Claude Code requests. The appliance maps the alias to the model it serves, so you do not pick the backend model. | `claude-opus-4-8`                   |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL`   | Optional. The alias Claude Code requests for its Opus-tier work. The appliance maps the alias to the model it serves.                       | `claude-opus-4-8`                   |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | Optional. The alias Claude Code requests for its Sonnet-tier work.                                                                          | `claude-sonnet-4-5`                 |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL`  | Optional. The alias Claude Code requests for its Haiku-tier, background work.                                                               | `claude-haiku-4-5`                  |
+| `CLAUDE_CODE_EFFORT_LEVEL`       | Optional. Sets Claude Code's reasoning effort. One of `low`, `medium`, `high`, or `max`.                                                    | `max`                               |
+
+{/* TODO: confirm the ANTHROPIC_DEFAULT_* and CLAUDE_CODE_EFFORT_LEVEL rows with an SME. The console's "Connect coding agent" snippet emits them, but their appliance behavior is unverified. */}
+
+## Endpoint URL
+
+The endpoint is your appliance's address, the same host you use to reach the console, with no path appended. The gateway
+serves the Anthropic Messages API at `/v1/messages`, and Claude Code adds that path itself, so `ANTHROPIC_BASE_URL` must
+not include `/v1`. If you do not know the address, ask the administrator who set up the appliance.
+
+## Model Name
+
+Claude Code requests a Claude alias (`claude-opus-4-8`, `claude-sonnet-4-5`, or `claude-haiku-4-5`), and the appliance
+maps that alias to the model it serves. Set `ANTHROPIC_MODEL` to one of these aliases. You do not select a backend model
+directly. Both the aliases the appliance accepts and the ids of the models it serves, such as `glm-5.2`, appear in the
+console's model list and in the appliance's `/v1/models` API response.
+
+## Token Quotas
+
+If the token's quota is exhausted, the appliance returns an HTTP `429` response and Claude Code surfaces the error.
+{/* TODO: link once the token quotas and metering reference page exists */}
+
+## Resources
+
+- [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md)
+- User and API token management {/* TODO: link once page exists */}
+- Token quotas and metering {/* TODO: link once page exists */}
+- Intelligent routing and tier maps {/* TODO: link once page exists */}

--- a/docs/docs-content/paletteai-inference-launchpad/reference/codex-reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/codex-reference.md
@@ -1,0 +1,84 @@
+---
+sidebar_label: "OpenAI Codex Configuration"
+title: "PaletteAI Inference Launchpad OpenAI Codex Configuration"
+description:
+  "Reference for the configuration file fields and values used to connect the OpenAI Codex CLI to a PaletteAI Inference
+  Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 7
+tags: ["paletteai-inference-launchpad", "codex", "reference"]
+keywords: ["launchpad", "ai", "openai codex", "codex cli", "config.toml", "responses api", "api token", "model"]
+---
+
+This page lists the configuration values the OpenAI Codex CLI uses to connect to a PaletteAI Inference Launchpad
+appliance. For the steps to set them, refer to
+[Use PaletteAI Inference Launchpad with OpenAI Codex](../how-to-guides/use-codex.md).
+
+## Configuration File
+
+Codex reads its configuration from `~/.codex/config.toml`. Add a custom model provider for the appliance.
+
+```toml
+model = "glm-5.2"
+model_provider = "lpai"
+
+[model_providers.lpai]
+name = "Launchpad"
+base_url = "https://amd.spectrocloud.com:8443/v1"
+env_key = "LPAI_KEY"
+wire_api = "responses"
+```
+
+## Fields
+
+| **Field**        | **Description**                                                                                                                           | **Example value**                      |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `model`          | The id of a model the appliance serves. Use a real served model id, not `auto`, because the Responses API passes the model to the engine. | `glm-5.2`                              |
+| `model_provider` | The provider Codex uses. Must match the name of the `[model_providers.<name>]` table.                                                     | `lpai`                                 |
+| `name`           | A display name for the provider.                                                                                                          | `Launchpad`                            |
+| `base_url`       | The appliance inference endpoint, with the `/v1` path appended.                                                                           | `https://amd.spectrocloud.com:8443/v1` |
+| `env_key`        | The name of the environment variable that holds your API token.                                                                           | `LPAI_KEY`                             |
+| `wire_api`       | The API Codex uses. Codex uses the Responses API, so set this to `responses`.                                                             | `responses`                            |
+
+## Endpoint URL
+
+Set `base_url` to your appliance's address, the same host you use to reach the console, with `/v1` appended. The gateway
+serves the Responses API at `/v1/responses`, and Codex appends the `/responses` path itself, so `base_url` ends at
+`/v1`. If you do not know the address, ask the administrator who set up the appliance.
+
+## API Token
+
+Codex reads the token from the environment variable named by `env_key`. Export it before you run Codex.
+
+```bash
+export LPAI_KEY=<lpai-token>
+```
+
+The token is generated in the console and begins with `lpai_`.
+
+## Model Name
+
+Codex sends the value of `model` straight to the appliance engine over the Responses API, so it must be a model the
+appliance serves, such as `glm-5.2`. Do not use `auto`. The served model ids appear in the console model list and in the
+appliance's `/v1/models` API response.
+
+{/* NEEDS REVIEW: the console's "Connect coding agent" > Codex snippet sets `model = "claude-opus-4-8"`, a tier-map alias rather than a served id. Confirm with an SME whether the tier map resolves aliases over the Responses API, which would contradict the preceding guidance. */}
+
+## Requirements
+
+- The appliance must present a valid, publicly trusted TLS certificate on a DNS hostname. Codex validates TLS strictly
+  and cannot skip certificate verification, so a self-signed certificate does not work.
+- The gateway must accept the `developer` message role, which the PaletteAI Inference Launchpad gateway does.
+
+## Token Quotas
+
+If the token's quota is exhausted, the appliance returns an HTTP `429` response and Codex surfaces the error.
+{/* TODO: link to the token quotas and metering reference once it exists */}
+
+## Resources
+
+- [Use PaletteAI Inference Launchpad with OpenAI Codex](../how-to-guides/use-codex.md)
+- [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md)
+- [Use PaletteAI Inference Launchpad with Cursor](../how-to-guides/use-cursor.md)
+- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- Token quotas and metering {/* TODO: link once page exists */}

--- a/docs/docs-content/paletteai-inference-launchpad/reference/cursor-reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/cursor-reference.md
@@ -1,0 +1,70 @@
+---
+sidebar_label: "Cursor Configuration"
+title: "PaletteAI Inference Launchpad Cursor Configuration"
+description:
+  "Reference for the settings and values used to connect the Cursor code editor to a PaletteAI Inference Launchpad
+  appliance."
+hide_table_of_contents: false
+sidebar_position: 6
+tags: ["paletteai-inference-launchpad", "cursor", "reference"]
+keywords: ["launchpad", "ai", "cursor", "openai-compatible", "base url", "model alias", "api token"]
+---
+
+This page lists the configuration values Cursor uses to connect to a PaletteAI Inference Launchpad appliance. For the
+steps to set them, refer to [Use PaletteAI Inference Launchpad with Cursor](../how-to-guides/use-cursor.md).
+
+## Settings
+
+Set the following in Cursor under **Settings** > **Models**.
+
+| **Setting**                  | **Description**                                                                                               | **Example value**                      |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| **Override OpenAI Base URL** | The PaletteAI Inference Launchpad inference endpoint. Use the appliance address with the `/v1` path appended. | `https://amd.spectrocloud.com:8443/v1` |
+| **OpenAI API Key**           | The API token generated in the console. It begins with `lpai_`.                                               | `lpai_YOUR_TOKEN`                      |
+| **Add model**                | The unique alias name the appliance serves. Enter the alias, not the backend model id.                        | `launchpad-glm52`                      |
+
+## Endpoint URL
+
+Cursor uses the OpenAI-compatible API, which the gateway serves at `/v1`. Set **Override OpenAI Base URL** to your
+appliance's address, the same host you use to reach the console, with `/v1` appended. This differs from Claude Code,
+which uses the Anthropic Messages API and adds the path itself.
+
+The appliance must have a valid, publicly trusted TLS certificate on a DNS name. Cursor sends the request from its own
+cloud servers rather than from your machine, so it does not accept a self-signed certificate and offers no way to skip
+certificate verification.
+
+## Model Name and Aliases
+
+Cursor decides where to route a request by the model name. If the name matches a model in Cursor's built-in catalog,
+such as `glm-5.2` or `gpt-4o`, Cursor routes the request to its own backend, and the appliance receives nothing. To
+reach the appliance, an operator must serve the model under a unique alias name that does not appear in Cursor's
+catalog.
+
+An operator creates the alias on the appliance, which maps it to a model the appliance already serves, such as
+`zai-org/GLM-5.2`. Both the alias and the ids of the models the appliance serves appear in the console model list and in
+the appliance's `/v1/models` API response.
+
+{/* NEEDS REVIEW: the console's "Connect coding agent" > Cursor tab suggests the model `claude-opus-4-8`, which likely matches Cursor's built-in catalog and would route to Cursor's own backend. Confirm with an SME; the unique-alias approach is what reliably reaches the appliance. */}
+
+## Supported Modes
+
+| **Cursor mode** | **Supported** | **Notes**                                                    |
+| --------------- | ------------- | ------------------------------------------------------------ |
+| Ask (chat)      | Yes           | Routes to the appliance through the model alias.             |
+| Agent           | No            | Locked to Cursor's own models for bring-your-own-key setups. |
+| Edit            | No            | Locked to Cursor's own models for bring-your-own-key setups. |
+| Tab             | No            | Locked to Cursor's own models for bring-your-own-key setups. |
+
+The unsupported modes are a limitation of Cursor's bring-your-own-key support, not of the appliance.
+
+## Token Quotas
+
+If the token's quota is exhausted, the appliance returns an HTTP `429` response and Cursor surfaces the error.
+{/* TODO: link to the token quotas and metering reference once it exists */}
+
+## Resources
+
+- [Use PaletteAI Inference Launchpad with Cursor](../how-to-guides/use-cursor.md)
+- [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md)
+- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- Token quotas and metering {/* TODO: link once page exists */}

--- a/docs/docs-content/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/glossary.md
@@ -1,0 +1,471 @@
+---
+id: glossary
+title: "PaletteAI Inference Launchpad Glossary"
+description:
+  "Definitions of the key AI, product, and platform terms used across the PaletteAI Inference Launchpad documentation."
+sidebar_label: "Glossary"
+sidebar_position: 1
+toc_max_heading_level: 2
+tags: ["paletteai-inference-launchpad", "reference", "glossary"]
+keywords:
+  ["launchpad", "ai", "glossary", "definitions", "terms", "llm", "inference", "quota", "client", "token", "appliance"]
+---
+
+This glossary defines the key AI, product, and platform terms used across the PaletteAI Inference Launchpad
+documentation. Use it to look up an unfamiliar term without leaving the guide you are reading.
+
+**Go to:** [A](#a) · [B](#b) · [C](#c) · [D](#d) · [E](#e) · [F](#f) · [H](#h) · [I](#i) · [J](#j) · [K](#k) · [L](#l) ·
+[M](#m) · [N](#n) · [O](#o) · [P](#p) · [Q](#q) · [R](#r) · [S](#s) · [T](#t) · [V](#v)
+
+## A
+
+### Administrative Workstation
+
+A separate Linux machine, also called a jumpbox, that an operator uses to reach the appliance for installation,
+post-installation validation, and day-two operations with tools such as `kubectl`. It is not part of the appliance
+itself. Refer to [Suggested Hardware](./hardware-requirements.md).
+
+### Air-Gapped
+
+Describes a deployment that has no direct or indirect connection to the internet or other outside networks. The
+appliance is designed to run air-gapped, requiring no outbound internet access during normal operation.
+
+### API Token
+
+A credential that authenticates requests to the appliance's inference endpoint. Every request carries its token in the
+`Authorization` header, and tokens issued by the appliance begin with the prefix `lpai_`. Each token belongs to a
+[client](#client), can be given an expiration, and inherits that client's [quotas](#quota). Refer to
+[Clients and Quotas](../explanation/clients-and-quotas.md).
+
+### Appliance
+
+The self-contained PaletteAI Inference Launchpad unit: a single server that ships as a bootable image and runs the
+operating system, orchestration, inference engine, and management UI as one pre-integrated stack. It deploys with no
+Palette or PaletteAI dependency.
+
+### Appliance Console
+
+The web UI served by the appliance, sometimes referred to as the admin UI. Platform [operators](#operator) use it to
+deploy models, create clients, issue API tokens, set quotas, and view usage.
+
+## B
+
+### BMC
+
+The baseboard management controller, a server's out-of-band management interface, available on enterprise servers under
+vendor names such as iDRAC on Dell, iLO on Hewlett Packard Enterprise (HPE), or IPMI as an open standard. Operators use
+the BMC to power the server on and off remotely, view console output during boot, and mount
+[virtual media](#virtual-media), which serves as the fallback for ISO boot when a USB stick is not available.
+
+### Bond
+
+An aggregated network interface, typically `bond0`, that combines two physical NICs into a single logical link. The
+appliance carries cluster traffic and [Piraeus](#piraeus) storage replication over a bond so both share the aggregated
+bandwidth of the data NICs, using dynamic Link Aggregation (802.3ad) and LACP. Refer to
+[Install the Appliance](../how-to-guides/install-the-appliance.md#create-a-bond).
+
+## C
+
+### Central Mode
+
+A deployment mode in which the appliance's built-in inference engine is turned off and the [gateway](#launchpad-gateway)
+is managed by [PaletteAI](#paletteai). PaletteAI handles model deployment through its model-as-a-service flow, while the
+gateway continues to handle routing, [token metering](#token-metering), quota control, and the UI.
+
+{/* NEEDS REVIEW: central mode is defined in the source glossary but is not yet referenced in any shipped PAIIL doc. Confirm it is a user-facing term for GA before publishing. */}
+
+### Certified Model
+
+A model that Spectro Cloud has validated to run correctly on the listed GPU configuration, based on its own testing
+rather than public benchmarks. Refer to [Model Certification](../explanation/model-certification.md) and
+[Certified Models by Hardware](./certified-models-by-hardware.md).
+
+### Chargeback
+
+The practice of tracking token and dollar spend per [client](#client) so that an organization can allocate AI
+infrastructure costs back to the teams or workloads that consumed them. Per-client [metering](#token-metering) is what
+makes chargeback possible.
+
+{/* NEEDS REVIEW: chargeback is defined in the source glossary but does not yet appear in any shipped PAIIL doc. Confirm the term and framing with an SME before publishing. */}
+
+### Client
+
+The identity the appliance uses to recognize who is sending a request, and the unit of both access and accounting. The
+appliance attributes every request to exactly one client and measures every quota and usage metric per client. A client
+is more often a workload, such as an AI [coding assistant](#coding-assistant), an internal chatbot, or a data pipeline,
+than a person. Each client holds one or more [API tokens](#api-token), its own [quotas](#quota), and its own usage
+visibility. Refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+### Cluster
+
+One or more [nodes](#node) operating together as the appliance. A single-node cluster acts as both control plane and
+worker; a multi-node cluster distributes those roles across nodes linked through [Linked Edge Hosts](#linked-edge-hosts)
+and uses an odd number of control-plane nodes for high availability.
+
+### CMVP
+
+The Cryptographic Module Validation Program, run jointly by NIST and the Canadian Centre for Cyber Security, which
+certifies cryptographic modules against [FIPS](#fips) 140-3. Public-sector deployments may require appliance components
+to run in CMVP-validated configurations.
+
+### Coding Assistant
+
+An AI development tool, such as Claude Code, Cursor, OpenAI Codex, or OpenCode, that sends its requests to a model.
+Coding assistants are the primary workloads the appliance is tuned for; each one connects to the appliance as a
+[client](#client) instead of to a cloud provider.
+
+### Content Bundle
+
+A compressed archive, larger than 20 GB, containing the appliance's platform and application software. Operators upload
+the bundle to the node through [Local UI](#local-ui) or the Palette CLI as part of installation. The bundle does not
+include LLM [model weights](#model-weights), which ship as a separate artifact and are uploaded independently through
+the CLI.
+
+### Context Window
+
+The maximum number of tokens a model can process in a single request, counting the prompt and the response together.
+Different models have different context window sizes.
+
+## D
+
+### Default Model
+
+The model the appliance routes a request to when the request does not name a specific model. Refer to
+[Set the Default Model](../how-to-guides/set-the-default-model.md).
+
+## E
+
+### Egress
+
+A client's ability to send requests off the appliance to an [external, or frontier, model](#frontier-model). Egress
+denies by default: a new client cannot reach external providers until an operator enables it. Refer to
+[Manage Client Model Access](../how-to-guides/manage-client-model-access.md).
+
+### Embedding
+
+A numerical representation of text, or other data, as a vector in a high-dimensional space, letting a system compare
+inputs by meaning rather than by exact wording. The appliance uses embeddings internally in its
+[intelligent routing](#intelligent-routing) layer to classify requests by semantic similarity.
+
+### Endpoint
+
+The network location, expressed as a URL path, at which the appliance exposes a served model or an API. Each loaded
+model is exposed as an [OpenAI-compatible endpoint](#openai-compatible-api) at paths such as `/v1/chat/completions`.
+
+## F
+
+### FIPS
+
+The U.S. Federal Information Processing Standards, a suite of government security standards. FIPS 140 covers
+cryptographic modules and is relevant to public-sector deployments; refer to [CMVP](#cmvp), which validates modules
+against FIPS 140-3.
+
+### Follower
+
+In a multi-node cluster, a node that joins the [leader](#leader) through [Linked Edge Hosts](#linked-edge-hosts).
+Followers run the same OS and packs as the leader and take on their share of the cluster's workload once linking
+completes.
+
+### Frontier Model
+
+A cloud-hosted, state-of-the-art model reached through an external provider's API rather than served on the appliance.
+The appliance can route to a frontier model when [egress](#egress) is enabled and routing policy calls for it. Frontier
+usage incurs per-token API costs, unlike a [local model](#local-model).
+
+## H
+
+### Helm and Helm Chart
+
+Helm is the packaging format used to deploy and configure the software components inside the appliance's Kubernetes
+cluster, and a Helm chart is one such package. The appliance's components, including the gateway, are delivered as Helm
+charts, so individual layers can be updated independently.
+
+## I
+
+### Inference
+
+The process of running a trained model to generate a response or prediction from a given input. Serving inference on
+your own hardware is the core purpose of the appliance: once a model is loaded, each [prompt](#prompt) is answered
+locally rather than by a cloud provider.
+
+### Inference Engine
+
+The runtime that loads a model and serves its requests behind the model's endpoint. It determines how a model runs,
+which hardware it can use, and which serving features are available. The appliance selects an engine automatically by
+default. Refer to [Inference Engines](../explanation/inference-engines.md) for the supported kinds, such as
+[vLLM](#vllm), SGLang, Ollama, and llama.cpp.
+
+### Intelligent Routing
+
+The capability that directs each request to the most appropriate model, [local](#local-model) or
+[frontier](#frontier-model), based on rules an operator configures. Routing decisions can consider the request's
+content, the API token used, cost policy, or semantic classification, so routine work runs on local models and frontier
+models are used only when policy demands.
+
+### Interactive Installer
+
+The Palette Edge installer that runs from the [slim ISO](#slim-iso) and writes the immutable [Kairos](#kairos)-based
+operating system to the local disk. The installer inspects every disk on the host, blocks the install if any disk still
+holds Kairos partitions from a prior install, and provides an in-flow wipe-all-disks option so the reader does not have
+to drop to a shell.
+
+## J
+
+### jumpbox
+
+An informal name for the [administrative workstation](#administrative-workstation), a separate Linux machine, distinct
+from the appliance itself, on which operators install the Palette CLI and from which they drive installation and day-two
+operations against the appliance nodes.
+
+## K
+
+### Kairos
+
+The immutable, image-based Linux operating system that the appliance runs on. Kairos is designed for edge and appliance
+deployments, and its read-only runtime prevents configuration drift. It is the foundation on which Kubernetes runs
+inside the appliance.
+
+### Kubernetes
+
+The orchestration layer that runs inside the appliance and manages the lifecycle of its containerized workloads,
+including scheduling, scaling, and health recovery. It runs on top of [Kairos](#kairos).
+
+### KV Cache
+
+The key-value cache that an [inference engine](#inference-engine) keeps in GPU and host memory while generating a
+response, holding the intermediate state for the tokens processed so far. Its size drives much of the appliance's memory
+and fast-storage requirements.
+
+## L
+
+### Large Language Model (LLM)
+
+A model trained on large amounts of text that can generate, summarize, translate, and reason over natural language. LLMs
+are the models that PaletteAI Inference Launchpad is built to host and serve on-premises.
+
+### Launchpad Gateway
+
+The proxy component that sits in front of the inference engine and handles every request. The gateway authenticates the
+calling [client](#client) from its [API token](#api-token), enforces that client's [quotas](#quota), meters usage, and
+routes the request to a local or frontier model. Refer to [Architecture Overview](../explanation/architecture.md).
+
+### Leader
+
+In a multi-node cluster, the node whose [Local UI](#local-ui) generates the token that [followers](#follower) present to
+join. The leader remains part of the control plane after linking. Use an odd number of control-plane nodes for high
+availability.
+
+### Linked Edge Hosts
+
+The [Local UI](#local-ui) feature that joins nodes to the [leader](#leader) using a Base64-encoded token containing the
+leader's IP address and a one-time password ([OTP](#otp)) valid for two minutes. Content synchronizes automatically
+across every linked host once the group is formed.
+
+### Local Mode
+
+A deployment mode in which the appliance operates as a fully standalone unit, with the inference engine enabled and all
+features active. This is the mode used for a standalone appliance without [PaletteAI](#paletteai).
+
+{/* NEEDS REVIEW: local mode is defined in the source glossary but is not yet referenced in any shipped PAIIL doc. Confirm it is a user-facing term for GA before publishing. */}
+
+### Local Model
+
+A model deployed and served directly on the appliance's own hardware. Local inference keeps data on-premises and avoids
+the per-token API costs of a [frontier model](#frontier-model). Every client can call every local model; the appliance
+meters and limits usage through quotas but does not gate access.
+
+### Local UI
+
+The web console the appliance's edge OS serves on TCP port `5080` at `https://<node-ip>:5080`, used to create the
+[bond](#bond), link nodes, upload the [content bundle](#content-bundle), and deploy the cluster. Distinct from the
+[appliance console](#appliance-console) that the running cluster serves once installation completes.
+
+## M
+
+### Model
+
+In the PaletteAI Inference Launchpad context, a large language model that the appliance serves. Each served model is
+exposed as an [OpenAI-compatible endpoint](#openai-compatible-api) and records its name, backend engine, and current
+serving status. The appliance turns a model off when a [quota](#quota) that covers it is exhausted.
+
+### Model Alias
+
+An alternate name under which a model is served, so a [coding assistant](#coding-assistant) can request a model by a
+name it recognizes, such as an Anthropic or OpenAI model id. Some tools require a unique alias rather than a name that
+collides with their own catalog.
+
+### Model Metadata
+
+A small YAML file, `metadata.yaml`, one per model, that describes how the Palette CLI should fetch the model's weights
+from Hugging Face and upload them to the appliance. The metadata is downloaded from Artifact Studio, or from the
+`launchpad-ai` repository, alongside the ISO and content bundle.
+
+### Model Weights
+
+The trained parameters of a model, shipped as a separate binary artifact from the software. Weights can be large, on the
+order of hundreds of gigabytes for a larger model, which is why the appliance sizes fast storage around them. Their
+[quantization](#quantization) affects how much space they occupy.
+
+### ModelGroupQuota
+
+The internal Kubernetes custom resource that represents a [quota](#quota) budget on the appliance's cluster. It selects
+the models it covers with label selectors and tracks usage across every dimension and time window. Operators interact
+with quotas through the [appliance console](#appliance-console); ModelGroupQuota is the underlying enforcement object.
+
+{/* NEEDS REVIEW: ModelGroupQuota is an internal CRD name from the source glossary and does not appear in any shipped PAIIL doc. Confirm whether it should be exposed to readers before publishing. */}
+
+## N
+
+### Node
+
+A single machine in the appliance's Kubernetes cluster. When you deploy a model, the appliance places it automatically
+on the best-fit node, the node with the most free GPUs that still fit the model. Most appliances are a single
+high-density GPU server, so they have a single node.
+
+## O
+
+### On-Premises
+
+Describes running the appliance on hardware you own and operate, inside your own environment, rather than as a cloud
+service. Running inference on-premises keeps data in your environment and turns per-token API costs into predictable
+infrastructure spend.
+
+### OpenAI-Compatible API
+
+The request and response format that the appliance exposes for each served model, matching the widely supported OpenAI
+API, at paths such as `/v1/chat/completions` and `/v1/models`. Because the interface is OpenAI-compatible, existing
+tools can point at the appliance by changing only the base URL and the API token.
+
+### Operator
+
+The person who administers the appliance, also referred to as a platform operator or administrator. Operators deploy
+models, create clients, issue tokens, and set quotas through the [appliance console](#appliance-console).
+
+### OTP
+
+One-time password. A short-lived credential embedded in the Base64-encoded token that a multi-node cluster's
+[leader](#leader) emits during [Linked Edge Hosts](#linked-edge-hosts) linking. The OTP is valid for two minutes, after
+which the leader must issue a fresh token.
+
+## P
+
+### Pack
+
+A unit of software the cluster installs as part of a cluster profile, such as `piraeus-operator` or
+`nvidia-gpu-operator-ai`. The PaletteAI Inference Launchpad profile bundles the edge OS, [Kubernetes](#kubernetes),
+[Piraeus](#piraeus) storage, networking, ingress, observability, and the PaletteAI Inference Launchpad application as
+packs. The exact pack list is defined by the profile and can change between releases.
+
+### PaletteAI
+
+Spectro Cloud's multi-cluster AI platform for the AI factory, offering GPU-as-a-Service, model-as-a-service, and AI
+Studio at data-center scale. It is a distinct product from PaletteAI Inference Launchpad, which is a standalone
+appliance that requires no PaletteAI dependency. Refer to
+[What is PaletteAI Inference Launchpad?](../paletteai-inference-launchpad.md).
+
+### Palette TUI
+
+The text-based console on the appliance node itself, used after the [interactive installer](#interactive-installer)
+reboots the node to set the initial administrator credentials, hostname, static IP, DNS, and NTP. To re-enter the
+Palette TUI after quitting, run `palette-tui` on the node.
+
+### Piraeus
+
+The storage layer inside the appliance that provisions and manages the volumes used for [model weights](#model-weights)
+and the [KV cache](#kv-cache). Piraeus stripes a data pool across the appliance's NVMe drives to combine their read and
+write bandwidth.
+
+### Prompt
+
+The input text sent to a model to elicit a response. A prompt consumes input [tokens](#token-and-tokenization).
+
+## Q
+
+### Quantization
+
+A technique that stores a model's weights at a lower numeric precision to reduce its memory footprint and speed up
+inference, usually with little loss in quality. `FP8`, an 8-bit floating-point format referenced in the hardware
+requirements, is one such precision.
+
+### Quota
+
+A consumption limit attached to a [client](#client), enforced across three dimensions: requests (the number of calls),
+tokens (the number of tokens processed), and cost (the computed dollar spend). Each dimension is measured over rolling
+windows of one second, one minute, one hour, and one day; there is no monthly window. When a client reaches a limit, the
+appliance rejects further requests with HTTP `429 Too Many Requests` until the window rolls over. Refer to
+[Manage Client Quotas](../how-to-guides/manage-client-quotas.md).
+
+{/* NEEDS REVIEW: per the current working assumption, quota enforcement is off by default behind a global switch. Confirm with an SME before publishing. */}
+
+## R
+
+### Rate Limit
+
+A [quota](#quota) on the number of requests per unit of time, such as 60 requests per minute. Rate limits are the
+request-dimension quotas enforced over short windows.
+
+### Reasoning
+
+The ability of some models to work through a problem in intermediate steps before producing a final answer. A model that
+does this is called a reasoning model, and the depth of that effort can sometimes be tuned. Reasoning steps consume
+[tokens](#token-and-tokenization) like any other output.
+
+## S
+
+### Slim ISO
+
+The small (approximately 1.5 GB) bootable installer image that contains the appliance's operating system, provisioning
+agent, and web console. Operators boot the node from the slim ISO, either flashed to a USB drive or mounted through the
+[BMC](#bmc) as [virtual media](#virtual-media). The [interactive installer](#interactive-installer) writes the OS to the
+local disk.
+
+### Smoke Test
+
+A short check the appliance runs against a newly deployed model before it accepts traffic. A model becomes routable only
+after its signature is verified and its smoke test passes, so the appliance never presents a model as ready before it
+can serve requests.
+
+### STIG
+
+The Security Technical Implementation Guides published by the U.S. Defense Information Systems Agency (DISA), which
+prescribe hardened configurations for information systems. STIG compliance is required for certain U.S. Department of
+Defense deployments.
+
+## T
+
+### Tier Map
+
+A routing overlay that governs which model handles a client's requests by default, mapping an incoming model name or
+alias to a served model. It selects the default target for a client's requests rather than acting as a hard access gate
+for local models. Refer to [Manage Client Model Access](../how-to-guides/manage-client-model-access.md).
+
+### Token and Tokenization
+
+A token is the unit of text that a model processes, roughly a word or a word fragment; tokenization is the process of
+splitting text into those units. Tokens are the primary unit of measurement for model usage and cost, and one of the
+dimensions a [quota](#quota) can limit. Both input tokens from your prompt and output tokens from the model's response
+are counted.
+
+### Token Metering
+
+The process of counting and tracking token consumption per request, per model, per [API token](#api-token), and per time
+window. The appliance meters input tokens, output tokens, and derived cost for every request, which is what enforces
+[quotas](#quota), gives operators usage visibility, and enables [chargeback](#chargeback).
+
+## V
+
+### VIP
+
+A single IP address that resolves to whichever cluster node currently holds the control-plane role, so a multi-node
+cluster presents one stable endpoint even as individual nodes fail over. Configured in the cluster-creation wizard.
+
+### Virtual Media
+
+The mechanism by which a server's [BMC](#bmc) presents a remote ISO to the host as if it were a locally attached optical
+drive or USB stick. Virtual media is the fallback for booting the [slim ISO](#slim-iso) when USB boot is not available.
+
+### vLLM
+
+An open source, high-throughput [inference engine](#inference-engine) for large language models. vLLM is one of the
+GPU-serving engines the appliance can run, exposing an [OpenAI-compatible endpoint](#openai-compatible-api) on the
+Kubernetes cluster.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/hardware-requirements.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/hardware-requirements.md
@@ -1,0 +1,124 @@
+---
+id: hardware-requirements
+title: Suggested Hardware
+description: >
+  Suggested hardware for a PaletteAI Inference Launchpad appliance: compute, GPU, memory, storage, and network.
+sidebar_label: Suggested Hardware
+sidebar_position: 2
+tags:
+  - paletteai-inference-launchpad
+  - reference
+  - requirements
+  - hardware
+keywords:
+  - launchpad
+  - ai
+  - hardware
+  - gpu
+  - nvme
+  - requirements
+  - appliance
+---
+
+This page lists the hardware requirements for a PaletteAI Inference Launchpad appliance. Requirements are model-driven:
+the target model determines the GPU count, GPU memory, host RAM, and storage.
+
+For model-to-hardware mapping, refer to [Certified Models by Hardware](./certified-models-by-hardware.md). For the
+design decisions behind these requirements, refer to [Architecture Overview](../explanation/architecture.md).
+
+## Hardware Requirements
+
+The following table lists the minimum and recommended hardware for the appliance on a single high-density GPU server.
+The appliance ships an immutable Kairos-based operating system, so no separate install is required.
+
+| **Component** | **Minimum Hardware**            | **Recommended Hardware**         | **Notes**                                                        |
+| ------------- | ------------------------------- | -------------------------------- | ---------------------------------------------------------------- |
+| CPU           | 2x 32-core CPU (64 cores total) | 2x 64-core CPU (128 cores total) | Dual-socket is required for 8x GPU systems                       |
+| GPU           | 2x NVIDIA or AMD GPU            | 8x NVIDIA or AMD GPU             | Larger models require much more VRAM, typically with 8 GPUs      |
+| GPU VRAM      | 128 GB (all GPUs combined)      | 1024 GB (all GPUs combined)      | Total VRAM across all installed GPUs; larger models require more |
+| RAM           | 1 TB                            | 2 TB or more                     | 128 GB RAM per GPU, plus 512 GB or more for KV cache             |
+| OS boot drive | 500 GB SSD                      | RAID1 of two 800 GB SSD drives   | Most servers provide an onboard RAID controller                  |
+| Data disks    | 1x 8 TB NVMe                    | 4x 8 TB NVMe                     | Model weights and persistent KV cache stored on these drives     |
+| Network       | 1x 10 Gbps NIC                  | 2x 10+ Gbps NICs, bonded         | 802.3ad LACP recommended                                         |
+
+## GPU
+
+The required GPU count depends on the target model. The minimum is 2 GPUs, and 8 GPUs are recommended for larger models.
+For example, GLM 5.2 FP8 requires 8 GPUs.
+
+The reference GPU is the NVIDIA H100 80 GB. The appliance supports both NVIDIA and AMD GPUs, and the GPU Operator
+installs GPU drivers automatically. For the models certified on each GPU configuration, refer to
+[Certified Models by Hardware](./certified-models-by-hardware.md).
+
+## Storage
+
+The OS boot drive is an SSD, and the data pool uses NVMe drives only. Spinning disks are not supported. Storage has two
+roles.
+
+| **Role**      | **Devices**                                                        | **Contents**                                                                                                                   |
+| ------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| OS boot drive | 500 GB SSD (minimum); two 800 GB SSD drives in RAID1 (recommended) | Operating system, plus a system partition for the Piraeus system storage pool used at cluster bootstrap.                       |
+| Data pool     | 1x 8 TB NVMe (minimum); 4x 8 TB NVMe (recommended)                 | Piraeus storage pool for the model-weights and KV cache volumes; striped across the data drives when more than one is present. |
+
+A single model artifact is large. For example, GLM 5.2 FP8 weights are approximately 750 GB. The Piraeus storage layer
+provisions a 1 TB volume for model weights and a 2 TB volume for the KV cache.
+
+## Network and IP Addressing
+
+The minimum is a single 10 Gbps NIC. The recommended configuration is a bond of two or more 10 Gbps or faster NICs using
+the 802.3ad Link Aggregation Control Protocol (LACP) with a `layer3+4` hash policy and a fast LACP rate, presented as a
+single logical interface.
+
+Required IP addresses:
+
+- A single unused platform IP address (not a range) for MetalLB to assign to Traefik, which fronts the appliance console
+  and API.
+- A cluster virtual IP address (VIP).
+
+The following network ranges apply by default and become read-only after day one.
+
+| **Network**           | **Default**    |
+| --------------------- | -------------- |
+| Pod network range     | 100.64.0.0/18  |
+| Service network range | 100.64.64.0/18 |
+
+The appliance listens on the following ports.
+
+| **Port** | **Purpose**                                                                               |
+| -------- | ----------------------------------------------------------------------------------------- |
+| 443/TCP  | Appliance console and API, served by Traefik on the platform IP address.                  |
+| 5080/TCP | Node Local UI, reached at `https://<node-ip>:5080` during installation.                   |
+| 5082/TCP | Node Local UI API, used by the Palette CLI to upload the content bundle from the jumpbox. |
+
+## Airgapped
+
+The appliance is airgapped. Application images ship in the content bundle, and model weights ship as a separate
+artifact. The appliance requires no outbound internet access during installation or day-two operation.
+
+## Administrative Workstation
+
+The appliance requires a separate Linux administrative workstation, also called a jumpbox, on the same network as the
+appliance nodes. The appliance does not provide this machine. It is used during
+[installation](../how-to-guides/install-the-appliance.md) and across the entire appliance lifecycle.
+
+The administrative workstation requires the following:
+
+- Network access to the appliance nodes over SSH.
+- An SSH client and a key pair, or password authentication, for the appliance nodes.
+- The Palette CLI, which uploads model artifacts to the appliance.
+- `kubectl`, for post-installation validation and day-two operations.
+- Enough local disk to stage model downloads. Model artifacts are large and can reach hundreds of gigabytes.
+
+### Model Download Access (Recommended)
+
+Outbound HTTPS access to `huggingface.co` from the administrative workstation is optional but recommended. It applies to
+the administrative workstation only and allows model weights to be downloaded there before they are uploaded to the
+appliance. As noted in [Airgapped](#airgapped), the appliance itself needs no outbound internet access.
+
+Without this access, model weights must be staged on a separate connected machine and transferred to the administrative
+workstation before upload.
+
+## Resources
+
+- [Certified Models by Hardware](./certified-models-by-hardware.md) for model-to-hardware mapping.
+- [Architecture Overview](../explanation/architecture.md) for the design decisions behind these requirements.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/known-issues.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/known-issues.md
@@ -1,0 +1,48 @@
+---
+id: known-issues
+title: Known Issues
+description: >
+  Known issues that operators may encounter during PaletteAI Inference Launchpad installation and validation, and the
+  workarounds for each.
+sidebar_label: Known Issues
+sidebar_position: 9
+tags:
+  - paletteai-inference-launchpad
+  - reference
+  - troubleshooting
+keywords: ["launchpad", "ai", "install", "known issues", "workaround", "troubleshooting", "hpe", "pci"]
+---
+
+This page lists the known issues that operators may encounter during installation and validation of the PaletteAI
+Inference Launchpad appliance, and the workaround for each. For the ordered procedure, refer to
+[Install the Appliance](../how-to-guides/install-the-appliance.md).
+
+## GPUs do not enumerate on HPE servers
+
+<!-- vale off -->
+
+**Symptom.** On some HPE servers, for example the DL380a Gen11, the GPUs do not enumerate on the PCI bus. Each GPU
+reports `Region 0/2/4: Memory at ignored` when you run `lspci` with `-vv`, and the kernel logs `NVRM: BAR0 is 0M @ 0x0`
+with a probe failure for every device.
+
+**Workaround.** Add `pci=realloc=off` to the GRUB kernel command line.
+
+1. Boot into GRUB and append `pci=realloc=off` to `GRUB_CMDLINE_LINUX_DEFAULT` so that it reads
+   `GRUB_CMDLINE_LINUX_DEFAULT="quiet splash pci=realloc=off"`, then reboot.
+2. Verify the GPUs by running `lspci` with `-v` and `-s <bus:device.function>`, then confirm with `nvidia-smi`.
+3. For better performance, enable Resizable BAR in the BIOS. On HPE Gen11 servers, go to **PCIe Device Configuration >
+   Advanced PCIe Configuration**. An RBSU BIOS upgrade may be required.
+
+**Side effect: NIC rename.** The workaround renames the NICs. Update the interface names in the `/etc/systemd/network`
+and `/oem` directories afterward.
+
+<!-- vale on -->
+
+## Installation stalls during cluster deployment
+
+**Symptom.** The cluster does not reach a **Running** and **Healthy** state during deployment, and one or more packs
+stay in a pending or installing state.
+
+**Workaround.** Confirm that the `piraeus-operator` and `nvidia-gpu-operator-ai` packs install correctly. GPU driver
+installation can take extra time on the first boot, so wait before you treat a slow pack as stalled. If the GPUs do not
+enumerate as expected, refer to [GPUs do not enumerate on HPE servers](#gpus-do-not-enumerate-on-hpe-servers).

--- a/docs/docs-content/paletteai-inference-launchpad/reference/model-upload-reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/model-upload-reference.md
@@ -1,0 +1,140 @@
+---
+sidebar_label: "Model Upload Reference"
+title: "PaletteAI Inference Launchpad Model Upload Reference"
+description:
+  "Reference for the Palette CLI model download and upload commands and the model metadata file used to place models on
+  a PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 4.5
+tags: ["paletteai-inference-launchpad", "reference", "models"]
+keywords: ["launchpad", "ai", "palette cli", "model upload", "metadata", "huggingface", "air-gapped"]
+---
+
+This reference lists the flags for the Palette CLI model commands and the fields of the model metadata file. It supports
+the [Upload a Model](../how-to-guides/upload-a-model.md) how-to, which walks through the download and upload flow.
+
+{/* NEEDS REVIEW: `palette content model download` and `palette content model upload` are a new command surface from the engineering source and are not yet in the published Palette CLI reference. Confirm the command names, flags, and defaults before publishing. */}
+
+## palette content model download
+
+Downloads a model from Hugging Face into a local directory on a connected workstation and records a completion manifest
+that a later upload validates against.
+
+| **Flag**                   | **Description**                                                                                          | **Required** |
+| -------------------------- | -------------------------------------------------------------------------------------------------------- | ------------ |
+| `--metadata`, `-f`         | Path to the model metadata YAML (from Artifact Studio), or a `.tar.gz` bundle of the metadata and files. | Yes          |
+| `--model-dir`              | Local directory to download into. The model lands at `<model-dir>/<name>/<version>/`.                    | Yes          |
+| `--hf-token` (`$HF_TOKEN`) | Hugging Face token for gated or private repositories.                                                    | No           |
+
+## palette content model upload
+
+Ships an already-downloaded model directory to one appliance node over `rsync` and SSH. By default the upload never
+contacts Hugging Face and fails if `--model-dir` is missing or incomplete; pass `--download` to fetch the model first.
+
+**Required flags**
+
+| **Flag**                        | **Description**                                                                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `--metadata`, `-f`              | Path to the model metadata YAML, or a `.tar.gz` bundle of the metadata and files.                                        |
+| `--model-dir`                   | Local directory holding the model at `<model-dir>/<name>/<version>/`. Required unless `--download` or `--metadata-only`. |
+| `--ssh-user`                    | SSH user on the target appliance node.                                                                                   |
+| `--ssh-host`                    | Address (IP or DNS name) of the target appliance node.                                                                   |
+| `--ssh-key` or `--ssh-password` | SSH authentication. Mutually exclusive; `--ssh-password` is supported on Unix workstations only.                         |
+
+**Optional flags**
+
+| **Flag**                         | **Description**                                                                                                                                     |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--download`                     | Fetch (or resume) the model from Hugging Face when `--model-dir` is not already complete, then upload. Mutually exclusive with `--metadata-only`.   |
+| `--metadata-only`                | Sync only `metadata.yaml` (and any logo); skip the weights. Mutually exclusive with `--download`.                                                   |
+| `--ssh-port`                     | SSH port. Defaults to `22`.                                                                                                                         |
+| `--hf-token` (`$HF_TOKEN`)       | Hugging Face token, used with `--download` or to fetch a logo hosted on Hugging Face.                                                               |
+| `--keep-model-dir`               | Retain a temporary model directory after a successful upload. Applies only when `--model-dir` is omitted; an explicit `--model-dir` is always kept. |
+| `--insecure-skip-host-key-check` | Disable SSH host key verification.                                                                                                                  |
+
+## Model Metadata File
+
+The metadata file is the operator's contract with the appliance. Only `name`, `version`, and `huggingface.repo` are
+required; everything else is optional. The parser rejects unknown top-level fields.
+
+| **Field**              | **Description**                                                                                                                             | **Required** |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `name`                 | Model name. Sets the `<name>` path segment on the appliance.                                                                                | Yes          |
+| `version`              | Model version. Sets the `<version>` path segment on the appliance.                                                                          | Yes          |
+| `huggingface.repo`     | Source Hugging Face repository.                                                                                                             | Yes          |
+| `huggingface.files`    | One or more globs selecting which repository files to download. When omitted, every file is downloaded.                                     | No           |
+| `huggingface.revision` | Hugging Face revision (branch, tag, or commit). Defaults to `main`.                                                                         | No           |
+| `huggingface.logo`     | Path inside the Hugging Face repository to a logo image, downloaded alongside the weights.                                                  | No           |
+| `logo`                 | A logo bundled from local disk. Mutually exclusive with `huggingface.logo`.                                                                 | No           |
+| `launchpad`            | Optional gateway tuning block (engine, variants, and so on). The Palette CLI ships it to the appliance unchanged and does not interpret it. | No           |
+
+The following example downloads GLM 5.2 weights from a Hugging Face repository and includes a `launchpad` tuning block.
+
+```yaml
+name: glm-5.2
+version: 1.0.0
+displayName: "GLM 5.2"
+description: "Zhipu AI GLM 5.2, served on the appliance for coding assistants."
+author: Zhipu AI
+license: mit
+
+huggingface:
+  repo: zai-org/GLM-5.2
+  revision: main
+  files:
+    - "*.safetensors"
+    - "*.json"
+    - "tokenizer*"
+  logo: assets/logo.png # optional: pulled from the Hugging Face repo, saved as logo.<ext>
+
+# logo: ./local-logo.png # OR bundle a local file from disk (mutually exclusive with huggingface.logo)
+
+launchpad: # optional: gateway tuning block, shipped verbatim (the Palette CLI does not interpret it)
+  engine: vllm
+  min_engine_version: "0.23.0"
+  variants:
+    - vendor: amd
+      gpu_product: MI325X
+      vram_gb: 256
+      min_gpus: 8
+      serve:
+        image: rocm/vllm-dev:nightly
+        tensor_parallel_size: 8
+```
+
+{/* NEEDS REVIEW: the GLM 5.2 example values (the zai-org/GLM-5.2 repository, file globs, and license) are representative. Confirm the canonical repository, weight files, and license with an SME before publishing. */}
+
+After a successful upload, the model directory on the appliance node has the following layout.
+
+```text
+/usr/local/spectrocloud/content/models/<name>/<version>/
+├── ...model files...   # written first (per huggingface.files globs)
+├── metadata.yaml       # written last—readiness signal
+└── logo.<ext>          # optional (local or Hugging Face-sourced)
+```
+
+{/* NEEDS REVIEW: the appliance path /usr/local/spectrocloud/content/models/<name>/<version>/ is from the engineering source. Confirm before publishing. */}
+
+## Upload behavior
+
+Before starting a transfer, the Palette CLI checks that the target host has enough free disk space to hold the model. It
+verifies file checksums during the transfer and resumes an interrupted download or upload from where it stopped rather
+than starting over.
+
+The CLI writes the weight files first and `metadata.yaml` last, so the presence of `metadata.yaml` on the appliance node
+is the "upload complete" signal for that host.
+
+On a multi-node cluster, the CLI uploads to a single node. The appliance then synchronizes the model to the other hosts,
+reconciling about every two minutes. In the deploy catalog, a model shows one of the following states, and only
+**Available** models are selectable for deployment.
+
+| **State**     | **Meaning**                                                                       |
+| ------------- | --------------------------------------------------------------------------------- |
+| **Available** | The model is ready on every node in the cluster and can be deployed.              |
+| **Pending**   | The model is uploaded but the appliance is still synchronizing it to every node.  |
+| **Missing**   | The appliance has metadata for the model but the weights are not yet on the node. |
+
+## Resources
+
+- [Upload a Model](../how-to-guides/upload-a-model.md) walks through the download and upload flow.
+- [Deploy a Model](../how-to-guides/deploy-a-model.md) deploys an uploaded model and verifies it is serving.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/opencode-reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/opencode-reference.md
@@ -1,0 +1,90 @@
+---
+sidebar_label: "OpenCode Configuration"
+title: "PaletteAI Inference Launchpad OpenCode Configuration"
+description:
+  "Reference for the configuration file fields and values used to connect the OpenCode terminal coding agent to a
+  PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 8
+tags: ["paletteai-inference-launchpad", "opencode", "reference"]
+keywords: ["launchpad", "ai", "opencode", "opencode.json", "openai-compatible", "custom provider", "api token", "model"]
+---
+
+This page lists the configuration values OpenCode uses to connect to a PaletteAI Inference Launchpad appliance. For the
+steps to set them, refer to [Use PaletteAI Inference Launchpad with OpenCode](../how-to-guides/use-opencode.md).
+
+## Configuration File
+
+OpenCode reads its configuration from `~/.config/opencode/opencode.json`. Add a custom provider for the appliance.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "launchpad": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Launchpad",
+      "options": {
+        "baseURL": "https://amd.spectrocloud.com:8443/v1",
+        "apiKey": "<lpai-token>"
+      },
+      "models": {
+        "glm-5.2": { "name": "GLM-5.2 (Launchpad)" }
+      }
+    }
+  }
+}
+```
+
+## Fields
+
+| **Field**         | **Description**                                                                                                                  | **Example value**                      |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `$schema`         | The OpenCode configuration schema. Enables validation and autocompletion in an editor.                                           | `https://opencode.ai/config.json`      |
+| `provider.<key>`  | A custom provider entry. The key, such as `launchpad`, is the provider name you combine with a model id when you select a model. | `launchpad`                            |
+| `npm`             | The provider plugin OpenCode loads. For an OpenAI-compatible endpoint, use `@ai-sdk/openai-compatible`.                          | `@ai-sdk/openai-compatible`            |
+| `name`            | A display name for the provider.                                                                                                 | `Launchpad`                            |
+| `options.baseURL` | The appliance inference endpoint, with the `/v1` path appended.                                                                  | `https://amd.spectrocloud.com:8443/v1` |
+| `options.apiKey`  | Your API token. The console generates it, and it begins with `lpai_`.                                                            | `<lpai-token>`                         |
+| `models`          | A map of the model ids the appliance serves that you want to use. Each key is a served model id, and its `name` is a label.      | `glm-5.2`                              |
+
+## Endpoint URL
+
+Set `baseURL` to your appliance's address, the same host you use to reach the console, with `/v1` appended. The gateway
+serves the OpenAI-compatible API under `/v1`, and the `@ai-sdk/openai-compatible` provider appends the remaining path,
+such as `/chat/completions`, itself, so `baseURL` ends at `/v1`. If you do not know the address, ask the administrator
+who set up the appliance.
+
+## API Token
+
+OpenCode reads the token from the `apiKey` field in the provider's `options`. The token is generated in the console and
+begins with `lpai_`.
+
+## Model Name
+
+OpenCode selects a model by a `provider/model` value, such as `launchpad/glm-5.2`, and splits the value on the first
+slash. The part before the slash is the provider key, and the part after it is a model id you listed under `models`. Use
+a model the appliance serves, such as `glm-5.2`. The served model ids appear in the console model list and in the
+appliance's `/v1/models` API response.
+
+## Requirements
+
+- The connection uses HTTPS. We strongly recommend a DNS hostname with a valid, publicly trusted TLS certificate so that
+  the certificate protects your token in transit.
+- OpenCode runs on Node.js. If the appliance uses a self-signed certificate, OpenCode rejects the connection by default.
+  As a temporary measure for testing, set `NODE_TLS_REJECT_UNAUTHORIZED=0` before you start OpenCode. This disables
+  certificate verification, so do not use it outside short-lived testing.
+
+## Token Quotas
+
+If the token's quota is exhausted, the appliance returns an HTTP `429` response and OpenCode surfaces the error.
+{/* TODO: link to the token quotas and metering reference once it exists */}
+
+## Resources
+
+- [Use PaletteAI Inference Launchpad with OpenCode](../how-to-guides/use-opencode.md)
+- [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md)
+- [Use PaletteAI Inference Launchpad with Cursor](../how-to-guides/use-cursor.md)
+- [Use PaletteAI Inference Launchpad with OpenAI Codex](../how-to-guides/use-codex.md)
+- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- Token quotas and metering {/* TODO: link once page exists */}

--- a/docs/docs-content/paletteai-inference-launchpad/reference/profile-variables.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/profile-variables.md
@@ -1,0 +1,87 @@
+---
+id: profile-variables
+title: Cluster Profile Variables
+description: >
+  Reference for the PaletteAI Inference Launchpad cluster profile variables collected by the Profile Config wizard.
+  Covers networking, OS and metrics, container registry, local admin, storage, and certificates with types, required
+  fields, defaults, and validation rules.
+sidebar_label: Cluster Profile Variables
+sidebar_position: 2.7
+tags:
+  - paletteai-inference-launchpad
+  - reference
+  - install
+  - profile
+keywords: ["launchpad", "ai", "profile", "cluster", "variables", "wizard", "kubernetes", "metallb"]
+---
+
+When you deploy the cluster from Local UI, the **Profile Config** step opens a PaletteAI Inference Launchpad custom
+wizard that collects the settings the platform packs need in order to install correctly on your hardware and network.
+This page documents every variable the wizard collects, in six sections, in the order the wizard presents them.
+
+For the step-by-step procedure, refer to
+[Install the Appliance](../how-to-guides/install-the-appliance.md#deploy-the-cluster).
+
+## Network
+
+| Variable                         | Type      | Required | Default          | Description                                                                                                                                                                                                                                                 |
+| -------------------------------- | --------- | -------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pod Network Range**            | IPv4 CIDR | Yes      | `100.64.0.0/18`  | Kubernetes pod network CIDR. Read-only after day 1. Pick a range that will not collide with your existing network.                                                                                                                                          |
+| **Service Network Range**        | IPv4 CIDR | Yes      | `100.64.64.0/18` | Kubernetes ClusterIP service CIDR. Read-only after day 1. Must not overlap the Pod Network Range or your existing network.                                                                                                                                  |
+| **Platform IP Address**          | IPv4      | Yes      | —                | Single IPv4 address (not a range or CIDR) that MetalLB assigns to Traefik; the console and API are reached at it. Must be in the same subnet as the Cilium and MetalLB interface and must not overlap the node's management IP or any other address in use. |
+| **Cilium and MetalLB interface** | string    | Yes      | —                | Host NIC that Cilium and MetalLB use to advertise the Platform IP Address on the local network. Select the bond that carries the node's management IP.                                                                                                      |
+
+## OS and metrics
+
+| Variable                      | Type   | Required | Default | Description                                                                                                                                                         |
+| ----------------------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **System Reserved CPU Cores** | string | Yes      | `0-1`   | Range of CPU cores Kubelet reserves for the operating system (`--reserved-cpus`). Validated against the regex `\d-\d`, so only single-digit endpoints are accepted. |
+| **Maximum Pods per Node**     | number | Yes      | `110`   | Kubelet `--max-pods` setting.                                                                                                                                       |
+| **Metrics Retention Period**  | string | Optional | `30d`   | How long Victoria Metrics keeps time-series data.                                                                                                                   |
+| **Metrics Storage Size**      | string | Optional | `20Gi`  | Size of the persistent volume Victoria Metrics uses for retained metrics. Increase in step with the retention period.                                               |
+
+## Container registry (Zot)
+
+| Variable              | Type               | Required | Default | Description                                                                                                                    |
+| --------------------- | ------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Registry Username** | string             | Yes      | `admin` | Username for the on-cluster Zot registry that hosts platform and application images.                                           |
+| **Registry Password** | string (sensitive) | Yes      | —       | Password for the Zot registry account. Must satisfy the [password complexity requirements](#password-complexity-requirements). |
+
+## Local admin
+
+| Variable                 | Type               | Required | Default | Description                                                                                                                                                 |
+| ------------------------ | ------------------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Local Admin Username** | string             | Yes      | `admin` | Administrator username shared by the appliance console and the Grafana dashboard.                                                                           |
+| **Local Admin Password** | string (sensitive) | Yes      | —       | Administrator password shared by the appliance console and Grafana. Must satisfy the [password complexity requirements](#password-complexity-requirements). |
+
+## Storage (Piraeus)
+
+| Variable                  | Type   | Required | Default | Description                                                                                                                                                                                             |
+| ------------------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Storage Replica Count** | string | Optional | `1`     | Number of Piraeus replicas kept for each stored volume. Allowed values are `1`, `2`, or `3`. Values above `1` require a matching number of nodes in the cluster, so a single-node install must use `1`. |
+
+## Certificates
+
+The appliance needs a certificate authority (CA) for its OIDC endpoint. Each certificate field offers two options:
+
+- **Generate.** Select **Generate** and the wizard creates a self-signed certificate and fills in the field for you. Use
+  this for internal or lab deployments, where a browser trust warning is acceptable.
+- **Provide.** Paste your own base64-encoded CA certificate and its private key. Use this in production, where you want
+  the appliance certificates signed by your organization's CA so clients trust them without an exception.
+
+| Variable         | Type   | Required | Default | Description                                                                                                         |
+| ---------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| **OIDC CA cert** | base64 | Yes      | —       | Base64-encoded CA certificate. Provide your own, or select **Generate** for a self-signed one.                      |
+| **OIDC CA key**  | base64 | Yes      | —       | Base64-encoded private key that pairs with the OIDC CA cert. The wizard fills this in when you select **Generate**. |
+
+## Password complexity requirements
+
+The **Registry Password** and **Local Admin Password** must both satisfy all of the following (rules inherited from
+[PVM-723](https://spectrocloud.atlassian.net/browse/PVM-723)):
+
+- Between **15** and **64** characters long.
+- At least **1 uppercase letter**.
+- At least **1 lowercase letter**.
+- At least **1 digit**.
+- At least **1 special character**.
+- Must **not** contain a double quote (`"`), single quote (`'`), backslash (`\`), or any whitespace.

--- a/docs/docs-content/paletteai-inference-launchpad/reference/reference.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/reference.md
@@ -1,0 +1,27 @@
+---
+sidebar_label: "Reference"
+title: "PaletteAI Inference Launchpad Reference"
+description: "Authoritative technical reference for requirements, certified models, and specifications."
+hide_table_of_contents: false
+sidebar_position: 0
+tags: ["paletteai-inference-launchpad", "reference"]
+---
+
+Reference pages give you technical information when you need to look something up. They describe what exists and how it
+is configured, not how to accomplish a task.
+
+## Contents
+
+| **Reference**                                                     | **What it covers**                                                                             |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [Glossary](./glossary.md)                                         | Definitions of the AI, product, and platform terms used across the docs.                       |
+| [Suggested Hardware](./hardware-requirements.md)                  | Compute, GPU, memory, storage, and network requirements for the appliance.                     |
+| [Bond Configuration](./bond-configuration.md)                     | Field-by-field reference for the Local UI bond form used during installation.                  |
+| [Cluster Profile Variables](./profile-variables.md)               | Every variable the Profile Config wizard collects, with types, defaults, and validation rules. |
+| [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration.                |
+| [Model Upload Reference](./model-upload-reference.md)             | Palette CLI model download and upload flags, and the model metadata file fields.               |
+| [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.                    |
+| [Cursor Configuration](./cursor-reference.md)                     | Settings and values for pointing Cursor at the appliance.                                      |
+| [OpenAI Codex Configuration](./codex-reference.md)                | Configuration file fields and values for pointing Codex at the appliance.                      |
+| [OpenCode Configuration](./opencode-reference.md)                 | Configuration file fields and values for pointing OpenCode at the appliance.                   |
+| [Known Issues](./known-issues.md)                                 | Known installation issues and their workarounds, including HPE PCI enumeration.                |

--- a/docs/docs-content/paletteai-inference-launchpad/reference/server-configurations.md
+++ b/docs/docs-content/paletteai-inference-launchpad/reference/server-configurations.md
@@ -1,0 +1,44 @@
+---
+id: server-configurations
+title: Example Server Configurations
+description: >
+  Example server configurations for a PaletteAI Inference Launchpad appliance, spanning AMD Instinct and NVIDIA GPUs
+  from multiple vendors.
+sidebar_label: Example Server Configurations
+sidebar_position: 3
+unlisted: true
+tags:
+  - paletteai-inference-launchpad
+  - reference
+  - hardware
+keywords:
+  - launchpad
+  - ai
+  - hardware
+  - server
+  - gpu
+  - amd
+  - nvidia
+---
+
+The following table lists example server configurations for PaletteAI Inference Launchpad. Each configuration meets the
+specifications in [Suggested Hardware](./hardware-requirements.md).
+
+<!-- vale Vale.Terms = NO -->
+
+| **Server vendor**        | **Server model**                                   | **GPU vendor** | **GPU**                                           | **CPU**                                            |
+| ------------------------ | -------------------------------------------------- | -------------- | ------------------------------------------------- | -------------------------------------------------- |
+| Supermicro               | SYS-421GE-TNHR-LC1 (liquid-cooled)                 | NVIDIA         | 8x H100 SXM                                       | Intel Xeon Platinum 8570                           |
+| Supermicro               | Contact your Supermicro representative for details | AMD            | 8x Instinct MI350X                                | Contact your Supermicro representative for details |
+| HPE                      | ProLiant Compute DL380a Gen12                      | NVIDIA         | 8x L40S                                           | Intel Xeon 6710E                                   |
+| Dell                     | PowerEdge XE9680                                   | NVIDIA         | 8x H100 80 GB SXM5                                | 2x Intel Xeon Platinum 8570                        |
+| Dell                     | PowerEdge XE7740                                   | NVIDIA         | 8x RTX PRO 6000 Blackwell Server Edition 96 GB/ea | 2x Intel Xeon 6                                    |
+| Vultr (bare metal cloud) | vbm-256c-3072gb-8-mi325x-gpu                       | AMD            | 8x Instinct MI325X 256 GB/ea                      | Contact your Vultr representative for details      |
+
+<!-- vale Vale.Terms = YES -->
+
+## Resources
+
+- [Suggested Hardware](./hardware-requirements.md) for the specifications these configurations meet.
+- [Certified Models by Hardware](./certified-models-by-hardware.md) for model-to-hardware mapping.
+- [Install the Appliance](../how-to-guides/install-the-appliance.md) to deploy the appliance.

--- a/docs/docs-content/paletteai-inference-launchpad/release-notes.md
+++ b/docs/docs-content/paletteai-inference-launchpad/release-notes.md
@@ -1,0 +1,92 @@
+---
+sidebar_label: "Release Notes"
+title: "PaletteAI Inference Launchpad Release Notes"
+description: "Release notes for PaletteAI Inference Launchpad, including new features, improvements, and bug fixes."
+hide_table_of_contents: false
+sidebar_position: 50
+tags: ["paletteai-inference-launchpad", "release-notes"]
+keywords: ["launchpad", "ai", "release notes", "changelog"]
+---
+
+## Version 1.0.0 - July 21, 2026 {#version-1-0-0}
+
+PaletteAI Inference Launchpad 1.0.0 is the first release. It is a standalone, turnkey AI appliance that turns your own
+hardware into a private AI platform: boot a single image, load a model, and serve large language models (LLMs) in your
+own environment, with no cloud dependency and no Palette or PaletteAI license required. Because inference runs on the
+appliance, your data stays in your environment and per-token API costs become a fixed infrastructure cost. For a
+conceptual introduction, refer to [What is PaletteAI Inference Launchpad?](./paletteai-inference-launchpad.md).
+
+### Features
+
+- Ships as a single bootable appliance with a pre-integrated stack: an immutable [Kairos](https://kairos.io) operating
+  system on Ubuntu 24.04, Kubernetes, vLLM, intelligent request routing, and platform services for authentication,
+  Role-Based Access Control (RBAC), monitoring, and observability. Refer to
+  [Architecture](./explanation/architecture.md) for more information.
+
+- Operates fully airgapped, with no outbound internet access required during installation or day-two operation.
+
+- Installs from bare hardware to a running console from a Linux administrative workstation, using an interactive
+  installer and a guided cluster wizard in the node Local UI. This release is tuned for a single-node topology. Refer to
+  [Install the Appliance](./how-to-guides/install-the-appliance.md) for more information.
+
+- Runs on a single high-density GPU server with NVIDIA or AMD GPUs, NVMe storage, and bonded NICs, sized to the target
+  model from a baseline of 4 GPUs. Refer to [Suggested Hardware](./reference/hardware-requirements.md) for more
+  information.
+
+- Certifies a focused set of LLMs for coding-assistant use, GLM 5.2, DeepSeek v4 Pro, Kimi 2.7, and Gemma 4, and lets
+  you load any other model that fits the available GPU memory. Refer to
+  [Certified Models by Hardware](./reference/certified-models-by-hardware.md) and
+  [Model Certification](./explanation/model-certification.md) for more information.
+
+- Uploads models from the administrative workstation with the Palette CLI, which verifies checksums and supports
+  resumable transfers. Refer to [Upload a Model](./how-to-guides/upload-a-model.md) for more information.
+
+- Deploys a model to the cluster and places it on the best-fit node automatically, after a guarded preview, gate,
+  provision, and smoke-test sequence. Refer to [Deploy a Model](./how-to-guides/deploy-a-model.md) for more information.
+
+- Lets you set a default model that handles requests no routing rule matches, and rebuilds the router in place when you
+  change it, without a gateway restart. Refer to [Set the Default Model](./how-to-guides/set-the-default-model.md) for
+  more information.
+
+- Exposes each model as an OpenAI-compatible endpoint and supports four engine kinds, vLLM, SGLang, Ollama, and
+  llama.cpp, selected automatically or pinned per model. Refer to
+  [Inference Engines](./explanation/inference-engines.md) for more information.
+
+- Serves many clients from one appliance, each identified by API tokens prefixed `lpai_`. Refer to
+  [Clients and Quotas](./explanation/clients-and-quotas.md) and [Create a Client](./how-to-guides/create-a-client.md)
+  for more information.
+
+- Enforces per-client quotas across requests, tokens, and cost over one-second, one-minute, one-hour, and one-day
+  windows, and returns HTTP `429` when a limit is reached. Refer to
+  [Manage Client Quotas](./how-to-guides/manage-client-quotas.md) for more information.
+
+- Grants every client access to all local models, and can burst to external frontier models. Refer to
+  [Manage Client Model Access](./how-to-guides/manage-client-model-access.md) for more information.
+
+- Reports per-client usage and lets you revoke a token or delete a client at any time. Refer to
+  [View Client Usage](./how-to-guides/view-client-usage.md) and
+  [Revoke or Delete a Client](./how-to-guides/revoke-or-delete-a-client.md) for more information.
+
+- Computes estimated savings by comparing locally served token volume against a configurable frontier provider reference
+  rate.
+
+- Connects AI coding assistants directly to the appliance with ready-to-paste console snippets: Claude Code, Cursor,
+  OpenAI Codex, and OpenCode. Refer to [Claude Code](./how-to-guides/use-claude-code.md),
+  [Cursor](./how-to-guides/use-cursor.md), [OpenAI Codex](./how-to-guides/use-codex.md), and
+  [OpenCode](./how-to-guides/use-opencode.md) for more information.
+
+### Known Issues
+
+- On some HPE servers, for example the DL380a Gen11, the GPUs do not enumerate on the PCI bus. Add `pci=realloc=off` to
+  the GRUB kernel command line as a workaround. Refer to [Known Issues](./reference/known-issues.md) for the full
+  procedure.
+
+- Cursor routes only some request types to the appliance. Only Ask mode (chat) reaches a custom endpoint. Agent, Edit,
+  and Tab remain locked to Cursor's own models. This is a limitation of the tool's bring-your-own-key support, not of
+  the appliance. Refer to [Use Cursor](./how-to-guides/use-cursor.md) for more information.
+
+- On Windows, model transfers require extra setup. The `palette content model download` and
+  `palette content model upload` commands stream artifacts over `rsync` and SSH, so they need `rsync` 3.2.3 or later and
+  OpenSSH 8.4 or later, which Windows does not ship by default. On Windows, only SSH key authentication works, because
+  `--ssh-password` is supported on Unix administrative workstations only. Use a Linux administrative workstation for
+  model transfers. Refer to [Model Upload Reference](./reference/model-upload-reference.md) for more information.

--- a/docs/docs-content/paletteai-inference-launchpad/tutorials/_category_.json
+++ b/docs/docs-content/paletteai-inference-launchpad/tutorials/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Tutorials",
+  "position": 10,
+  "link": {
+    "type": "doc",
+    "id": "paletteai-inference-launchpad/tutorials/tutorials"
+  }
+}

--- a/docs/docs-content/paletteai-inference-launchpad/tutorials/tutorials.md
+++ b/docs/docs-content/paletteai-inference-launchpad/tutorials/tutorials.md
@@ -1,0 +1,22 @@
+---
+sidebar_label: "Tutorials"
+title: "Tutorials"
+description: "Hands-on, end-to-end tutorials for deploying and running PaletteAI Inference Launchpad."
+hide_table_of_contents: false
+sidebar_position: 0
+tags: ["paletteai-inference-launchpad", "tutorial"]
+---
+
+Tutorials are lessons that introduce PaletteAI Inference Launchpad by guiding you through a complete, working example
+from start to finish. They are learning-oriented and hands-on. You follow each step, learn by doing, and finish with a
+result you can build on. If you are new to the appliance, tutorials are a great place to start.
+
+:::info
+
+We are still developing tutorials for PaletteAI Inference Launchpad. In the meantime, the
+[How-to Guides](../how-to-guides/how-to-guides.md) take you through the full practical path, from
+[installing the appliance](../how-to-guides/install-the-appliance.md) to
+[deploying your first model](../how-to-guides/deploy-a-model.md). If you need help getting started,
+[contact Spectro Cloud](https://www.spectrocloud.com/contact) to discuss your use case.
+
+:::


### PR DESCRIPTION
## Summary

Backports the full **PaletteAI Inference Launchpad (PAIIL)** documentation set from `master` onto the `version-4-9` branch so the pages appear on the **v4.9.x** archived docs site (`version-4-9.legacy.docs.spectrocloud.com`).

The set existed only on `master` (the "current" docs version); `version-4-9` had **0** of these files before this PR. Same pattern as PR #11431.

## What's included (44 files)

- **42 doc files** under `docs/docs-content/paletteai-inference-launchpad/` (Explanation, How-to Guides, Reference, Tutorials, release notes, and `_category_.json` sidebar files), snapshotted from `master`.
- **`_partials/paletteai-inference-launchpad/_request-routing-and-quotas.mdx`** — the shared partial the four coding-tool guides render through `<PartialsComponent>`. Required: without it the build throws `No partial found for name request-routing-and-quotas`.
- The glossary-scoped **`.vale.ini`** override the reference glossary page depends on.

**Intentionally omitted:** `_partials/.../_unreleased-banner.mdx` — no page references it, and its "unreleased / not yet GA" text does not apply to a released branch.

## Verification

- [x] Staged set = 42 PAIIL docs + 1 partial + `.vale.ini`; nothing outside the section.
- [x] Prettier `--check` clean (prettier 3.5.3).
- [x] **Full `docusaurus build` run locally on this branch → `[SUCCESS] Generated static files`** with `onBrokenLinks/Anchors/MarkdownLinks: "throw"` enforced. The first push failed the Netlify preview on the missing partial; this was reproduced locally, fixed, and re-verified green.
- [x] Only cross-section link (`../../automation/palette-cli/install-palette-cli.md`) confirmed present on `version-4-9`.

> The Pre-merge Checks (Vale/Prettier/build) workflow is intentionally excluded from `version-*` branches, so those checks don't appear here; the Netlify deploy-preview is the build gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)