### PR TITLE
docs: document required GPU BIOS settings

### DIFF
--- a/docs/products/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
@@ -32,6 +32,13 @@ Confirm each prerequisite before starting:
 - The appliance server and administrative workstation (jumpbox) meet the
   [Hardware Requirements](../reference/hardware-requirements.md), which covers GPU, CPU, RAM, storage, network, and IP
   addressing.
+- **Above 4G Decoding** and **Re-Size BAR Support** are enabled in the appliance server's BIOS. Both settings are
+  required on any server with GPUs, for every GPU brand and every server brand, and you must enable them before you boot
+  the slim ISO. If either setting is turned off, the slim ISO may not appear in the boot menu, or the screen may go
+  black after you select it. Setting names and menu paths vary by server vendor, so refer to your server vendor's
+  documentation to enable them. **Re-Size BAR Support** is also called **Resizable BAR** or **Smart Access Memory**. For
+  the symptoms, refer to
+  [Known Issues: Slim ISO does not boot on a GPU server](../reference/known-issues.md#slim-iso-does-not-boot-on-a-gpu-server).
 - The Palette CLI is installed and configured on the jumpbox.
 - The hardware supports Ubuntu 24.04.
 - The server has [baseboard management controller (BMC)](../reference/glossary.md#bmc) access available for
@@ -72,7 +79,10 @@ begin. The slim ISO and content bundle must match the target hardware's GPU (NVI
 2. Attach the media to the node and set the boot order to boot from it first.
 3. Power on the node. At the GRUB menu, let it select the Palette Edge interactive installer. After the selection, the
    screen can stay blank for several minutes with no output while the installer loads. This is expected, so wait for the
-   interactive installer to appear instead of assuming the boot has stalled.
+   interactive installer to appear instead of assuming the boot has stalled. If the media never appears in the boot
+   menu, or the screen stays black and the interactive installer never appears, confirm that **Above 4G Decoding** and
+   **Re-Size BAR Support** are enabled in the BIOS. Refer to
+   [Known Issues: Slim ISO does not boot on a GPU server](../reference/known-issues.md#slim-iso-does-not-boot-on-a-gpu-server).
 4. In the interactive installer:
    - When the installer prompts for the registration option after its first boot, select **Palette eXtended Kubernetes
      (PXK)**. This registers the node with the edge Kubernetes distribution the appliance uses.

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
@@ -36,9 +36,9 @@ Confirm each prerequisite before starting:
   required on any server with GPUs, for every GPU brand and every server brand, and you must enable them before you boot
   the slim ISO. If either setting is turned off, the slim ISO may not appear in the boot menu, or the screen may go
   black after you select it. Setting names and menu paths vary by server vendor, so refer to your server vendor's
-  documentation to enable them. **Re-Size BAR Support** is also called **Resizable BAR** or **Smart Access Memory**. For
-  the symptoms, refer to
-  [Known Issues: Slim ISO does not boot on a GPU server](../reference/known-issues.md#slim-iso-does-not-boot-on-a-gpu-server).
+  documentation to enable both settings. **Re-Size BAR Support** is also called **Resizable BAR** or **Smart Access
+  Memory**. For the symptoms, refer to
+  [Known Issues: Slim ISO Does Not Boot on a GPU Server](../reference/known-issues.md#slim-iso-does-not-boot-on-a-gpu-server).
 - The Palette CLI is installed and configured on the jumpbox.
 - The hardware supports Ubuntu 24.04.
 - The server has [baseboard management controller (BMC)](../reference/glossary.md#bmc) access available for
@@ -82,7 +82,7 @@ begin. The slim ISO and content bundle must match the target hardware's GPU (NVI
    interactive installer to appear instead of assuming the boot has stalled. If the media never appears in the boot
    menu, or the screen stays black and the interactive installer never appears, confirm that **Above 4G Decoding** and
    **Re-Size BAR Support** are enabled in the BIOS. Refer to
-   [Known Issues: Slim ISO does not boot on a GPU server](../reference/known-issues.md#slim-iso-does-not-boot-on-a-gpu-server).
+   [Known Issues: Slim ISO Does Not Boot on a GPU Server](../reference/known-issues.md#slim-iso-does-not-boot-on-a-gpu-server).
 4. In the interactive installer:
    - When the installer prompts for the registration option after its first boot, select **Palette eXtended Kubernetes
      (PXK)**. This registers the node with the edge Kubernetes distribution the appliance uses.

--- a/docs/products/paletteai-inference-launchpad/reference/hardware-requirements.md
+++ b/docs/products/paletteai-inference-launchpad/reference/hardware-requirements.md
@@ -50,6 +50,22 @@ The reference GPU is the NVIDIA H100 80 GB. The appliance supports both NVIDIA a
 installs GPU drivers automatically. For the models certified on each GPU configuration, refer to
 [Certified Models by Hardware](./certified-models-by-hardware.md).
 
+### Required BIOS Settings
+
+On a server with GPUs, two BIOS settings must be enabled before you boot the slim ISO. They are required for every GPU
+brand and every server brand.
+
+- **Above 4G Decoding**: Enabled.
+- **Re-Size BAR Support**: Enabled. This setting is also called **Resizable BAR** or **Smart Access Memory**.
+
+Setting names and menu paths vary by server vendor, so refer to your server vendor's documentation to enable them. On
+HPE Gen11 servers, for example, **Re-Size BAR Support** is under **PCIe Device Configuration > Advanced PCIe
+Configuration**.
+
+If either setting is turned off, the slim ISO may not appear in the boot menu, or the screen may go black after you
+select it. Refer to
+[Known Issues: Slim ISO does not boot on a GPU server](./known-issues.md#slim-iso-does-not-boot-on-a-gpu-server).
+
 ## Storage
 
 The OS boot drive is an SSD, and the data pool uses NVMe drives only. Spinning disks are not supported. Storage has two

--- a/docs/products/paletteai-inference-launchpad/reference/hardware-requirements.md
+++ b/docs/products/paletteai-inference-launchpad/reference/hardware-requirements.md
@@ -58,13 +58,13 @@ brand and every server brand.
 - **Above 4G Decoding**: Enabled.
 - **Re-Size BAR Support**: Enabled. This setting is also called **Resizable BAR** or **Smart Access Memory**.
 
-Setting names and menu paths vary by server vendor, so refer to your server vendor's documentation to enable them. On
-HPE Gen11 servers, for example, **Re-Size BAR Support** is under **PCIe Device Configuration > Advanced PCIe
-Configuration**.
+Setting names and menu paths vary by server vendor, so refer to your server vendor's documentation to enable both
+settings. On HPE Gen11 servers, for example, **Re-Size BAR Support** is under **PCIe Device Configuration > Advanced
+PCIe Configuration**.
 
 If either setting is turned off, the slim ISO may not appear in the boot menu, or the screen may go black after you
 select it. Refer to
-[Known Issues: Slim ISO does not boot on a GPU server](./known-issues.md#slim-iso-does-not-boot-on-a-gpu-server).
+[Known Issues: Slim ISO Does Not Boot on a GPU Server](./known-issues.md#slim-iso-does-not-boot-on-a-gpu-server).
 
 ## Storage
 

--- a/docs/products/paletteai-inference-launchpad/reference/known-issues.md
+++ b/docs/products/paletteai-inference-launchpad/reference/known-issues.md
@@ -17,7 +17,7 @@ This page lists the known issues that operators may encounter during installatio
 Inference Launchpad appliance, and the workaround for each. For the ordered procedure, refer to
 [Install the Appliance](../how-to-guides/install-the-appliance.md).
 
-## Slim ISO does not boot on a GPU server
+## Slim ISO Does Not Boot on a GPU Server
 
 **Symptom.** On a server with GPUs, the slim ISO does not appear in the boot menu, or the screen goes black after you
 select it and the interactive installer never appears. This applies to any GPU brand and any server brand.
@@ -30,8 +30,8 @@ server vendor, so refer to your server vendor's documentation. On HPE Gen11 serv
 Support** is under **PCIe Device Configuration > Advanced PCIe Configuration**. For the prerequisite, refer to
 [Suggested Hardware: Required BIOS Settings](./hardware-requirements.md#required-bios-settings).
 
-Note that a blank screen for several minutes immediately after the GRUB selection is expected while the installer loads.
-This issue applies when the installer never appears at all, not to that initial pause.
+A blank screen for several minutes immediately after the GRUB selection is expected while the installer loads. This
+issue applies only when the installer never appears at all.
 
 ## GPUs do not enumerate on HPE servers
 

--- a/docs/products/paletteai-inference-launchpad/reference/known-issues.md
+++ b/docs/products/paletteai-inference-launchpad/reference/known-issues.md
@@ -17,6 +17,22 @@ This page lists the known issues that operators may encounter during installatio
 Inference Launchpad appliance, and the workaround for each. For the ordered procedure, refer to
 [Install the Appliance](../how-to-guides/install-the-appliance.md).
 
+## Slim ISO does not boot on a GPU server
+
+**Symptom.** On a server with GPUs, the slim ISO does not appear in the boot menu, or the screen goes black after you
+select it and the interactive installer never appears. This applies to any GPU brand and any server brand.
+
+**Root cause.** The **Above 4G Decoding** or **Re-Size BAR Support** BIOS setting is turned off. Both are required to
+boot the installer on a GPU server.
+
+**Workaround.** Enable both settings in the server's BIOS, then boot the ISO again. Setting names and menu paths vary by
+server vendor, so refer to your server vendor's documentation. On HPE Gen11 servers, for example, **Re-Size BAR
+Support** is under **PCIe Device Configuration > Advanced PCIe Configuration**. For the prerequisite, refer to
+[Suggested Hardware: Required BIOS Settings](./hardware-requirements.md#required-bios-settings).
+
+Note that a blank screen for several minutes immediately after the GRUB selection is expected while the installer loads.
+This issue applies when the installer never appears at all, not to that initial pause.
+
 ## GPUs do not enumerate on HPE servers
 
 <!-- vale off -->
@@ -30,8 +46,10 @@ with a probe failure for every device.
 1. Boot into GRUB and append `pci=realloc=off` to `GRUB_CMDLINE_LINUX_DEFAULT` so that it reads
    `GRUB_CMDLINE_LINUX_DEFAULT="quiet splash pci=realloc=off"`, then reboot.
 2. Verify the GPUs by running `lspci` with `-v` and `-s <bus:device.function>`, then confirm with `nvidia-smi`.
-3. For better performance, enable Resizable BAR in the BIOS. On HPE Gen11 servers, go to **PCIe Device Configuration >
-   Advanced PCIe Configuration**. An RBSU BIOS upgrade may be required.
+3. Confirm **Re-Size BAR Support** is enabled in the BIOS. It is required on any GPU server, as described in
+   [Suggested Hardware: Required BIOS Settings](./hardware-requirements.md#required-bios-settings), and it also improves
+   performance. On HPE Gen11 servers, go to **PCIe Device Configuration > Advanced PCIe Configuration**. An RBSU BIOS
+   upgrade may be required.
 
 **Side effect: NIC rename.** The workaround renames the NICs. Update the interface names in the `/etc/systemd/network`
 and `/oem` directories afterward.


### PR DESCRIPTION
## Description

Documents the two BIOS settings that must be enabled on any server with GPUs before the slim ISO is booted: **Above 4G Decoding** and **Re-Size BAR Support**. If either is turned off, the ISO may not appear in the boot menu, or the screen goes black after it is selected.

Changes:

- **Install the Appliance → Before You Begin**: new prerequisite bullet naming both settings, the symptoms, and a pointer to the vendor's own BIOS documentation for the menu paths.
- **Install the Appliance → Install the OS**: qualified the existing "the screen can stay blank for several minutes, this is expected" guidance. As written it told readers to wait through the exact symptom of this failure.
- **Suggested Hardware → GPU**: new **Required BIOS Settings** subsection, next to the GPU requirements.
- **Known Issues**: new entry *Slim ISO does not boot on a GPU server* with the symptoms, root cause, and a link back to the prerequisite.
- **Known Issues → GPUs do not enumerate on HPE servers**: this entry already told readers to enable Resizable BAR "for better performance." Reframed as a required setting so the two mentions agree.

## Jira

DOC-3075

## Notes for reviewers

- The ticket asked for a one-line note in the prerequisites and a one-line troubleshooting entry. The Known Issues entry follows that page's existing Symptom / Root cause / Workaround shape instead, and the fix itself is not duplicated: it points at the vendor documentation and the prerequisite.
- **Above 4G Decoding** is documented without alias names. Only the Re-Size BAR aliases (Resizable BAR, Smart Access Memory) are sourced from the ticket.
- The HPE Gen11 menu path (**PCIe Device Configuration > Advanced PCIe Configuration**) is reused from the existing HPE known issue on this page, not newly asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)