### PR TITLE
doc-2858: system section and kubevirt for vm launchpad

### DIFF
--- a/docs/docs-content/vm-management/vm-launchpad/kubevirt-configuration.md
+++ b/docs/docs-content/vm-management/vm-launchpad/kubevirt-configuration.md
@@ -73,7 +73,7 @@ Select **Reload** at any point to discard your draft and fetch the current resou
 | **Enable CPU emulation**        | Falls back to software CPU emulation when the host does not provide hardware virtualization extensions. Intended for lab and development environments.                                                                      | Cleared     |
 | **Memory overcommit ratio (%)** | Sets the cluster-wide level of memory overcommit. At `100`, the memory request of a VM equals its guest memory. Higher values reduce the request proportionally, so `200` requests about half and allows more VMs per node. | `100`       |
 | **CPU allocation ratio**        | Defines how much physical CPU is reserved per vCPU. Lower values give each vCPU more guaranteed CPU. Higher values increase VM density with less CPU per VM.                                                                | `10`        |
-| **Feature gates**               | KubeVirt feature gates enabled on the cluster.                                                                                                                                                                              | Varies      |
+| **Feature gates**               | KubeVirt feature gates enabled on the cluster.                                                                                                                                                                              | _Varies_      |
 
 To enable a feature gate, enter its name in the **Add a gate** field and select **Add**. To disable a gate, select the
 **x** on the gate. VMO submits the list as you entered it, so the KubeVirt admission webhook rejects a name it does not

--- a/docs/docs-content/vm-management/vm-launchpad/kubevirt-configuration.md
+++ b/docs/docs-content/vm-management/vm-launchpad/kubevirt-configuration.md
@@ -73,7 +73,7 @@ Select **Reload** at any point to discard your draft and fetch the current resou
 | **Enable CPU emulation**        | Falls back to software CPU emulation when the host does not provide hardware virtualization extensions. Intended for lab and development environments.                                                                      | Cleared     |
 | **Memory overcommit ratio (%)** | Sets the cluster-wide level of memory overcommit. At `100`, the memory request of a VM equals its guest memory. Higher values reduce the request proportionally, so `200` requests about half and allows more VMs per node. | `100`       |
 | **CPU allocation ratio**        | Defines how much physical CPU is reserved per vCPU. Lower values give each vCPU more guaranteed CPU. Higher values increase VM density with less CPU per VM.                                                                | `10`        |
-| **Feature gates**               | KubeVirt feature gates enabled on the cluster.                                                                                                                                                                              | _Varies_      |
+| **Feature gates**               | KubeVirt feature gates enabled on the cluster.                                                                                                                                                                              | _Varies_    |
 
 To enable a feature gate, enter its name in the **Add a gate** field and select **Add**. To disable a gate, select the
 **x** on the gate. VMO submits the list as you entered it, so the KubeVirt admission webhook rejects a name it does not

--- a/docs/docs-content/vm-management/vm-launchpad/kubevirt-configuration.md
+++ b/docs/docs-content/vm-management/vm-launchpad/kubevirt-configuration.md
@@ -31,16 +31,16 @@ runs on the appliance.
 
 The page is organized into the following sections, each of which maps to a part of the `KubeVirt` resource.
 
-| **Section**                 | **Description**                                                                       | **Resource fields**                                                                                     |
-| --------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Developer Configuration** | CPU emulation, cluster-wide overcommit ratios, and the list of enabled feature gates. | `spec.configuration.developerConfiguration`, including `featureGates`                                   |
-| **Strategies**              | Cluster defaults for eviction, VM rollout, and uninstall behavior.                    | `spec.configuration.evictionStrategy`, `spec.configuration.vmRolloutStrategy`, `spec.uninstallStrategy` |
-| **Live Migration**          | Concurrency, bandwidth, and timeout limits that apply to live migration.              | `spec.configuration.migrations`                                                                         |
-| **Workload Updates**        | How KubeVirt applies updates to VMs that are already running.                         | `spec.workloadUpdateStrategy`                                                                           |
-| **KSM Configuration**       | Node label selector that determines where KSM runs.                                   | `spec.configuration.ksmConfiguration`                                                                   |
-| **Ownership**               | Read-only list of the controllers that own fields on the resource.                    | `metadata.managedFields`                                                                                |
+| **Section**                                             | **Description**                                                                       | **Resource fields**                                                                                     |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| [**Developer Configuration**](#developer-configuration) | CPU emulation, cluster-wide overcommit ratios, and the list of enabled feature gates. | `spec.configuration.developerConfiguration`, including `featureGates`                                   |
+| [**Strategies**](#strategies)                           | Cluster defaults for eviction, VM rollout, and uninstall behavior.                    | `spec.configuration.evictionStrategy`, `spec.configuration.vmRolloutStrategy`, `spec.uninstallStrategy` |
+| [**Live Migration**](#live-migration)                   | Concurrency, bandwidth, and timeout limits that apply to live migration.              | `spec.configuration.migrations`                                                                         |
+| [**Workload Updates**](#workload-updates)               | How KubeVirt applies updates to VMs that are already running.                         | `spec.workloadUpdateStrategy`                                                                           |
+| [**KSM Configuration**](#ksm-configuration)             | Node label selector that determines where KSM runs.                                   | `spec.configuration.ksmConfiguration`                                                                   |
+| [**Ownership**](#ownership)                             | Read-only list of the controllers that own fields on the resource.                    | `metadata.managedFields`                                                                                |
 
-## Access the KubeVirt Configuration Page
+## Configure KubeVirt
 
 1. Log in to VMO.
 
@@ -48,25 +48,21 @@ The page is organized into the following sections, each of which maps to a part 
 
 3. Under **Configuration**, select **KubeVirt**. The page loads the current `KubeVirt` resource from the cluster.
 
-## Configure KubeVirt
-
-1. Access the **KubeVirt Configuration** page.
-
-2. Adjust the fields you want to change in any section. To reach fields that the form does not display, select **Open
+4. Adjust the fields you want to change in any section. To reach fields that the form does not display, select **Open
    YAML** and edit the resource spec directly. VMO validates your YAML and merges it into the same draft as the form
    fields.
 
-3. Select **Apply**. VMO makes **Apply** available only when your draft differs from the version stored in the cluster
+5. Select **Apply**. VMO makes **Apply** available only when your draft differs from the version stored in the cluster
    and every field passes validation.
 
-4. Review the **Diff Preview**, which compares the current spec with the spec you are about to submit.
+6. Review the **Diff Preview**, which compares the current spec with the spec you are about to submit.
 
-5. Select **Apply** in the **Diff Preview** to send the change to the cluster. VMO reloads the form from the updated
+7. Select **Apply** in the **Diff Preview** to send the change to the cluster. VMO reloads the form from the updated
    resource and clears your draft.
 
 Select **Reload** at any point to discard your draft and fetch the current resource from the cluster.
 
-## Developer Configuration
+### Developer Configuration
 
 | **Field**                       | **Description**                                                                                                                                                                                                             | **Default** |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
@@ -86,7 +82,7 @@ refer to [VM Overcommitment and Memory Optimization](./vmo-overcommit-memory-opt
 
 :::
 
-## Strategies
+### Strategies
 
 | **Field**                     | **Description**                                                                    | **Default**                            |
 | ----------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------- |
@@ -94,7 +90,7 @@ refer to [VM Overcommitment and Memory Optimization](./vmo-overcommit-memory-opt
 | **VM rollout strategy**       | When a configuration change to a VM takes effect.                                  | **Live update**                        |
 | **Uninstall strategy**        | Whether KubeVirt can be uninstalled while VM workloads still exist on the cluster. | **Block uninstall if workloads exist** |
 
-## Live Migration
+### Live Migration
 
 | **Field**                                        | **Description**                                                                                                     | **Default** |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ----------- |
@@ -107,10 +103,12 @@ refer to [VM Overcommitment and Memory Optimization](./vmo-overcommit-memory-opt
 | **Allow post-copy**                              | Allows KubeVirt to switch to post-copy migration when pre-copy migration does not converge.                         | Cleared     |
 | **Allow workload disruption during maintenance** | Allows KubeVirt to disrupt workloads that cannot migrate when a node enters maintenance.                            | Cleared     |
 
-An empty field means that the KubeVirt default applies. VMO validates the bandwidth format before you apply, so a value
-in the wrong format keeps **Apply** unavailable instead of failing at the admission webhook.
+An empty field means that the KubeVirt default applies. To review the upstream defaults, refer to
+[Live Migration](https://kubevirt.io/user-guide/compute/live_migration/) in the KubeVirt user guide. VMO validates the
+bandwidth format before you apply, so a value in the wrong format keeps **Apply** unavailable instead of failing at the
+admission webhook.
 
-## Workload Updates
+### Workload Updates
 
 | **Field**                   | **Description**                                                                                | **Default**     |
 | --------------------------- | ---------------------------------------------------------------------------------------------- | --------------- |
@@ -118,7 +116,7 @@ in the wrong format keeps **Apply** unavailable instead of failing at the admiss
 | **Batch eviction size**     | Number of VMs that KubeVirt updates in a single batch.                                         | Empty           |
 | **Batch eviction interval** | Time that KubeVirt waits between batches. Enter a Go duration, such as `1m0s`.                 | Empty           |
 
-## KSM Configuration
+### KSM Configuration
 
 [KSM](https://docs.kernel.org/admin-guide/mm/ksm.html) is a Linux kernel feature that allows deduplication of identical
 memory pages across VMs. It reduces memory consumption when many VMs run the same guest operating system.
@@ -137,7 +135,7 @@ worth that cost, refer to
 
 :::
 
-## Ownership
+### Ownership
 
 The **Ownership** section lists every field manager that owns fields on the `KubeVirt` resource, along with the
 operation it used, when it last wrote, and how many fields it owns. Typical managers are `vmo-manager`,

--- a/docs/docs-content/vm-management/vm-launchpad/kubevirt-configuration.md
+++ b/docs/docs-content/vm-management/vm-launchpad/kubevirt-configuration.md
@@ -1,0 +1,190 @@
+---
+sidebar_label: "KubeVirt Configuration"
+title: "KubeVirt Configuration"
+description:
+  "Adjust feature gates, migration policy, workload updates, and KSM on the cluster-scoped KubeVirt custom resource in
+  PaletteAI VM Launchpad."
+icon: " "
+hide_table_of_contents: false
+sidebar_position: 8
+tags: ["vmo", "vm launchpad", "kubevirt", "configuration"]
+---
+
+The **KubeVirt Configuration** page is a guided editor for the cluster-scoped `KubeVirt` custom resource that
+[KubeVirt](https://kubevirt.io/user-guide/) uses to configure the virtualization layer. Use the page to adjust feature
+gates, eviction and migration policy, workload update behavior, and Kernel Same-Page Merging (KSM) without editing the
+custom resource directly.
+
+Virtual Machine Orchestrator (VMO) submits your changes with
+[Server-Side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) and identifies itself as the
+`vmo-manager` field manager. This allows VMO to share the resource with the KubeVirt operator and other controllers that
+own fields on it.
+
+:::warning
+
+This page edits the live configuration of your cluster. Changes take effect when you apply them and affect every VM that
+runs on the appliance.
+
+:::
+
+## Configuration Sections
+
+The page is organized into the following sections, each of which maps to a part of the `KubeVirt` resource.
+
+| **Section**                 | **Description**                                                                       | **Resource fields**                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Developer Configuration** | CPU emulation, cluster-wide overcommit ratios, and the list of enabled feature gates. | `spec.configuration.developerConfiguration`, including `featureGates`                                   |
+| **Strategies**              | Cluster defaults for eviction, VM rollout, and uninstall behavior.                    | `spec.configuration.evictionStrategy`, `spec.configuration.vmRolloutStrategy`, `spec.uninstallStrategy` |
+| **Live Migration**          | Concurrency, bandwidth, and timeout limits that apply to live migration.              | `spec.configuration.migrations`                                                                         |
+| **Workload Updates**        | How KubeVirt applies updates to VMs that are already running.                         | `spec.workloadUpdateStrategy`                                                                           |
+| **KSM Configuration**       | Node label selector that determines where KSM runs.                                   | `spec.configuration.ksmConfiguration`                                                                   |
+| **Ownership**               | Read-only list of the controllers that own fields on the resource.                    | `metadata.managedFields`                                                                                |
+
+## Access the KubeVirt Configuration Page
+
+1. Log in to VMO.
+
+2. From the VMO left main menu, select **Settings**.
+
+3. Under **Configuration**, select **KubeVirt**. The page loads the current `KubeVirt` resource from the cluster.
+
+## Configure KubeVirt
+
+1. Access the **KubeVirt Configuration** page.
+
+2. Adjust the fields you want to change in any section. To reach fields that the form does not display, select **Open
+   YAML** and edit the resource spec directly. VMO validates your YAML and merges it into the same draft as the form
+   fields.
+
+3. Select **Apply**. VMO makes **Apply** available only when your draft differs from the version stored in the cluster
+   and every field passes validation.
+
+4. Review the **Diff Preview**, which compares the current spec with the spec you are about to submit.
+
+5. Select **Apply** in the **Diff Preview** to send the change to the cluster. VMO reloads the form from the updated
+   resource and clears your draft.
+
+Select **Reload** at any point to discard your draft and fetch the current resource from the cluster.
+
+## Developer Configuration
+
+| **Field**                       | **Description**                                                                                                                                                                                                             | **Default** |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Enable CPU emulation**        | Falls back to software CPU emulation when the host does not provide hardware virtualization extensions. Intended for lab and development environments.                                                                      | Cleared     |
+| **Memory overcommit ratio (%)** | Sets the cluster-wide level of memory overcommit. At `100`, the memory request of a VM equals its guest memory. Higher values reduce the request proportionally, so `200` requests about half and allows more VMs per node. | `100`       |
+| **CPU allocation ratio**        | Defines how much physical CPU is reserved per vCPU. Lower values give each vCPU more guaranteed CPU. Higher values increase VM density with less CPU per VM.                                                                | `10`        |
+| **Feature gates**               | KubeVirt feature gates enabled on the cluster.                                                                                                                                                                              | Varies      |
+
+To enable a feature gate, enter its name in the **Add a gate** field and select **Add**. To disable a gate, select the
+**x** on the gate. VMO submits the list as you entered it, so the KubeVirt admission webhook rejects a name it does not
+recognize when you apply.
+
+:::info
+
+The overcommit ratios change resource density across the whole cluster. To review the trade-offs before you adjust them,
+refer to [VM Overcommitment and Memory Optimization](./vmo-overcommit-memory-optimization-appliance.md).
+
+:::
+
+## Strategies
+
+| **Field**                     | **Description**                                                                    | **Default**                            |
+| ----------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------- |
+| **Default eviction strategy** | What KubeVirt does with a running VM when its node is drained.                     | **Live migrate**                       |
+| **VM rollout strategy**       | When a configuration change to a VM takes effect.                                  | **Live update**                        |
+| **Uninstall strategy**        | Whether KubeVirt can be uninstalled while VM workloads still exist on the cluster. | **Block uninstall if workloads exist** |
+
+## Live Migration
+
+| **Field**                                        | **Description**                                                                                                     | **Default** |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Parallel outbound migrations per node**        | Maximum number of migrations that can leave a single node at the same time.                                         | Empty       |
+| **Parallel migrations per cluster**              | Maximum number of migrations that can run across the cluster at the same time.                                      | Empty       |
+| **Bandwidth per migration**                      | Network bandwidth limit for a single migration. Enter a Kubernetes quantity, such as `1Gi`. Enter `0` for no limit. | Empty       |
+| **Completion timeout (s / GiB)**                 | Seconds allowed for each GiB of memory before KubeVirt cancels a migration that has not finished.                   | `150`       |
+| **Progress timeout (s)**                         | Seconds that a migration can run without making progress before KubeVirt cancels it.                                | Empty       |
+| **Allow auto-converge**                          | Throttles the guest CPU when a migration cannot keep pace with the rate at which the guest changes memory.          | Selected    |
+| **Allow post-copy**                              | Allows KubeVirt to switch to post-copy migration when pre-copy migration does not converge.                         | Cleared     |
+| **Allow workload disruption during maintenance** | Allows KubeVirt to disrupt workloads that cannot migrate when a node enters maintenance.                            | Cleared     |
+
+An empty field means that the KubeVirt default applies. VMO validates the bandwidth format before you apply, so a value
+in the wrong format keeps **Apply** unavailable instead of failing at the admission webhook.
+
+## Workload Updates
+
+| **Field**                   | **Description**                                                                                | **Default**     |
+| --------------------------- | ---------------------------------------------------------------------------------------------- | --------------- |
+| **Workload update methods** | How KubeVirt updates VMs that are already running. Select **LiveMigrate**, **Evict**, or both. | **LiveMigrate** |
+| **Batch eviction size**     | Number of VMs that KubeVirt updates in a single batch.                                         | Empty           |
+| **Batch eviction interval** | Time that KubeVirt waits between batches. Enter a Go duration, such as `1m0s`.                 | Empty           |
+
+## KSM Configuration
+
+[KSM](https://docs.kernel.org/admin-guide/mm/ksm.html) is a Linux kernel feature that allows deduplication of identical
+memory pages across VMs. It reduces memory consumption when many VMs run the same guest operating system.
+
+The **Node label selector** determines where KSM runs. KSM runs on the nodes whose labels match every key and value pair
+in the selector. You can add up to eight pairs.
+
+To restrict KSM to a set of nodes, enter a label key and its value, and then select **Add**. To remove a pair, select
+the delete icon at the end of its row.
+
+:::info
+
+KSM adds CPU overhead because the kernel continuously scans memory pages. For guidance on when the memory savings are
+worth that cost, refer to
+[VM Overcommitment and Memory Optimization](./vmo-overcommit-memory-optimization-appliance.md).
+
+:::
+
+## Ownership
+
+The **Ownership** section lists every field manager that owns fields on the `KubeVirt` resource, along with the
+operation it used, when it last wrote, and how many fields it owns. Typical managers are `vmo-manager`,
+`virt-controller`, and `virt-operator`.
+
+This section is read-only. Review it when you plan to change a field that another controller manages, because
+Server-Side Apply returns a conflict when two managers claim the same field.
+
+## Apply Errors
+
+VMO displays the following errors at the top of the form when an apply does not succeed.
+
+| **Error**                    | **Cause**                                                                                                                                                               | **Resolution**                                                                                          |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Server-Side Apply conflict   | Another field manager, often the KubeVirt operator, owns a field that you changed.                                                                                      | Select **Reload** to fetch the current resource, and then make your change again on the updated state.  |
+| Kubernetes permission denied | Your Kubernetes identity does not hold `update` permission on the `kubevirts.kubevirt.io` resource. Both your VMO permission and Kubernetes RBAC must allow the change. | Ask a cluster administrator to grant the permission, or apply the change with an account that holds it. |
+| Admission rejection          | The KubeVirt admission webhook rejected the change, such as an unrecognized feature gate name or a malformed duration.                                                  | Correct the value that the message identifies, and then apply again.                                    |
+
+## Permissions
+
+Two permissions control this page.
+
+- `vmo:kubevirt:read` - Displays the configuration and the YAML editor in read-only form.
+
+- `vmo:kubevirt:write` - Allows you to edit the draft and apply changes. Without this permission, the page displays a
+  read-only banner and **Apply** remains unavailable.
+
+Only the built-in **Platform Admin** role holds these permissions. Because the `KubeVirt` resource is cluster-scoped,
+the **Configuration** group is available only to users whose access is not restricted to specific namespaces.
+
+To review the permissions that each built-in role holds, refer to
+[VM User Roles and Permissions](../rbac/vm-roles-permissions.md).
+
+## Feature Gate Considerations
+
+The `DeclarativeHotplugVolumes` gate is required to define a CD-ROM drive that has no ISO mounted when you create a VM.
+Without the gate, VMO omits empty CD-ROM entries from the manifest it generates. For more information about adding
+CD-ROM drives, refer to [Create a VM](./virtual-machines/creating.md).
+
+`HotplugVolumes` and `DeclarativeHotplugVolumes` can both appear in the list without the admission webhook rejecting
+them. When the list contains both gates, `HotplugVolumes` takes precedence for the imperative hotplug API, while
+`DeclarativeHotplugVolumes` still allows empty CD-ROM drives at creation time. To move fully to the declarative model,
+remove `HotplugVolumes` and keep `DeclarativeHotplugVolumes`.
+
+:::warning
+
+Before you remove `DeclarativeHotplugVolumes`, attach an ISO to every VM that has an empty CD-ROM drive, or remove the
+empty drive from those VMs. VMs that keep an empty CD-ROM drive after you remove the gate can enter a degraded state.
+
+:::

--- a/docs/docs-content/vm-management/vm-launchpad/system/audit.md
+++ b/docs/docs-content/vm-management/vm-launchpad/system/audit.md
@@ -1,0 +1,121 @@
+---
+sidebar_label: "Audit Trail"
+title: "Audit Trail"
+description:
+  "Review authentication attempts, VM operations, and configuration changes recorded in the audit trail on PaletteAI VM
+  Launchpad."
+icon: " "
+hide_table_of_contents: false
+sidebar_position: 10
+tags: ["vmo", "vm launchpad", "system", "audit"]
+---
+
+Virtual Machine Orchestrator (VMO) records security-relevant actions in an audit trail. Each event captures who
+performed an action, what the action targeted, and when it happened, which gives you one place to answer compliance and
+troubleshooting questions about activity in the appliance.
+
+VMO stores audit events as `VmoAuditEvent` custom resources in the `virtualization.spectrocloud.com/v1beta1` API group.
+
+## Audited Actions
+
+VMO records the following actions.
+
+| **Category**       | **Actions**                                          |
+| ------------------ | ---------------------------------------------------- |
+| Authentication     | `login`, `login-failed`, `logout`, `password-change` |
+| Resource lifecycle | `create`, `update`, `delete`                         |
+| VM operations      | `start`, `stop`, `restart`, `migrate`, `restore`     |
+| Access control     | `grant`, `revoke`                                    |
+
+Authentication events cover both OIDC and local user accounts. VMO records a `login-failed` event when the credentials
+are incorrect and when the OIDC provider is unavailable.
+
+## View the Audit Trail
+
+1. Log in to VMO.
+
+2. From the VMO left main menu, select **System** > **Audit**.
+
+3. Review the events on the **Audit Trail** page. VMO lists the newest event first and displays the total number of
+   events below the page title.
+
+The events table contains the following columns.
+
+| **Column**    | **Description**                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| **Time**      | Date and time the event occurred.                                                                     |
+| **User**      | Identity that performed the action. Failed logins display `unknown` when VMO cannot resolve the user. |
+| **Action**    | Operation performed, such as `create` or `login`.                                                     |
+| **Resource**  | Resource type that the action targeted, such as **Vm** or **Oidc-User**.                              |
+| **Name**      | Name of the affected resource.                                                                        |
+| **Namespace** | Namespace of the affected resource. Cluster-level actions display a dash.                             |
+| **Detail**    | Additional context, such as `VM tmp-nad-test patched`.                                                |
+
+Select a column heading to sort the table by that column. Select **Refresh** to load the events that VMO has recorded
+since you opened the page.
+
+### Customize the Columns
+
+Hide the columns you do not need so that the columns you care about have more room. Column changes apply to the **Audit
+Trail** page only.
+
+1. On the **Audit Trail** page, select the gear icon.
+
+2. In the **Show / Hide Columns** menu, clear the checkbox for each column you want to hide. Select a cleared checkbox
+   to display that column again. The table updates as you make each change.
+
+3. _(Optional)_ Select **Reset to defaults** to display all columns again.
+
+### Filter Audit Events
+
+The **Audit Trail** page provides the following controls for narrowing the events table.
+
+| **Control**       | **Description**                                                               |
+| ----------------- | ----------------------------------------------------------------------------- |
+| **Filter rows**   | Search box that matches text in the displayed columns.                        |
+| **All Actions**   | Drop-down menu that limits the table to a single action, such as `delete`.    |
+| **All Resources** | Drop-down menu that limits the table to a single resource type, such as `vm`. |
+
+The **All Resources** drop-down menu lists every resource type that VMO audits. The following table groups those
+resource types by area to help you find the one you need.
+
+| **Area**                | **Resource Types**                                                                                                                                                                                 |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Virtual machines        | `vm`, `datavolume`, `snapshot`, `snapshot-policy`, `snapshot-schedule`, `instancetype`, `preference`                                                                                               |
+| Templates and images    | `template`, `vmtemplate`, `image-template`, `cloud-init-template`, `auto-install-script`, `builder`                                                                                                |
+| Infrastructure          | `namespace`, `namespacepolicy`, `network`, `kubevirt`                                                                                                                                              |
+| Identity and access     | `user`, `group`, `usergroup`, `oidc-user`, `local-user`, `apikey`, `accesspolicy`, `iam-role`, `role`, `clusterrole`, `rolebinding`, `clusterrolebinding`, `rbac`, `group-mapping`, `user-mapping` |
+| Appliance configuration | `config`, `config-bundle`, `config-seed`, `settings`, `feature-flag`, `dashboard-manifest`, `certificate`, `tls-certificate`                                                                       |
+
+:::info
+
+The events table includes a **User** column, but the page does not provide a matching filter. Use the **Filter rows**
+search box to narrow the table to a specific user.
+
+:::
+
+## Audit Event Visibility
+
+The events that appear on the **Audit Trail** page depend on your access. VMO scopes the list along two axes.
+
+- **Namespace** - The page displays events that targeted a namespace you can access. Users with cluster-wide access can
+  review events from every namespace.
+
+- **Resource type** - The page displays events for a resource type only when your role grants read access to that
+  resource type. For example, a role that can read VMs but not identity resources displays VM events and hides role and
+  user events.
+
+The page always displays the events for actions that you performed, including cluster-level actions and actions that
+targeted namespaces you no longer have access to. This preserves individual accountability when a role or namespace
+scope is narrowed later.
+
+To review the permissions that each built-in role holds, refer to
+[VM User Roles and Permissions](../../rbac/vm-roles-permissions.md).
+
+## Audit Event Retention
+
+VMO deletes audit events that are older than 30 days and runs the cleanup once per day. This keeps the volume of stored
+audit data bounded without any action on your part.
+
+If you need to keep audit records beyond the retention window, forward them to an external Security Information and
+Event Management (SIEM) system or log aggregator before they expire.

--- a/docs/docs-content/vm-management/vm-launchpad/system/system.md
+++ b/docs/docs-content/vm-management/vm-launchpad/system/system.md
@@ -1,0 +1,28 @@
+---
+sidebar_label: "System"
+title: "System"
+description: "Review the record of activity in the appliance on PaletteAI VM Launchpad."
+hide_table_of_contents: false
+sidebar_position: 5
+tags: ["vmo", "vm launchpad", "system", "audit"]
+---
+
+Use the **System** section of Virtual Machine Orchestrator (VMO) to review the record of activity in the appliance. VMO
+captures authentication attempts, VM operations, and configuration changes as audit events, which gives you a single
+place to answer questions about who changed what and when.
+
+## System Tasks
+
+| **Task**                  | **Description**                                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [Audit Trail](./audit.md) | Review authentication attempts, VM operations, and configuration changes, and control which details the events table displays. |
+
+## Related Workflows
+
+- [VM User Roles and Permissions](../../rbac/vm-roles-permissions.md)
+
+- [KubeVirt Configuration](../kubevirt-configuration.md)
+
+- [Infrastructure](../infrastructure/infrastructure.md)
+
+- [Virtual Machine Management](../virtual-machines/virtual-machines.md)


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context. -->

This PR adds the System section for PaletteAI VM Launchpad, completing the section refactor under epic DOC-2695.

**New pages**

- **System** (`system/system.md`) - Section index at `sidebar_position: 5`, placed after Infrastructure.
- **Audit Trail** (`system/audit.md`) - How to read, sort, filter, and customize the audit events table, what VMO
  audits, how event visibility is scoped, and the default retention window.
- **KubeVirt Configuration** (`kubevirt-configuration.md`) - Guided editor for the cluster-scoped `KubeVirt` custom
  resource, covering all six form sections, the apply workflow, apply errors, permissions, and feature gate guidance.

**Two structural decisions worth a reviewer's attention**

- `system/` is a folder holding a single page. This mirrors the appliance's **System** > **Audit** navigation and
  leaves room for the section to grow, rather than flattening Audit to a root-level page now and moving it later at the
  cost of a redirect.
- **KubeVirt Configuration** lives at the `vm-launchpad/` root at `sidebar_position: 8`, not under System or Settings.
  In the UI it sits at **Settings** > **Configuration** > **KubeVirt**, but it is environment-tuning material, so it is
  grouped with the other tuning pages (`vmo-networking` and `vmo-overcommit-memory-optimization-appliance`, both at 9). The page body still gives the literal UI path.

**Content was verified against a live 4.9.15 appliance**, not only the engineering-authored source docs, which turned
out to be stale in several places:

- The audit **All Actions** menu has 14 actions; the source listed four authentication actions plus generic CRUD. The
  page now documents `start`, `stop`, `restart`, `migrate`, `restore`, `grant`, and `revoke` as well.
- The column editor and the **Filter rows** search box are absent from the source entirely.
- Three KubeVirt section names were wrong in the source: **Live Migration**, **Workload Updates**, and **Ownership** were documented as "Migration Configuration", "Workload Update Strategy", and "Managed Fields Summary".
- The source described Developer Configuration as log verbosity and allowed/denied devices. The live section exposes CPU emulation, memory overcommit ratio, CPU allocation ratio, and feature gates. Field descriptions for the two ratios come from the in-product tooltips.

**Known follow-ups, intentionally not in this PR**

- `vmo-overcommit-memory-optimization-appliance.md` documents `cpuAllocationRatio`, `memoryOvercommit`, and `ksmConfiguration` as pack YAML edits. The KubeVirt UI now exposes all three. This PR links from the new page to the overcommit page for the trade-offs; reconciling the overcommit page so it points back for the mechanics is a separate change, kept apart to keep both diffs reviewable.
- The audit page carries a short **Audit Event Visibility** section that cross-links to the roles page rather than
  restating the full permission matrix. The detailed matrix is being reconciled under DOC-2865.
- The KubeVirt page does not state what an empty KSM node label selector does, because the source doc and the
  overcommit page disagree and the behavior is not yet confirmed against the appliance.

---

## 💻 Changed Pages

<!-- Add a link to the preview URL generated by Netlify. Include direct links to the pages affected by the PR. -->

- [System](https://deploy-preview-11502--docs-spectrocloud.netlify.app/vm-management/vm-launchpad/system/)
- [Audit Trail](https://deploy-preview-11502--docs-spectrocloud.netlify.app/vm-management/vm-launchpad/system/audit)
- [KubeVirt Configuration](https://deploy-preview-11502--docs-spectrocloud.netlify.app/vm-management/vm-launchpad/kubevirt-configuration)

---

## 🎫 Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable). -->

[Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-2858)
