### PR TITLE
chore: fail fast on lapsed Super SSO session in release scripts

### DIFF
--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -98,6 +98,14 @@ page.
 | `JIRA_API_TOKEN`         | Issue tracker API token. | `XXX`                   |
 | `SUPER_API_TOKEN`        | Super API token.         | `XXX`                   |
 
+Super API keys are personal, and Super only accepts a key while its owner has a current SSO session. When the owner has
+not signed in to [Super](https://app.super.work) recently, Super rejects the key with an HTTP 401 error. Because Super
+has no way to complete an SSO login from a script, the `generate-patch-release-notes` and `generate-component-updates`
+targets check the key before they make any other API calls. In a terminal, the script opens Super so that you can sign
+in, waits for you to confirm, and then continues. A GitHub Actions runner has no browser, so the script stops with an
+error instead. The owner of the key stored in the `SUPER_API_TOKEN` repository secret must sign in to Super before you
+run the workflow again.
+
 #### Release Notes
 
 | **Environment Variable**    | **Description**                                       | **Example Value**  |

--- a/scripts/release/generate-component-updates-ai.sh
+++ b/scripts/release/generate-component-updates-ai.sh
@@ -54,6 +54,13 @@ if ! check_env "RELEASE_TERRAFORM_VERSION"; then
     exit 1
 fi
 
+# Confirm Super authentication up front. The token is only rejected until its owner signs
+# in to Super through SSO, so checking here avoids making every issue tracker call below
+# and then failing at the one call that needs Super.
+if ! require_super_auth "$SUPER_ASSISTANT_ID"; then
+    exit 1
+fi
+
 if [[ -z "${JIRA_TICKET:-}" ]]; then
   read -p "Specify ticket to generate component updates for (for example, DOC-2852): " JIRA_TICKET
 fi
@@ -271,18 +278,32 @@ fi
 
 SUPER_COMPONENT_UPDATES_BODY=""
 
+SUPER_RESPONSE_FILE="$(mktemp)"
+
 for ((i=1; i<=MAX_RETRIES; i++)); do
   echo "Attempt Super POST call $i/$MAX_RETRIES..."
 
-  if RESPONSE=$(
-    curl -sS --fail-with-body \
+  HTTP_STATUS=$(
+    curl -sS \
+      --output "$SUPER_RESPONSE_FILE" \
+      --write-out '%{http_code}' \
       --request POST \
       --url https://api.super.work/v1/super \
       --header "Authorization: Bearer ${SUPER_API_TOKEN}" \
       --header "Content-Type: application/json" \
-      --data "$(jq -n --arg question "$SUPER_QUESTION" --arg assistantID "$SUPER_ASSISTANT_ID" '{question: $question, assistantId: $assistantID}')"
-  ); then
-    SUPER_COMPONENT_UPDATES_BODY=$(echo "$RESPONSE" | jq -r '.answer // empty')
+      --data "$(jq -n --arg question "$SUPER_QUESTION" --arg assistantID "$SUPER_ASSISTANT_ID" '{question: $question, assistantId: $assistantID}')" || echo "000"
+  )
+
+  # Retrying an authentication failure never helps, because the token stays rejected until
+  # its owner signs in to Super through SSO.
+  if [[ "$HTTP_STATUS" == "401" || "$HTTP_STATUS" == "403" ]]; then
+    echo "❌ Super rejected SUPER_API_TOKEN (HTTP $HTTP_STATUS) part way through this run. Sign in at https://app.super.work and run this script again." >&2
+    rm -f "$SUPER_RESPONSE_FILE"
+    exit 1
+  fi
+
+  if [[ "$HTTP_STATUS" == "200" ]]; then
+    SUPER_COMPONENT_UPDATES_BODY=$(jq -r '.answer // empty' < "$SUPER_RESPONSE_FILE" 2>/dev/null || true)
 
     if [[ -n "$SUPER_COMPONENT_UPDATES_BODY" ]]; then
       echo "✅ Successfully retrieved component updates body from Super API."
@@ -291,7 +312,8 @@ for ((i=1; i<=MAX_RETRIES; i++)); do
 
     echo "⚠️ Empty response, retrying in ${SLEEP_SECONDS}s..." >&2
   else
-    echo "⚠️ Super API call failed, retrying in ${SLEEP_SECONDS}s..." >&2
+    echo "⚠️ Super API call failed (HTTP $HTTP_STATUS): $(head -c 300 "$SUPER_RESPONSE_FILE")" >&2
+    echo "⚠️ Retrying in ${SLEEP_SECONDS}s..." >&2
   fi
 
   if (( i < MAX_RETRIES )); then
@@ -300,6 +322,8 @@ for ((i=1; i<=MAX_RETRIES; i++)); do
   fi
 
 done
+
+rm -f "$SUPER_RESPONSE_FILE"
 
 if [[ -z "$SUPER_COMPONENT_UPDATES_BODY" ]]; then
   echo "❌ Failed to retrieve SUPER_COMPONENT_UPDATES_BODY after $MAX_RETRIES attempts" >&2

--- a/scripts/release/generate-patch-release-notes.sh
+++ b/scripts/release/generate-patch-release-notes.sh
@@ -30,6 +30,13 @@ if ! check_env "SUPER_API_TOKEN"; then
     exit 1
 fi
 
+# Confirm Super authentication up front. The token is only rejected until its owner signs
+# in to Super through SSO, so checking here avoids making every issue tracker call below
+# and then failing at the one call that needs Super.
+if ! require_super_auth "$SUPER_ASSISTANT_ID"; then
+    exit 1
+fi
+
 if [[ -z "${PATCH_RELEASE_TICKET:-}" ]]; then
   read -p "Specify ticket to generate patch release notes for (for example, DOC-2815): " PATCH_RELEASE_TICKET
 fi
@@ -150,18 +157,32 @@ fi
 
 SUPER_BUG_FIXES_BODY=""
 
+RESPONSE_FILE="$(mktemp)"
+trap 'rm -f "$RESPONSE_FILE"' EXIT
+
 for ((i=1; i<=MAX_RETRIES; i++)); do
   echo "Attempt Super POST call $i/$MAX_RETRIES..."
 
-  if RESPONSE=$(
-    curl -sS --fail-with-body \
+  HTTP_STATUS=$(
+    curl -sS \
+      --output "$RESPONSE_FILE" \
+      --write-out '%{http_code}' \
       --request POST \
       --url https://api.super.work/v1/super \
       --header "Authorization: Bearer ${SUPER_API_TOKEN}" \
       --header "Content-Type: application/json" \
-      --data "$(jq -n --arg question "$SUPER_QUESTION" --arg assistantID "$SUPER_ASSISTANT_ID" '{question: $question, assistantId: $assistantID}')"
-  ); then
-    SUPER_BUG_FIXES_BODY=$(echo "$RESPONSE" | jq -r '.answer // empty')
+      --data "$(jq -n --arg question "$SUPER_QUESTION" --arg assistantID "$SUPER_ASSISTANT_ID" '{question: $question, assistantId: $assistantID}')" || echo "000"
+  )
+
+  # Retrying an authentication failure never helps, because the token stays rejected until
+  # its owner signs in to Super through SSO.
+  if [[ "$HTTP_STATUS" == "401" || "$HTTP_STATUS" == "403" ]]; then
+    echo "❌ Super rejected SUPER_API_TOKEN (HTTP $HTTP_STATUS) part way through this run. Sign in at https://app.super.work and run this script again." >&2
+    exit 1
+  fi
+
+  if [[ "$HTTP_STATUS" == "200" ]]; then
+    SUPER_BUG_FIXES_BODY=$(jq -r '.answer // empty' < "$RESPONSE_FILE" 2>/dev/null || true)
 
     if [[ -n "$SUPER_BUG_FIXES_BODY" ]]; then
       echo "✅ Successfully retrieved bug fixes body from Super API."
@@ -170,7 +191,8 @@ for ((i=1; i<=MAX_RETRIES; i++)); do
 
     echo "⚠️ Empty response, retrying in ${SLEEP_SECONDS}s..." >&2
   else
-    echo "⚠️ Super API call failed, retrying in ${SLEEP_SECONDS}s..." >&2
+    echo "⚠️ Super API call failed (HTTP $HTTP_STATUS): $(head -c 300 "$RESPONSE_FILE")" >&2
+    echo "⚠️ Retrying in ${SLEEP_SECONDS}s..." >&2
   fi
 
   if (( i < MAX_RETRIES )); then

--- a/scripts/release/utilities.sh
+++ b/scripts/release/utilities.sh
@@ -235,3 +235,74 @@ check_env() {
 
     return 0    
 }
+
+# Utility function to check whether the Super API currently accepts SUPER_API_TOKEN.
+# Super only issues personal API keys, and a key returns HTTP 401 until its owner has
+# signed in to https://app.super.work through SSO. The Super API has no unauthenticated
+# health endpoint to probe - routing happens before authentication, so every other path
+# returns 404 regardless of the token - so this sends a trivial question to the assistant.
+# Params:
+# $1 - Super assistant ID
+# Returns 0 if Super accepts the token, 1 if Super rejects it.
+check_super_auth() {
+    local assistant_id="$1"
+    local status
+
+    status=$(curl -s --max-time 60 \
+        --output /dev/null \
+        --write-out '%{http_code}' \
+        --request POST \
+        --url https://api.super.work/v1/super \
+        --header "Authorization: Bearer ${SUPER_API_TOKEN}" \
+        --header "Content-Type: application/json" \
+        --data "$(jq -n --arg question "Reply with the single word OK." --arg assistantID "$assistant_id" '{question: $question, assistantId: $assistantID}')" || echo "000")
+
+    if [[ "$status" == "401" || "$status" == "403" ]]; then
+        return 1
+    fi
+
+    # Any other status, including a network failure reported as 000, is left for the
+    # calling script's own retry loop to handle.
+    return 0
+}
+
+# Utility function to confirm Super authentication before a script does any other work,
+# so a lapsed SSO session fails immediately instead of after every issue tracker call.
+# In an interactive terminal, a rejected token opens Super so that the SSO login can be
+# completed, waits, then checks again. There is no browser in CI, so the script stops.
+# Params:
+# $1 - Super assistant ID
+# Returns 0 if Super accepts the token, 1 if the script should stop.
+require_super_auth() {
+    local assistant_id="$1"
+
+    echo "Verifying that Super accepts SUPER_API_TOKEN..."
+
+    if check_super_auth "$assistant_id"; then
+        echo "✅ Super accepted SUPER_API_TOKEN."
+        return 0
+    fi
+
+    if [[ ! -t 0 || -n "${CI:-}" ]]; then
+        echo "❌ Super rejected SUPER_API_TOKEN (HTTP 401). Super API keys are personal and are only valid while their owner has a current SSO session. Sign in at https://app.super.work and run this job again." >&2
+        return 1
+    fi
+
+    echo "🔐 Super rejected SUPER_API_TOKEN (HTTP 401). Your Super SSO session has lapsed."
+
+    if command -v open >/dev/null 2>&1; then
+        open "https://app.super.work"
+    else
+        echo "ℹ️  Sign in to Super at https://app.super.work."
+    fi
+
+    read -r -p "Press Enter once you have signed in to Super: "
+
+    if check_super_auth "$assistant_id"; then
+        echo "✅ Super accepted SUPER_API_TOKEN."
+        return 0
+    fi
+
+    echo "❌ Super still rejects SUPER_API_TOKEN. Confirm that SUPER_API_TOKEN in your .env file matches a current key in your Super settings." >&2
+    return 1
+}


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

`make generate-patch-release-notes` and `make generate-component-updates` die with an opaque
`curl: (22) ... 401` whenever the Super API key owner has not recently signed in to Super through SSO. Super issues only
personal API keys and offers no way to complete an SSO login from a script, so these scripts now handle the 401 rather
than failing on it:

- **Check Super before doing any other work.** New `require_super_auth` gate in `utilities.sh`, called after the env
  checks in both Super-backed scripts, so a lapsed session no longer costs the full Jira sweep first. In a terminal it
  opens Super, waits for you to sign in, re-checks, and continues. With no TTY (CI) it exits with a message naming the
  cause.
- **Stop retrying a 401.** Both retry loops now capture the HTTP status, exit immediately on 401/403 rather than
  retrying five times, and print the status plus response body on other failures.
- **Document the constraint** in `release-process.md`, including what it means for the `SUPER_API_TOKEN` repo secret.

Tested against the live Super API (valid key accepted, invalid rejected, `CI=true` fails without prompting), the
interactive re-auth path in a pty, and every retry-loop branch with a stubbed `curl`.

Labelled for backport to `version-4-2` through `version-4-9`, matching how release tooling and CI changes are normally
backported. All four files exist on those branches and both edit sites apply verbatim, so the cherry-picks should be
clean.

---

## 💻 Changed Pages

No user-facing changes. Only `docs/contributing/release-process.md` is touched, which is contributor documentation and
is not published to docs.spectrocloud.com — the site builds from `docs/docs-content` and `docs/api-content` only.

---

## 🎫 Jira Tickets

No corresponding Jira ticket — this is a tooling fix for the release scripts.
