### PR TITLE
updating makefile to fix broken url checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,6 @@ CHANGED_FILES=$(shell \
 
 TEMP_DIR=$(shell $TMPDIR)
 
-CPUS := $(shell sysctl -n hw.ncpu | awk '{print int($$1 / 2)}')
-
 ALOGLIA_CONFIG=$(shell cat docsearch.dev.config.json | jq -r tostring)
 
 # Find all *.md files in docs, cut the prefix ./ 
@@ -298,23 +296,36 @@ pdf-local: ## Generate PDF from local docs
 
 verify-url-links:
 	@echo "Checking for broken external URLs in markdown files..."
-	rm link_report.csv || echo "No report exists. Proceeding to scan step"
-	@npx linkinator $(VERIFY_URL_PATHS) --config ./linkinator/linkinator.config.json > temp_report.csv && sleep 2
-	@grep -E 'https?://' temp_report.csv > filtered_report.csv
-	@grep -E ',[[:space:]]*([4-9][0-9]{2}|[0-9]{4,}),' filtered_report.csv > link_report.csv && rm temp_report.csv filtered_report.csv
+	@rm -f link_report.csv
+	@# linkinator exits 1 when it finds broken links, which is the outcome this target
+	@# exists to capture. Tolerate it, then fail below if no report was produced at all.
+	@npx linkinator $(VERIFY_URL_PATHS) --config ./linkinator/linkinator.config.json > temp_report.csv || true
+	@sleep 2
+	@test -s temp_report.csv || { echo "linkinator produced no output"; exit 1; }
+	@# grep exits 1 when it matches nothing, which here just means "no broken links".
+	@grep -E 'https?://' temp_report.csv > filtered_report.csv || true
+	@grep -E ',[[:space:]]*([4-9][0-9]{2}|[0-9]{4,}),' filtered_report.csv > link_report.csv || true
+	@rm -f temp_report.csv filtered_report.csv
 
 verify-rate-limited-links:
 	@echo "Checking for broken URLs in security-bulletins and oss-licenses markdown files..."
-	@rm link_rate_limit_report.csv || echo "No rate limited report exists. Proceeding to scan step"
+	@rm -f link_rate_limit_report.csv
 	@echo "Checking the following paths: $(RATE_LIMITED_FILES_LIST)"
-	@npx linkinator $(RATE_LIMITED_FILES_LIST) --config ./linkinator/linkinator-rate-limit.config.json  > temp_rate_limit_report.csv && sleep 2
-	@grep -E 'https?://' temp_rate_limit_report.csv > filtered_rate_limit_report.csv
-	@grep -E ',[[:space:]]*([4-9][0-9]{2}|[0-9]{4,}),' filtered_rate_limit_report.csv > link_rate_limit_report.csv && rm temp_rate_limit_report.csv filtered_rate_limit_report.csv
+	@npx linkinator $(RATE_LIMITED_FILES_LIST) --config ./linkinator/linkinator-rate-limit.config.json  > temp_rate_limit_report.csv || true
+	@sleep 2
+	@test -s temp_rate_limit_report.csv || { echo "linkinator produced no output"; exit 1; }
+	@grep -E 'https?://' temp_rate_limit_report.csv > filtered_rate_limit_report.csv || true
+	@grep -E ',[[:space:]]*([4-9][0-9]{2}|[0-9]{4,}),' filtered_rate_limit_report.csv > link_rate_limit_report.csv || true
+	@rm -f temp_rate_limit_report.csv filtered_rate_limit_report.csv
 
 verify-url-links-ci: ## Check for broken URLs in production in a GitHub Actions CI environment
 	@echo "Checking for broken external URLs in CI environment..."
-	@rm link_report.json || echo "No report exists. Proceeding to scan step"
-	@npx linkinator $(VERIFY_URL_PATHS) --config ./linkinator/linkinator-ci.config.json  > temp_report.json
+	@rm -f scripts/link_report.json
+	@# linkinator exits 1 when it finds broken links, which is the outcome this target
+	@# exists to capture. Tolerate it, then fail below if the report is unusable, so a
+	@# genuine linkinator failure is still loud.
+	@npx linkinator $(VERIFY_URL_PATHS) --config ./linkinator/linkinator-ci.config.json  > temp_report.json || true
+	@jq -e 'has("links")' temp_report.json > /dev/null || { echo "linkinator produced no usable report"; exit 1; }
 	@# Use jq to filter out links that do not start with http or https and keep only broken links
 	@jq '[.links[] | select(.url | test("^https?://")) | select(.status >= 400)]' temp_report.json > filtered_report.json
 	@rm temp_report.json
@@ -322,9 +333,10 @@ verify-url-links-ci: ## Check for broken URLs in production in a GitHub Actions 
 
 verify-rate-limited-links-ci: ## Check for broken URLs in production in a GitHub Actions CI environment
 	@echo "Checking for broken URLs in security-bulletins and oss-licenses markdown files in CI environment..."
-	@rm link_rate_limit_report.json || echo "No rate limited report exists. Proceeding to scan step"
+	@rm -f scripts/link_rate_limit_report.json
 	@echo "Checking the following paths: $(RATE_LIMITED_FILES_LIST)"
-	@npx linkinator $(RATE_LIMITED_FILES_LIST) --config ./linkinator/linkinator-rate-limit-ci.config.json  > temp_rate_limit_report.json
+	@npx linkinator $(RATE_LIMITED_FILES_LIST) --config ./linkinator/linkinator-rate-limit-ci.config.json  > temp_rate_limit_report.json || true
+	@jq -e 'has("links")' temp_rate_limit_report.json > /dev/null || { echo "linkinator produced no usable report"; exit 1; }
 	@# Use jq to filter out links that do not start with http or https and keep only broken links
 	@jq '[.links[] | select(.url | test("^https?://")) | select(.status >= 400)]' temp_rate_limit_report.json > filtered_rate_limit_report.json
 	@rm temp_rate_limit_report.json


### PR DESCRIPTION
# ✅ Pull Request Checklist

- [x] The **PR description** explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided. _No Jira ticket, see below._
- [x] **Preview links** provided. _This PR makes no user-facing changes._
- [x] Conduct a **self-review**. _Verified locally, see Verification below._
- [x] **Check formatting.** _Makefile only, no docs content._
- [x] Ensure all **Vale comments** are resolved. _No prose changed._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions.
      _Intentionally none, see Backport below._
- [ ] **Outside review:** Does this PR require review outside of Docs?
- [x] Add the `notify-slack` label once this checklist has been completed.

---

## 📝 Describe the Change

The weekly **Broken URL check** job has been failing with no usable output, most recently on August 17. The tool is fine; the Makefile is wrong.

### Root cause

`Makefile:317` is the `npx linkinator ... > temp_report.json` line, and **linkinator exits 1 when it finds broken links.** Confirmed against the pinned v8.0.3 by running it on a file with a single 404: exit code 1, **empty stderr**, valid JSON on stdout. That empty stderr is why the CI log shows no stack trace and reads like a mystery
failure.

The recipe had no error tolerance, so make aborted at that line. The jq filter, the report, and the `mv` to `scripts/link_report.json` never ran, and the later **Post Comment** step that posts findings to Slack never fired.

**The job could only be green when the scan found nothing.** The moment it found what it exists to find, it died before reporting.

### What changed

- **`verify-url-links-ci`** and **`verify-rate-limited-links-ci`** — tolerate linkinator's exit 1, then gate on `jq -e 'has("links")'`. The guard is the important half: a genuine linkinator crash still fails loudly, so this does not
  trade a noisy failure for a silent one.
- **`verify-url-links`** and **`verify-rate-limited-links`** — the inverse bug. These pipe through `grep`, which exits 1 when it matches nothing, so they failed when everything was clean. Now tolerated, with a `test -s` guard playing the same role as the jq guard above.
- **`rm`** now targets `scripts/`, where the reports actually live. The old `rm` pointed at the repo root and had never removed anything, which is the `rm: cannot remove 'link_report.json'` line in the CI log.
- **`CPUS` deleted** (`Makefile:15`). It called `sysctl -n hw.ncpu`, which is macOS-only, and was evaluated at parse time on every make invocation, so every Linux CI run logged `sysctl: cannot stat /proc/sys/hw/ncpu`. The variable was referenced nowhere.

### Verification

Run locally against controlled inputs:

| Test | Before | After |
| --- | --- | --- |
| CI target against a file with a known 404 | aborted at `Makefile:317`, no report | exit 0, report written with the broken link |
| Guard against empty linkinator output | n/a | fails correctly |
| Guard against malformed report | n/a | fails correctly |
| Local target with zero broken links | failed on `grep` | exit 0 |

The `sysctl` line no longer appears on stderr.

### Backport

**Deliberately none.** GitHub Actions `schedule` triggers only fire on the repository's default branch, so the `cron` in each version branch's copy of `merged-links-checks.yaml` never runs. Confirmed empirically: all 20 sampled runs of
that workflow ran on `master`, none on any version branch. On a version branch this fix would only matter for a manual `workflow_dispatch` or a local `make verify-url-links`.

If we later want the fleet uniform, the `verify-url-links-ci` recipe is byte-identical across all eight branches down to the version-4-2 floor, so a cherry-pick of this single commit applies cleanly. It should be all eight or none, not just version-4-9. Note the surrounding Makefiles have drifted between branches, so any backport should stay scoped to this commit.

### Left alone

`Makefile:13`, `TEMP_DIR=$(shell $TMPDIR)`. In make, `$T` is the undefined variable `T`, so this shells out to the nonexistent command `MPDIR` and yields an empty string. `TEMP_DIR` is referenced nowhere, making it the same dead-variable class as `CPUS`. Out of scope for this PR.

---

## 💻 Changed Pages

No user-facing changes. This PR touches only the `Makefile`.

---

## 🎫 Jira Tickets

[Jira Ticket](https://spectrocloud.atlassian.net/browse/DOC-3121)
