### PR TITLE
AIL-479: Document bringing your own model

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/model-certification.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/model-certification.md
@@ -44,6 +44,23 @@ and [Deploy a Model](../how-to-guides/deploy-a-model.md). To bring a model that 
 [Bring Your Own Model](../how-to-guides/bring-your-own-model.md). To let a certified text-only model answer questions
 about images, refer to [Enable Vision Preprocessing](../how-to-guides/enable-vision-preprocessing.md).
 
+## Certification Compared with Bringing Your Own Model
+
+Both paths place a model on the same appliance and serve it with the same inference engines. What differs is who writes
+the serving recipe and who establishes that the model works on the hardware.
+
+| **Aspect**                | **Certified model**                                                                                                         | **Your own model**                                                                  |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **Metadata file**         | Spectro Cloud authors it, and you download it from Artifact Studio.                                                         | You author it.                                                                      |
+| **Hardware fit**          | Validated on the GPU configurations listed in [Certified Models by Hardware](../reference/certified-models-by-hardware.md). | You state what the model needs, and you confirm it fits your GPUs.                  |
+| **Serving configuration** | Tuned per GPU configuration by Spectro Cloud.                                                                               | You choose the inference engine, the tensor-parallel width, and the context length. |
+| **Validation**            | Spectro Cloud tests that the model loads and serves on the listed configurations.                                           | You test the model on your hardware.                                                |
+
+Bringing your own model does not change how the appliance handles the model once it is serving. The gateway routes
+requests, meters tokens, and enforces quotas the same way it does for a certified model.
+
+{/* NEEDS REVIEW: confirm the formal support statement for an uncertified model before publishing, and add it to the comparison table. */}
+
 ## How Certification Differs from Model as a Service
 
 PaletteAI Inference Launchpad is not a Model as a Service. Rather than offering the widest possible catalog of models on

--- a/docs/products/paletteai-inference-launchpad/explanation/model-certification.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/model-certification.md
@@ -33,15 +33,16 @@ Other models may serve other use cases better, so if your primary need is not a 
 
 :::info
 
-The certified list is not exclusive. You can load models beyond it as long as they fit within the GPU resources
-available on your appliance. If the model you want is not certified for your hardware,
-[contact Spectro Cloud](https://www.spectrocloud.com/contact) to discuss your use case.
+The certified list is not exclusive. You can bring your own model as long as it fits within the GPU resources available
+on your appliance. Refer to [Bring Your Own Model](../how-to-guides/bring-your-own-model.md). If you want Spectro Cloud
+to certify a model for your hardware, [contact Spectro Cloud](https://www.spectrocloud.com/contact).
 
 :::
 
-For how to add a model to a running appliance, refer to [Deploy a Model](../how-to-guides/deploy-a-model.md). To let a
-certified text-only model answer questions about images, refer to
-[Enable Vision Preprocessing](../how-to-guides/enable-vision-preprocessing.md).
+For how to add a certified model to a running appliance, refer to [Upload a Model](../how-to-guides/upload-a-model.md)
+and [Deploy a Model](../how-to-guides/deploy-a-model.md). To bring a model that is not certified, refer to
+[Bring Your Own Model](../how-to-guides/bring-your-own-model.md). To let a certified text-only model answer questions
+about images, refer to [Enable Vision Preprocessing](../how-to-guides/enable-vision-preprocessing.md).
 
 ## How Certification Differs from Model as a Service
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/bring-your-own-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/bring-your-own-model.md
@@ -93,15 +93,9 @@ launchpad:
         max_model_len: 32768
 ```
 
-The following fields decide whether the model can run.
-
-| **Field**                    | **What it does**                                                                                                                                                |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `min_gpus`                   | The minimum number of GPUs the model needs, not the width it runs at. A node with fewer GPUs than this does not fit the variant.                                |
-| `vram_gb`                    | A floor on per-GPU memory. The appliance compares it at deploy time against the memory the nodes advertise, and blocks the deployment if the floor is too high. |
-| `serve.tensor_parallel_size` | The number of GPUs the engine spreads the model across.                                                                                                         |
-| `serve.max_model_len`        | The maximum context length the engine serves. A longer context reserves more GPU memory for the key-value cache.                                                |
-| `vendor` and `gpu_product`   | Pins the variant to one GPU vendor or one GPU model. Both are unset in the preceding example, which lets the variant fit any node that satisfies `min_gpus`.    |
+This example sets a floor of four GPUs, requires 141 GB of memory per GPU, and spreads the model across four GPUs at a
+32,768-token context. It leaves `vendor` and `gpu_product` unset, so the variant fits any node that meets the GPU floor.
+For what each field does, refer to [The launchpad Block](../reference/model-upload-reference.md#the-launchpad-block).
 
 :::warning
 
@@ -112,9 +106,6 @@ marked as not deployable, with a reason naming what the variant needs against wh
 unless you know the exact label your nodes publish.
 
 :::
-
-For every field the file accepts, refer to
-[Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
 
 ## Download and Upload the Model
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/bring-your-own-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/bring-your-own-model.md
@@ -1,0 +1,153 @@
+---
+sidebar_label: "Bring Your Own Model"
+title: "Bring Your Own Model"
+description:
+  "Step-by-step guidance for platform operators on how to bring a model that is not in the certified catalog onto a
+  PaletteAI Inference Launchpad appliance: author metadata.yaml, download from Hugging Face, upload to the appliance,
+  and deploy."
+hide_table_of_contents: false
+sidebar_position: 1.6
+tags: ["paletteai-inference-launchpad", "models", "how-to"]
+keywords: ["launchpad", "ai", "bring your own model", "metadata", "huggingface", "upload", "deploy"]
+---
+
+This guide explains how to bring a model that is not in the certified catalog onto a PaletteAI Inference Launchpad
+appliance. You author `metadata.yaml`, download the weights from Hugging Face onto a jumpbox, upload them to the
+appliance, and deploy the model. Download, upload, and deploy match the certified-model flow. The extra step is
+authoring the metadata file instead of downloading it from Artifact Studio.
+
+Spectro Cloud has not validated a model you bring yourself. You confirm that it fits your GPUs and that it serves
+requests on your hardware. For what certification covers, refer to
+[Model Certification](../explanation/model-certification.md). For the certified list, refer to
+[Certified Models by Hardware](../reference/certified-models-by-hardware.md).
+
+|                              | **Certified model**                                           | **Your own model**                           |
+| ---------------------------- | ------------------------------------------------------------- | -------------------------------------------- |
+| **Metadata**                 | Download `metadata.yaml` from Artifact Studio.                | Author `metadata.yaml` yourself.             |
+| **Download, upload, deploy** | Follow [Upload a Model](./upload-a-model.md), then deploy.    | The same steps, using the file you authored. |
+| **Validation**               | Spectro Cloud has tested it on the listed GPU configurations. | You validate it on your hardware.            |
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
+- A jumpbox with the Palette CLI, `rsync`, SSH access to the appliance, and network access to Hugging Face. Refer to
+  [Upload a Model](./upload-a-model.md#prerequisites).
+- The Hugging Face repository for the model, and a token if the repository is gated or private.
+- Enough GPU memory on the appliance for the model. Refer to
+  [Suggested Hardware](../reference/hardware-requirements.md).
+
+## Create the Metadata File
+
+On the jumpbox, create a YAML file for the model. Only `name`, `version`, and `huggingface.repo` are required. The
+Palette CLI uses `name` and `version` as the path `<model-dir>/<name>/<version>/`. The appliance uses `name` as the
+catalog name.
+
+The following example is a starting point. Replace the repository, version, and GPU fields with values for your model
+and hardware. For every field, refer to
+[Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
+
+```yaml
+name: my-model
+version: 1.0.0
+
+huggingface:
+  repo: org/my-model
+  revision: main
+  files:
+    - "*.safetensors"
+    - "*.json"
+    - "tokenizer*"
+
+launchpad:
+  engine: vllm
+  variants:
+    - vendor: nvidia
+      gpu_product: NVIDIA-H200
+      vram_gb: 141
+      min_gpus: 4
+      serve:
+        tensor_parallel_size: 4
+```
+
+`launchpad` is optional. Include it when you need to pin an engine or describe which GPUs can host the model. The
+Palette CLI ships the block to the appliance unchanged.
+
+Save the file, for example as `my-model.yaml`. Pass that path as `--metadata` in the download and upload commands.
+
+:::info
+
+The parser rejects unknown top-level fields. Stay with the fields listed in
+[Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
+
+:::
+
+## Download the Model from Hugging Face
+
+On the jumpbox, download the model from Hugging Face into a writable local directory. Do not use a read-only NFS mount.
+
+1. Run the download command, using the path to the metadata file you authored and the directory to download into.
+
+   ```bash
+   palette content model download \
+       --metadata my-model.yaml \
+       --model-dir ./models
+   ```
+
+   The model downloads to `<model-dir>/<name>/<version>/`, where `<name>` and `<version>` come from the metadata file.
+
+2. _(Gated or private Hugging Face repositories)_ Provide a Hugging Face token through the `HF_TOKEN` environment
+   variable.
+
+   ```bash
+   HF_TOKEN=<hugging-face-token> palette content model download \
+       --metadata my-model.yaml \
+       --model-dir ./models
+   ```
+
+## Upload the Model to the Appliance
+
+Ship the downloaded directory from the jumpbox to the appliance over SSH. On a multi-node appliance, upload to a single
+node; the appliance syncs the model to the remaining nodes automatically.
+
+1. Run the upload command with the model directory and the appliance's SSH details.
+
+   ```bash
+   palette content model upload \
+       --metadata my-model.yaml \
+       --model-dir ./models \
+       --ssh-user <ssh-user> \
+       --ssh-host <appliance-host> \
+       --ssh-key <private-key-path>
+   ```
+
+   Replace `<ssh-user>` and `<appliance-host>` with the appliance's SSH user and address, and `<private-key-path>` with
+   the path to your private key, such as `~/.ssh/id_ed25519`.
+
+   :::warning `--model-dir` points at the parent, not the model's own directory
+
+   `--model-dir` is the directory that _contains_ `<name>/<version>/`, not the directory named after the model. For a
+   model at `./models/my-model/1.0.0/`, pass `--model-dir ./models`. Refer to
+   [Upload a Model](./upload-a-model.md#upload-the-model-to-the-appliance).
+
+   :::
+
+For the full flag list, refer to
+[Model Upload Reference](../reference/model-upload-reference.md#palette-content-model-upload).
+
+## Deploy the Model
+
+1. In the appliance console, select **Cluster** from the left main menu, then select **Deploy model**.
+
+2. Open the model drop-down menu and confirm the model you uploaded is listed. On a single-node appliance, the model
+   appears on the next catalog scan after the upload finishes. On a multi-node appliance, the catalog shows the model's
+   cluster-wide state: `Available` when the model is ready on every node, `Pending N/M` while nodes are still syncing,
+   or `Missing`. Only an **Available** model can be deployed.
+
+3. Deploy and verify the model. Refer to [Deploy a Model](./deploy-a-model.md).
+
+## Next Steps
+
+- [Upload a Model](./upload-a-model.md)
+- [Deploy a Model](./deploy-a-model.md)
+- [Model Upload Reference](../reference/model-upload-reference.md)
+- [Model Certification](../explanation/model-certification.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/bring-your-own-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/bring-your-own-model.md
@@ -3,8 +3,7 @@ sidebar_label: "Bring Your Own Model"
 title: "Bring Your Own Model"
 description:
   "Step-by-step guidance for platform operators on how to bring a model that is not in the certified catalog onto a
-  PaletteAI Inference Launchpad appliance: author metadata.yaml, download from Hugging Face, upload to the appliance,
-  and deploy."
+  PaletteAI Inference Launchpad appliance by authoring its metadata file, then uploading and deploying it."
 hide_table_of_contents: false
 sidebar_position: 1.6
 tags: ["paletteai-inference-launchpad", "models", "how-to"]
@@ -12,80 +11,119 @@ keywords: ["launchpad", "ai", "bring your own model", "metadata", "huggingface",
 ---
 
 This guide explains how to bring a model that is not in the certified catalog onto a PaletteAI Inference Launchpad
-appliance. You author `metadata.yaml`, download the weights from Hugging Face onto a jumpbox, upload them to the
-appliance, and deploy the model. Download, upload, and deploy match the certified-model flow. The extra step is
-authoring the metadata file instead of downloading it from Artifact Studio.
+appliance. The download, upload, and deploy steps are the same as for a certified model. The addition is the metadata
+file. Because there is no Artifact Studio download for an uncertified model, you author the file yourself, and that file
+is where you tell the appliance which weights to fetch and what the model needs to run.
 
-Spectro Cloud has not validated a model you bring yourself. You confirm that it fits your GPUs and that it serves
-requests on your hardware. For what certification covers, refer to
-[Model Certification](../explanation/model-certification.md). For the certified list, refer to
-[Certified Models by Hardware](../reference/certified-models-by-hardware.md).
-
-|                              | **Certified model**                                           | **Your own model**                           |
-| ---------------------------- | ------------------------------------------------------------- | -------------------------------------------- |
-| **Metadata**                 | Download `metadata.yaml` from Artifact Studio.                | Author `metadata.yaml` yourself.             |
-| **Download, upload, deploy** | Follow [Upload a Model](./upload-a-model.md), then deploy.    | The same steps, using the file you authored. |
-| **Validation**               | Spectro Cloud has tested it on the listed GPU configurations. | You validate it on your hardware.            |
+Spectro Cloud has not tested a model you bring yourself on your hardware. Confirming that it loads, serves requests, and
+answers acceptably is yours to do. For what certification covers and how the two paths differ, refer to
+[Model Certification](../explanation/model-certification.md).
 
 ## Prerequisites
 
 - A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
-- A jumpbox with the Palette CLI, `rsync`, SSH access to the appliance, and network access to Hugging Face. Refer to
-  [Upload a Model](./upload-a-model.md#prerequisites).
-- The Hugging Face repository for the model, and a token if the repository is gated or private.
-- Enough GPU memory on the appliance for the model. Refer to
+
+- A jumpbox that meets the prerequisites in [Upload a Model](./upload-a-model.md#prerequisites), including the Palette
+  CLI, `rsync`, SSH access to the appliance, and network access to Hugging Face.
+
+- The Hugging Face repository that holds the model, and an access token if the repository is gated or private.
+
+- Enough free GPU memory on the appliance for the model. Refer to
   [Suggested Hardware](../reference/hardware-requirements.md).
 
-## Create the Metadata File
+## Author the Metadata File
 
-On the jumpbox, create a YAML file for the model. Only `name`, `version`, and `huggingface.repo` are required. The
-Palette CLI uses `name` and `version` as the path `<model-dir>/<name>/<version>/`. The appliance uses `name` as the
-catalog name.
+The metadata file tells the Palette CLI which weights to download and tells the appliance how to serve them. The CLI
+reads `name` and `version` to build the model path `<model-dir>/<name>/<version>/`, and the appliance reads the same
+file after the upload to place the model in the deploy catalog under `name`.
 
-The following example is a starting point. Replace the repository, version, and GPU fields with values for your model
-and hardware. For every field, refer to
-[Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
+Create the file on the jumpbox. You choose the filename, for example `my-model.yaml`, and pass its path as `--metadata`
+in the commands that follow.
 
-```yaml
-name: my-model
-version: 1.0.0
+1. Start with the model identity and the source of the weights. A working file cannot omit `name`, `version`, or
+   `huggingface.repo`.
 
-huggingface:
-  repo: org/my-model
-  revision: main
-  files:
-    - "*.safetensors"
-    - "*.json"
-    - "tokenizer*"
+   ```yaml
+   name: my-model
+   version: 1.0.0
 
-launchpad:
-  engine: vllm
-  variants:
-    - vendor: nvidia
-      gpu_product: NVIDIA-H200
-      vram_gb: 141
-      min_gpus: 4
-      serve:
-        tensor_parallel_size: 4
-```
+   huggingface:
+     repo: org/my-model
+     revision: main
+     files:
+       - "*.safetensors"
+       - "*.json"
+       - "tokenizer*"
+   ```
 
-`launchpad` is optional. Include it when you need to pin an engine or describe which GPUs can host the model. The
-Palette CLI ships the block to the appliance unchanged.
+   The `files` globs narrow the download to the weight, configuration, and `tokenizer*` files rather than every file in
+   the repository. Omit `files` to download the whole repository.
 
-Save the file, for example as `my-model.yaml`. Pass that path as `--metadata` in the download and upload commands.
+2. _(Optional)_ Add a `launchpad` block to describe what the model needs to run. Refer to
+   [Describe the Hardware the Model Needs](#describe-the-hardware-the-model-needs).
 
-:::info
+   Without the block, the appliance serves the model with vLLM and treats it as needing at least one GPU.
 
-The parser rejects unknown top-level fields. Stay with the fields listed in
-[Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
+3. Check every field name against [Model Metadata File](../reference/model-upload-reference.md#model-metadata-file),
+   then save the file.
+
+:::warning
+
+The appliance ignores fields it does not recognize instead of rejecting them. A misspelled field name is therefore
+dropped without an error, and the model deploys with the default the field was meant to override. Only `name` and
+`version` are enforced, and a file missing either one never reaches the deploy catalog.
 
 :::
 
-## Download the Model from Hugging Face
+### Describe the Hardware the Model Needs
 
-On the jumpbox, download the model from Hugging Face into a writable local directory. Do not use a read-only NFS mount.
+Inside `launchpad`, `variants` is a list of per-hardware tuning cells. The appliance detects each node's GPU product,
+GPU count, and per-GPU memory, then selects the single variant that fits that node. Fields set at the `launchpad` level
+are defaults, and a variant overrides them.
 
-1. Run the download command, using the path to the metadata file you authored and the directory to download into.
+```yaml
+launchpad:
+  engine: vllm
+  min_gpus: 4
+  variants:
+    - min_gpus: 4
+      vram_gb: 141
+      serve:
+        tensor_parallel_size: 4
+        max_model_len: 32768
+```
+
+The following fields decide whether the model can run.
+
+| **Field**                    | **What it does**                                                                                                                                                |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `min_gpus`                   | The minimum number of GPUs the model needs, not the width it runs at. A node with fewer GPUs than this does not fit the variant.                                |
+| `vram_gb`                    | A floor on per-GPU memory. The appliance compares it at deploy time against the memory the nodes advertise, and blocks the deployment if the floor is too high. |
+| `serve.tensor_parallel_size` | The number of GPUs the engine spreads the model across.                                                                                                         |
+| `serve.max_model_len`        | The maximum context length the engine serves. A longer context reserves more GPU memory for the key-value cache.                                                |
+| `vendor` and `gpu_product`   | Pins the variant to one GPU vendor or one GPU model. Both are unset in the preceding example, which lets the variant fit any node that satisfies `min_gpus`.    |
+
+:::warning
+
+The appliance compares `vendor` and `gpu_product` against the GPU labels a node publishes by exact string match, so the
+value has to be the node's own product label, such as `NVIDIA-H200` or `AMD_Instinct_MI325_OAM`, rather than a marketing
+name such as `H200`. A value that no node publishes does not fail quietly: the model appears in the deploy catalog
+marked as not deployable, with a reason naming what the variant needs against what the node has. Leave both fields unset
+unless you know the exact label your nodes publish.
+
+:::
+
+For every field the file accepts, refer to
+[Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
+
+## Download and Upload the Model
+
+The download and upload commands are the same ones a certified model uses, with your authored file as `--metadata`. For
+the full flag list, password authentication, and the one-step `--download` form, refer to
+[Upload a Model](./upload-a-model.md#upload-the-model-to-the-appliance).
+
+1. On the jumpbox, download the model from Hugging Face into a writable local directory. Do not use a read-only NFS
+   mount.
 
    ```bash
    palette content model download \
@@ -93,10 +131,10 @@ On the jumpbox, download the model from Hugging Face into a writable local direc
        --model-dir ./models
    ```
 
-   The model downloads to `<model-dir>/<name>/<version>/`, where `<name>` and `<version>` come from the metadata file.
+   The model lands at `<model-dir>/<name>/<version>/`, where `<name>` and `<version>` come from your metadata file.
 
 2. _(Gated or private Hugging Face repositories)_ Provide a Hugging Face token through the `HF_TOKEN` environment
-   variable.
+   variable instead.
 
    ```bash
    HF_TOKEN=<hugging-face-token> palette content model download \
@@ -104,12 +142,8 @@ On the jumpbox, download the model from Hugging Face into a writable local direc
        --model-dir ./models
    ```
 
-## Upload the Model to the Appliance
-
-Ship the downloaded directory from the jumpbox to the appliance over SSH. On a multi-node appliance, upload to a single
-node; the appliance syncs the model to the remaining nodes automatically.
-
-1. Run the upload command with the model directory and the appliance's SSH details.
+3. Upload the downloaded directory to the appliance over SSH. On a multi-node appliance, upload to a single node, and
+   the appliance syncs the model to the remaining nodes.
 
    ```bash
    palette content model upload \
@@ -121,33 +155,57 @@ node; the appliance syncs the model to the remaining nodes automatically.
    ```
 
    Replace `<ssh-user>` and `<appliance-host>` with the appliance's SSH user and address, and `<private-key-path>` with
-   the path to your private key, such as `~/.ssh/id_ed25519`.
+   the path to your private key, such as `~/.ssh/id_ed25519`. Pass the parent directory to `--model-dir`, not the
+   directory named after the model.
 
-   :::warning `--model-dir` points at the parent, not the model's own directory
+## Deploy and Validate the Model
 
-   `--model-dir` is the directory that _contains_ `<name>/<version>/`, not the directory named after the model. For a
-   model at `./models/my-model/1.0.0/`, pass `--model-dir ./models`. Refer to
-   [Upload a Model](./upload-a-model.md#upload-the-model-to-the-appliance).
+1. Deploy the model by following [Deploy a Model](./deploy-a-model.md). The model appears in the deploy catalog on the
+   next catalog scan after the upload finishes, and only a model in the `Available` state can be deployed.
 
-   :::
+2. Confirm the model reaches the `ready` or `serving` state and reports `N/N healthy`. If it does not, refer to
+   [Troubleshoot a Model That Does Not Deploy](#troubleshoot-a-model-that-does-not-deploy).
 
-For the full flag list, refer to
-[Model Upload Reference](../reference/model-upload-reference.md#palette-content-model-upload).
+3. Send the workload you intend to run against the model and review the responses. A certified model arrives with
+   Spectro Cloud's own testing on a given GPU configuration, and a model you bring yourself does not, so this step is
+   where you establish that the model is fit for your use case.
 
-## Deploy the Model
+## Troubleshoot a Model That Does Not Deploy
 
-1. In the appliance console, select **Cluster** from the left main menu, then select **Deploy model**.
+A model whose metadata does not match your hardware is never hidden. It appears in the deploy catalog marked as not
+deployable, with a reason. Use the following table to map the reason to the field to change.
 
-2. Open the model drop-down menu and confirm the model you uploaded is listed. On a single-node appliance, the model
-   appears on the next catalog scan after the upload finishes. On a multi-node appliance, the catalog shows the model's
-   cluster-wide state: `Available` when the model is ready on every node, `Pending N/M` while nodes are still syncing,
-   or `Missing`. Only an **Available** model can be deployed.
+| **What you observe**                                                                                                                   | **What it means**                                                                                                                                                                                   | **What to change**                                                                                          |
+| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| The model does not appear in the deploy catalog at all.                                                                                | The upload has not finished, or the file sets no `name` or `version`. The appliance treats `metadata.yaml` as the last file of an upload, so the model surfaces only once the weights are in place. | Confirm the upload completed, and confirm the file sets both `name` and `version`.                          |
+| The model is listed as not deployable, with a reason such as `needs 8+ GPU NVIDIA-H200 141GB VRAM; this node has 4x NVIDIA-L40S 46GB`. | No variant in your file fits the node.                                                                                                                                                              | Lower `min_gpus`, correct `gpu_product` or `vendor`, or remove those two pins so the variant fits any node. |
+| The deployment is blocked with `no node in this cluster advertises GPU product <product>`.                                             | `gpu_product` is not a label any node in the cluster publishes.                                                                                                                                     | Correct the value to the node's exact GPU product label, or remove the field.                               |
+| The deployment is blocked with `MinVRAMGB <n> exceeds the <memory> per GPU advertised by nodes running <product>`.                     | `vram_gb` is higher than the per-GPU memory your GPUs advertise.                                                                                                                                    | Lower `vram_gb` to the memory your GPUs provide.                                                            |
+| The deployment is blocked with `no node advertises a driver version; MinDriver <version> cannot be verified`.                          | `min_driver` is set, but the appliance cannot read a driver version from any node.                                                                                                                  | Remove `min_driver`, or confirm the GPU driver is installed and reporting its version.                      |
+| The model deploys but reaches the `failed` or `verification failed` state.                                                             | The engine started but never became ready. For an uncertified model, the usual cause is that the weights and the requested context length do not fit the GPU memory.                                | Lower `serve.max_model_len`, or raise `serve.tensor_parallel_size` to spread the model across more GPUs.    |
 
-3. Deploy and verify the model. Refer to [Deploy a Model](./deploy-a-model.md).
+For deploy reasons that are about cluster capacity rather than your metadata, refer to
+[Resolve a Blocked Deployment](./deploy-a-model.md#resolve-a-blocked-deployment).
+
+## Limitations
+
+- Spectro Cloud does not test or support a model you bring yourself. Certification covers a model, an engine version,
+  and a GPU configuration together, and none of that applies to a model you author metadata for.
+
+- The appliance selects one variant per node from the hardware it detects, and it expects every node to carry the same
+  GPU model. Author variants for the hardware in your cluster rather than for a mixed fleet.
+
+{/* NEEDS REVIEW: per the epic, day-2 operations for an uncertified model are not supported. Confirm which day-2 operations are excluded, and add them to Limitations. */}
 
 ## Next Steps
 
-- [Upload a Model](./upload-a-model.md)
-- [Deploy a Model](./deploy-a-model.md)
-- [Model Upload Reference](../reference/model-upload-reference.md)
-- [Model Certification](../explanation/model-certification.md)
+Now that the model is serving, put it in front of clients.
+
+- **Make it the default:** To have this model answer requests that do not name a model, refer to
+  [Switch the Default Model](./set-the-default-model.md).
+
+- **Give a client access:** To route a client to the model, refer to
+  [Manage a Client's Model Access](./manage-client-model-access.md).
+
+- **Tune the metadata:** For every field the metadata file accepts, refer to
+  [Model Upload Reference](../reference/model-upload-reference.md).

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
@@ -80,4 +80,5 @@ resolve the unknown allocation on the affected nodes. Then deploy the model agai
 
 To change which model handles requests that do not name a model explicitly, refer to
 [Switch the Default Model](./set-the-default-model.md). To let a text-only model answer questions about images, refer to
-[Enable Vision Preprocessing](./enable-vision-preprocessing.md).
+[Enable Vision Preprocessing](./enable-vision-preprocessing.md). To bring a model that is not in the certified catalog,
+refer to [Bring Your Own Model](./bring-your-own-model.md).

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -18,7 +18,7 @@ you the steps to do it without teaching background concepts.
 | [Install the Appliance](./install-the-appliance.md)               | Flash the installer ISO, boot the hardware, and bring up the appliance console.      |
 | [Deploy a Model](./deploy-a-model.md)                             | Deploy an LLM to the cluster and verify it is serving.                               |
 | [Upload a Model](./upload-a-model.md)                             | Download a model on a jumpbox and upload it to the appliance.                        |
-| [Bring Your Own Model](./bring-your-own-model.md) | Author metadata for a model that is not certified, then upload and deploy it. |
+| [Bring Your Own Model](./bring-your-own-model.md)                 | Author metadata for a model that is not certified, then upload and deploy it.        |
 | [Switch the Default Model](./set-the-default-model.md)            | Switch the default model when the current default becomes unavailable.               |
 | [Enable Vision Preprocessing](./enable-vision-preprocessing.md)   | Deploy a vision model and turn on image-to-text preprocessing for a text-only model. |
 | [Create a Client](./create-a-client.md)                           | Create a client and issue its first API token.                                       |
@@ -31,4 +31,3 @@ you the steps to do it without teaching background concepts.
 | [Use Cursor](./use-cursor.md)                                     | Connect Cursor's Ask mode to the appliance through a uniquely named model alias.     |
 | [Use OpenAI Codex](./use-codex.md)                                | Connect the OpenAI Codex CLI to the appliance with a custom model provider.          |
 | [Use OpenCode](./use-opencode.md)                                 | Connect the OpenCode terminal agent to the appliance through a custom provider.      |
-

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -18,6 +18,7 @@ you the steps to do it without teaching background concepts.
 | [Install the Appliance](./install-the-appliance.md)               | Flash the installer ISO, boot the hardware, and bring up the appliance console.      |
 | [Deploy a Model](./deploy-a-model.md)                             | Deploy an LLM to the cluster and verify it is serving.                               |
 | [Upload a Model](./upload-a-model.md)                             | Download a model on a jumpbox and upload it to the appliance.                        |
+| [Bring Your Own Model](./bring-your-own-model.md) | Author metadata for a model that is not certified, then upload and deploy it. |
 | [Switch the Default Model](./set-the-default-model.md)            | Switch the default model when the current default becomes unavailable.               |
 | [Enable Vision Preprocessing](./enable-vision-preprocessing.md)   | Deploy a vision model and turn on image-to-text preprocessing for a text-only model. |
 | [Create a Client](./create-a-client.md)                           | Create a client and issue its first API token.                                       |
@@ -30,3 +31,4 @@ you the steps to do it without teaching background concepts.
 | [Use Cursor](./use-cursor.md)                                     | Connect Cursor's Ask mode to the appliance through a uniquely named model alias.     |
 | [Use OpenAI Codex](./use-codex.md)                                | Connect the OpenAI Codex CLI to the appliance with a custom model provider.          |
 | [Use OpenCode](./use-opencode.md)                                 | Connect the OpenCode terminal agent to the appliance through a custom provider.      |
+

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md
@@ -69,8 +69,8 @@ begin. The slim ISO and content bundle must match the target hardware's GPU (NVI
   (recommended) or Local UI after the node is on the network.
 - **Model metadata (`metadata.yaml`, a few KB)**. one file per model you intend to deploy. It is a separate download,
   not part of the ISO or content bundle. You use it later, with the Palette CLI, to download the model weights from
-  Hugging Face and upload them to the appliance. Download it from Artifact Studio, or from the `models/` directory of
-  the `launchpad-ai` repository, for example `models/glm-5.2/1.0.0/metadata.yaml`.
+  Hugging Face and upload them to the appliance. For a certified model, download it from Artifact Studio. For a model
+  that is not certified, author the file. Refer to [Bring Your Own Model](./bring-your-own-model.md).
 
 ## Install the OS
 
@@ -506,7 +506,8 @@ or later.
 For the full flag list, the metadata file schema, the on-appliance layout, and the deploy-catalog states, refer to
 [Model Upload Reference](../reference/model-upload-reference.md).
 
-1. Download the model metadata (`metadata.yaml`) from Artifact Studio.
+1. Download the model metadata (`metadata.yaml`) from Artifact Studio. For a model that is not certified, author the
+   file instead. Refer to [Bring Your Own Model](./bring-your-own-model.md).
 2. On the jumpbox, download the model to a writable local directory, for example `/home/ubuntu/downloads`. Do not use an
    NFS share, which may be mounted read-only. The model lands at `<model-dir>/<name>/<version>/`.
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/upload-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/upload-a-model.md
@@ -17,7 +17,8 @@ rather than having the appliance pull them at deploy time. You download a model 
 appliance over SSH, after which the model appears in the appliance's deploy catalog.
 
 This guide comes before [Deploy a Model](./deploy-a-model.md): the upload puts the model in the catalog, and the deploy
-serves it. For the full command flags and metadata file fields, refer to
+serves it. For a model that is not in the certified catalog, author `metadata.yaml` first, then follow this guide. Refer
+to [Bring Your Own Model](./bring-your-own-model.md). For the full command flags and metadata file fields, refer to
 [Model Upload Reference](../reference/model-upload-reference.md).
 
 :::info
@@ -37,8 +38,9 @@ downloads models itself. For how to provision the jumpbox, refer to
   [Administrative Workstation](../reference/hardware-requirements.md#administrative-workstation) and
   [Model Download Access](../reference/hardware-requirements.md#model-download-access-recommended).
 - `rsync` on the jumpbox. The Palette CLI uses it to transfer the model to the appliance over SSH.
-- The metadata YAML for the model you intend to upload, obtained from Artifact Studio. For its fields, refer to
-  [Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
+- The metadata YAML for the model you intend to upload. For a certified model, obtain it from Artifact Studio. For a
+  model that is not certified, author it yourself. Refer to [Bring Your Own Model](./bring-your-own-model.md). For its
+  fields, refer to [Model Metadata File](../reference/model-upload-reference.md#model-metadata-file).
 - The appliance's SSH host address (IP or DNS name) and an SSH user.
 - _(Gated or private Hugging Face repositories)_ A Hugging Face access token.
 
@@ -104,18 +106,6 @@ The upload command accepts other flags, including password authentication (`--ss
 
 ## Verify the Model and Deploy It
 
-:::warning
-
-The appliance surfaces an uploaded model only when it matches an entry in the appliance's curated model catalog. If you
-upload a model that is not in the curated catalog, the upload succeeds but the model does not appear in the deploy
-catalog.
-
-:::
-
-{/* NEEDS REVIEW: per the source, an uploaded model that does not match a curated catalog entry is logged but not surfaced today, with a schema-gap follow-up planned. Confirm current behavior before publishing. */}
-
-{/* NEEDS REVIEW: multi-node catalog states and automatic peer sync are from the engineering source. Confirm the labels and behavior before publishing. */}
-
 1. In the appliance console, select **Cluster** from the left main menu, then select **Deploy model** to open the deploy
    panel.
 
@@ -130,6 +120,8 @@ catalog.
 
 - **Deploy the model:** Follow [Deploy a Model](./deploy-a-model.md) to deploy the uploaded model and verify it is
   serving.
+- **Bring your own model:** Follow [Bring Your Own Model](./bring-your-own-model.md) to author metadata for a model that
+  is not in the certified catalog, then download, upload, and deploy it.
 - **Review the reference:** Refer to [Model Upload Reference](../reference/model-upload-reference.md) for the full
   command flags and metadata file fields.
 - **Enable vision preprocessing:** If you uploaded a vision model to use with a text-only model, follow

--- a/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -100,9 +100,8 @@ Whatever brought you here, these are the fastest paths in.
 
 - **Get started**: [Suggested Hardware](./reference/hardware-requirements.md) •
   [Install the appliance](./how-to-guides/install-the-appliance.md) •
-  [Upload a model](./how-to-guides/upload-a-model.md) •
-  [Bring your own model](./how-to-guides/bring-your-own-model.md) •
-  [Deploy your first model](./how-to-guides/deploy-a-model.md)
+  [Upload a model](./how-to-guides/upload-a-model.md) • [Bring your own model](./how-to-guides/bring-your-own-model.md)
+  • [Deploy your first model](./how-to-guides/deploy-a-model.md)
 - **Understand the product**: [Architecture](./explanation/architecture.md) •
   [Vision Preprocessing](./explanation/vision-preprocessing.md) •
   [Clients and Quotas](./explanation/clients-and-quotas.md) •

--- a/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -61,9 +61,9 @@ vLLM serves language models with high GPU throughput and handles concurrent requ
 ships with the ability to download one of these flagship open-weight models (GLM, DeepSeek, Kimi, or Gemma) and run it
 entirely on your hardware with no external API calls. NVIDIA and AMD GPU support provides the parallel processing that
 large language models require to respond at production speed. The certified models are a starting point rather than a
-boundary, so you can also bring your own model and serve it alongside them. Bringing your own model means you author its
-metadata and validate it on your hardware yourself, rather than starting from a configuration Spectro Cloud has already
-tested.
+boundary, so you can also [bring your own model](./how-to-guides/bring-your-own-model.md) and serve it alongside them.
+Bringing your own model means you author its metadata and validate it on your hardware yourself, rather than starting
+from a configuration Spectro Cloud has already tested.
 
 Intelligent routing directs each request to the most appropriate model. Requests that involve private data or require
 low latency stay local. Other requests can route outbound when the network allows.
@@ -100,7 +100,9 @@ Whatever brought you here, these are the fastest paths in.
 
 - **Get started**: [Suggested Hardware](./reference/hardware-requirements.md) •
   [Install the appliance](./how-to-guides/install-the-appliance.md) •
-  [Upload a model](./how-to-guides/upload-a-model.md) • [Deploy your first model](./how-to-guides/deploy-a-model.md)
+  [Upload a model](./how-to-guides/upload-a-model.md) •
+  [Bring your own model](./how-to-guides/bring-your-own-model.md) •
+  [Deploy your first model](./how-to-guides/deploy-a-model.md)
 - **Understand the product**: [Architecture](./explanation/architecture.md) •
   [Vision Preprocessing](./explanation/vision-preprocessing.md) •
   [Clients and Quotas](./explanation/clients-and-quotas.md) •

--- a/docs/products/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
+++ b/docs/products/paletteai-inference-launchpad/reference/certified-models-by-hardware.md
@@ -19,9 +19,9 @@ For what certification covers, refer to [Model Certification](../explanation/mod
 
 :::info
 
-This is not an exclusive list. You can load other models on the appliance as long as they fit within the available GPU
-resources. If the model you want does not appear here, [contact Spectro Cloud](https://www.spectrocloud.com/contact) to
-discuss your use case.
+This is not an exclusive list. You can bring your own model as long as it fits within the available GPU resources. Refer
+to [Bring Your Own Model](../how-to-guides/bring-your-own-model.md). If you want Spectro Cloud to certify a model for
+your hardware, [contact Spectro Cloud](https://www.spectrocloud.com/contact).
 
 :::
 

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -78,7 +78,8 @@ gateway continues to handle routing, [token metering](#token-metering), quota co
 
 A model that Spectro Cloud has validated to run correctly on the listed GPU configuration, based on its own testing
 rather than public benchmarks. Refer to [Model Certification](../explanation/model-certification.md) and
-[Certified Models by Hardware](./certified-models-by-hardware.md).
+[Certified Models by Hardware](./certified-models-by-hardware.md). To bring a model that is not certified, refer to
+[Bring Your Own Model](../how-to-guides/bring-your-own-model.md).
 
 ### Chargeback
 
@@ -297,8 +298,10 @@ collides with their own catalog.
 ### Model Metadata
 
 A small YAML file, `metadata.yaml`, one per model, that describes how the Palette CLI should fetch the model's weights
-from Hugging Face and upload them to the appliance. The metadata is downloaded from Artifact Studio, or from the
-`launchpad-ai` repository, alongside the ISO and content bundle.
+from Hugging Face and upload them to the appliance. For a [certified model](#certified-model), the metadata is
+downloaded from Artifact Studio. For a model you bring yourself, you author the file. Refer to
+[Bring Your Own Model](../how-to-guides/bring-your-own-model.md) and
+[Model Upload Reference](./model-upload-reference.md#model-metadata-file).
 
 ### Model Weights
 

--- a/docs/products/paletteai-inference-launchpad/reference/model-upload-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/model-upload-reference.md
@@ -11,7 +11,8 @@ keywords: ["launchpad", "ai", "palette cli", "model upload", "metadata", "huggin
 ---
 
 This reference lists the flags for the Palette CLI model commands and the fields of the model metadata file. It supports
-the [Upload a Model](../how-to-guides/upload-a-model.md) how-to, which walks through the download and upload flow.
+the [Upload a Model](../how-to-guides/upload-a-model.md) how-to and
+[Bring Your Own Model](../how-to-guides/bring-your-own-model.md).
 
 {/* NEEDS REVIEW: `palette content model download` and `palette content model upload` are a new command surface from the engineering source and are not yet in the published Palette CLI reference. Confirm the command names, flags, and defaults before publishing. */}
 
@@ -136,5 +137,7 @@ reconciling about every two minutes. In the deploy catalog, a model shows one of
 
 ## Resources
 
-- [Upload a Model](../how-to-guides/upload-a-model.md) walks through the download and upload flow.
+- [Upload a Model](../how-to-guides/upload-a-model.md) walks through the download and upload flow for a certified model.
+- [Bring Your Own Model](../how-to-guides/bring-your-own-model.md) authors metadata, then downloads, uploads, and
+  deploys a model that is not in the certified catalog.
 - [Deploy a Model](../how-to-guides/deploy-a-model.md) deploys an uploaded model and verifies it is serving.

--- a/docs/products/paletteai-inference-launchpad/reference/model-upload-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/model-upload-reference.md
@@ -55,19 +55,29 @@ contacts Hugging Face and fails if `--model-dir` is missing or incomplete; pass 
 
 ## Model Metadata File
 
-The metadata file is the operator's contract with the appliance. Only `name`, `version`, and `huggingface.repo` are
-required; everything else is optional. The parser rejects unknown top-level fields.
+The metadata file is the operator's contract with the appliance. The appliance enforces `name` and `version`. A file
+missing either one never reaches the deploy catalog. The appliance does not enforce `huggingface.repo`, but the download
+command has no source without it, so a working file sets all three. Every other field is optional.
 
-| **Field**              | **Description**                                                                                                                             | **Required** |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `name`                 | Model name. Sets the `<name>` path segment on the appliance.                                                                                | Yes          |
-| `version`              | Model version. Sets the `<version>` path segment on the appliance.                                                                          | Yes          |
-| `huggingface.repo`     | Source Hugging Face repository.                                                                                                             | Yes          |
-| `huggingface.files`    | One or more globs selecting which repository files to download. When omitted, every file is downloaded.                                     | No           |
-| `huggingface.revision` | Hugging Face revision (branch, tag, or commit). Defaults to `main`.                                                                         | No           |
-| `huggingface.logo`     | Path inside the Hugging Face repository to a logo image, downloaded alongside the weights.                                                  | No           |
-| `logo`                 | A logo bundled from local disk. Mutually exclusive with `huggingface.logo`.                                                                 | No           |
-| `launchpad`            | Optional gateway tuning block (engine, variants, and so on). The Palette CLI ships it to the appliance unchanged and does not interpret it. | No           |
+Unknown fields are ignored rather than rejected, so that a file written by a newer authoring tool still parses. A
+misspelled field name is therefore dropped without an error, and the model is served with the default that the field was
+meant to override.
+
+| **Field**                   | **Description**                                                                                                                                                                                                                    | **Required** |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `name`                      | Model name. Sets the `<name>` path segment on the appliance and the name the model appears under in the deploy catalog.                                                                                                            | Yes          |
+| `version`                   | Model version. Sets the `<version>` path segment on the appliance.                                                                                                                                                                 | Yes          |
+| `displayName`               | Human-readable model name for the console. Defaults to `name`.                                                                                                                                                                     | No           |
+| `description`               | Short description of the model, surfaced in the console.                                                                                                                                                                           | No           |
+| `author`                    | Publisher of the model, surfaced in the console.                                                                                                                                                                                   | No           |
+| `license`                   | License identifier for the model, surfaced in the console.                                                                                                                                                                         | No           |
+| `huggingface.repo`          | Source Hugging Face repository. The only source the download command reads.                                                                                                                                                        | Yes          |
+| `huggingface.files`         | One or more globs selecting which repository files to download. When omitted, every file is downloaded.                                                                                                                            | No           |
+| `huggingface.revision`      | Hugging Face revision (branch, tag, or commit). Defaults to `main`.                                                                                                                                                                | No           |
+| `huggingface.logo`          | Path inside the Hugging Face repository to a logo image, downloaded alongside the weights.                                                                                                                                         | No           |
+| `huggingface.file_manifest` | Generated list of the repository's files, sizes, and checksums at the pinned revision, which lets a staged copy be verified without network access. Generated, not hand-written.                                                   | No           |
+| `logo`                      | A logo bundled from local disk. Mutually exclusive with `huggingface.logo`.                                                                                                                                                        | No           |
+| `launchpad`                 | Serving recipe: engine, GPU requirements, per-hardware variants, and engine settings. The Palette CLI ships it to the appliance unchanged, and the appliance reads it to pick a variant for each node and to configure the engine. | No           |
 
 The following example downloads GLM 5.2 weights from a Hugging Face repository and includes a `launchpad` tuning block.
 
@@ -90,7 +100,7 @@ huggingface:
 
 # logo: ./local-logo.png # OR bundle a local file from disk (mutually exclusive with huggingface.logo)
 
-launchpad: # optional: gateway tuning block, shipped verbatim (the Palette CLI does not interpret it)
+launchpad: # optional: serving recipe, shipped verbatim by the Palette CLI
   engine: vllm
   min_engine_version: "0.23.0"
   variants:
@@ -104,6 +114,53 @@ launchpad: # optional: gateway tuning block, shipped verbatim (the Palette CLI d
 ```
 
 {/* NEEDS REVIEW: the GLM 5.2 example values (the zai-org/GLM-5.2 repository, file globs, and license) are representative. Confirm the canonical repository, weight files, and license with an SME before publishing. */}
+
+### The `launchpad` Block
+
+The `launchpad` block is the serving recipe. Fields set directly on the block are defaults, and each entry in `variants`
+overrides them for one hardware cell. When the block is absent, the appliance serves the model with the `vllm` engine
+and a floor of one GPU.
+
+| **Field**            | **Description**                                                                                                                                                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `engine`             | Inference engine that serves the model. Defaults to `vllm`.                                                                                                     |
+| `min_gpus`           | Minimum number of GPUs the model needs. This is a floor, not the width the model runs at. A node with fewer GPUs does not fit the variant.                      |
+| `widths`             | Tensor-parallel widths the deploy picker offers. When omitted, the picker offers `min_gpus` only.                                                               |
+| `vram_gb`            | Floor on per-GPU memory, in GB. Checked at deploy time against the memory the nodes advertise. A floor higher than the hardware provides blocks the deployment. |
+| `size_gb`            | Approximate on-disk size of the model, surfaced in the console.                                                                                                 |
+| `min_driver`         | Minimum GPU driver version. If no node advertises a driver version, the deployment is blocked rather than allowed through unverified.                           |
+| `min_engine_version` | Minimum version of the inference engine.                                                                                                                        |
+| `rationale`          | Prose explaining why these values were chosen, surfaced in the deploy picker.                                                                                   |
+| `serve`              | Engine settings for the cell. Refer to the following table.                                                                                                     |
+| `tools`              | The model's tool-calling, structured-output, and reasoning capabilities, which decide the parser flags the engine starts with.                                  |
+| `variants`           | List of per-hardware cells. Each entry accepts every field in this table, plus `vendor` and `gpu_product`.                                                      |
+
+Each entry in `variants` may additionally pin the hardware it applies to.
+
+| **Field**     | **Description**                                                                                                                                                                                                                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `vendor`      | GPU vendor the cell applies to, such as `nvidia` or `amd`. When unset, the cell applies to any vendor.                                                                                                                                                             |
+| `gpu_product` | GPU product label the cell applies to, matched against the node's own label by exact string match. Use the label value the node publishes, such as `NVIDIA-H200` or `AMD_Instinct_MI325_OAM`, not a marketing name. When unset, the cell applies to any GPU model. |
+
+The appliance detects each node's GPU vendor, product, count, and per-GPU memory, then selects the single variant that
+fits that node. It expects every node in the cluster to carry the same GPU model. A model that no variant fits still
+appears in the deploy catalog, marked as not deployable, with a reason naming what the variant needs against what the
+node has.
+
+The following `serve` fields are the ones a serving recipe most often sets.
+
+| **Field**              | **Description**                                                                                               |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `image`                | Container image the engine runs. Pin it by digest for a reproducible deployment.                              |
+| `tensor_parallel_size` | Number of GPUs the engine spreads the model across.                                                           |
+| `max_model_len`        | Maximum context length the engine serves. A longer context reserves more GPU memory for the key-value cache.  |
+| `gpu_memory_util`      | Fraction of each GPU's memory the engine may use.                                                             |
+| `quantization`         | Quantization the engine applies to the weights.                                                               |
+| `shm_size`             | Size of the shared-memory volume. Multi-GPU serving needs more than the Kubernetes default of 64 Mi.          |
+| `env`                  | Environment variables set on the engine.                                                                      |
+| `extra_args`           | Additional command-line arguments passed to the engine verbatim.                                              |
+| `probe`                | Health-probe budgets as durations: `startup_timeout`, `liveness_timeout`, `interval`, and `response_timeout`. |
+| `volumes`              | Additional volumes the engine mounts. Each entry sets `mount_path` and exactly one source.                    |
 
 After a successful upload, the model directory on the appliance node has the following layout.
 

--- a/docs/products/paletteai-inference-launchpad/release-notes.md
+++ b/docs/products/paletteai-inference-launchpad/release-notes.md
@@ -34,9 +34,10 @@ conceptual introduction, refer to [What is PaletteAI Inference Launchpad?](./pal
   information.
 
 - Certifies a focused set of LLMs for coding-assistant use, GLM 5.2, DeepSeek v4 Pro, Kimi 2.7, and Gemma 4, and lets
-  you load any other model that fits the available GPU memory. Refer to
-  [Certified Models by Hardware](./reference/certified-models-by-hardware.md) and
-  [Model Certification](./explanation/model-certification.md) for more information.
+  you bring your own model if it fits the available GPU memory. Refer to
+  [Certified Models by Hardware](./reference/certified-models-by-hardware.md),
+  [Model Certification](./explanation/model-certification.md), and
+  [Bring Your Own Model](./how-to-guides/bring-your-own-model.md) for more information.
 
 - Uploads models from the administrative workstation with the Palette CLI, which verifies checksums and supports
   resumable transfers. Refer to [Upload a Model](./how-to-guides/upload-a-model.md) for more information.


### PR DESCRIPTION
## Summary

Adds a **Bring Your Own Model** how-to so operators can put a model that is not in the certified catalog onto a
PaletteAI Inference Launchpad appliance, and reconciles the surrounding pages with it.

The guide is scoped to what only an uncertified model requires: authoring `metadata.yaml`, and in particular the
`launchpad` block that tells the appliance what the model needs to run. The download, upload, and deploy steps hand off
to **Upload a Model** and **Deploy a Model** rather than restating them.

---

- Jira: [AIL-479](https://spectrocloud.atlassian.net/browse/AIL-479) (parent epic
  [AIL-249](https://spectrocloud.atlassian.net/browse/AIL-249))
- Netlify deploy preview:
  [Bring Your Own Model](https://deploy-preview-11693--docs-spectrocloud.netlify.app/paletteai-inference-launchpad/how-to-guides/bring-your-own-model/)
  •
  [Model Certification](https://deploy-preview-11693--docs-spectrocloud.netlify.app/paletteai-inference-launchpad/explanation/model-certification/)
  •
  [Model Upload Reference](https://deploy-preview-11693--docs-spectrocloud.netlify.app/paletteai-inference-launchpad/reference/model-upload-reference/)

[AIL-479]: https://spectrocloud.atlassian.net/browse/AIL-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AIL-249]: https://spectrocloud.atlassian.net/browse/AIL-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ