### PR TITLE
docs: document box-wide quota enforcement

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
@@ -88,9 +88,14 @@ When a client reaches a limit, the appliance rejects further requests with HTTP 
 dimension and window that tripped. It does not queue or slow the requests. It blocks them until the window rolls over
 and the client is back under the limit.
 
-{/* NEEDS REVIEW: quota enforcement is off by default (global switch) per current working assumption. Confirm with an SME before publishing. */}
+Above the per-client limits sits a single switch, quota enforcement, that covers the whole appliance. It decides whether
+a limit refuses a request or the appliance ignores it. A new appliance starts with enforcement on. While enforcement is
+off, the appliance honors no client's limits, though it keeps every limit you have set. Two things must hold before the
+appliance limits a client: enforcement on for the appliance, and a window limit on the client. To read the current
+setting or change it, refer to
+[Set and Manage Client Quotas](../how-to-guides/manage-client-quotas.md#check-quota-enforcement).
 
-{/* TODO: link to the Set and Manage Quotas how-to (DOC-2940) and Quota & Rate Limit reference (DOC-2941) once they exist. */}
+{/* TODO: link to a Quota & Rate Limit reference page once one exists; DOC-2941 was never created. */}
 
 ## What Clients Can Access
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-quotas.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-quotas.md
@@ -15,11 +15,49 @@ Launchpad appliance. A quota limits how much a client consumes. A quota applies 
 belongs to the client draws on the same limits. To understand how quotas fit with clients and API tokens, refer to
 [Clients and Quotas](../explanation/clients-and-quotas.md).
 
+Quotas have two layers. **Quota enforcement** is a single switch that covers the whole appliance and decides whether
+limits are enforced at all. The **quota windows** you set on each client are the limits themselves. Both must hold
+before the appliance limits a client, so confirm enforcement is on before you set a client's limits.
+
 ## Prerequisites
 
 - A running PaletteAI Inference Launchpad appliance, with the console reachable.
 - An existing client. To create one, refer to [Create a Client](./create-a-client.md).
 - Console access with permission to manage clients. Managing clients can require operator access.
+
+## Check Quota Enforcement
+
+Quota enforcement applies to the entire appliance, not to one client. While it is off, the appliance does not enforce
+any client's quota windows, and a client that passes its limits is not rejected. The limits you have set stay saved and
+take effect again when you turn enforcement back on.
+
+A new appliance starts with quota enforcement on.
+
+1. From the left main menu, select **Overview**.
+
+2. Find the **Quota Enforcement** card and read its badge. **On** means the appliance enforces client quota windows.
+   **Off** means it does not.
+
+To change the setting, use the following steps.
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select **Quota Enforcement** in the page header. The **Quota enforcement**
+   dialog opens.
+
+3. Select or clear the enforcement checkbox.
+
+4. Select **Save**.
+
+5. If you turned enforcement off, the console asks you to confirm. Select **Disable Enforcement**.
+
+:::warning
+
+Turning quota enforcement off removes the limits protecting the appliance's GPU capacity. A single client can then
+consume all available throughput and starve the others. Turn it off only for a deliberate, time-boxed reason, such as
+clearing a backlog, and turn it back on afterward.
+
+:::
 
 ## Set a Client Quota
 


### PR DESCRIPTION
## What

Documents **quota enforcement**, the appliance-wide switch that decides whether client quota windows are enforced at all. It was undocumented, and the explanation page carried a working assumption about it that turned out to be backwards.

- `how-to-guides/manage-client-quotas.md` — new `Check Quota Enforcement` section: how to read the current state (Overview page's **Quota Enforcement** card badge) and how to change it (Access & Policy header → **Quota Enforcement** dialog → checkbox → **Save**, plus the **Disable Enforcement** confirmation). Adds a two-layer framing to the intro so readers know an unenforced limit is a no-op.
- `explanation/clients-and-quotas.md` — replaces the stale `NEEDS REVIEW` comment with accurate prose and links into the new section.

## Ticket

Closes the one genuinely-missing acceptance criterion from [DOC-2940](https://spectrocloud.atlassian.net/browse/DOC-2940). That ticket is otherwise superseded — the page itself already shipped under DOC-3052 — and I've commented there with the AC-by-AC status. Two of its ACs are not actionable: per-model quotas don't exist on an appliance (`ModelGroupQuota.modelSelector` is central-mode only), and DOC-2941 was never created.

## Checks

- `prettier --check` clean.
- `vale` — **0 errors** (remaining warnings/suggestions are the files' pre-existing register).
- Netlify preview is the real gate for rendering and the new in-page anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-2940]: https://spectrocloud.atlassian.net/browse/DOC-2940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ