### PR TITLE
docs: add token usage how-to and usage metrics reference for Launchpad for AI

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
@@ -95,9 +95,8 @@ appliance limits a client: enforcement on for the appliance, and a window limit 
 setting or change it, refer to
 [Set and Manage Client Quotas](../how-to-guides/manage-client-quotas.md#check-quota-enforcement).
 
-Limits are only half the picture. To read how much of a limit each client has actually spent, and to find a client
-approaching a limit before it is refused, refer to
-[View Token Usage](../how-to-guides/view-token-usage.md#view-quota-consumption-per-client).
+Limits are only half the picture. The console also reports how much of a limit each client has actually spent. For the
+meters and states it uses, refer to [Usage Metrics Reference](../reference/usage-metrics-reference.md#quota-usage-tab).
 
 {/* TODO: link to a Quota & Rate Limit reference page once one exists; DOC-2941 was never created. */}
 

--- a/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/clients-and-quotas.md
@@ -95,6 +95,10 @@ appliance limits a client: enforcement on for the appliance, and a window limit 
 setting or change it, refer to
 [Set and Manage Client Quotas](../how-to-guides/manage-client-quotas.md#check-quota-enforcement).
 
+Limits are only half the picture. To read how much of a limit each client has actually spent, and to find a client
+approaching a limit before it is refused, refer to
+[View Token Usage](../how-to-guides/view-token-usage.md#view-quota-consumption-per-client).
+
 {/* TODO: link to a Quota & Rate Limit reference page once one exists; DOC-2941 was never created. */}
 
 ## What Clients Can Access

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -24,7 +24,7 @@ you the steps to do it without teaching background concepts.
 | [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.               |
 | [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, and remove a client's request, token, and cost limits.                    |
 | [Manage a Client's Model Access](./manage-client-model-access.md) | Route a client to models and allow it to reach external models.                      |
-| [View Token Usage](./view-token-usage.md)                         | Find token usage by model and by client, rank consumers, and export a usage report.  |
+| [View Token Usage](./view-token-usage.md)                         | Find token usage by model and by client, and read quota consumption.                 |
 | [View Client Usage](./view-client-usage.md)                       | View a client's per-token consumption, requests, and cost.                           |
 | [Revoke or Delete a Client](./revoke-or-delete-a-client.md)       | Find expired keys, revoke a token, or delete a client.                               |
 | [Use Claude Code](./use-claude-code.md)                           | Connect Claude Code to the appliance so a local model serves each request.           |

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -24,7 +24,7 @@ you the steps to do it without teaching background concepts.
 | [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.               |
 | [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, and remove a client's request, token, and cost limits.                    |
 | [Manage a Client's Model Access](./manage-client-model-access.md) | Route a client to models and allow it to reach external models.                      |
-| [View Token Usage](./view-token-usage.md)                         | Find token usage by model and by client, and read quota consumption.                 |
+| [View Token Usage](./view-token-usage.md)                         | Find token usage by model and by client, and open the metrics dashboards.            |
 | [View Client Usage](./view-client-usage.md)                       | View a client's per-token consumption, requests, and cost.                           |
 | [Revoke or Delete a Client](./revoke-or-delete-a-client.md)       | Find expired keys, revoke a token, or delete a client.                               |
 | [Use Claude Code](./use-claude-code.md)                           | Connect Claude Code to the appliance so a local model serves each request.           |

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -24,6 +24,7 @@ you the steps to do it without teaching background concepts.
 | [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.               |
 | [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, and remove a client's request, token, and cost limits.                    |
 | [Manage a Client's Model Access](./manage-client-model-access.md) | Route a client to models and allow it to reach external models.                      |
+| [View Token Usage](./view-token-usage.md)                         | Find token usage by model and by client, rank consumers, and export a usage report.  |
 | [View Client Usage](./view-client-usage.md)                       | View a client's per-token consumption, requests, and cost.                           |
 | [Revoke or Delete a Client](./revoke-or-delete-a-client.md)       | Find expired keys, revoke a token, or delete a client.                               |
 | [Use Claude Code](./use-claude-code.md)                           | Connect Claude Code to the appliance so a local model serves each request.           |

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
@@ -45,8 +45,8 @@ period, the card displays a note naming the span it does cover.
 
 ## Further Reading
 
-- [View Token Usage](./view-token-usage.md) covers the rest of the **Usage** page, including per-model usage, finding
-  the top consumers, and quota consumption.
+- [View Token Usage](./view-token-usage.md) covers the rest of the **Usage** page, including per-model usage and finding
+  the top consumers.
 - [Usage Metrics Reference](../reference/usage-metrics-reference.md) defines every metric, column, and export field.
 
 ## Next Steps

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
@@ -45,8 +45,8 @@ period, the card displays a note naming the span it does cover.
 
 ## Further Reading
 
-- [View Token Usage](./view-token-usage.md) covers the rest of the **Usage** page, including per-model usage, ranking
-  consumers, and exporting a report.
+- [View Token Usage](./view-token-usage.md) covers the rest of the **Usage** page, including per-model usage, finding
+  the top consumers, and quota consumption.
 - [Usage Metrics Reference](../reference/usage-metrics-reference.md) defines every metric, column, and export field.
 
 ## Next Steps

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
@@ -38,11 +38,16 @@ The client view shows:
 
 :::info
 
-Usage counts reflect activity since the appliance gateway last restarted.
+The figures cover the period set in the **Data window** menu in the page header. When a figure cannot cover that whole
+period, the card displays a note naming the span it does cover.
 
 :::
 
-<!--TODO: once these sibling pages publish, add a "Further reading" list here linking to: View Token Usage and Consumption Metrics (DOC-2925) for more detail on usage metrics; and the Usage Metrics Reference (DOC-2942) for every metric and field. -->
+## Further Reading
+
+- [View Token Usage](./view-token-usage.md) covers the rest of the **Usage** page, including per-model usage, ranking
+  consumers, and exporting a report.
+- [Usage Metrics Reference](../reference/usage-metrics-reference.md) defines every metric, column, and export field.
 
 ## Next Steps
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
@@ -3,11 +3,11 @@ sidebar_label: "View Token Usage"
 title: "View Token Usage and Consumption Metrics"
 description:
   "Step-by-step guidance for platform administrators on how to view token usage by model and by client, find the top
-  consumers, export a usage report, and open the metrics dashboards on a PaletteAI Inference Launchpad appliance."
+  consumers, read quota consumption, and open the metrics dashboards on a PaletteAI Inference Launchpad appliance."
 hide_table_of_contents: false
 sidebar_position: 6.5
 tags: ["paletteai-inference-launchpad", "usage", "metrics", "how-to"]
-keywords: ["launchpad", "ai", "token usage", "metrics", "consumption", "export", "grafana", "quota utilization"]
+keywords: ["launchpad", "ai", "token usage", "metrics", "consumption", "grafana", "quota utilization"]
 ---
 
 This guide explains how a platform administrator views token consumption on a PaletteAI Inference Launchpad appliance.
@@ -134,35 +134,6 @@ Use these steps to find which clients consumed the most tokens over the last wee
 
 To find the heaviest consumers of one specific model rather than of the appliance as a whole, select that model on the
 **By Model** tab. The model detail view lists only the clients that sent requests to it, with the tokens each one spent.
-
-:::
-
-## Export a Usage Report
-
-The **By Client** tab exports the figures it currently displays, for the period it currently covers.
-
-1. From the left main menu, select **Usage**.
-
-2. Set the **Data window** menu to the period you want to report on.
-
-3. Select the **By Client** tab.
-
-4. Select **Export** in the card header.
-
-5. Select one of the following formats.
-
-   | **Format**        | **Use it for**                                                                             |
-   | ----------------- | ------------------------------------------------------------------------------------------ |
-   | **Export as CSV** | Reconciliation and analysis. Cells carry bare numbers that a spreadsheet totals or pivots. |
-   | **Export as PDF** | Sharing and filing. The table is formatted and paginated for a reader.                     |
-
-The file downloads with a timestamped name, such as `usage-by-client-2026-08-18T10-22-04Z.csv`. Both formats state the
-period the figures cover. For the fields each file contains, refer to
-[Usage Metrics Reference](../reference/usage-metrics-reference.md).
-
-:::info
-
-The export covers the **By Client** table only, and the control is unavailable until at least one client exists.
 
 :::
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
@@ -1,0 +1,256 @@
+---
+sidebar_label: "View Token Usage"
+title: "View Token Usage and Consumption Metrics"
+description:
+  "Step-by-step guidance for platform administrators on how to view token usage by model and by client, find the top
+  consumers, export a usage report, and open the metrics dashboards on a PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 6.5
+tags: ["paletteai-inference-launchpad", "usage", "metrics", "how-to"]
+keywords: ["launchpad", "ai", "token usage", "metrics", "consumption", "export", "grafana", "quota utilization"]
+---
+
+This guide explains how a platform administrator views token consumption on a PaletteAI Inference Launchpad appliance.
+The **Usage** page reports every request the appliance handled, and you can narrow it to one model, one client, or one
+API token.
+
+Use this guide to answer questions such as which model consumes the most tokens, which client is the heaviest consumer
+over the last week, and how much of its quota a client has spent. For the meaning of each individual metric, tile, and
+column, refer to [Usage Metrics Reference](../reference/usage-metrics-reference.md). To understand how usage relates to
+clients and quotas, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+
+- At least one deployed model that has served traffic. Until a model answers a request, every figure on the page is
+  zero. To deploy a model, refer to [Deploy a Model](./deploy-a-model.md).
+
+- One or more clients with API tokens. To create a client, refer to [Create a Client](./create-a-client.md).
+
+- Console access with permission to view usage. The **By Client** and **Quota Usage** tabs read the client roster, which
+  can require operator access.
+
+## Set the Reporting Period
+
+Every tab except **Quota Usage** reports over a period you choose. Set the period first, because it scopes every figure
+you read afterward.
+
+1. From the left main menu, select **Usage**.
+
+2. In the page header, select the **Data window** drop-down menu. The default is **Last 7 days**.
+
+3. Choose one of the following periods.
+
+   | **Option**       | **Period the figures cover**  |
+   | ---------------- | ----------------------------- |
+   | **Last 24h**     | The previous 24 hours.        |
+   | **Last 7 days**  | The previous seven days.      |
+   | **Last 30 days** | The previous 30 days.         |
+   | **Date range**   | Dates you pick on a calendar. |
+
+4. _(Date range only)_ Select the first and last day of the range, and then apply it. The calendar accepts any range
+   within the last 90 days.
+
+The appliance reports usage over fixed periods only. When you apply a date range that is not one of the three presets,
+the console serves the figures from the shortest preset that still contains your range and displays a note naming the
+period the figures actually cover. A range that starts more than 30 days ago is reported over the last 30 days.
+
+{/* NEEDS REVIEW, per AIL-415: that ticket asks for Last 60 Days and Last 90 Days quick-select presets and a range of up to 90 days. The build ships the 24-hour, seven-day, and 30-day presets plus a calendar that accepts 90 days but serves any custom range from the widest preset, so no figure covers more than 30 days. Confirm whether the 60-day and 90-day reporting is still planned before this page publishes. */}
+
+:::info
+
+The **Quota Usage** tab counts consumption against each limit as it stands right now, so it has no period to set. The
+**Data window** menu is hidden while that tab is open.
+
+:::
+
+## View Appliance-Wide Token Totals
+
+The **Overview** tab reports the whole appliance for the selected period.
+
+1. From the left main menu, select **Usage**.
+
+2. Select the **Overview** tab.
+
+3. Read the **Totals** card for the headline figures: requests, input tokens, output tokens, total tokens, and estimated
+   cost.
+
+4. _(Optional)_ Select the information button on any tile to display a description of that figure.
+
+The tab also reports the following.
+
+- **On-box token breakdown**, which separates the prompt tokens the engine answered from its own cache from the tokens
+  it computed fresh, and reports the tokens that left the appliance.
+
+- **Local vs external**, which reports the share of traffic that stayed on your own engines against the share routed to
+  an external provider.
+
+- **Usage over time**, a chart of input, output, and total tokens across the selected period.
+
+- **Semantic routing**, a table of which model handled each request category.
+
+To scope every card on the tab to a single client, select that client in the **Client** drop-down menu in the page
+header.
+
+## View Token Usage for a Model
+
+1. From the left main menu, select **Usage**.
+
+2. Select the **By Model** tab. Each row is one model, with its requests, its input and output tokens, its estimated
+   cost, and its average latency.
+
+3. Select a model row to display the clients that sent requests to that model.
+
+4. To return to the model list, select **All Models**.
+
+:::info
+
+The **Location** column separates models running on the appliance from models reached through an external provider. Only
+external traffic carries a cost, because models you host are priced at `0`. To set the per-model rates that produce the
+cost figures, go to **Settings** > **Pricing**.
+
+:::
+
+## View Token Usage for a Client
+
+1. From the left main menu, select **Usage**.
+
+2. Select the **By Client** tab. Each row is one registered client, with its API token count, its local and external
+   requests and tokens, its quota entitlement and the share of that entitlement it has spent, its local and external
+   cost, and its estimated savings.
+
+3. Select a client row to display its API tokens and their individual consumption.
+
+4. Select an API token row to open a dialog with the full metrics for that token.
+
+5. To return to the client list, select **All Clients**.
+
+For the per-token breakdown in detail, refer to [View Client Usage](./view-client-usage.md).
+
+## Identify the Top Token Consumers
+
+Use these steps to find which clients consumed the most tokens over the last week.
+
+1. From the left main menu, select **Usage**.
+
+2. In the page header, set the **Data window** menu to **Last 7 days**.
+
+3. Select the **By Client** tab.
+
+4. Compare the **Local / Egress Tokens** column down the table. The left figure is the tokens the appliance served
+   itself, and the right figure is the tokens routed to an external provider.
+
+The table lists clients in a fixed order and its columns do not sort, so on an appliance with many clients, export the
+table and rank it in a spreadsheet instead.
+
+1. Select **Export** in the **By Client** card header.
+
+2. Select **Export as CSV**.
+
+3. Open the file in a spreadsheet and sort it by the **Local tokens** column, descending.
+
+:::tip
+
+To find the heaviest consumers of one specific model rather than of the appliance as a whole, select that model on the
+**By Model** tab. The model detail view lists only the clients that sent requests to it, with the tokens each one spent.
+
+:::
+
+## Export a Usage Report
+
+The **By Client** tab exports the figures it currently displays, for the period it currently covers.
+
+1. From the left main menu, select **Usage**.
+
+2. Set the **Data window** menu to the period you want to report on.
+
+3. Select the **By Client** tab.
+
+4. Select **Export** in the card header.
+
+5. Select one of the following formats.
+
+   | **Format**        | **Use it for**                                                                             |
+   | ----------------- | ------------------------------------------------------------------------------------------ |
+   | **Export as CSV** | Reconciliation and analysis. Cells carry bare numbers that a spreadsheet totals or pivots. |
+   | **Export as PDF** | Sharing and filing. The table is formatted and paginated for a reader.                     |
+
+The file downloads with a timestamped name, such as `usage-by-client-2026-08-18T10-22-04Z.csv`. Both formats state the
+period the figures cover, and both repeat the substitution note when the appliance reported a shorter period than the
+date range you picked. For the fields each file contains, refer to
+[Usage Metrics Reference](../reference/usage-metrics-reference.md).
+
+:::info
+
+The export covers the **By Client** table only, and the control is unavailable until at least one client exists.
+
+:::
+
+## View Quota Consumption per Client
+
+The **Quota Usage** tab reports each client's consumption against the limits you set, so you can find a client that is
+close to a limit before it is rejected.
+
+1. From the left main menu, select **Usage**.
+
+2. Select the **Quota Usage** tab. Each row is one client, with a meter for each configured limit under **Requests**,
+   **Tokens**, and **Cost**.
+
+3. To bring the most-consumed limits to the top, select the **Tokens** column heading. The **Requests**, **Cost**, and
+   **Client** headings sort the table as well.
+
+4. Select a client row to display its limits in full. Each limit reports the amount consumed, the amount remaining, and
+   when its window next resets.
+
+A client that has reached a limit carries a **Reached limit** badge, and a banner at the top of the tab names every such
+client. The appliance rejects further requests from that client with HTTP `429` until the window resets or you raise the
+limit.
+
+To raise one limit from this tab, use the following steps.
+
+1. Select the client row to open its detail.
+
+2. Find the limit to raise and select **Increase limit**. The **Increase limit?** dialog opens.
+
+3. In **New limit**, enter the new limit. The field is pre-filled with double the current limit.
+
+4. Select **Increase limit** to preview the change. The dialog reports what the change does before anything is applied.
+
+5. Select **Confirm & Apply**.
+
+:::warning
+
+Raising a limit takes effect immediately and grants the client more of the appliance's GPU capacity. Raise a limit only
+when the appliance has the headroom to serve it. Without that headroom, the other clients slow down.
+
+:::
+
+Quota enforcement is a separate appliance-wide switch. While it is off, this tab still records consumption but the
+appliance does not reject a client that passes a limit. To check the switch or to set a client's limits, refer to
+[Set and Manage Client Quotas](./manage-client-quotas.md).
+
+## Open the Metrics Dashboards
+
+The appliance ships with its metrics backend and Grafana enabled, and the console links to the infrastructure
+dashboards.
+
+1. From the left main menu, select **Usage**.
+
+2. Select **Grafana** in the page header. The dashboards open in a new browser tab.
+
+Use Grafana for infrastructure-level questions the **Usage** page does not answer, such as GPU utilization and engine
+throughput over time. Token and cost accounting stays on the **Usage** page.
+
+:::info
+
+The **Grafana** link appears only when the appliance reports a reachable dashboard address. If the link is absent, the
+appliance still collects metrics, but no browser-reachable dashboard address is configured for it.
+
+:::
+
+## Next Steps
+
+- [Usage Metrics Reference](../reference/usage-metrics-reference.md)
+- [View Client Usage](./view-client-usage.md)
+- [Set and Manage Client Quotas](./manage-client-quotas.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
@@ -52,18 +52,7 @@ you read afterward.
 4. _(Date range only)_ Select the first and last day of the range, and then apply it. The calendar accepts any range
    within the last 90 days.
 
-The appliance reports usage over fixed periods only. When you apply a date range that is not one of the three presets,
-the console serves the figures from the shortest preset that still contains your range and displays a note naming the
-period the figures actually cover. A range that starts more than 30 days ago is reported over the last 30 days.
-
 {/* NEEDS REVIEW, per AIL-415: that ticket asks for Last 60 Days and Last 90 Days quick-select presets and a range of up to 90 days. The build ships the 24-hour, seven-day, and 30-day presets plus a calendar that accepts 90 days but serves any custom range from the widest preset, so no figure covers more than 30 days. Confirm whether the 60-day and 90-day reporting is still planned before this page publishes. */}
-
-:::info
-
-The **Quota Usage** tab counts consumption against each limit as it stands right now, so it has no period to set. The
-**Data window** menu is hidden while that tab is open.
-
-:::
 
 ## View Appliance-Wide Token Totals
 
@@ -177,8 +166,7 @@ The **By Client** tab exports the figures it currently displays, for the period 
    | **Export as PDF** | Sharing and filing. The table is formatted and paginated for a reader.                     |
 
 The file downloads with a timestamped name, such as `usage-by-client-2026-08-18T10-22-04Z.csv`. Both formats state the
-period the figures cover, and both repeat the substitution note when the appliance reported a shorter period than the
-date range you picked. For the fields each file contains, refer to
+period the figures cover. For the fields each file contains, refer to
 [Usage Metrics Reference](../reference/usage-metrics-reference.md).
 
 :::info

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
@@ -3,21 +3,21 @@ sidebar_label: "View Token Usage"
 title: "View Token Usage and Consumption Metrics"
 description:
   "Step-by-step guidance for platform administrators on how to view token usage by model and by client, find the top
-  consumers, read quota consumption, and open the metrics dashboards on a PaletteAI Inference Launchpad appliance."
+  consumers, and open the metrics dashboards on a PaletteAI Inference Launchpad appliance."
 hide_table_of_contents: false
 sidebar_position: 6.5
 tags: ["paletteai-inference-launchpad", "usage", "metrics", "how-to"]
-keywords: ["launchpad", "ai", "token usage", "metrics", "consumption", "grafana", "quota utilization"]
+keywords: ["launchpad", "ai", "token usage", "metrics", "consumption", "grafana"]
 ---
 
 This guide explains how a platform administrator views token consumption on a PaletteAI Inference Launchpad appliance.
 The **Usage** page reports every request the appliance handled, and you can narrow it to one model, one client, or one
 API token.
 
-Use this guide to answer questions such as which model consumes the most tokens, which client is the heaviest consumer
-over the last week, and how much of its quota a client has spent. For the meaning of each individual metric, tile, and
-column, refer to [Usage Metrics Reference](../reference/usage-metrics-reference.md). To understand how usage relates to
-clients and quotas, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
+Use this guide to answer questions such as which model consumes the most tokens and which client is the heaviest
+consumer over the last week. For the meaning of each individual metric, tile, and column, refer to
+[Usage Metrics Reference](../reference/usage-metrics-reference.md). To understand how usage relates to clients and
+quotas, refer to [Clients and Quotas](../explanation/clients-and-quotas.md).
 
 ## Prerequisites
 
@@ -28,13 +28,12 @@ clients and quotas, refer to [Clients and Quotas](../explanation/clients-and-quo
 
 - One or more clients with API tokens. To create a client, refer to [Create a Client](./create-a-client.md).
 
-- Console access with permission to view usage. The **By Client** and **Quota Usage** tabs read the client roster, which
-  can require operator access.
+- Console access with permission to view usage. The **By Client** tab reads the client roster, which can require
+  operator access.
 
 ## Set the Reporting Period
 
-Every tab except **Quota Usage** reports over a period you choose. Set the period first, because it scopes every figure
-you read afterward.
+Each tab reports over a period you choose. Set the period first, because it scopes every figure you read afterward.
 
 1. From the left main menu, select **Usage**.
 
@@ -136,49 +135,6 @@ To find the heaviest consumers of one specific model rather than of the applianc
 **By Model** tab. The model detail view lists only the clients that sent requests to it, with the tokens each one spent.
 
 :::
-
-## View Quota Consumption per Client
-
-The **Quota Usage** tab reports each client's consumption against the limits you set, so you can find a client that is
-close to a limit before it is rejected.
-
-1. From the left main menu, select **Usage**.
-
-2. Select the **Quota Usage** tab. Each row is one client, with a meter for each configured limit under **Requests**,
-   **Tokens**, and **Cost**.
-
-3. To bring the most-consumed limits to the top, select the **Tokens** column heading. The **Requests**, **Cost**, and
-   **Client** headings sort the table as well.
-
-4. Select a client row to display its limits in full. Each limit reports the amount consumed, the amount remaining, and
-   when its window next resets.
-
-A client that has reached a limit carries a **Reached limit** badge, and a banner at the top of the tab names every such
-client. The appliance rejects further requests from that client with HTTP `429` until the window resets or you raise the
-limit.
-
-To raise one limit from this tab, use the following steps.
-
-1. Select the client row to open its detail.
-
-2. Find the limit to raise and select **Increase limit**. The **Increase limit?** dialog opens.
-
-3. In **New limit**, enter the new limit. The field is pre-filled with double the current limit.
-
-4. Select **Increase limit** to preview the change. The dialog reports what the change does before anything is applied.
-
-5. Select **Confirm & Apply**.
-
-:::warning
-
-Raising a limit takes effect immediately and grants the client more of the appliance's GPU capacity. Raise a limit only
-when the appliance has the headroom to serve it. Without that headroom, the other clients slow down.
-
-:::
-
-Quota enforcement is a separate appliance-wide switch. While it is off, this tab still records consumption but the
-appliance does not reject a client that passes a limit. To check the switch or to set a client's limits, refer to
-[Set and Manage Client Quotas](./manage-client-quotas.md).
 
 ## Open the Metrics Dashboards
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-token-usage.md
@@ -130,15 +130,6 @@ Use these steps to find which clients consumed the most tokens over the last wee
 4. Compare the **Local / Egress Tokens** column down the table. The left figure is the tokens the appliance served
    itself, and the right figure is the tokens routed to an external provider.
 
-The table lists clients in a fixed order and its columns do not sort, so on an appliance with many clients, export the
-table and rank it in a spreadsheet instead.
-
-1. Select **Export** in the **By Client** card header.
-
-2. Select **Export as CSV**.
-
-3. Open the file in a spreadsheet and sort it by the **Local tokens** column, descending.
-
 :::tip
 
 To find the heaviest consumers of one specific model rather than of the appliance as a whole, select that model on the

--- a/docs/products/paletteai-inference-launchpad/reference/reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/reference.md
@@ -20,6 +20,7 @@ is configured, not how to accomplish a task.
 | [Cluster Profile Variables](./profile-variables.md)               | Every variable the Profile Config wizard collects, with types, defaults, and validation rules. |
 | [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration.                |
 | [Model Upload Reference](./model-upload-reference.md)             | Palette CLI model download and upload flags, and the model metadata file fields.               |
+| [Usage Metrics Reference](./usage-metrics-reference.md)           | Every filter, metric, table column, and export field on the Usage page.                        |
 | [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.                    |
 | [Cursor Configuration](./cursor-reference.md)                     | Settings and values for pointing Cursor at the appliance.                                      |
 | [OpenAI Codex Configuration](./codex-reference.md)                | Configuration file fields and values for pointing Codex at the appliance.                      |

--- a/docs/products/paletteai-inference-launchpad/reference/usage-metrics-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/usage-metrics-reference.md
@@ -1,0 +1,301 @@
+---
+sidebar_label: "Usage Metrics Reference"
+title: "PaletteAI Inference Launchpad Usage Metrics Reference"
+description:
+  "Reference for every filter, metric, table column, and export field on the Usage page of a PaletteAI Inference
+  Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 4.7
+tags: ["paletteai-inference-launchpad", "reference", "usage", "metrics"]
+keywords: ["launchpad", "ai", "usage", "metrics", "tokens", "cost", "quota", "export", "csv", "pdf"]
+---
+
+This reference defines every filter, metric, and column on the **Usage** page of the appliance console, and the fields
+of the usage report it exports. It supports the [View Token Usage](../how-to-guides/view-token-usage.md) how-to, which
+walks through the tasks these figures serve.
+
+Counts render in a compact form, such as `177.7K`. Hold the pointer over a compact figure to display the exact value.
+Costs render to two decimal places in dollars.
+
+## Page Filters
+
+Both filters are in the page header and apply to whichever tab is open.
+
+| **Filter**      | **Default**     | **What it does**                              | **Available on**              |
+| --------------- | --------------- | --------------------------------------------- | ----------------------------- |
+| **Client**      | All clients     | Scopes every figure on the tab to one client. | Overview, By Model            |
+| **Data window** | **Last 7 days** | Sets the period the figures cover.            | Overview, By Model, By Client |
+
+The **Client** filter is hidden on the **By Client** tab, where you scope by opening a client row, and on the **Quota
+Usage** tab, which reports configured limits rather than usage over a period.
+
+### Data Window Options
+
+| **Option**       | **Period**                                    |
+| ---------------- | --------------------------------------------- |
+| **Last 24h**     | The previous 24 hours.                        |
+| **Last 7 days**  | The previous seven days.                      |
+| **Last 30 days** | The previous 30 days.                         |
+| **Date range**   | A start and end day you pick from a calendar. |
+
+The calendar accepts any range that falls within the last 90 days. The appliance serves usage over fixed periods only,
+so a range that is not one of the three presets is served by the shortest preset that still contains it. When that
+happens, the console displays a note naming the period the figures actually cover, and the exported file repeats that
+note. A range beginning more than 30 days ago is served over the last 30 days.
+
+## Overview Tab
+
+### Totals
+
+| **Tile**          | **Definition**                                                                                                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **requests**      | Every request the appliance handled in the period, both local and external.                                                                                                    |
+| **input tokens**  | Tokens sent to the model, including the prompt, the system prompt, and the conversation history.                                                                               |
+| **output tokens** | Tokens the model generated.                                                                                                                                                    |
+| **total tokens**  | Input tokens plus output tokens across every request in the period.                                                                                                            |
+| **est. cost**     | Tokens multiplied by the per-model rate set under **Settings** > **Pricing**. Models hosted on the appliance are priced at `0`, so this figure reflects external traffic only. |
+
+### On-Box Token Breakdown
+
+These tiles report cache reuse on the appliance's own engines. A total prompt figure much larger than the fresh input
+figure indicates cache reuse, not traffic leaving the appliance.
+
+| **Tile**                       | **Definition**                                                                                                                                                                         |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **total prompt (incl. cache)** | Every prompt token processed on the appliance, including tokens answered from cache.                                                                                                   |
+| **cache reads, on-box**        | Prompt tokens answered from the engine's own key-value cache in the period. These tokens never left the appliance. The tile also reports the share of the total prompt they represent. |
+| **fresh input**                | Prompt tokens the engine computed fresh, which is the total prompt minus the cache reads.                                                                                              |
+| **egress**                     | Prompt and output tokens routed to an external provider or a registered external endpoint. This is a separate count from the on-box prompt total.                                      |
+
+### Local vs External
+
+| **Tile**                      | **Definition**                                                                                                                                                                               |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **kept on the Launchpad**     | The share of tokens served by the appliance's own engines, with the token count and a cost of `$0.00`.                                                                                       |
+| **routed externally**         | The share of tokens routed to an external provider, with the token count and the cost.                                                                                                       |
+| **external providers in use** | The number of distinct external providers that served traffic in the period.                                                                                                                 |
+| **spilled at capacity**       | The share of requests that asked for local serving and went to an external provider because the appliance was at capacity. This tile appears only when the appliance reports capacity spill. |
+
+The egress meter records tokens and cost but not a request count, so the external request count always reads `0`.
+
+### Usage over Time
+
+A stacked area chart of the input, output, and total token rates across the selected period, scoped by the **Client**
+filter. The chart legend selects which series are drawn.
+
+### Semantic Routing
+
+Which model handled each request category, as classified by the semantic router.
+
+<!-- vale off -->
+
+| **Column**    | **Definition**                                                        |
+| ------------- | --------------------------------------------------------------------- |
+| **Category**  | The category the classifier assigned to the conversation.             |
+| **Model**     | The model that handled requests in that category.                     |
+| **Requests**  | Requests in that category.                                            |
+| **Total tok** | Input plus output tokens for that category.                           |
+| **Cost**      | Estimated cost for that category.                                     |
+| **Avg conf**  | The classifier's average confidence in the category, as a percentage. |
+
+<!-- vale on -->
+
+## By Model Tab
+
+One row per model that the appliance knows about. Selecting a row opens the clients that used that model.
+
+| **Column**                | **Definition**                                                                                              |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Model**                 | The model identifier.                                                                                       |
+| **Location**              | Whether the model runs on the appliance, with its GPU hardware, or is reached through an external provider. |
+| **Requests**              | Requests the model served in the period.                                                                    |
+| **Input / Output Tokens** | Input tokens and output tokens, reported as a pair. The figures are not summed.                             |
+| **Est. cost**             | Estimated cost for the model. Models hosted on the appliance are priced at `0`.                             |
+| **Avg latency**           | Average request latency in milliseconds.                                                                    |
+
+A model that served no requests in the period renders dimmed, with `—` in place of its figures.
+
+### Model Detail View
+
+| **Column**       | **Definition**                                            |
+| ---------------- | --------------------------------------------------------- |
+| **Client**       | A client that sent requests to this model.                |
+| **Requests**     | The client's requests to this model.                      |
+| **Total tokens** | The client's input plus output tokens for this model.     |
+| **Local %**      | The share of those tokens served on the appliance.        |
+| **External %**   | The share of those tokens routed to an external provider. |
+| **Est. cost**    | Estimated cost of the client's traffic to this model.     |
+
+## By Client Tab
+
+One row per registered client. Selecting a row opens the client's API tokens.
+
+| **Column**                  | **Definition**                                                                                                       |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Client**                  | The client name. A client that has reached a quota limit also carries a blocked icon that names each limit reached.  |
+| **API Keys**                | The number of API tokens issued to the client, or `none`.                                                            |
+| **Local / Egress Requests** | Requests served on the appliance and requests routed externally, reported as a pair.                                 |
+| **Local / Egress Tokens**   | Tokens served on the appliance and tokens routed externally, reported as a pair.                                     |
+| **Total Local Quota**       | The client's total local token entitlement across the period, or `Unlimited` when the client carries no token limit. |
+| **Local Quota Used**        | The share of that entitlement the client has spent. Reads `—` when there is no entitlement to measure against.       |
+| **$ Cost Local / Egress**   | Local cost and external cost, reported as a pair.                                                                    |
+| **$ Savings**               | The estimated amount avoided by serving on the appliance instead of a benchmark external model.                      |
+
+Local and external figures are paired rather than summed, because a local quota and an external spend cap are separate
+budgets. Hold the pointer over a paired cell to display which figure is which.
+
+The columns on this tab do not sort. To rank clients, export the table and sort it in a spreadsheet.
+
+Above the table, the appliance reports total savings against two benchmark external models, measured since the appliance
+first started. That figure covers all clients and is not a per-client figure.
+
+### Client Detail View
+
+Four tiles summarize the open client.
+
+| **Tile**          | **Definition**                                                         |
+| ----------------- | ---------------------------------------------------------------------- |
+| **local input**   | Input tokens the appliance served for this client.                     |
+| **local output**  | Output tokens the appliance served for this client.                    |
+| **egress tokens** | Tokens routed to an external provider or registered external endpoint. |
+| **egress cost**   | External spend for this client.                                        |
+
+The **API keys** table lists each of the client's tokens.
+
+| **Column**                | **Definition**                                                       |
+| ------------------------- | -------------------------------------------------------------------- |
+| **Label**                 | The name given to the token at creation.                             |
+| **Key**                   | The token's prefix. The full secret is shown only once, at creation. |
+| **Status**                | Whether the token is active, expired, or revoked.                    |
+| **Last used**             | When the token last authenticated a request, or `never`.             |
+| **Created**               | When the token was created.                                          |
+| **Expires**               | When the token expires.                                              |
+| **Requests**              | Requests made with this token.                                       |
+| **Input / Output Tokens** | Input and output tokens for this token, reported as a pair.          |
+| **Total Tokens**          | Input plus output tokens for this token.                             |
+| **Cost**                  | Estimated cost of this token's traffic.                              |
+
+A **Conversation routing** table follows, reporting which models handled the client's requests, with the requests, total
+tokens, and cost for each.
+
+:::info
+
+Traffic from internal principals and service accounts carries no listed API token. When a client has such traffic, the
+client detail view states how many requests and tokens it accounts for, so the API token rows do not have to add up to
+the client's total.
+
+:::
+
+### Per-Token Metrics
+
+Selecting an API token row opens a dialog reporting that token's usage over the selected period.
+
+| **Tile**               | **Definition**                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------ |
+| **requests**           | Requests made with this token.                                                                   |
+| **input tokens**       | Input tokens for this token.                                                                     |
+| **output tokens**      | Output tokens for this token.                                                                    |
+| **total tokens**       | Input plus output tokens.                                                                        |
+| **cached tokens**      | Input tokens answered from cache, with the share of input they represent.                        |
+| **est. cost**          | Estimated cost of this token's traffic.                                                          |
+| **avg / request**      | Average total tokens per request.                                                                |
+| **avg cost / request** | Average estimated cost per request.                                                              |
+| **output : input**     | The ratio of output tokens to input tokens.                                                      |
+| **share of user**      | This token's share of the owning client's total tokens, compared with the client's other tokens. |
+
+{/* NEEDS REVIEW: the tile label reads share of user, while every other surface on the page uses the term Client. Confirm whether the label is being renamed before this page publishes, or whether the docs should keep quoting user here. */}
+
+A **Key details** section reports the token id, its owning client, the token prefix, its scope, and its creation,
+expiry, and last-used times. A scope of `unrestricted` means the token reaches every model, provider, and tier its
+owning client can reach, with no limit specific to the token.
+
+:::info
+
+A token that recorded requests but no tokens indicates requests that failed or returned no usage data. Per-token error
+rates are not reported.
+
+:::
+
+## Quota Usage Tab
+
+This tab reports consumption against each client's configured limits as it stands right now, so it takes no period. To
+set the limits themselves, refer to [Set and Manage Client Quotas](../how-to-guides/manage-client-quotas.md).
+
+| **Column**   | **Definition**                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------- |
+| **Client**   | The client name. A client at 100 percent of a limit also carries a **Reached limit** badge. |
+| **Requests** | A meter for each configured request limit, most-consumed first.                             |
+| **Tokens**   | A meter for each configured token limit, most-consumed first.                               |
+| **Cost**     | A meter for each configured cost limit, most-consumed first.                                |
+
+Each meter reads as a percentage followed by its window, such as `62% /hr`. Meters that do not fit the column width
+collapse behind a `+N` chip that lists the rest. These columns sort, and the table sorts by client name by default.
+
+A dimension with no configured limit reports a state instead of meters.
+
+| **State**        | **Meaning**                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| **Unlimited**    | No limit is set for that dimension.                              |
+| **Not enforced** | Appliance-wide quota enforcement is off, so no limit is applied. |
+| **Unknown**      | The limits could not be read. This is not the same as unlimited. |
+
+When enforcement is on and one or more clients have reached a limit, a banner names them and states that further
+requests are throttled until each window resets or the limit is raised. When enforcement is off, a notice states that
+client usage is recorded but not enforced.
+
+### Client Quota Detail View
+
+Selecting a client row reports its limits in full, grouped into **Requests**, **Tokens**, and **Cost** cards. Each limit
+reports the share consumed, the amount consumed against the limit, the amount remaining, a progress bar, and when the
+window next resets. Windows appear shortest first.
+
+An **Increase limit** control appears on each limit that can be raised. Raising a limit is a two-step action: the first
+selection previews the change, and **Confirm & Apply** commits it.
+
+## Export Fields
+
+The **By Client** tab exports as CSV or PDF. Both formats carry the same columns, taken from the rows on screen for the
+period on screen. Files are named `usage-by-client-<timestamp>.<extension>`.
+
+Each file opens with the report name, the period the figures cover, the substitution note when the appliance served a
+shorter period than the range requested, and the time the file was generated.
+
+| **Field**                | **Definition**                                                           |
+| ------------------------ | ------------------------------------------------------------------------ |
+| **Client**               | The client name.                                                         |
+| **API keys**             | The number of API tokens issued to the client.                           |
+| **Local requests**       | Requests served on the appliance.                                        |
+| **Frontier requests**    | Requests routed to an external provider.                                 |
+| **Local tokens**         | Tokens served on the appliance.                                          |
+| **Frontier tokens**      | Tokens routed to an external provider.                                   |
+| **Total local quota**    | The client's total local token entitlement, or `Unlimited`.              |
+| **Local quota used (%)** | The share of that entitlement spent. Empty when there is no entitlement. |
+| **Cost local (USD)**     | Cost of locally served traffic.                                          |
+| **Cost frontier (USD)**  | Cost of externally routed traffic.                                       |
+| **Savings (USD)**        | Estimated amount avoided by serving on the appliance.                    |
+| **Limits reached**       | Whether the client has reached a quota limit.                            |
+
+Local and external figures are separate columns because they are separate budgets. Adding them together is not
+meaningful.
+
+The export names its external columns **Frontier**, while the on-screen table names the same figures **Egress**. The two
+terms refer to the same traffic: requests and tokens that left the appliance.
+
+The two formats differ in how they carry values. CSV cells hold bare numbers so a spreadsheet can total or pivot them.
+PDF cells hold the formatted value with its unit, for a reader.
+
+## Period Coverage Notes
+
+Not every figure can always cover the period requested. When a figure covers a shorter span, the console displays a note
+on that card naming the span it does cover and why. The most common causes are a client that has existed for less time
+than the period requested, and an appliance that does not accept the requested window.
+
+The **Quota Usage** tab is exempt, because its counters are point-in-time rather than accumulated over a period. Each
+limit there reports when its own window resets.
+
+## Resources
+
+- [View Token Usage](../how-to-guides/view-token-usage.md)
+- [View Client Usage](../how-to-guides/view-client-usage.md)
+- [Set and Manage Client Quotas](../how-to-guides/manage-client-quotas.md)
+- [Clients and Quotas](../explanation/clients-and-quotas.md)

--- a/docs/products/paletteai-inference-launchpad/reference/usage-metrics-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/usage-metrics-reference.md
@@ -31,17 +31,11 @@ Usage** tab, which reports configured limits rather than usage over a period.
 
 ### Data Window Options
 
-| **Option**       | **Period**                                    |
-| ---------------- | --------------------------------------------- |
-| **Last 24h**     | The previous 24 hours.                        |
-| **Last 7 days**  | The previous seven days.                      |
-| **Last 30 days** | The previous 30 days.                         |
-| **Date range**   | A start and end day you pick from a calendar. |
-
-The calendar accepts any range that falls within the last 90 days. The appliance serves usage over fixed periods only,
-so a range that is not one of the three presets is served by the shortest preset that still contains it. When that
-happens, the console displays a note naming the period the figures actually cover, and the exported file repeats that
-note. A range beginning more than 30 days ago is served over the last 30 days.
+| **Option**       | **Period**               |
+| ---------------- | ------------------------ |
+| **Last 24h**     | The previous 24 hours.   |
+| **Last 7 days**  | The previous seven days. |
+| **Last 30 days** | The previous 30 days.    |
 
 ## Overview Tab
 
@@ -257,8 +251,8 @@ selection previews the change, and **Confirm & Apply** commits it.
 The **By Client** tab exports as CSV or PDF. Both formats carry the same columns, taken from the rows on screen for the
 period on screen. Files are named `usage-by-client-<timestamp>.<extension>`.
 
-Each file opens with the report name, the period the figures cover, the substitution note when the appliance served a
-shorter period than the range requested, and the time the file was generated.
+Each file opens with the report name, the period the figures cover, a note when the figures cover a shorter period than
+the one requested, and the time the file was generated.
 
 | **Field**                | **Definition**                                                           |
 | ------------------------ | ------------------------------------------------------------------------ |


### PR DESCRIPTION
## What This Changes

Implements[ DOC-2925](https://spectrocloud.atlassian.net/browse/DOC-2925).

**New how-to** — `how-to-guides/view-token-usage.md` (View Token Usage and Consumption Metrics). Task steps only.
**New reference** — `reference/usage-metrics-reference.md` (Usage Metrics Reference). Definitions only: every page filter,
tile, table column, dialog field, quota meter state, and export field. The ticket explicitly defers "what each metric
means" to a reference, so the how-to links here rather than defining anything itself.

## Links

- Jira: [DOC-2925 — View Token Usage and Consumption Metrics](https://spectrocloud.atlassian.net/browse/DOC-2925)
- Related epics: [AIL-415](https://spectrocloud.atlassian.net/browse/AIL-415),
  [AIL-257](https://spectrocloud.atlassian.net/browse/AIL-257)
- Netlify deploy preview: <https://deploy-preview-11706--docs-spectrocloud.netlify.app>
  - [View Token Usage and Consumption Metrics](https://deploy-preview-11706--docs-spectrocloud.netlify.app/paletteai-inference-launchpad/how-to-guides/view-token-usage/)
  - [Usage Metrics Reference](https://deploy-preview-11706--docs-spectrocloud.netlify.app/paletteai-inference-launchpad/reference/usage-metrics-reference/)
  - [View Client Usage (edited)](https://deploy-preview-11706--docs-spectrocloud.netlify.app/paletteai-inference-launchpad/how-to-guides/view-client-usage/)
  - [Clients and Quotas (edited)](https://deploy-preview-11706--docs-spectrocloud.netlify.app/paletteai-inference-launchpad/explanation/clients-and-quotas/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AIL-415]: https://spectrocloud.atlassian.net/browse/AIL-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AIL-257]: https://spectrocloud.atlassian.net/browse/AIL-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ