### PR TITLE
[version-4-4] chore: bump actions/checkout from 7.0.0 to 7.0.1 (#11463)

### DIFF
--- a/.github/workflows/aloglia_crawler.yaml
+++ b/.github/workflows/aloglia_crawler.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # - name: Run scraper
       #   env:

--- a/.github/workflows/api_format.yaml
+++ b/.github/workflows/api_format.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Checkout Code
               # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 as of May 6, 2026
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/bump-impersonaid-sha.yaml
+++ b/.github/workflows/bump-impersonaid-sha.yaml
@@ -48,7 +48,7 @@ jobs:
           secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
 
       - name: Checkout librarium (master)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: master
           token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}

--- a/.github/workflows/clean-up-report.yaml
+++ b/.github/workflows/clean-up-report.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
       - name: Checkout GitHub Pages Branch
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         
       - name: Remove Branch From Netlify
         run: cd scripts && ./netlify_remove_branch.sh 
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub Pages Branch
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
 

--- a/.github/workflows/clean-up-unused-images.yaml
+++ b/.github/workflows/clean-up-unused-images.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
 

--- a/.github/workflows/cluster-scanner-librarium.yaml
+++ b/.github/workflows/cluster-scanner-librarium.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Palette Samples Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           repository: spectrocloud/palette-samples
 

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -38,7 +38,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'dependabot-preview[bot]' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/eslint-test.yaml
+++ b/.github/workflows/eslint-test.yaml
@@ -36,7 +36,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/generate_component_updates.yaml
+++ b/.github/workflows/generate_component_updates.yaml
@@ -61,7 +61,7 @@ jobs:
           secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
 
       - name: Checkout Librarium Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           repository: spectrocloud/librarium
           ref: ${{ env.BASE_BRANCH }}

--- a/.github/workflows/generate_patch_release_notes.yaml
+++ b/.github/workflows/generate_patch_release_notes.yaml
@@ -45,7 +45,7 @@ jobs:
           secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
 
       - name: Checkout Librarium Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           repository: spectrocloud/librarium
           ref: ${{ env.BASE_BRANCH }}

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -29,7 +29,7 @@ jobs:
     
     steps:
     - name: Checkout current branch
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ env.BRANCH_NAME }}
 

--- a/.github/workflows/image_optimizer.yaml
+++ b/.github/workflows/image_optimizer.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Checkout Repository
         # Pin to SHA to prevent supply-chain attacks on actions
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Compress Images
         # Third-party action also pinned for the same reason

--- a/.github/workflows/merged-links-checks.yaml
+++ b/.github/workflows/merged-links-checks.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/monthly-assessment.yaml
+++ b/.github/workflows/monthly-assessment.yaml
@@ -81,13 +81,13 @@ jobs:
           secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
 
       - name: Checkout librarium (master)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: master
           token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
 
       - name: Checkout Impersonaid
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: spectrocloud/impersonaid
           ref: ${{ env.IMPERSONAID_REF }}

--- a/.github/workflows/netlify-version-release.yaml
+++ b/.github/workflows/netlify-version-release.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Trigger Netlify build hook per version branch
         env:

--- a/.github/workflows/nightly-docker-build.yaml
+++ b/.github/workflows/nightly-docker-build.yaml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/permissions-update.yaml
+++ b/.github/workflows/permissions-update.yaml
@@ -80,14 +80,14 @@ jobs:
           secrets: /providers/github/organizations/spectrocloud/token?org_name=spectrocloud token | VAULT_GITHUB_TOKEN
 
       - name: Checkout Librarium Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           repository: spectrocloud/librarium
           ref: ${{ matrix.target }}
           token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
 
       - name: Checkout required-permissions-data Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           repository: spectrocloud/required-permissions-data
           path: ${{ env.PATH_PERMISSIONS }}

--- a/.github/workflows/persona-check.yaml
+++ b/.github/workflows/persona-check.yaml
@@ -126,12 +126,12 @@ jobs:
 
       # Trusted base-ref checkout: provides .github/persona-check/* (our scripts).
       - name: Checkout base (trusted scripts)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Untrusted PR head content — read only as data, never executed.
       - name: Checkout PR head
         if: ${{ steps.resolve.outputs.mode == 'run' }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/pull/${{ steps.resolve.outputs.pr_number }}/head
           path: pr
@@ -139,7 +139,7 @@ jobs:
 
       - name: Checkout Impersonaid
         if: ${{ steps.resolve.outputs.mode == 'run' }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: spectrocloud/impersonaid
           ref: ${{ env.IMPERSONAID_REF }}

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js Environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Checkout Repository
         # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 as of May 6, 2026
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
@@ -111,7 +111,7 @@ jobs:
     steps:
       - name: Checkout Repository
         # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 as of May 6, 2026
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js environment
         # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.

--- a/.github/workflows/release-branch-pr.yaml
+++ b/.github/workflows/release-branch-pr.yaml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Check out repository
       # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 as of May 6, 2026
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Setup Node.js environment
       # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ["self-hosted", "linux", "x64", "vcenter3"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: "master"
@@ -125,7 +125,7 @@ jobs:
       labels: docbot
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: "master"
@@ -219,7 +219,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/screenshot_capture.yaml
+++ b/.github/workflows/screenshot_capture.yaml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js Environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -102,7 +102,7 @@ jobs:
         shardTotal: [4]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js Environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/spellcheck-report.yaml
+++ b/.github/workflows/spellcheck-report.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update_component_updates.yaml
+++ b/.github/workflows/update_component_updates.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Checkout Librarium Repository
         if: steps.check.outputs.run == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           repository: spectrocloud/librarium
           ref: ${{ env.BASE_BRANCH }}

--- a/.github/workflows/update_patch_release_notes.yaml
+++ b/.github/workflows/update_patch_release_notes.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Checkout Librarium Repository
         if: steps.check.outputs.run == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           repository: spectrocloud/librarium
           ref: ${{ env.BASE_BRANCH }}

--- a/.github/workflows/versions_robot.yaml
+++ b/.github/workflows/versions_robot.yaml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Checkout Repository
         # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 as of May 6, 2026
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Checkout Repository
         # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 as of May 6, 2026
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js Environment
         # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
@@ -142,7 +142,7 @@ jobs:
     steps:
       - name: Check out repository code
         # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 as of May 6, 2026
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js environment
         # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
@@ -196,7 +196,7 @@ jobs:
     steps:
     - name: Check out repository code
       # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 as of May 6, 2026
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Setup Node.js environment
       # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
@@ -245,7 +245,7 @@ jobs:
 
     - name: Checkout GitHub Pages Branch
       # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 as of May 6, 2026
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: gh-pages  
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-4`:

- [chore: bump actions/checkout from 7.0.0 to 7.0.1 (#11463)](https://github.com/spectrocloud/librarium/pull/11463)

**Note on scope.** The auto-backport bot failed on this branch because
`actions/checkout` was still pinned to v6 — earlier bumps (v4→v5, v5→v6,
v6→v7) also never backported cleanly. Rather than resolve each of those
missed backports separately, this PR takes the incoming v7.0.1 pin from
#11463 everywhere, rolling up the intermediate bumps for
`actions/checkout` specifically. Only `actions/checkout` lines changed
(42 lines across 29 workflow files); no other workflow content was
modified.

<!--- Backport version: manual (cherry-pick with conflict resolution) -->

### Questions ?

Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
