### PR TITLE
AIL-565: Document external inference endpoints

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -75,7 +75,10 @@ place. The gateway does not restart, and it does not drain requests that are in 
 already routed continue on their assigned model, and the new default applies only to later requests.
 
 Before it routes a request, the gateway authenticates the calling client from its API token and enforces that client's
-quotas. For how clients, API tokens, and quotas work together, refer to [Clients and Quotas](./clients-and-quotas.md).
+quotas. When routing policy sends a request off the appliance, the gateway can reach a built-in frontier provider or a
+registered external inference endpoint. That traffic is metered as egress. For how clients, API tokens, and quotas work
+together, refer to [Clients and Quotas](./clients-and-quotas.md). To register a host, refer to
+[Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md).
 
 When vision preprocessing is on, a request that includes images is rewritten before that routing step. A vision model
 converts each image to text, and the text model then answers as it would for any other prompt. Text-only requests skip

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -103,8 +103,8 @@ cannot be changed after registration, and it cannot collide with a built-in fron
 client, which is why the client drawer shows `box-managed` in place of a per-client key for that row.
 
 Disabling or removing an endpoint takes effect immediately, and it is fail-safe: any routing rule that still points at
-that endpoint falls back to the appliance's local serving in flight rather than erroring. To register a host, refer to
-[Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md).
+that endpoint falls back to the appliance's local serving in flight rather than returning an error. To register a host,
+refer to [Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md).
 
 ## Network Topology
 

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -94,6 +94,18 @@ the current default stops serving, the appliance raises an incident on the **Ove
 so you can switch the default to a model that is currently serving. For that procedure, refer to
 [Switch the Default Model](../how-to-guides/set-the-default-model.md).
 
+### External Inference Endpoints {#external-inference-endpoints}
+
+An external inference endpoint is a box-wide OpenAI-compatible host that an operator registers so the gateway can route
+tier traffic to it as egress. Each endpoint carries a short **Endpoint id** that becomes the routing prefix. The id
+cannot be changed after registration, and it cannot collide with a built-in frontier provider (`anthropic`, `openai`,
+`gemini`); registration refuses a colliding id. The credential is stored once for the appliance and is never held per
+client, which is why the client drawer shows `box-managed` in place of a per-client key for that row.
+
+Disabling or removing an endpoint takes effect immediately, and it is fail-safe: any routing rule that still points at
+that endpoint falls back to the appliance's local serving in flight rather than erroring. To register a host, refer to
+[Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md).
+
 ## Network Topology
 
 ## Data Residency and Isolation

--- a/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
@@ -158,6 +158,12 @@ Access to models depends on whether a model runs locally on the appliance or is 
   registered endpoint, or model only when that provider, endpoint, or model is explicitly allowed for it. To register a
   host, refer to [Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md).
 
+### Sovereignty and Egress {#sovereignty-and-egress}
+
+Sovereignty is a separate switch that overrides every client's egress. When it is armed for the appliance, no request
+leaves the box regardless of any client's permission, and a client's egress chip reads **Blocked by sovereignty** until
+an operator disarms it under **Access & Policy → Sovereignty**.
+
 ## How It Fits Together
 
 A single request from a coding assistant ties these ideas together.

--- a/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
@@ -58,8 +58,9 @@ cannot:
   and plan accordingly.
 - **Contain credentials.** A token that a developer commits to a repository by mistake affects only its client. You
   revoke that one token without disrupting any other workload.
-- **Govern outbound reach.** When the appliance routes to external providers, you can control which clients may send
-  requests off the appliance. For example, you can allow only certain coding assistants to reach a paid frontier model.
+- **Govern outbound reach.** When the appliance routes to external providers, including built-in frontier providers and
+  registered external inference endpoints, you can control which clients may send requests off the appliance. For
+  example, you can allow only certain coding assistants to reach a paid frontier model or a registered host.
 
 Creating separate clients is not about distributing access for its own sake. It is how you keep a shared, finite
 appliance usable by many workloads at once.
@@ -152,9 +153,10 @@ Access to models depends on whether a model runs locally on the appliance or is 
 - **Local models.** Every client can call every model served locally on the appliance. The appliance does not restrict
   which local models a client may call. It meters and limits how much a client uses through quotas, but it does not gate
   access to any local model.
-- **External models.** If the appliance is configured to route to external providers, each client's reach is governed by
-  an allow-list that denies by default. A client can call an external provider or model only when that provider or model
-  is explicitly allowed for it.
+- **External models.** If the appliance is configured to route to external providers or registered inference endpoints,
+  each client's reach is governed by an allow-list that denies by default. A client can call an external provider,
+  registered endpoint, or model only when that provider, endpoint, or model is explicitly allowed for it. To register a
+  host, refer to [Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md).
 
 ## How It Fits Together
 
@@ -175,6 +177,8 @@ quotas, so it is ready to run on every request.
   token.
 - [Set and Manage Client Quotas](../how-to-guides/manage-client-quotas.md) walks through setting limits, turning
   enforcement on or off, and raising a ceiling.
+- [Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md) walks through
+  registering an OpenAI-compatible host and authorizing a client to use it.
 - [View Client Usage](../how-to-guides/view-client-usage.md) walks through **Quota Usage**, historical data windows, and
   per-client consumption.
 - [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md) walks through connecting a

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/create-a-client.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/create-a-client.md
@@ -37,9 +37,12 @@ grants model access, and optionally issues the client's first API token.
 4. _(Optional)_ On the **Quotas** step, add usage limits for the client, and then select **Next step**. For details,
    refer to [Set and Manage Client Quotas](./manage-client-quotas.md).
 
-5. _(Optional)_ On the **Egress** step, select **Enable egress** to let the client reach external, or frontier, models,
-   and then select **Next step**. External access is denied by default. To add a provider key and set a daily spend cap,
+5. _(Optional)_ On the **Egress** step, select **Enable egress** to let the client reach external models, including
+   built-in frontier providers and registered external inference endpoints, and then select **Next step**. External
+   access is denied by default. To add a provider key or authorize a registered endpoint, and to set a daily spend cap,
    refer to [Manage a Client's Model Access](./manage-client-model-access.md#allow-a-client-to-reach-external-models).
+   To register an endpoint first, refer to
+   [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md).
 
 6. _(Optional)_ On the **Routing** step, leave the **Tier map** unchanged to route the client with the appliance's
    default model routing, or edit the **Tier map** to route the client's model aliases to specific models. Then select
@@ -84,5 +87,6 @@ After you create a client, configure how much it can consume and which models it
 
 - [Set and Manage Client Quotas](./manage-client-quotas.md)
 - [Manage a Client's Model Access](./manage-client-model-access.md)
+- [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md)
 - [View Client Usage](./view-client-usage.md)
 - [Revoke or Delete a Client](./revoke-or-delete-a-client.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -13,25 +13,26 @@ you the steps to do it without teaching background concepts.
 
 ## Contents
 
-| **Guide**                                                           | **What you do**                                                                      |
-| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Install the Appliance](./install-the-appliance.md)                 | Flash the installer ISO, boot the hardware, and bring up the appliance console.      |
-| [Manage Cluster Infrastructure](./manage-cluster-infrastructure.md) | Index the Local UI tasks for day-two cluster infrastructure operations.              |
-| [Upgrade the Platform](./upgrade-the-platform.md)                   | Upload a newer content bundle from Artifact Studio and apply **Update** in Local UI. |
-| [Deploy a Model](./deploy-a-model.md)                               | Deploy an LLM, choose which nodes run it, and verify it is serving.                  |
-| [Replace a Model](./replace-a-model.md)                             | Remove a model from a node, then deploy a newer version or a different model.        |
-| [Upload a Model](./upload-a-model.md)                               | Download a model on a jumpbox and upload it to the appliance.                        |
-| [Bring Your Own Model](./bring-your-own-model.md)                   | Author metadata for a model that is not certified, then upload and deploy it.        |
-| [Switch the Default Model](./set-the-default-model.md)              | Switch the default model when the current default becomes unavailable.               |
-| [Enable Vision Preprocessing](./enable-vision-preprocessing.md)     | Deploy a vision model and turn on image-to-text preprocessing for a text-only model. |
-| [Create a Client](./create-a-client.md)                             | Create a client and issue its first API token.                                       |
-| [Generate an API Token](./generate-an-api-token.md)                 | Create an API token that clients use to authenticate to the appliance.               |
-| [Set and Manage Client Quotas](./manage-client-quotas.md)           | Set, edit, raise, and remove a client's request, token, and cost limits.             |
-| [Manage a Client's Model Access](./manage-client-model-access.md)   | Route a client to models and allow it to reach external models.                      |
-| [View Token Usage](./view-token-usage.md)                           | Find token usage by model and by client, and open the metrics dashboards.            |
-| [View Client Usage](./view-client-usage.md)                         | View quota utilization, historical consumption, and per-token usage.                 |
-| [Revoke or Delete a Client](./revoke-or-delete-a-client.md)         | Find expired keys, revoke a token, or delete a client.                               |
-| [Use Claude Code](./use-claude-code.md)                             | Connect Claude Code to the appliance so a local model serves each request.           |
-| [Use Cursor](./use-cursor.md)                                       | Connect Cursor's Ask mode to the appliance through a uniquely named model alias.     |
-| [Use OpenAI Codex](./use-codex.md)                                  | Connect the OpenAI Codex CLI to the appliance with a custom model provider.          |
-| [Use OpenCode](./use-opencode.md)                                   | Connect the OpenCode terminal agent to the appliance through a custom provider.      |
+| **Guide**                                                                               | **What you do**                                                                      |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Install the Appliance](./install-the-appliance.md)                                     | Flash the installer ISO, boot the hardware, and bring up the appliance console.      |
+| [Manage Cluster Infrastructure](./manage-cluster-infrastructure.md)                     | Index the Local UI tasks for day-two cluster infrastructure operations.              |
+| [Upgrade the Platform](./upgrade-the-platform.md)                                       | Upload a newer content bundle from Artifact Studio and apply **Update** in Local UI. |
+| [Deploy a Model](./deploy-a-model.md)                                                   | Deploy an LLM, choose which nodes run it, and verify it is serving.                  |
+| [Replace a Model](./replace-a-model.md)                                                 | Remove a model from a node, then deploy a newer version or a different model.        |
+| [Upload a Model](./upload-a-model.md)                                                   | Download a model on a jumpbox and upload it to the appliance.                        |
+| [Bring Your Own Model](./bring-your-own-model.md)                                       | Author metadata for a model that is not certified, then upload and deploy it.        |
+| [Switch the Default Model](./set-the-default-model.md)                                  | Switch the default model when the current default becomes unavailable.               |
+| [Enable Vision Preprocessing](./enable-vision-preprocessing.md)                         | Deploy a vision model and turn on image-to-text preprocessing for a text-only model. |
+| [Create a Client](./create-a-client.md)                                                 | Create a client and issue its first API token.                                       |
+| [Generate an API Token](./generate-an-api-token.md)                                     | Create an API token that clients use to authenticate to the appliance.               |
+| [Set and Manage Client Quotas](./manage-client-quotas.md)                               | Set, edit, raise, and remove a client's request, token, and cost limits.             |
+| [Manage a Client's Model Access](./manage-client-model-access.md)                       | Route a client to models and allow it to reach external models.                      |
+| [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md) | Register an OpenAI-compatible host, authorize a client, and route to its models.     |
+| [View Token Usage](./view-token-usage.md)                                               | Find token usage by model and by client, and open the metrics dashboards.            |
+| [View Client Usage](./view-client-usage.md)                                             | View quota utilization, historical consumption, and per-token usage.                 |
+| [Revoke or Delete a Client](./revoke-or-delete-a-client.md)                             | Find expired keys, revoke a token, or delete a client.                               |
+| [Use Claude Code](./use-claude-code.md)                                                 | Connect Claude Code to the appliance so a local model serves each request.           |
+| [Use Cursor](./use-cursor.md)                                                           | Connect Cursor's Ask mode to the appliance through a uniquely named model alias.     |
+| [Use OpenAI Codex](./use-codex.md)                                                      | Connect the OpenAI Codex CLI to the appliance with a custom model provider.          |
+| [Use OpenCode](./use-opencode.md)                                                       | Connect the OpenCode terminal agent to the appliance through a custom provider.      |

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
@@ -17,8 +17,10 @@ provider.
 - **Local models.** Every client with a valid API token can call every model served locally on the appliance. You do not
   grant access to local models. To choose which local model handles a client's requests, route the client with a tier
   map.
-- **External models.** A new client cannot reach external, or frontier, models until you enable egress for it. External
-  access is denied by default and is granted per client.
+- **External models.** A new client cannot reach external models until you enable egress for it. External access is
+  denied by default and is granted per client. External models include built-in frontier providers and hosts you
+  register as external inference endpoints. Refer to
+  [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md).
 
 To understand how clients and models relate, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
 
@@ -27,7 +29,9 @@ To understand how clients and models relate, refer to [Clients and Quotas](../ex
 - A running PaletteAI Inference Launchpad appliance, with the console reachable.
 - An existing client. To create one, refer to [Create a Client](./create-a-client.md).
 - Console access with permission to manage clients. Managing clients can require operator access.
-- _(External models only)_ A provider key for the external provider.
+- _(External models only)_ For a built-in frontier provider, a provider key. For a registered endpoint, the endpoint
+  already registered. Refer to
+  [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md).
 
 ## Route a Client to Specific Models
 
@@ -41,7 +45,9 @@ Use a client's tier map to route the client's model aliases to the models you ch
 
 4. In the **Tier map**, select **Add alias rule**, or edit an existing row.
 
-5. Set the **Alias prefix**, such as `claude-opus-`, and the **Model** it routes to.
+5. Set the **Alias prefix**, such as `claude-opus-`, and the **Model** it routes to. Local models, frontier targets, and
+   models from a registered external inference endpoint appear in the picker. Endpoint models are listed as
+   `<id> / <model>`.
 
 6. Save the client.
 
@@ -54,6 +60,8 @@ routed to that model unless you configure their tier maps as well.
 
 ## Allow a Client to Reach External Models
 
+Enable egress, then add each provider or registered endpoint the client may use.
+
 1. From the left main menu, select **Access & Policy**.
 
 2. On the **Clients & API tokens** page, select the client to open its detail panel.
@@ -62,20 +70,24 @@ routed to that model unless you configure their tier maps as well.
 
 4. Select **Enable egress**.
 
-5. Add a provider key for the external provider.
+5. Select **Add provider key**.
 
-6. Set a daily spend cap for the client. Egress is fail-closed on the cap, so a cap of `0` blocks egress.
+6. In **Provider**, select a built-in frontier provider or a registered endpoint id.
 
-7. _(Optional)_ List the provider models the client may reach. Leave the list empty to allow every model from that
-   provider.
+   - For a frontier provider, enter the provider key.
+   - For a registered endpoint, the **Key** field is hidden. The credential was set when you registered the endpoint,
+     and the table shows **box-managed**. To register an endpoint first, refer to
+     [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md).
 
-8. Save the client.
+7. Set a positive **Daily limit**, and then select **Save**. Egress is fail-closed on the cap, so a limit of `$0` blocks
+   that provider or endpoint for the client, and the table shows **$0 blocked**.
 
 Frontier-model bursting is configured separately and is out of scope for this guide.
 {/* TODO: link to the frontier-model bursting guide once published. */}
 
 ## Next Steps
 
+- [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md)
 - [Set and Manage Client Quotas](./manage-client-quotas.md)
 - [View Client Usage](./view-client-usage.md)
 - [Replace a Model](./replace-a-model.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
@@ -30,8 +30,7 @@ To understand how clients and models relate, refer to [Clients and Quotas](../ex
 - An existing client. To create one, refer to [Create a Client](./create-a-client.md).
 - Console access with permission to manage clients. Managing clients can require operator access.
 - _(External models only)_ For a built-in frontier provider, a provider key. For a registered endpoint, the endpoint
-  already registered. Refer to
-  [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md).
+  already registered. Refer to [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md).
 
 ## Route a Client to Specific Models
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/register-an-external-inference-endpoint.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/register-an-external-inference-endpoint.md
@@ -1,0 +1,86 @@
+---
+sidebar_label: "Register an External Inference Endpoint"
+title: "Register an External Inference Endpoint"
+description:
+  "Step-by-step guidance for platform operators on how to register an OpenAI-compatible external inference endpoint,
+  authorize a client to use it, and route requests to its models."
+hide_table_of_contents: false
+sidebar_position: 6.5
+tags: ["paletteai-inference-launchpad", "models", "how-to"]
+keywords: ["launchpad", "ai", "external", "inference", "endpoint", "egress", "integrations", "openrouter"]
+---
+
+This guide explains how to register an OpenAI-compatible inference host and route client requests to it through the
+PaletteAI Inference Launchpad gateway. The host can be a hosted router, a partner API, a second appliance, or an
+in-house inference server. Traffic to a registered endpoint is egress, the same as traffic to a built-in frontier
+provider.
+
+The credential is stored once for the appliance. You do not enter it again per client. Built-in frontier providers
+(Anthropic, OpenAI, and Gemini) still use a per-client key. Registering an endpoint does not replace those providers.
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
+- The endpoint's URL, reachable from the appliance, and a key if the host requires one.
+- An existing client to authorize. To create one, refer to [Create a Client](./create-a-client.md).
+
+## Register the Endpoint
+
+1. From the left main menu, select **Integrations**.
+
+2. In **External inference endpoints**, enter an **Endpoint id**, the **Endpoint URL**, and the **Key** if the host
+   requires one. Enter the origin only, such as `https://host.example.com`. The id is a short name that later appears in
+   the model picker. Do not use `anthropic`, `openai`, or `gemini`; registration refuses those ids.
+
+3. _(Optional)_ Enter **Input $/1M tokens** and **Output $/1M tokens** so usage is priced at the rates you set. If you
+   leave them blank, the appliance applies a generic rate.
+
+4. Select **Probe models**. The appliance contacts the host and lists the models it serves. A bad key or an unreachable
+   host reports the failure and stores nothing.
+
+5. Review **Discovered models**, then select **Add endpoint**. Review the preview, and then select **Confirm & apply**.
+
+The list shows the endpoint as **enabled**, with its URL, model count, and a **key set** indicator when a key is stored.
+The key is never shown again.
+
+To stop routing to the endpoint without deleting it, select **Disable**. To remove it, select **Remove**. Either change
+takes effect immediately. A rule that still points at that endpoint falls back to a local model instead of failing.
+
+## Authorize a Client
+
+1. From the left main menu, select **Access & Policy**.
+
+2. On the **Clients & API tokens** page, select the client to open its detail panel.
+
+3. Select the **Egress** section, and then select **Enable egress**.
+
+4. Select **Add provider key**.
+
+5. In **Provider**, select the endpoint id you registered. The **Key** field is hidden because the credential was set at
+   registration. The **Key** column later shows **box-managed**.
+
+6. Set a positive **Daily limit**, and then select **Save**. A limit of `$0` blocks the client from that endpoint, and
+   the table shows **$0 blocked**.
+
+Repeat for each client that should reach the endpoint. Refer to
+[Allow a Client to Reach External Models](./manage-client-model-access.md#allow-a-client-to-reach-external-models).
+
+## Route Requests to the Endpoint
+
+1. Open the client's **Routing** section.
+
+2. In the **Tier map**, select **Add alias rule**, or edit an existing row.
+
+3. Set the **Alias prefix**, then open **Model**. Registered endpoint models appear as `<id> / <model>` alongside local
+   models and frontier targets. Select the model you want.
+
+4. Save the client.
+
+Requests that match that alias go to the registered host and are counted as egress. Refer to
+[View Client Usage](./view-client-usage.md).
+
+## Next Steps
+
+- [Manage a Client's Model Access](./manage-client-model-access.md)
+- [View Client Usage](./view-client-usage.md)
+- [Create a Client](./create-a-client.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/register-an-external-inference-endpoint.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/register-an-external-inference-endpoint.md
@@ -5,32 +5,33 @@ description:
   "Step-by-step guidance for platform operators on how to register an OpenAI-compatible external inference endpoint,
   authorize a client to use it, and route requests to its models."
 hide_table_of_contents: false
-sidebar_position: 6.5
+sidebar_position: 6.3
 tags: ["paletteai-inference-launchpad", "models", "how-to"]
 keywords: ["launchpad", "ai", "external", "inference", "endpoint", "egress", "integrations", "openrouter"]
 ---
 
-This guide explains how to register an OpenAI-compatible inference host and route client requests to it through the
-PaletteAI Inference Launchpad gateway. The host can be a hosted router, a partner API, a second appliance, or an
-in-house inference server. Traffic to a registered endpoint is egress, the same as traffic to a built-in frontier
-provider.
-
-The credential is stored once for the appliance. You do not enter it again per client. Built-in frontier providers
-(Anthropic, OpenAI, and Gemini) still use a per-client key. Registering an endpoint does not replace those providers.
+This guide explains how to register an OpenAI-compatible inference host as an external inference endpoint on a PaletteAI
+Inference Launchpad appliance, authorize a client to use it, and route the client's requests to a model the host serves.
+To understand how registered endpoints relate to built-in frontier providers and how the appliance meters their traffic
+together as egress, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
 
 ## Prerequisites
 
 - A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
 - The endpoint's URL, reachable from the appliance, and a key if the host requires one.
 - An existing client to authorize. To create one, refer to [Create a Client](./create-a-client.md).
+- Egress permitted for the appliance. Box sovereignty overrides every client's egress setting. When sovereignty is
+  armed, no request leaves the appliance, and a client's chip reads **Blocked by sovereignty**. To check or disarm it,
+  open **Access & Policy → Sovereignty**.
 
 ## Register the Endpoint
 
 1. From the left main menu, select **Integrations**.
 
-2. In **External inference endpoints**, enter an **Endpoint id**, the **Endpoint URL**, and the **Key** if the host
-   requires one. Enter the origin only, such as `https://host.example.com`. The id is a short name that later appears in
-   the model picker. Do not use `anthropic`, `openai`, or `gemini`; registration refuses those ids.
+2. In **External inference endpoints**, under **Add an endpoint**, enter an **Endpoint id**, the **Endpoint URL**, and
+   the **Key** if the host requires one. Enter the origin only, such as `https://host.example.com`. The id is a short
+   name that becomes the routing prefix. It cannot be changed later, and it must not be `anthropic`, `openai`, or
+   `gemini`; registration refuses those ids.
 
 3. _(Optional)_ Enter **Input $/1M tokens** and **Output $/1M tokens** so usage is priced at the rates you set. If you
    leave them blank, the appliance applies a generic rate.
@@ -54,10 +55,14 @@ takes effect immediately. A rule that still points at that endpoint falls back t
 
 3. Select the **Egress** section, and then select **Enable egress**.
 
-4. Select **Add provider key**.
+4. Select **Add provider key**. The **Add provider key** dialog opens.
 
-5. In **Provider**, select the endpoint id you registered. The **Key** field is hidden because the credential was set at
-   registration. The **Key** column later shows **box-managed**.
+5. In **Provider**, select the endpoint id you registered. Registered endpoint ids appear alongside `anthropic`,
+   `openai`, and `gemini`. The **Key** field is hidden, and the dialog reads:
+
+   > This endpoint's key is set once at registration and shared by every client.
+
+   The credential is box-global. On the **Egress** table, the **Key** column shows **box-managed** for the row.
 
 6. Set a positive **Daily limit**, and then select **Save**. A limit of `$0` blocks the client from that endpoint, and
    the table shows **$0 blocked**.
@@ -76,8 +81,19 @@ Repeat for each client that should reach the endpoint. Refer to
 
 4. Save the client.
 
-Requests that match that alias go to the registered host and are counted as egress. Refer to
-[View Client Usage](./view-client-usage.md).
+Requests that match that alias go to the registered host and are counted as egress.
+
+## Validate the Endpoint
+
+Send a request through the appliance that matches an alias rule you just routed to the endpoint, then confirm the
+appliance metered it as egress from that endpoint.
+
+1. From a client with a valid API token, call the alias you routed to the endpoint.
+
+2. From the left main menu, select **Usage**.
+
+3. Select the **By Model** tab. A row served by a registered endpoint is labeled **External · egress**. To review a
+   single client's split of local versus egress traffic, refer to [View Client Usage](./view-client-usage.md).
 
 ## Next Steps
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/register-an-external-inference-endpoint.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/register-an-external-inference-endpoint.md
@@ -20,18 +20,17 @@ together as egress, refer to [Clients and Quotas](../explanation/clients-and-quo
 - A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
 - The endpoint's URL, reachable from the appliance, and a key if the host requires one.
 - An existing client to authorize. To create one, refer to [Create a Client](./create-a-client.md).
-- Egress permitted for the appliance. Box sovereignty overrides every client's egress setting. When sovereignty is
-  armed, no request leaves the appliance, and a client's chip reads **Blocked by sovereignty**. To check or disarm it,
-  open **Access & Policy → Sovereignty**.
+- Egress permitted for the appliance. Sovereignty must not be armed. To check or disarm it, refer to
+  [Sovereignty and Egress](../explanation/clients-and-quotas.md#sovereignty-and-egress).
 
 ## Register the Endpoint
 
 1. From the left main menu, select **Integrations**.
 
 2. In **External inference endpoints**, under **Add an endpoint**, enter an **Endpoint id**, the **Endpoint URL**, and
-   the **Key** if the host requires one. Enter the origin only, such as `https://host.example.com`. The id is a short
-   name that becomes the routing prefix. It cannot be changed later, and it must not be `anthropic`, `openai`, or
-   `gemini`; registration refuses those ids.
+   the **Key** if the host requires one. Enter the origin only, such as `https://host.example.com`. For the id's
+   constraints and role, refer to
+   [External Inference Endpoints](../explanation/architecture.md#external-inference-endpoints).
 
 3. _(Optional)_ Enter **Input $/1M tokens** and **Output $/1M tokens** so usage is priced at the rates you set. If you
    leave them blank, the appliance applies a generic rate.
@@ -41,11 +40,12 @@ together as egress, refer to [Clients and Quotas](../explanation/clients-and-quo
 
 5. Review **Discovered models**, then select **Add endpoint**. Review the preview, and then select **Confirm & apply**.
 
-The list shows the endpoint as **enabled**, with its URL, model count, and a **key set** indicator when a key is stored.
-The key is never shown again.
+6. Confirm the endpoint appears in the list with an **enabled** chip, its URL, its model count, and a **key set** or
+   **no key** indicator on its row.
 
-To stop routing to the endpoint without deleting it, select **Disable**. To remove it, select **Remove**. Either change
-takes effect immediately. A rule that still points at that endpoint falls back to a local model instead of failing.
+To stop routing to the endpoint without deleting it, select **Disable**. To delete it, select **Remove**. For the
+fail-safe behavior that catches a routing rule still pointing at a disabled or removed endpoint, refer to
+[External Inference Endpoints](../explanation/architecture.md#external-inference-endpoints).
 
 ## Authorize a Client
 
@@ -57,12 +57,9 @@ takes effect immediately. A rule that still points at that endpoint falls back t
 
 4. Select **Add provider key**. The **Add provider key** dialog opens.
 
-5. In **Provider**, select the endpoint id you registered. Registered endpoint ids appear alongside `anthropic`,
-   `openai`, and `gemini`. The **Key** field is hidden, and the dialog reads:
-
-   > This endpoint's key is set once at registration and shared by every client.
-
-   The credential is box-global. On the **Egress** table, the **Key** column shows **box-managed** for the row.
+5. In **Provider**, select the endpoint id you registered. The dialog hides the **Key** field for a registered endpoint
+   and shows a **box-managed** chip on the row instead. For why, refer to
+   [External Inference Endpoints](../explanation/architecture.md#external-inference-endpoints).
 
 6. Set a positive **Daily limit**, and then select **Save**. A limit of `$0` blocks the client from that endpoint, and
    the table shows **$0 blocked**.
@@ -92,8 +89,8 @@ appliance metered it as egress from that endpoint.
 
 2. From the left main menu, select **Usage**.
 
-3. Select the **By Model** tab. A row served by a registered endpoint is labeled **External · egress**. To review a
-   single client's split of local versus egress traffic, refer to [View Client Usage](./view-client-usage.md).
+3. Select the **By Model** tab and find the row labeled **External · egress**. For the field it uses and the per-client
+   split, refer to [Usage Metrics Reference: By Model Tab](../reference/usage-metrics-reference.md#by-model-tab).
 
 ## Next Steps
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
@@ -84,6 +84,11 @@ on the client detail view, refer to
 
 4. Select a client to open its API keys, per-token consumption, and the models that handled its requests.
 
+The **By Client** columns split each metric into **Local / Egress Requests**, **Local / Egress Tokens**, and **$ Cost
+Local / Egress**. **Egress** covers traffic to built-in frontier providers and to registered external inference
+endpoints together. The tab does not split those two sources. To see which registered endpoint served a request, select
+the **By Model** tab; a row served by a registered endpoint is labeled **External · egress**.
+
 ## Further Reading
 
 - [View Token Usage](./view-token-usage.md) covers the **Overview** and **By Model** tabs, appliance-wide totals, top
@@ -94,4 +99,5 @@ on the client detail view, refer to
 ## Next Steps
 
 - [Set and Manage Client Quotas](./manage-client-quotas.md)
+- [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md)
 - [Revoke or Delete a Client](./revoke-or-delete-a-client.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
@@ -84,11 +84,6 @@ on the client detail view, refer to
 
 4. Select a client to open its API keys, per-token consumption, and the models that handled its requests.
 
-The **By Client** columns split each metric into **Local / Egress Requests**, **Local / Egress Tokens**, and **$ Cost
-Local / Egress**. **Egress** covers traffic to built-in frontier providers and to registered external inference
-endpoints together. The tab does not split those two sources. To see which registered endpoint served a request, select
-the **By Model** tab; a row served by a registered endpoint is labeled **External · egress**.
-
 ## Further Reading
 
 - [View Token Usage](./view-token-usage.md) covers the **Overview** and **By Model** tabs, appliance-wide totals, top

--- a/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -114,6 +114,7 @@ Whatever brought you here, these are the fastest paths in.
   [Replace a model](./how-to-guides/replace-a-model.md) •
   [Enable vision preprocessing](./how-to-guides/enable-vision-preprocessing.md) •
   [Create a client](./how-to-guides/create-a-client.md) • [Set client quotas](./how-to-guides/manage-client-quotas.md) •
+  [Register an external inference endpoint](./how-to-guides/register-an-external-inference-endpoint.md) •
   [View client usage](./how-to-guides/view-client-usage.md) •
   [Revoke or delete a client](./how-to-guides/revoke-or-delete-a-client.md)
 - **Look something up**: [Glossary](./reference/glossary.md) •

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -138,9 +138,10 @@ The model the appliance routes a request to when the request does not name a spe
 
 ### Egress
 
-A client's ability to send requests off the appliance to an [external, or frontier, model](#frontier-model). Egress
-denies by default: a new client cannot reach external providers until an operator enables it. Refer to
-[Manage Client Model Access](../how-to-guides/manage-client-model-access.md).
+A client's ability to send requests off the appliance to an [external, or frontier, model](#frontier-model) or to a
+registered [external inference endpoint](#external-inference-endpoint). Egress denies by default: a new client cannot
+reach external providers or registered endpoints until an operator enables it. Usage labels this combined traffic
+**Egress**. Refer to [Manage Client Model Access](../how-to-guides/manage-client-model-access.md).
 
 ### Embedding
 
@@ -152,6 +153,13 @@ inputs by meaning rather than by exact wording. The appliance uses embeddings in
 
 The network location, expressed as a URL path, at which the appliance exposes a served model or an API. Each loaded
 model is exposed as an [OpenAI-compatible endpoint](#openai-compatible-api) at paths such as `/v1/chat/completions`.
+
+### External Inference Endpoint
+
+An OpenAI-compatible inference host registered on the appliance as an appliance-wide [egress](#egress) target. The host
+can be a hosted router, a partner API, a second appliance, or an in-house inference server. After you register it, its
+models appear in a client's routing picker, and traffic to it is metered as egress. Refer to
+[Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md).
 
 ## F
 

--- a/docs/products/paletteai-inference-launchpad/reference/usage-metrics-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/usage-metrics-reference.md
@@ -140,8 +140,8 @@ One row per registered client. Selecting a row opens the client's API tokens.
 
 Local and external figures are paired rather than summed, because a local quota and an external spend cap are separate
 budgets. Hold the pointer over a paired cell to display which figure is which. **Egress** covers traffic to built-in
-frontier providers and to registered external inference endpoints together. To see which registered endpoint served a
-request, open the **By Model** tab and look for the **External · egress** label.
+frontier providers and to registered external inference endpoints together. To identify which registered endpoint served
+a request, open the **By Model** tab and look for the **External · egress** label.
 
 The columns on this tab do not sort. To rank clients, export the table and sort it in a spreadsheet.
 

--- a/docs/products/paletteai-inference-launchpad/reference/usage-metrics-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/usage-metrics-reference.md
@@ -109,6 +109,9 @@ One row per model that the appliance knows about. Selecting a row opens the clie
 
 A model that served no requests in the period renders dimmed, with `—` in place of its figures.
 
+A row served by a registered external inference endpoint is labeled **External · egress** in the **Location** column,
+alongside rows for built-in frontier providers. The tab does not split those two sources further.
+
 ### Model Detail View
 
 | **Column**       | **Definition**                                            |
@@ -136,7 +139,9 @@ One row per registered client. Selecting a row opens the client's API tokens.
 | **$ Savings**               | The estimated amount avoided by serving on the appliance instead of a benchmark external model.                      |
 
 Local and external figures are paired rather than summed, because a local quota and an external spend cap are separate
-budgets. Hold the pointer over a paired cell to display which figure is which.
+budgets. Hold the pointer over a paired cell to display which figure is which. **Egress** covers traffic to built-in
+frontier providers and to registered external inference endpoints together. To see which registered endpoint served a
+request, open the **By Model** tab and look for the **External · egress** label.
 
 The columns on this tab do not sort. To rank clients, export the table and sort it in a spreadsheet.
 

--- a/docs/products/paletteai-inference-launchpad/release-notes.md
+++ b/docs/products/paletteai-inference-launchpad/release-notes.md
@@ -8,6 +8,15 @@ tags: ["paletteai-inference-launchpad", "release-notes"]
 keywords: ["launchpad", "ai", "release notes", "changelog"]
 ---
 
+## Version 1.1.0 {#version-1-1-0}
+
+### Features
+
+- Register any OpenAI-compatible inference host as a box-wide egress target, then authorize each client and cap its
+  daily spend. Traffic to a registered endpoint is metered as egress. Refer to
+  [Register an External Inference Endpoint](./how-to-guides/register-an-external-inference-endpoint.md) for more
+  information.
+
 ## Version 1.0.0 - July 21, 2026 {#version-1-0-0}
 
 PaletteAI Inference Launchpad 1.0.0 is the first release. It is a standalone, turnkey AI appliance that turns your own


### PR DESCRIPTION
## Summary
- Adds **Register an External Inference Endpoint** so operators can register an OpenAI-compatible host, authorize a client, and route to its models from the console ([AIL-565](https://spectrocloud.atlassian.net/browse/AIL-565), parent [AIL-552](https://spectrocloud.atlassian.net/browse/AIL-552)).
- Distinguishes built-in frontier per-client keys from registered endpoints, whose credential is appliance-wide and shows as **box-managed**.
- Updates client access, usage, architecture, glossary, the landing page, and the 1.0.0 release notes so egress includes registered endpoints as well as frontier providers.

Closes [AIL-565](https://spectrocloud.atlassian.net/browse/AIL-565).

## Test plan
- [ ] Preview **Register an External Inference Endpoint**. Confirm register → probe → add → authorize → route, with no screenshots.
- [ ] Confirm **Integrations** field names: **Endpoint id**, **Endpoint URL**, **Key**, **Input $/1M tokens**, **Output $/1M tokens**, **Probe models**, **Discovered models**, **Add endpoint**, **Confirm & apply**.
- [ ] Confirm reserved ids `anthropic`, `openai`, and `gemini` are refused, and that Disable or Remove falls back to a local model.
- [ ] Confirm **Access & Policy** → **Egress**: **Enable egress**, **Add provider key**, hidden **Key** for a registered id, **box-managed**, positive **Daily limit**, and **$0 blocked**.
- [ ] Confirm the tier-map picker lists registered models as `<id> / <model>`, and that usage labels the combined bucket **Egress** (no frontier-vs-external split).
- [ ] Confirm the pages describe console behavior only: no GitHub, admin API, or implementation identifiers.


Made with [Cursor](https://cursor.com)

[AIL-565]: https://spectrocloud.atlassian.net/browse/AIL-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIL-552]: https://spectrocloud.atlassian.net/browse/AIL-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIL-565]: https://spectrocloud.atlassian.net/browse/AIL-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ