### PR TITLE
[version-4-4] chore: bump hashicorp/vault-action from 3.4.0 to 4.0.0 (#11458)

### DIFF
--- a/.github/workflows/bump-impersonaid-sha.yaml
+++ b/.github/workflows/bump-impersonaid-sha.yaml
@@ -39,7 +39,7 @@ jobs:
       # (the default GITHUB_TOKEN would not).
       - name: Retrieve org GitHub token
         id: import-secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle

--- a/.github/workflows/monthly-assessment.yaml
+++ b/.github/workflows/monthly-assessment.yaml
@@ -72,7 +72,7 @@ jobs:
       # and used as the push/PR token so the resulting PR triggers normal CI.
       - name: Retrieve org GitHub token
         id: import-secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle

--- a/.github/workflows/persona-check.yaml
+++ b/.github/workflows/persona-check.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: Retrieve org GitHub token (for private Impersonaid checkout)
         if: ${{ steps.resolve.outputs.mode == 'run' }}
         id: import-secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Retrieve Credentials
         id: import-secrets
          # Security: pin third-party actions to immutable commits; keep the original version in the comment for Dependabot/reviewers.
-        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # 4.0.0
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: https://vault.prism.spectrocloud.com
           method: approle


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-4`:
 - [chore: bump hashicorp/vault-action from 3.4.0 to 4.0.0 (#11458)](https://github.com/spectrocloud/librarium/pull/11458)

Applied by hand rather than cherry-picked. The auto-backport bot failed on all eight
`version-4-*` branches with merge conflicts (run
[31522681924](https://github.com/spectrocloud/librarium/actions/runs/31522681924)).
On this branch 12 of the 16 `vault-action` call sites were already at the target
SHA, because the original bump (#10566) was backported here and the later revert
(#10650) never was. A cherry-pick of the squash commit `f022bfb0d` would therefore
have been mostly no-op hunks conflicting against context that no longer exists, so the
equivalent end state was applied directly instead.

This changes 4 lines. Two things are corrected:

1. Call sites still pinned to `4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b` (v3.4.0) move
   to `892a26828f195e65540a40b4768ae4571f51ebfc` (v4.0.0).
2. `pull_request.yaml` carried the comment `# 4.0.0` with no `v` prefix. Normalized
   to `# v4.0.0` so all 16 pins match and Dependabot will keep them current.

After this lands, `version-4-4` matches `master`: 16 call sites, all
`hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0`.

<!--- Backport version: manual -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
