### PR TITLE
[version-4-3] pre-emptive fixing broken links after updating linkinator dependency (#11635)

### DIFF
--- a/_partials/packs/_portworkx-operator.mdx
+++ b/_partials/packs/_portworkx-operator.mdx
@@ -16,7 +16,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 - `StorageClass` resource for dynamic provisioning of `PersistentVolumes`` using the `pxd.portworx.com` provisioner.
 
-- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html).
+- [Stork](https://docs.portworx.com/portworx-enterprise/deploy-your-applications/stateful-applications/stork).
   Portworx's storage scheduler for Kubernetes.
 
 <!-- Optionally for Portworx 2.x, you can enable Lighthouse for basic monitoring of the Portworx cluster. -->
@@ -627,7 +627,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 - `StorageClass` resource for dynamic provisioning of `PersistentVolumes`` using the `pxd.portworx.com` provisioner.
 
-- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html).
+- [Stork](https://docs.portworx.com/portworx-enterprise/deploy-your-applications/stateful-applications/stork).
   Portworx's storage scheduler for Kubernetes.
 
 - [Lighthouse](https://portworx.com/blog/manage-portworx-clusters-using-lighthouse/). Portworx's monitoring and alerting
@@ -1154,7 +1154,7 @@ The default installation of Portworx /w Operator will deploy the following compo
 
 - `StorageClass` resource for dynamic provisioning of `PersistentVolumes`` using the `pxd.portworx.com` provisioner.
 
-- [Stork](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/stork.html).
+- [Stork](https://docs.portworx.com/portworx-enterprise/deploy-your-applications/stateful-applications/stork).
   Portworx's storage scheduler for Kubernetes.
 
 - [Lighthouse](https://portworx.com/blog/manage-portworx-clusters-using-lighthouse/). Portworx's monitoring and alerting

--- a/_partials/packs/_rke2.mdx
+++ b/_partials/packs/_rke2.mdx
@@ -20,7 +20,7 @@ RKE2 documentation:
 
 - [Inbound Network Rules](https://docs.rke2.io/install/requirements#inbound-network-rules)
 
-- [Registries Configuration](https://docs.rke2.io/install/containerd_registry_configuration)
+- [Registries Configuration](https://docs.rke2.io/install/private_registry)
 
 - [Advanced Options](https://docs.rke2.io/advanced)
 
@@ -41,7 +41,7 @@ RKE2 documentation:
 
 - [Inbound Network Rules](https://docs.rke2.io/install/requirements#inbound-network-rules)
 
-- [Registries Configuration](https://docs.rke2.io/install/containerd_registry_configuration)
+- [Registries Configuration](https://docs.rke2.io/install/private_registry)
 
 - [Advanced Options](https://docs.rke2.io/advanced)
 
@@ -61,7 +61,7 @@ RKE2 documentation:
 
 - [Inbound Network Rules](https://docs.rke2.io/install/requirements#inbound-network-rules)
 
-- [Registries Configuration](https://docs.rke2.io/install/containerd_registry_configuration)
+- [Registries Configuration](https://docs.rke2.io/install/private_registry)
 
 - [Advanced Options](https://docs.rke2.io/advanced)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-3`:
 - [pre-emptive fixing broken links after updating linkinator dependency (#11635)](https://github.com/spectrocloud/librarium/pull/11635)

The management appliance partial does not exist on this branch, so only the two pack partials are included.