### PR TITLE
AIL-478: Document replacing a deployed model

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -63,6 +63,9 @@ single per-model endpoint. The appliance treats unknown GPU capacity as unusable
 which nodes run a model, why a node may be ineligible, and how the Cluster view reports placement, refer to
 [Model Placement](./model-placement.md).
 
+To put a newer version or a different model on a node, remove the current model from that node, then deploy the
+replacement. There is no in-place replace. Refer to [Replace a Model](../how-to-guides/replace-a-model.md).
+
 ## Request Routing
 
 The gateway routes each request to a model. A request that names a model uses that model, and a request that does not

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -63,8 +63,8 @@ single per-model endpoint. The appliance treats unknown GPU capacity as unusable
 which nodes run a model, why a node may be ineligible, and how the Cluster view reports placement, refer to
 [Model Placement](./model-placement.md).
 
-To put a newer version or a different model on a node, remove the current model from that node, then deploy the
-replacement. There is no in-place replace. Removing the model from one node leaves it serving on the others. Refer to
+The appliance does not support in-place replacement: changing what a node serves requires removing the current model and
+then deploying the replacement. Removing the model from one node leaves it serving on the others. Refer to
 [Replace a Model](../how-to-guides/replace-a-model.md).
 
 ## Request Routing

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -64,7 +64,8 @@ which nodes run a model, why a node may be ineligible, and how the Cluster view 
 [Model Placement](./model-placement.md).
 
 To put a newer version or a different model on a node, remove the current model from that node, then deploy the
-replacement. There is no in-place replace. Refer to [Replace a Model](../how-to-guides/replace-a-model.md).
+replacement. There is no in-place replace. Removing the model from one node leaves it serving on the others. Refer to
+[Replace a Model](../how-to-guides/replace-a-model.md).
 
 ## Request Routing
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
@@ -151,13 +151,15 @@ reasons include the following:
 
 To resolve the reason, free GPUs on a node by removing another model from that node, stage the model's weights on the
 node, add capacity to the cluster, or resolve the unknown allocation on the affected nodes. Then deploy the model again.
-For the full list of eligibility reasons and how the appliance behaves when a node degrades between selection and
-confirmation, refer to [Model Placement](../explanation/model-placement.md).
+To replace what a node is serving, refer to [Replace a Model](./replace-a-model.md). For the full list of eligibility
+reasons and how the appliance behaves when a node degrades between selection and confirmation, refer to
+[Model Placement](../explanation/model-placement.md).
 
 ## Next Steps
 
 To change which model handles requests that do not name a model explicitly, refer to
-[Switch the Default Model](./set-the-default-model.md). For why you would pin a model to some nodes and not others,
-refer to [Model Placement](../explanation/model-placement.md). To let a text-only model answer questions about images,
-refer to [Enable Vision Preprocessing](./enable-vision-preprocessing.md). To bring a model that is not in the certified
-catalog, refer to [Bring Your Own Model](./bring-your-own-model.md).
+[Switch the Default Model](./set-the-default-model.md). To put a newer version or a different model on a node, refer to
+[Replace a Model](./replace-a-model.md). For why you would pin a model to some nodes and not others, refer to
+[Model Placement](../explanation/model-placement.md). To let a text-only model answer questions about images, refer to
+[Enable Vision Preprocessing](./enable-vision-preprocessing.md). To bring a model that is not in the certified catalog,
+refer to [Bring Your Own Model](./bring-your-own-model.md).

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
@@ -55,7 +55,7 @@ dialog. For why you would pin a model to some nodes and not others, refer to
    snapshot. A node you add to the cluster later does not receive this model until you add it, as described in
    [Add a Model to More Nodes](#add-a-model-to-more-nodes).
 
-7. Select **Deploy**, review the deployment preview, and then select **Confirm & Apply**.
+7. Select **Deploy**, review the deployment preview, and then select **Confirm & apply**.
 
 The appliance writes nothing until you confirm. It then brings the model through gate, provision, smoke-test, and ready
 stages on each chosen node. For that lifecycle, refer to
@@ -110,7 +110,7 @@ serve the model stay selected and show **Already deployed**.
 3. Select the same model. In **Nodes**, already serving nodes are locked with **Already deployed**. Select each
    additional eligible node.
 
-4. Select **Deploy**, review the preview, and then select **Confirm & Apply**.
+4. Select **Deploy**, review the preview, and then select **Confirm & apply**.
 
 The appliance creates an engine on each newly chosen node and leaves the existing engines and the model's endpoint
 alone. Traffic continues on the nodes that were already serving.

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -19,6 +19,7 @@ you the steps to do it without teaching background concepts.
 | [Manage Cluster Infrastructure](./manage-cluster-infrastructure.md) | Index the Local UI tasks for day-two cluster infrastructure operations.              |
 | [Upgrade the Platform](./upgrade-the-platform.md)                   | Upload a newer content bundle from Artifact Studio and apply **Update** in Local UI. |
 | [Deploy a Model](./deploy-a-model.md)                               | Deploy an LLM, choose which nodes run it, and verify it is serving.                  |
+| [Replace a Model](./replace-a-model.md)                             | Remove a model from a node, then deploy a newer version or a different model.        |
 | [Upload a Model](./upload-a-model.md)                               | Download a model on a jumpbox and upload it to the appliance.                        |
 | [Bring Your Own Model](./bring-your-own-model.md)                   | Author metadata for a model that is not certified, then upload and deploy it.        |
 | [Switch the Default Model](./set-the-default-model.md)              | Switch the default model when the current default becomes unavailable.               |

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
@@ -78,3 +78,4 @@ Frontier-model bursting is configured separately and is out of scope for this gu
 
 - [Set and Manage Client Quotas](./manage-client-quotas.md)
 - [View Client Usage](./view-client-usage.md)
+- [Replace a Model](./replace-a-model.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
@@ -19,11 +19,6 @@ Use this procedure in either of the following situations:
   deploy the newer version.
 - **Different model.** Remove the model that occupies the node, then deploy the model you want.
 
-You can change one node and leave the others running the previous model, or you can remove the model from every node and
-deploy the replacement everywhere. The node you change stops serving the removed model until the replacement is ready.
-Requests that named the removed model fall back to the default model, or fail if there is no default. For details on how
-the default is chosen, refer to [The Default Model](../explanation/architecture.md#the-default-model).
-
 ## Prerequisites
 
 - A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
@@ -37,19 +32,14 @@ the default is chosen, refer to [The Default Model](../explanation/architecture.
 
 Review these points before you remove anything.
 
-- **Other nodes.** Removing a model from one node leaves it running on every other node that still serves it. Those
-  nodes are not interrupted.
-- **Default model.** Removing the cluster default shows a warning before you confirm. You can still remove it. Requests
-  that do not name a model then have no fallback until you deploy a replacement and switch the default. After you remove
-  it, the **Overview** page raises an incident. After the replacement is serving, switch the default. Refer to
-  [Switch the Default Model](./set-the-default-model.md). Removing the default from the cluster requires you to type the
-  model name to confirm.
-- **Routing and quotas.** Client routing rules and quotas stay in place. You do not recreate them after a
-  remove-and-deploy. If the replacement keeps the same name, those rules continue to work. If the replacement uses a
-  different name, update any client tier maps that pointed at the old name. Refer to
-  [Manage a Client's Model Access](./manage-client-model-access.md).
-- **Last node.** Removing a model from its last node means it is no longer deployed anywhere. You must deploy it again
-  to serve it.
+- **Other nodes.** Expect the model to keep serving on every other node that runs it. Refer to
+  [Model Provisioning Lifecycle](../explanation/architecture.md#model-provisioning-lifecycle).
+- **Default model.** After removing the cluster default, switch the default to the replacement once it is serving. Refer
+  to [The Default Model](../explanation/architecture.md#the-default-model).
+- **Routing and quotas.** If the replacement uses a different name than the current model, update any client tier maps
+  that pointed at the old name. Refer to [Request Routing](../explanation/architecture.md#request-routing).
+- **Last node.** Deploy the replacement after removing the model from its last node, or the model is no longer deployed
+  anywhere. Refer to [Model Provisioning Lifecycle](../explanation/architecture.md#model-provisioning-lifecycle).
 
 ## Replace the Model on One Node
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
@@ -1,0 +1,94 @@
+---
+sidebar_label: "Replace a Model"
+title: "Replace a Model"
+description:
+  "Step-by-step guidance for platform operators on how to put a newer version of a model, or a different model, on a
+  node by removing the current model and then deploying the replacement."
+hide_table_of_contents: false
+sidebar_position: 1.2
+tags: ["paletteai-inference-launchpad", "models", "how-to"]
+keywords:
+  ["launchpad", "ai", "replace", "upgrade", "model", "version", "weights", "remove", "deploy"]
+---
+
+This guide explains how to put a different model, or a newer version of a model you already serve, onto a node. There is
+no in-place replace and no rolling upgrade. You remove the current model from the node, then deploy the model you want
+from **Deploy model**.
+
+Use this procedure for both of the following:
+
+- **Same model, newer version.** The newer version is already in the catalog. You remove the version that is serving,
+  then deploy the newer version.
+- **Different model.** You remove the model that occupies the node, then deploy the model you want.
+
+The node stops serving the removed model until the replacement is ready. Requests that named the removed model fall back
+to the default model, or fail if there is no default. For how the default is chosen, refer to
+[The Default Model](../explanation/architecture.md#the-default-model).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
+- The replacement model already in the appliance catalog. For a newer version that is not in the catalog yet, upload it
+  first. Refer to [Upload a Model](./upload-a-model.md).
+- Enough GPU capacity on the target node after you remove the current model. To confirm support, refer to
+  [Certified Models by Hardware](../reference/certified-models-by-hardware.md).
+
+## Before You Remove a Model
+
+Review these points before you remove anything.
+
+- **Default model.** If you remove the cluster default, requests that do not name a model have no fallback until you
+  deploy a replacement and switch the default. After you remove it, the **Overview** page raises an incident. After the
+  replacement is serving, switch the default. Refer to [Switch the Default Model](./set-the-default-model.md). Removing
+  the default from the cluster requires you to type the model name to confirm.
+- **Routing.** Local clients can call every local model by name. If the replacement uses a different name, update any
+  client tier maps that pointed at the old name. Refer to
+  [Manage a Client's Model Access](./manage-client-model-access.md). If the replacement keeps the same name, those maps
+  continue to work after the new deploy is serving.
+- **Last node.** Removing a model from its last node means it is no longer deployed anywhere. You must deploy it again
+  to serve it.
+
+## Remove the Model from a Node
+
+1. From the left main menu, select **Cluster**.
+
+2. In the _Model_ table, expand the model you want to replace.
+
+3. On the node that should run the replacement, open the three-dot menu and select **Remove**.
+
+4. Review the preview. It states that the appliance will remove the model from that node and stop serving it.
+
+5. Select **Confirm & apply**.
+
+Wait until that node no longer lists the model and its GPUs are free. The model row shows `deleting` while the engine
+stops. Then deploy the replacement.
+
+### Remove the Model from Every Node
+
+To stop the model on every node at once, select **Remove model from cluster** on the model row. Confirm that you intend
+to stop the model everywhere, then select **Remove**. If it is the default model, type the model name before **Remove**
+is available.
+
+## Deploy the Replacement
+
+1. Select **Deploy model**.
+
+2. Select the newer version or the different model.
+
+3. Confirm that a node can host it. If **Deploy** is unavailable, the panel explains why, such as no free GPUs. Finish
+   removing the previous model, or free capacity, then try again. Refer to
+   [Resolve a Blocked Deployment](./deploy-a-model.md#resolve-a-blocked-deployment).
+
+4. Select **Deploy**, review the preview, and then select **Confirm & apply**.
+
+5. Verify that the replacement reaches `ready` or `serving`. Refer to
+   [Verify the Model Is Serving](./deploy-a-model.md#verify-the-model-is-serving).
+
+If you removed the default model, switch the default to the replacement after the replacement is serving. Refer to
+[Switch the Default Model](./set-the-default-model.md).
+
+## Next Steps
+
+- [Deploy a Model](./deploy-a-model.md)
+- [Switch the Default Model](./set-the-default-model.md)
+- [Manage a Client's Model Access](./manage-client-model-access.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
@@ -7,34 +7,33 @@ description:
 hide_table_of_contents: false
 sidebar_position: 1.2
 tags: ["paletteai-inference-launchpad", "models", "how-to"]
-keywords: ["launchpad", "ai", "replace", "upgrade", "model", "version", "weights", "remove", "deploy"]
+keywords: ["launchpad", "ai", "replace", "upgrade", "model", "version", "weights", "remove", "deploy", "day-2"]
 ---
 
-This guide explains how to put a different model, or a newer version of a model you already serve, onto a node. There is
-no in-place replace and no rolling upgrade. You remove the current model from the node, then deploy the model you want
-from **Deploy New Model**.
+Put a newer version of a model you already serve, or a different model, onto a node. There is no in-place replace and no
+rolling upgrade. Remove the current model from the node, then deploy the model you want from **Deploy New Model**.
 
-Use this procedure for both of the following:
+Use this procedure in either of the following situations:
 
-- **Same model, newer version.** The newer version is already in the catalog. You remove the version that is serving,
-  then deploy the newer version.
-- **Different model.** You remove the model that occupies the node, then deploy the model you want.
+- **Same model, newer version.** The newer version is already in the catalog. Remove the version that is serving, then
+  deploy the newer version.
+- **Different model.** Remove the model that occupies the node, then deploy the model you want.
 
 You can change one node and leave the others running the previous model, or you can remove the model from every node and
 deploy the replacement everywhere. The node you change stops serving the removed model until the replacement is ready.
-Requests that named the removed model fall back to the default model, or fail if there is no default. For how the
-default is chosen, refer to [The Default Model](../explanation/architecture.md#the-default-model).
+Requests that named the removed model fall back to the default model, or fail if there is no default. For details on how
+the default is chosen, refer to [The Default Model](../explanation/architecture.md#the-default-model).
 
 ## Prerequisites
 
 - A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
-- The replacement model already in the appliance catalog, with its weights on every node you will deploy to. For a newer
-  version that is not in the catalog yet, upload it first. Refer to [Upload a Model](./upload-a-model.md). A node that
-  does not have the model's weights cannot be selected.
+- The replacement model already in the appliance catalog, with its weights on every node that should serve it. For a
+  newer version that is not in the catalog yet, upload it first. Refer to [Upload a Model](./upload-a-model.md). A node
+  that does not have the model's weights is not selectable.
 - Enough GPU capacity on the target node after you remove the current model. To confirm support, refer to
   [Certified Models by Hardware](../reference/certified-models-by-hardware.md).
 
-## Before You Remove a Model
+## Considerations
 
 Review these points before you remove anything.
 
@@ -60,7 +59,7 @@ Review these points before you remove anything.
 
 3. On the node that should run the replacement, open the three-dot menu and select **Remove**.
 
-4. Review the preview. It states that the appliance will remove the model from that node and stop serving it.
+4. Review the preview. It states that the appliance removes the model from that node and stops serving it.
 
 5. Select **Confirm & apply**.
 
@@ -73,7 +72,7 @@ Review these points before you remove anything.
 
 1. From the left main menu, select **Cluster**, and then select the **Models** tab.
 
-2. On the model row, select the trash control. The **Remove model from cluster** dialog opens.
+2. On the model row, select the trash icon. The **Remove model from cluster** dialog opens.
 
 3. Confirm that you intend to stop the model on every node. If it is the default model, the dialog warns you and asks
    you to type the model name.
@@ -116,10 +115,15 @@ That node's deploy stops. The node is free to deploy to again, and the model you
 Deploys that are still in progress on other nodes continue. Deploy the replacement onto the freed node again from
 **Deploy New Model**.
 
-## After the Change
+## Verify the Replacement
 
-New requests are counted against the replacement. Refer to [View Client Usage](./view-client-usage.md). Client routing
-and quotas continue to apply without you setting them again.
+1. From the left main menu, select **Cluster**, and then select the **Models** tab. Confirm the replacement is listed as
+   serving on every node you deployed to.
+2. Send a request that names the replacement, and confirm you receive a successful response.
+3. Open [View Client Usage](./view-client-usage.md) and confirm the replacement records new requests.
+
+Client routing rules and quotas continue to apply without you setting them again. If the replacement uses a different
+name than the model it replaced, update any client tier maps that pointed at the old name.
 
 ## Next Steps
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
@@ -7,8 +7,7 @@ description:
 hide_table_of_contents: false
 sidebar_position: 1.2
 tags: ["paletteai-inference-launchpad", "models", "how-to"]
-keywords:
-  ["launchpad", "ai", "replace", "upgrade", "model", "version", "weights", "remove", "deploy"]
+keywords: ["launchpad", "ai", "replace", "upgrade", "model", "version", "weights", "remove", "deploy"]
 ---
 
 This guide explains how to put a different model, or a newer version of a model you already serve, onto a node. There is

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
@@ -112,7 +112,8 @@ Deploys that are still in progress on other nodes continue. Deploy the replaceme
 2. Send a request that names the replacement, and confirm you receive a successful response.
 3. Open [View Client Usage](./view-client-usage.md) and confirm the replacement records new requests.
 
-Client routing and quotas survive a remove-then-deploy. Refer to [Request Routing](../explanation/architecture.md#request-routing).
+Client routing and quotas survive a remove-then-deploy. Refer to
+[Request Routing](../explanation/architecture.md#request-routing).
 
 ## Next Steps
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
@@ -12,7 +12,7 @@ keywords: ["launchpad", "ai", "replace", "upgrade", "model", "version", "weights
 
 This guide explains how to put a different model, or a newer version of a model you already serve, onto a node. There is
 no in-place replace and no rolling upgrade. You remove the current model from the node, then deploy the model you want
-from **Deploy model**.
+from **Deploy New Model**.
 
 Use this procedure for both of the following:
 
@@ -20,15 +20,17 @@ Use this procedure for both of the following:
   then deploy the newer version.
 - **Different model.** You remove the model that occupies the node, then deploy the model you want.
 
-The node stops serving the removed model until the replacement is ready. Requests that named the removed model fall back
-to the default model, or fail if there is no default. For how the default is chosen, refer to
-[The Default Model](../explanation/architecture.md#the-default-model).
+You can change one node and leave the others running the previous model, or you can remove the model from every node and
+deploy the replacement everywhere. The node you change stops serving the removed model until the replacement is ready.
+Requests that named the removed model fall back to the default model, or fail if there is no default. For how the
+default is chosen, refer to [The Default Model](../explanation/architecture.md#the-default-model).
 
 ## Prerequisites
 
 - A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
-- The replacement model already in the appliance catalog. For a newer version that is not in the catalog yet, upload it
-  first. Refer to [Upload a Model](./upload-a-model.md).
+- The replacement model already in the appliance catalog, with its weights on every node you will deploy to. For a newer
+  version that is not in the catalog yet, upload it first. Refer to [Upload a Model](./upload-a-model.md). A node that
+  does not have the model's weights cannot be selected.
 - Enough GPU capacity on the target node after you remove the current model. To confirm support, refer to
   [Certified Models by Hardware](../reference/certified-models-by-hardware.md).
 
@@ -36,22 +38,25 @@ to the default model, or fail if there is no default. For how the default is cho
 
 Review these points before you remove anything.
 
-- **Default model.** If you remove the cluster default, requests that do not name a model have no fallback until you
-  deploy a replacement and switch the default. After you remove it, the **Overview** page raises an incident. After the
-  replacement is serving, switch the default. Refer to [Switch the Default Model](./set-the-default-model.md). Removing
-  the default from the cluster requires you to type the model name to confirm.
-- **Routing.** Local clients can call every local model by name. If the replacement uses a different name, update any
-  client tier maps that pointed at the old name. Refer to
-  [Manage a Client's Model Access](./manage-client-model-access.md). If the replacement keeps the same name, those maps
-  continue to work after the new deploy is serving.
+- **Other nodes.** Removing a model from one node leaves it running on every other node that still serves it. Those
+  nodes are not interrupted.
+- **Default model.** Removing the cluster default shows a warning before you confirm. You can still remove it. Requests
+  that do not name a model then have no fallback until you deploy a replacement and switch the default. After you remove
+  it, the **Overview** page raises an incident. After the replacement is serving, switch the default. Refer to
+  [Switch the Default Model](./set-the-default-model.md). Removing the default from the cluster requires you to type the
+  model name to confirm.
+- **Routing and quotas.** Client routing rules and quotas stay in place. You do not recreate them after a
+  remove-and-deploy. If the replacement keeps the same name, those rules continue to work. If the replacement uses a
+  different name, update any client tier maps that pointed at the old name. Refer to
+  [Manage a Client's Model Access](./manage-client-model-access.md).
 - **Last node.** Removing a model from its last node means it is no longer deployed anywhere. You must deploy it again
   to serve it.
 
-## Remove the Model from a Node
+## Replace the Model on One Node
 
-1. From the left main menu, select **Cluster**.
+1. From the left main menu, select **Cluster**, and then select the **Models** tab.
 
-2. In the _Model_ table, expand the model you want to replace.
+2. Expand the model you want to replace.
 
 3. On the node that should run the replacement, open the three-dot menu and select **Remove**.
 
@@ -59,35 +64,66 @@ Review these points before you remove anything.
 
 5. Select **Confirm & apply**.
 
-Wait until that node no longer lists the model and its GPUs are free. The model row shows `deleting` while the engine
-stops. Then deploy the replacement.
+6. Wait until that node no longer lists the model and its GPUs are free. The model row shows `deleting` while the engine
+   stops. Other nodes that still serve the model keep running it.
 
-### Remove the Model from Every Node
+7. Deploy the replacement onto that node only, as described in [Deploy the Replacement](#deploy-the-replacement).
 
-To stop the model on every node at once, select **Remove model from cluster** on the model row. Confirm that you intend
-to stop the model everywhere, then select **Remove**. If it is the default model, type the model name before **Remove**
-is available.
+## Replace the Model on Every Node
+
+1. From the left main menu, select **Cluster**, and then select the **Models** tab.
+
+2. On the model row, select the trash control. The **Remove model from cluster** dialog opens.
+
+3. Confirm that you intend to stop the model on every node. If it is the default model, the dialog warns you and asks
+   you to type the model name.
+
+4. Select **Remove**.
+
+5. Wait until the model is gone from every node.
+
+6. Deploy the replacement onto every node that should serve it, as described in
+   [Deploy the Replacement](#deploy-the-replacement).
 
 ## Deploy the Replacement
 
-1. Select **Deploy model**.
+1. Select **Deploy New Model**. The **Deploy model** dialog opens.
 
 2. Select the newer version or the different model.
 
-3. Confirm that a node can host it. If **Deploy** is unavailable, the panel explains why, such as no free GPUs. Finish
-   removing the previous model, or free capacity, then try again. Refer to
-   [Resolve a Blocked Deployment](./deploy-a-model.md#resolve-a-blocked-deployment).
+3. In **Nodes**, select only the node or nodes you just freed. Leave nodes that should keep the previous model
+   unselected. If a node cannot run the model, it is not selectable and states why, such as missing weights or too few
+   free GPUs. If **Deploy** is unavailable, finish removing the previous model, or free capacity, then try again. Refer
+   to [Resolve a Blocked Deployment](./deploy-a-model.md#resolve-a-blocked-deployment).
 
 4. Select **Deploy**, review the preview, and then select **Confirm & apply**.
 
-5. Verify that the replacement reaches `ready` or `serving`. Refer to
+5. Wait until the replacement is running on each node you selected, then verify it. Refer to
    [Verify the Model Is Serving](./deploy-a-model.md#verify-the-model-is-serving).
 
 If you removed the default model, switch the default to the replacement after the replacement is serving. Refer to
 [Switch the Default Model](./set-the-default-model.md).
+
+### Stop a Deploy That Is Still in Progress
+
+If the replacement is still deploying on a node, you can stop that deploy and try again.
+
+1. Expand the model row.
+
+2. On the node that is still deploying, select **Abort**, and then select **Abort** in the confirmation.
+
+That node's deploy stops. The node is free to deploy to again, and the model you removed does not come back on its own.
+Deploys that are still in progress on other nodes continue. Deploy the replacement onto the freed node again from
+**Deploy New Model**.
+
+## After the Change
+
+New requests are counted against the replacement. Refer to [View Client Usage](./view-client-usage.md). Client routing
+and quotas continue to apply without you setting them again.
 
 ## Next Steps
 
 - [Deploy a Model](./deploy-a-model.md)
 - [Switch the Default Model](./set-the-default-model.md)
 - [Manage a Client's Model Access](./manage-client-model-access.md)
+- [View Client Usage](./view-client-usage.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
@@ -112,8 +112,7 @@ Deploys that are still in progress on other nodes continue. Deploy the replaceme
 2. Send a request that names the replacement, and confirm you receive a successful response.
 3. Open [View Client Usage](./view-client-usage.md) and confirm the replacement records new requests.
 
-Client routing rules and quotas continue to apply without you setting them again. If the replacement uses a different
-name than the model it replaced, update any client tier maps that pointed at the old name.
+Client routing and quotas survive a remove-then-deploy. Refer to [Request Routing](../explanation/architecture.md#request-routing).
 
 ## Next Steps
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/replace-a-model.md
@@ -10,29 +10,20 @@ tags: ["paletteai-inference-launchpad", "models", "how-to"]
 keywords: ["launchpad", "ai", "replace", "upgrade", "model", "version", "weights", "remove", "deploy", "day-2"]
 ---
 
-Put a newer version of a model you already serve, or a different model, onto a node. There is no in-place replace and no
-rolling upgrade. Remove the current model from the node, then deploy the model you want from **Deploy New Model**.
-
-Use this procedure in either of the following situations:
-
-- **Same model, newer version.** The newer version is already in the catalog. Remove the version that is serving, then
-  deploy the newer version.
-- **Different model.** Remove the model that occupies the node, then deploy the model you want.
+The appliance does not support in-place replacement. To change the model or version a node serves, remove the current
+model and then deploy the replacement from **Deploy New Model**.
 
 ## Prerequisites
 
-- A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
-- The replacement model already in the appliance catalog, with its weights on every node that should serve it. For a
-  newer version that is not in the catalog yet, upload it first. Refer to [Upload a Model](./upload-a-model.md). A node
-  that does not have the model's weights is not selectable.
-- Enough GPU capacity on the target node after you remove the current model. To confirm support, refer to
+- Operator access to a running PaletteAI Inference Launchpad appliance.
+- The replacement model in the appliance catalog. If it is not there yet, refer to
+  [Upload a Model](./upload-a-model.md).
+- Enough free GPU capacity on the target node after you remove the current model. Refer to
   [Certified Models by Hardware](../reference/certified-models-by-hardware.md).
 
 ## Considerations
 
-Review these points before you remove anything.
-
-- **Other nodes.** Expect the model to keep serving on every other node that runs it. Refer to
+- **Other nodes.** A per-node remove affects only the target node. Refer to
   [Model Provisioning Lifecycle](../explanation/architecture.md#model-provisioning-lifecycle).
 - **Default model.** After removing the cluster default, switch the default to the replacement once it is serving. Refer
   to [The Default Model](../explanation/architecture.md#the-default-model).
@@ -44,73 +35,51 @@ Review these points before you remove anything.
 ## Replace the Model on One Node
 
 1. From the left main menu, select **Cluster**, and then select the **Models** tab.
-
 2. Expand the model you want to replace.
-
 3. On the node that should run the replacement, open the three-dot menu and select **Remove**.
-
-4. Review the preview. It states that the appliance removes the model from that node and stops serving it.
-
-5. Select **Confirm & apply**.
-
-6. Wait until that node no longer lists the model and its GPUs are free. The model row shows `deleting` while the engine
-   stops. Other nodes that still serve the model keep running it.
-
-7. Deploy the replacement onto that node only, as described in [Deploy the Replacement](#deploy-the-replacement).
+4. Review the preview, then select **Confirm & apply**.
+5. Wait until the model clears from the node. The row shows `deleting` while the engine stops.
+6. Deploy the replacement onto that node only. Refer to [Deploy the Replacement](#deploy-the-replacement).
 
 ## Replace the Model on Every Node
 
 1. From the left main menu, select **Cluster**, and then select the **Models** tab.
-
 2. On the model row, select the trash icon. The **Remove model from cluster** dialog opens.
-
-3. Confirm that you intend to stop the model on every node. If it is the default model, the dialog warns you and asks
-   you to type the model name.
-
+3. If the model is the cluster default, type the model name to confirm.
 4. Select **Remove**.
-
-5. Wait until the model is gone from every node.
-
-6. Deploy the replacement onto every node that should serve it, as described in
+5. Wait until the model clears from every node.
+6. Deploy the replacement onto every node that should serve it. Refer to
    [Deploy the Replacement](#deploy-the-replacement).
 
 ## Deploy the Replacement
 
 1. Select **Deploy New Model**. The **Deploy model** dialog opens.
-
 2. Select the newer version or the different model.
-
-3. In **Nodes**, select only the node or nodes you just freed. Leave nodes that should keep the previous model
-   unselected. If a node cannot run the model, it is not selectable and states why, such as missing weights or too few
-   free GPUs. If **Deploy** is unavailable, finish removing the previous model, or free capacity, then try again. Refer
-   to [Resolve a Blocked Deployment](./deploy-a-model.md#resolve-a-blocked-deployment).
-
+3. In **Nodes**, select the node or nodes you just freed.
 4. Select **Deploy**, review the preview, and then select **Confirm & apply**.
-
-5. Wait until the replacement is running on each node you selected, then verify it. Refer to
+5. Wait until the replacement is running on each node you selected. Refer to
    [Verify the Model Is Serving](./deploy-a-model.md#verify-the-model-is-serving).
 
-If you removed the default model, switch the default to the replacement after the replacement is serving. Refer to
+If a node is not selectable, it is missing the model's weights or has too few free GPUs. If **Deploy** is unavailable,
+finish removing the previous model or free capacity, then try again. Refer to
+[Resolve a Blocked Deployment](./deploy-a-model.md#resolve-a-blocked-deployment).
+
+If you removed the default model, switch the default to the replacement once it is serving. Refer to
 [Switch the Default Model](./set-the-default-model.md).
 
 ### Stop a Deploy That Is Still in Progress
 
-If the replacement is still deploying on a node, you can stop that deploy and try again.
-
 1. Expand the model row.
+2. On the node that is still deploying, select **Abort**. In the confirmation, select **Abort** again.
 
-2. On the node that is still deploying, select **Abort**, and then select **Abort** in the confirmation.
-
-That node's deploy stops. The node is free to deploy to again, and the model you removed does not come back on its own.
-Deploys that are still in progress on other nodes continue. Deploy the replacement onto the freed node again from
-**Deploy New Model**.
+That node returns to a deployable state. Redeploy from **Deploy New Model**.
 
 ## Verify the Replacement
 
-1. From the left main menu, select **Cluster**, and then select the **Models** tab. Confirm the replacement is listed as
-   serving on every node you deployed to.
-2. Send a request that names the replacement, and confirm you receive a successful response.
-3. Open [View Client Usage](./view-client-usage.md) and confirm the replacement records new requests.
+1. From the left main menu, select **Cluster**, and then select the **Models** tab.
+2. Confirm the replacement is listed as serving on every node you deployed to.
+3. Send a request that names the replacement, and confirm you receive a successful response.
+4. Open [View Client Usage](./view-client-usage.md) and confirm the replacement records new requests.
 
 Client routing and quotas survive a remove-then-deploy. Refer to
 [Request Routing](../explanation/architecture.md#request-routing).

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/set-the-default-model.md
@@ -44,6 +44,8 @@ If no model is currently serving, the card reports that there is nothing to swit
 
 - **Generate an API token** to send requests to the default model. Refer to
   [Generate an API Token](./generate-an-api-token.md).
+- **Replace a serving model** when you need a newer version or a different model on a node. Refer to
+  [Replace a Model](./replace-a-model.md).
 - **Deploy another model** to the appliance. Refer to [Deploy a Model](./deploy-a-model.md).
 - **Keep the default on the text model** if you use vision preprocessing. Refer to
   [Enable Vision Preprocessing](./enable-vision-preprocessing.md).

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/upload-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/upload-a-model.md
@@ -120,6 +120,8 @@ The upload command accepts other flags, including password authentication (`--ss
   serving.
 - **Bring your own model:** Follow [Bring Your Own Model](./bring-your-own-model.md) to author metadata for a model that
   is not in the certified catalog, then download, upload, and deploy it.
+- **Replace a serving model:** Follow [Replace a Model](./replace-a-model.md) to remove the current model from a node
+  and deploy this one instead.
 - **Review the reference:** Refer to [Model Upload Reference](../reference/model-upload-reference.md) for the full
   command flags and metadata file fields.
 - **Enable vision preprocessing:** If you uploaded a vision model to use with a text-only model, follow

--- a/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -111,6 +111,7 @@ Whatever brought you here, these are the fastest paths in.
   [OpenCode](./how-to-guides/use-opencode.md)
 - **Operate day to day**: [Manage cluster infrastructure](./how-to-guides/manage-cluster-infrastructure.md) •
   [Upgrade the platform](./how-to-guides/upgrade-the-platform.md) •
+  [Replace a model](./how-to-guides/replace-a-model.md) •
   [Enable vision preprocessing](./how-to-guides/enable-vision-preprocessing.md) •
   [Create a client](./how-to-guides/create-a-client.md) • [Set client quotas](./how-to-guides/manage-client-quotas.md) •
   [View client usage](./how-to-guides/view-client-usage.md) •

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -288,7 +288,9 @@ installation completes. Refer to [Manage Cluster Infrastructure](../how-to-guide
 
 In the PaletteAI Inference Launchpad context, a large language model that the appliance serves. Each served model is
 exposed as an [OpenAI-compatible endpoint](#openai-compatible-api) and records its name, backend engine, and current
-serving status. The appliance turns a model off when a [quota](#quota) that covers it is exhausted.
+serving status. The appliance turns a model off when a [quota](#quota) that covers it is exhausted. To put a newer
+version or a different model on a [node](#node), remove the current model from that node and then deploy the
+replacement. Refer to [Replace a Model](../how-to-guides/replace-a-model.md).
 
 ### Model Alias
 

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -288,9 +288,9 @@ installation completes. Refer to [Manage Cluster Infrastructure](../how-to-guide
 
 In the PaletteAI Inference Launchpad context, a large language model that the appliance serves. Each served model is
 exposed as an [OpenAI-compatible endpoint](#openai-compatible-api) and records its name, backend engine, and current
-serving status. The appliance turns a model off when a [quota](#quota) that covers it is exhausted. To put a newer
-version or a different model on a [node](#node), remove the current model from that node and then deploy the
-replacement. Refer to [Replace a Model](../how-to-guides/replace-a-model.md).
+serving status. The appliance turns a model off when a [quota](#quota) that covers it is exhausted. Changing which model
+a [node](#node) serves uses a remove-then-deploy workflow. Refer to
+[Replace a Model](../how-to-guides/replace-a-model.md).
 
 ### Model Alias
 

--- a/docs/products/paletteai-inference-launchpad/release-notes.md
+++ b/docs/products/paletteai-inference-launchpad/release-notes.md
@@ -49,6 +49,9 @@ conceptual introduction, refer to [What is PaletteAI Inference Launchpad?](./pal
 - Deploys a model to the cluster after a guarded preview, gate, provision, and smoke-test sequence. Refer to
   [Deploy a Model](./how-to-guides/deploy-a-model.md) for more information.
 
+- Replaces a serving model by removing it from a node and then deploying a newer version or a different model. Refer to
+  [Replace a Model](./how-to-guides/replace-a-model.md) for more information.
+
 - Lets you set a default model that handles requests no routing rule matches, and rebuilds the router in place when you
   change it, without a gateway restart. Refer to [Set the Default Model](./how-to-guides/set-the-default-model.md) for
   more information.


### PR DESCRIPTION
## Summary
- Documents how to put a newer version of a model, or a different model, onto a PaletteAI Inference Launchpad node: remove the current model from that node, then deploy from **Deploy New Model** ([AIL-478](https://spectrocloud.atlassian.net/browse/AIL-478), parent [AIL-253](https://spectrocloud.atlassian.net/browse/AIL-253)).
- Splits the how-to into replace on one node (other nodes keep serving) and replace on every node (trash / **Remove model from cluster**), then deploy only onto the freed node or nodes.
- Covers default-model warning and typed confirmation, routing and quotas that stay in place, **Abort** of an in-progress deploy, and usage counted against the replacement.

Closes [AIL-478](https://spectrocloud.atlassian.net/browse/AIL-478).

## Test plan
- [ ] Preview **Replace a Model**. Confirm **Cluster** → **Models**, per-node **Remove** / **Confirm & apply**, and cluster-wide trash → **Remove model from cluster**.
- [ ] Confirm one-node replace leaves the previous model running on the other nodes, and all-node replace waits until the model is gone everywhere before **Deploy New Model**.
- [ ] Confirm **Nodes** selection targets only the freed node or nodes. Confirm a node without weights is described as not selectable.
- [ ] Confirm default-model warning / typed name, **Abort** (that node only; the removed model does not come back), and that routing and quotas persist without being set again.
- [ ] Confirm the pages describe console behavior only: no Replace menu item, no admin API, curl, pod restarts, or deleting weight files from disk.

[AIL-478]: https://spectrocloud.atlassian.net/browse/AIL-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIL-253]: https://spectrocloud.atlassian.net/browse/AIL-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIL-478]: https://spectrocloud.atlassian.net/browse/AIL-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ