### PR TITLE
pvm-973: okta SSO for PAVL 4.10.0

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -70,6 +70,14 @@ Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible ver
 
 ### Docs and Education
 
+<!-- https://spectrocloud.atlassian.net/browse/PVM-973 -->
+
+- A new
+  [Federate an External Identity Provider with Keycloak](../vm-management/vm-launchpad/access-management/oidc-federation.md)
+  guide is now available. The guide explains how to federate an external OIDC identity provider, such as Okta, into
+  PaletteAI VM Launchpad, and covers the email claim and group membership requirements that a federated account must
+  satisfy.
+
 ### Packs
 
 #### Pack Notes

--- a/docs/docs-content/vm-management/vm-launchpad/access-management/access-management.md
+++ b/docs/docs-content/vm-management/vm-launchpad/access-management/access-management.md
@@ -39,3 +39,4 @@ a VMO role, the group mappings determine their effective permissions. Refer to
 | [Access Mapping](./access-mapping.md)   | View the resolved Kubernetes bindings and VMO IAM mappings across every user and group.                        |
 | [API Keys](./api-keys.md)               | Create, use, and revoke self-service API keys for programmatic access.                                         |
 | [LDAP Federation](./ldap-federation.md) | Federate users from an LDAP directory and satisfy the OIDC email claim requirement.                            |
+| [OIDC Federation](./oidc-federation.md) | Federate an external OIDC identity provider, such as Okta, and map its groups to VMO roles.                    |

--- a/docs/docs-content/vm-management/vm-launchpad/access-management/oidc-federation.md
+++ b/docs/docs-content/vm-management/vm-launchpad/access-management/oidc-federation.md
@@ -147,7 +147,7 @@ Return to the Keycloak admin console, on the **OpenID Connect v1.0** form you op
    | **Field**              | **Value**                                                                                                                                                                    |
    | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
    | **Alias**              | A short identifier for the provider, such as `okta`. This value appears in the redirect URI.                                                                                 |
-   | **Display name**       | The label shown on the VM Launchpad sign-in page, such as `Okta`.                                                                                                            |
+   | **Display name**       | A human-readable label for the provider in Keycloak, such as `Okta`.                                                                                                         |
    | **Discovery endpoint** | Your provider's OIDC discovery document, such as `https://<your-okta-domain>/.well-known/openid-configuration`. Keycloak populates the authorization and token URLs from it. |
    | **Client ID**          | The client ID from the application you created.                                                                                                                              |
    | **Client Secret**      | The client secret from the application you created.                                                                                                                          |
@@ -222,20 +222,40 @@ permissions until the user signs in again. Refer to [API Keys](./api-keys.md).
 
 ## Verify
 
-1. Open VM Launchpad in a fresh browser session, or use a private browsing window.
+:::info
 
-2. Confirm that the sign-in page offers your provider under the display name you configured, and sign in as a user who
-   belongs to a mapped group.
+In this release, the VM Launchpad sign-in page does not surface a per-provider button for federated identity providers,
+so the end-user brokered sign-in flow cannot be initiated from the appliance sign-in page. The steps below verify the
+Keycloak-side configuration you can confirm today. The user-side verification steps apply once a federated user
+completes a brokered sign-in through their identity provider.
 
-3. In the Keycloak admin console, select **Users** from the left main menu, and then select the account that just signed
-   in. Confirm that the **Email** field is populated and that **Email verified** is enabled.
+:::
 
-4. Select the **Groups** tab for that account, and confirm that the mapped Keycloak group is listed.
+### Verify the Keycloak configuration
 
-5. Log in to VM Launchpad and go to **Settings** > **Access Management** > **Access Mapping**. Confirm that the account
+1. In the Keycloak admin console for the `vmo` realm, select **Identity providers** from the left main menu, and confirm
+   that the provider you configured appears in the list.
+
+2. Select the provider. On the **Settings** tab, expand **Advanced settings** and confirm that **Trust Email** is
+   enabled and that **Scopes** is set to `openid profile email groups`.
+
+3. Select the **Mappers** tab and confirm that a mapper exists for each provider group you federate. Confirm that each
+   mapper uses the **Advanced Claim to Group** mapper type with **Sync mode override** set to **Force** and that its
+   **Claims** and **Group** values match the provider group and the target Keycloak group.
+
+### Verify a federated user's account
+
+Complete these steps after a federated user has completed their first brokered sign-in.
+
+1. In the Keycloak admin console, select **Users** from the left main menu, and then select the account. Confirm that
+   the **Email** field is populated and that **Email verified** is enabled.
+
+2. Select the **Groups** tab for that account, and confirm that the mapped Keycloak group is listed.
+
+3. Log in to VM Launchpad and go to **Settings** > **Access Management** > **Access Mapping**. Confirm that the account
    resolves to the VMO role and namespace scope you expect. Refer to [Access Mapping](./access-mapping.md).
 
-6. Ask the user to confirm that the resources their role grants are available.
+4. Ask the user to confirm that the resources their role grants are available.
 
 If the account appears in Keycloak with no group, the claim that the provider sent does not match the **Claims** value
 on the mapper. Compare the group name in the provider against the mapper configuration, including case.

--- a/docs/docs-content/vm-management/vm-launchpad/access-management/oidc-federation.md
+++ b/docs/docs-content/vm-management/vm-launchpad/access-management/oidc-federation.md
@@ -1,0 +1,250 @@
+---
+sidebar_label: "OIDC Federation"
+title: "Federate an External Identity Provider with Keycloak"
+description:
+  "Learn how to federate an external OIDC identity provider, such as Okta, into PaletteAI VM Launchpad through Keycloak."
+icon: " "
+hide_table_of_contents: false
+sidebar_position: 8
+tags: ["vmo", "vm launchpad", "access management", "oidc", "okta"]
+---
+
+PaletteAI VM Launchpad uses [Keycloak](https://www.keycloak.org/documentation) as its OIDC identity provider. If your
+organization authenticates users through an external identity provider, you can federate that provider into Keycloak
+instead of creating accounts individually on the [Users](./users.md) page. Keycloak calls this pattern identity
+brokering. Users sign in against your provider, and Keycloak issues the token that VM Launchpad and the Kubernetes API
+server consume.
+
+This page uses [Okta](https://www.okta.com) as the example provider. The same steps apply to any OIDC-compliant
+provider, though field names in the provider's administration console vary.
+
+Federating a provider is not sufficient on its own. A brokered account must satisfy two separate requirements before it
+can use VM Launchpad, and each one fails in a way that looks like a permissions problem rather than a configuration
+problem. Review both before you begin.
+
+## Federation Requirements
+
+| **Requirement**  | **Why It Is Needed**                                                                              | **How It Is Satisfied**                             |
+| ---------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Email claim      | The Kubernetes API server identifies users by email address.                                      | Trust the email address on the identity provider.   |
+| Group membership | VM Launchpad resolves VMO roles from Keycloak group membership, not from claims inside the token. | Map the provider's groups claim to Keycloak groups. |
+
+### Email Claim Requirement
+
+The Kubernetes API server in a VM Launchpad cluster runs with `--oidc-username-claim=email`. Every token the API server
+accepts must contain both of the following claims.
+
+| **Claim**        | **Required Value**                           | **Purpose**                                                         |
+| ---------------- | -------------------------------------------- | ------------------------------------------------------------------- |
+| `email`          | A valid email address, such as `user@domain` | Identifies the user to the Kubernetes API server.                   |
+| `email_verified` | `true`                                       | Confirms the address is trusted. Unverified addresses are rejected. |
+
+This requirement is identical to the one that applies to federated LDAP accounts. Refer to
+[Email Claim Requirement](./ldap-federation.md#email-claim-requirement) for the full explanation of how VM Launchpad
+behaves when the claim is absent.
+
+### Group Membership Requirement
+
+VM Launchpad reads a user's groups from Keycloak through the Keycloak Admin API. It does not read a groups claim out of
+the token. A brokered user who signs in successfully is therefore a member of no Keycloak group until a mapper places
+them in one, and a user in no group carries no VMO role.
+
+The symptom is a user who authenticates without error, reaches VM Launchpad, and finds that no resources are available
+to them. Refer to [Map Provider Groups to Keycloak Groups](#map-provider-groups-to-keycloak-groups) to configure the
+mapper that resolves this.
+
+:::info
+
+You can also assign a VMO role to a brokered user directly on the [Users](./users.md) page after their first sign-in,
+without configuring a group mapper. Group mapping is the maintainable approach when you manage access for more than a
+handful of users, because it keeps the source of truth in your identity provider.
+
+:::
+
+## Prerequisites
+
+- A cluster created using VM Launchpad. Refer to [Install VM Launchpad](../install.md) for guidance.
+
+- An account with the **Platform Admin** VMO role, or membership in a group mapped to Platform Admin.
+
+- Access to the Keycloak admin console for your appliance. The console is available at `https://<platform-ip>/iam`,
+  where `<platform-ip>` is the platform IP address you assigned during cluster creation. Sign in with the Keycloak
+  administrator credentials you set in the **Keycloak Admin** section of
+  [Install VM Launchpad](../install.md#create-cluster).
+
+- Administrator access to the external identity provider, with permission to create an OIDC application and to configure
+  the claims that the application emits.
+
+- The Keycloak groups that carry your VMO roles already exist. Refer to [Groups](./groups.md) to create them.
+
+## Collect the Keycloak Redirect URI
+
+The identity provider needs the exact URI that Keycloak listens on for the brokered response. Keycloak generates this
+value and displays it when you add the provider.
+
+1. Log in to the Keycloak admin console as an administrator.
+
+2. From the realm drop-down menu at the top of the left main menu, select the `vmo` realm. The admin console opens in a
+   different realm, so switch realms before you continue.
+
+3. From the left main menu, select **Identity providers**.
+
+4. Select **OpenID Connect v1.0**.
+
+5. In the **Redirect URI** field at the top of the form, copy the displayed value. It follows this pattern.
+
+   ```text
+   https://<platform-ip>/iam/realms/vmo/broker/<alias>/endpoint
+   ```
+
+   The `<alias>` segment reflects the **Alias** field on the same form. Set the alias before you copy the URI, because
+   changing the alias later changes the redirect URI and breaks the provider configuration.
+
+Leave this page open. You return to it after you create the application in your identity provider.
+
+## Create the OIDC Application
+
+Create an application in your identity provider that Keycloak authenticates against. In Okta, go to **Applications** >
+**Applications** > **Create App Integration** and select **OIDC - OpenID Connect** with an application type of **Web
+Application**.
+
+Configure the application as follows.
+
+| **Setting**                | **Value**                                                                                      |
+| -------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Grant type**             | Enable **Authorization Code**. Enable **Refresh Token** to avoid repeated sign-in prompts.     |
+| **Sign-in redirect URIs**  | The Keycloak redirect URI you collected in the previous section. The value must match exactly. |
+| **Sign-out redirect URIs** | _(Optional)_ Set only if you configure a logout URL on the Keycloak identity provider.         |
+| **Assignments**            | Assign the users and groups that need VM Launchpad access.                                     |
+
+Record the **Client ID** and **Client Secret**. Keycloak requires both.
+
+### Configure the Groups Claim
+
+Keycloak cannot map groups that the provider does not send. In Okta, open the application, select the **Sign On** tab,
+and edit the **OpenID Connect ID Token** section.
+
+| **Field**             | **Value**                                                                                |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| **Groups claim type** | `Filter`                                                                                 |
+| **Groups claim name** | `groups`                                                                                 |
+| **Filter**            | `Matches regex` with a pattern covering the groups you grant access to, such as `vmo-.*` |
+
+:::warning
+
+Okta applies a limit to the number of groups in a claim, which defaults to 100. A broad filter combined with a user who
+belongs to many groups can produce a truncated claim, which silently omits the group that carries the user's VMO role.
+Keep the filter narrow enough that the groups you use for access are always present.
+
+:::
+
+## Add the Identity Provider in Keycloak
+
+Return to the Keycloak admin console, on the **OpenID Connect v1.0** form you opened earlier.
+
+1. Complete the following fields.
+
+   | **Field**              | **Value**                                                                                                                                                                    |
+   | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Alias**              | A short identifier for the provider, such as `okta`. This value appears in the redirect URI.                                                                                 |
+   | **Display name**       | The label shown on the VM Launchpad sign-in page, such as `Okta`.                                                                                                            |
+   | **Discovery endpoint** | Your provider's OIDC discovery document, such as `https://<your-okta-domain>/.well-known/openid-configuration`. Keycloak populates the authorization and token URLs from it. |
+   | **Client ID**          | The client ID from the application you created.                                                                                                                              |
+   | **Client Secret**      | The client secret from the application you created.                                                                                                                          |
+
+2. Select **Add**.
+
+3. On the provider's settings page, expand **Advanced settings**.
+
+4. Set **Scopes** to `openid profile email groups` so that the provider returns the groups claim alongside the identity
+   claims.
+
+5. Select **Save**.
+
+## Trust Email Addresses from the Provider
+
+Keycloak marks a brokered address as verified only when the identity provider is configured to trust it. **Trust Email**
+is a setting on the identity provider, and it defaults to **Off**. Without it, tokens carry `email_verified: false` and
+the Kubernetes API server rejects the user.
+
+1. In the Keycloak admin console, select **Identity providers** from the left main menu, and then select your provider.
+
+2. Expand **Advanced settings**.
+
+3. Set **Trust Email** to **On**.
+
+4. Select **Save**.
+
+:::tip
+
+Enable **Trust Email** before the first user signs in. Keycloak sets the verified flag when it creates the local account
+during the initial brokered sign-in, so accounts created before you enable the setting keep `email_verified: false`, and
+you must correct each one individually on the **Users** page.
+
+:::
+
+## Map Provider Groups to Keycloak Groups
+
+This mapper is what places a brokered user into a Keycloak group, which is what gives them a VMO role. Create one mapper
+for each group you federate.
+
+1. In the Keycloak admin console, select **Identity providers**, and then select your provider.
+
+2. Select the **Mappers** tab, and then select **Add mapper**.
+
+3. Complete the following fields.
+
+   | **Field**              | **Value**                                                                                                           |
+   | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+   | **Name**               | A descriptive name for the mapping, such as `okta-vmo-admins`.                                                      |
+   | **Sync mode override** | **Force**, so that Keycloak reapplies the mapping on every sign-in and reflects group changes made in the provider. |
+   | **Mapper type**        | **Advanced Claim to Group**.                                                                                        |
+   | **Claims**             | Key `groups`, value set to the group name as the provider emits it, such as `vmo-admins`.                           |
+   | **Group**              | The Keycloak group that carries the VMO role you want the user to receive.                                          |
+
+4. Select **Save**.
+
+5. Repeat for each provider group you federate.
+
+:::warning
+
+Set **Sync mode override** to **Force**. With the default sync mode, Keycloak applies the mapping only when it first
+creates the account, so a user removed from a group in your identity provider retains their VM Launchpad access
+indefinitely.
+
+:::
+
+### Refresh Existing Sessions
+
+Users who are already signed in continue to hold their previous token until it expires, and that token does not reflect
+the new mapping. Ask affected users to sign out and sign in again. API keys created before the change also keep the old
+permissions until the user signs in again. Refer to [API Keys](./api-keys.md).
+
+## Verify
+
+1. Open VM Launchpad in a fresh browser session, or use a private browsing window.
+
+2. Confirm that the sign-in page offers your provider under the display name you configured, and sign in as a user who
+   belongs to a mapped group.
+
+3. In the Keycloak admin console, select **Users** from the left main menu, and then select the account that just signed
+   in. Confirm that the **Email** field is populated and that **Email verified** is enabled.
+
+4. Select the **Groups** tab for that account, and confirm that the mapped Keycloak group is listed.
+
+5. Log in to VM Launchpad and go to **Settings** > **Access Management** > **Access Mapping**. Confirm that the account
+   resolves to the VMO role and namespace scope you expect. Refer to [Access Mapping](./access-mapping.md).
+
+6. Ask the user to confirm that the resources their role grants are available.
+
+If the account appears in Keycloak with no group, the claim that the provider sent does not match the **Claims** value
+on the mapper. Compare the group name in the provider against the mapper configuration, including case.
+
+## Next Steps
+
+- Review the VMO roles you can assign to federated groups. Refer to [VMO Roles](./vmo-roles.md).
+
+- Manage the role and namespace scope for each federated group in one place. Refer to [Groups](./groups.md).
+
+- Review how VM Launchpad combines role grants from users and groups. Refer to
+  [How Effective Permissions Are Calculated](./users.md#how-effective-permissions-are-calculated).

--- a/docs/docs-content/vm-management/vm-launchpad/access-management/users.md
+++ b/docs/docs-content/vm-management/vm-launchpad/access-management/users.md
@@ -142,8 +142,7 @@ fixed.
 :::info
 
 When the user belongs to a group that already carries a VMO role, an amber banner appears over the role cards listing
-the inherited role (for example, _Platform Admin is inherited from group cluster-admins_). Take the banner at its word.
-A role you set here does not take effect while the user remains in that group. Refer to
+the inherited role (for example, _Platform Admin is inherited from group cluster-admins_). A role you set here does not take effect while the user remains in that group. Refer to
 [How Effective Permissions Are Calculated](#how-effective-permissions-are-calculated) below.
 
 :::

--- a/docs/docs-content/vm-management/vm-launchpad/access-management/users.md
+++ b/docs/docs-content/vm-management/vm-launchpad/access-management/users.md
@@ -142,7 +142,8 @@ fixed.
 :::info
 
 When the user belongs to a group that already carries a VMO role, an amber banner appears over the role cards listing
-the inherited role (for example, _Platform Admin is inherited from group cluster-admins_). A role you set here does not take effect while the user remains in that group. Refer to
+the inherited role (for example, _Platform Admin is inherited from group cluster-admins_). A role you set here does not
+take effect while the user remains in that group. Refer to
 [How Effective Permissions Are Calculated](#how-effective-permissions-are-calculated) below.
 
 :::


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages).
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display. _No images in this PR._
- [x] Ensure all **Vale comments** are resolved. _No Vale comments raised._
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _Not required for this PR._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _Not applicable: this PR targets
      the `docs-rel-4-10-0` release branch, which merges forward at release. See [Backporting](#backporting)._
- [ ] **Outside review:** Does this PR require review outside of Docs? **Yes.** Five items need confirmation from
      Ahmed Kadri or Rob Eckhardt before merge. See [Outstanding Verifications](#outstanding-verifications).
- [ ] Add the `notify-slack` label once this checklist has been completed.

Good job! 👏👏👏

---

## 📝 Describe the Change

This PR adds an appliance-side OIDC federation guide for PaletteAI VM Launchpad, covering how to federate an external identity provider such as Okta into the appliance's embedded Keycloak.

### Why this scope, and not the VMO pack

PVM-973 arrived as a bare ticket with no description, comments, or links. Its apparent scope, Ahmed Kadri's two
Confluence handoff pages, turned out to be **already drafted** on the PVM-990 branch in #11496. Section by section, Ahmed's Okta guide maps onto `configure-external-oidc.md`, which already uses Okta as its worked example, and onto `upgrade-vmo-pack.md` for the VMO 1.0 to 2.0 migration, parameter mapping, and secret rotation. The pack half was never unstarted; it was written and waiting on the open questions tracked in PVM-990.

Epic PVM-788 required integrating **both the VMO UI and VMMA**, but #11496 covers only the VMO pack on a Palette cluster, and Ahmed's presets page explicitly scopes itself to "Palette (not Palette Appliance / VerteX Appliance)". So this PR covers the piece nobody had: the **appliance**. The pack/appliance split keeps the two guides from contradicting each other, and it is unaffected by the 4.10.0 date question that currently parks PVM-990.

### The technical problem the guide is built around

VM Launchpad resolves group membership through the **Keycloak Admin API** (`GetUserGroups`, `AddUserToGroup`, `ListGroups` in `internal/keycloak/client.go`), **not** from a groups claim in the incoming token. A brokered external user therefore lands in no Keycloak group and carries no VMO role. That presents to an administrator as a permissions bug rather than as a configuration gap, which is the single thing this guide exists to prevent.

The fix is a Keycloak **Advanced Claim to Group** identity provider mapper with **Sync mode override** set to
**Force**, so the mapping re-applies on every login rather than only at first login. The guide also covers the email
claim requirement, which the appliance shares with the existing LDAP path.

Structure mirrors the sibling `ldap-federation.md` so the two federation guides read as a pair: requirements, then
prerequisites, then the provider-side application, then the Keycloak-side broker and mappers, then verification.

### Confirmed from `spectrocloud/vmo-manager`

Keycloak **26.6.3**, realm `vmo`, base path `/iam`, service client `vmo-admin`.

### Release note

A **Docs and Education** entry, not a Features entry, because no product capability changed in 4.10.0. The house
pattern for a new guide is "A new [X] guide is now available". The entry is included so reviewers can preview it, and
comes out before merge if Product objects to announcing appliance-side federation.

---

## Outstanding Verifications

No handoff material exists for the appliance side. A Confluence sweep for Okta returned only Ahmed's two pack-scoped pages, so parts of this guide are reasoned from Keycloak 26 behavior rather than from an observed procedure. Ranked for Ahmed Kadri and Rob Eckhardt:

1. **Is appliance-side external OIDC federation actually supported and tested?** The epic's only validation child,
   PVM-960, was pack-side, yet PVM-788 closed as Resolved. The VMMA half of its own acceptance criteria looks unmet. This is the one question that could invalidate the page rather than correct it.
2. **Redirect URI.** `https://<platform-ip>/iam/realms/vmo/broker/<alias>/endpoint` is derived from Keycloak's standard broker endpoint plus the confirmed `/iam` base path and `vmo` realm. Never observed on a live appliance.
3. **Does the VM Launchpad sign-in page surface a brokered provider button?** The guide's verification step assumes it does.
4. **Keycloak 26.6.3 admin console labels** — **Identity providers**, **Advanced Claim to Group**, **Sync mode override**, **Trust Email** — are unverified against the appliance build.
5. **Can `vmo-admin`'s service account see brokered users** without additional realm-management roles?

Items 2 through 5 are roughly fifteen minutes on a live appliance. Item 1 is a question for whoever owns PVM-788.

---

## Backporting

Not applicable. This PR targets `docs-rel-4-10-0`, the 4.10.0 release branch, and the content describes a guide
published for 4.10.0. No `auto-backport` or `backport-version-**` labels.

## Related JIRAs

- [PVM-788](https://spectrocloud.atlassian.net/browse/PVM-788) — parent epic, Validate and document Okta SSO Support (Resolved; see verification 1 above)

---

## 💻 Changed Pages

- [Federate an External Identity Provider with Keycloak](https://deploy-preview-11585--docs-spectrocloud.netlify.app/vm-management/vm-launchpad/access-management/oidc-federation) — new guide
- [Access Management](https://deploy-preview-11585--docs-spectrocloud.netlify.app/vm-management/vm-launchpad/access-management) — new **OIDC Federation** row in the section table
- [Release Notes](https://deploy-preview-11585--docs-spectrocloud.netlify.app/release-notes) — **Docs and Education** entry for 4.10.0

---

## 🎫 Jira Tickets

- [PVM-973](https://spectrocloud.atlassian.net/browse/PVM-973) — Document Okta SSO for Palette AI VM Launchpad/VMO (4.10.0)


[PVM-788]: https://spectrocloud.atlassian.net/browse/PVM-788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ