### PR TITLE
chore: use prebuilt sharp binaries in make ci-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,16 @@ init: ## Initialize npm dependencies
 	grep -q "^SHOW_LAST_UPDATE_TIME=" .env || echo "\nSHOW_LAST_UPDATE_TIME=false" >> .env
 	npm run prepare
 
+# SHARP_IGNORE_GLOBAL_LIBVIPS forces sharp to use its prebuilt binaries instead of compiling from source.
+# Without it, sharp prefers any compatible libvips it finds on the system (for example a Homebrew `vips`
+# install), which pulls in node-gyp and a C++ toolchain. That source build is unreliable here because the
+# nested sharp copies under @argos-ci/cli and @argos-ci/core resolve their node-addon-api gyp include to
+# the same generated makefile, so building them concurrently races and fails with
+# "No rule to make target `Release/nothing.a'". CI has no global libvips and so never hits this.
 ci-local: ## Initialize npm dependencies for local development
 	@echo "initializing npm dependencies for local development"
 	npm ci --ignore-scripts
-	npm_config_ignore_scripts=false npm rebuild sharp
+	SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm_config_ignore_scripts=false npm rebuild sharp
 
 start: ## Start a local development server
 	npm run start


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

### Problem

On a Mac with Homebrew `vips` installed, `make ci-local` fails during `npm rebuild sharp`:

```
sharp: Detected globally-installed libvips v8.18.4
sharp: Attempting to build from source via node-gyp
make[1]: *** No rule to make target `Release/nothing.a', needed by
             `Release/obj.target/sharp-darwin-arm64/common.o'.  Stop.
```

### Cause

sharp prefers any compatible system libvips over its own prebuilt binaries, so a Homebrew `vips` install switches
`npm rebuild sharp` to a node-gyp source build. That build then races: the nested sharp copies under `@argos-ci/cli`
and `@argos-ci/core` both resolve their `node-addon-api` gyp include to the same generated
`@argos-ci/node-addon-api/nothing.target.mk`, and `npm rebuild` builds them concurrently — so whichever `make` runs
while the other is mid-regeneration finds no rule for `nothing.a`. Building the two serially always succeeds, and which
copy fails varies between runs.

CI has no global libvips, so it takes the prebuilt path and never hits this.

### Fix

Set `SHARP_IGNORE_GLOBAL_LIBVIPS=1` on the rebuild step, so local installs use the same prebuilt binaries as CI. No
node-gyp, no compiler, no Python.

### Verification

- `make ci-local` from a clean install now succeeds in 36s; it previously failed.
- All three sharp copies load afterwards, on prebuilt libvips 8.17.3 rather than the Homebrew 8.18.4.
- `make help` output is unchanged — the explanatory comment uses the single-`#`-above-target idiom already used by
  `build-ci`, keeping it out of the help target's awk parser.

### Note

This covers `make ci-local` only. A bare `npm ci` or `npm rebuild sharp` still takes the source build; contributors can
`export SHARP_IGNORE_GLOBAL_LIBVIPS=1` to avoid that. `make ci-local` exists on the `version-4-*` branches too, so
backport labels may be warranted.

---

## 💻 Changed Pages

This PR makes no user-facing changes — it touches only the `Makefile`, so there are no docs pages to preview.

---

## 🎫 Jira Tickets

No corresponding Jira ticket. This came out of a local development environment failure while setting up Node 24 after
#11654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
