### PR TITLE
PE-9264: LTS upgrade for CK8S airgap

### DIFF
--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -148,6 +148,9 @@ Skipping worker node updates is supported for the following cluster types:
   Local UI API rather than through Palette. Refer to
   [Edge Cluster Upgrade Behavior](../edge/cluster-management/upgrade-behavior.md#decoupled-control-plane-and-worker-node-upgrades).
 
+For Edge Native clusters, both connected and locally managed, only Palette eXtended Kubernetes Edge (PXK-E) and
+Canonical Kubernetes are supported. K3s and RKE2 clusters are not supported.
+
 ### Cluster Profile Upgrade Behavior
 
 When a cluster profile update bumps the Kubernetes version, Palette upgrades the control plane and any worker pools that

--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -144,8 +144,8 @@ Skipping worker node updates is supported for the following cluster types:
 - MAAS clusters
 - VMware vSphere clusters
 - Connected (centrally managed) Edge Native clusters
-- Locally managed Edge Native clusters in an airgapped environment, running Canonical Kubernetes (CK8s). Configure these
-  clusters through Local UI or the Local UI API rather than through Palette. Refer to
+- Locally managed Edge Native clusters in an airgapped environment. Configure these clusters through Local UI or the
+  Local UI API rather than through Palette. Refer to
   [Edge Cluster Upgrade Behavior](../edge/cluster-management/upgrade-behavior.md#decoupled-control-plane-and-worker-node-upgrades).
 
 ### Cluster Profile Upgrade Behavior

--- a/docs/docs-content/clusters/cluster-management/node-pool.md
+++ b/docs/docs-content/clusters/cluster-management/node-pool.md
@@ -144,6 +144,9 @@ Skipping worker node updates is supported for the following cluster types:
 - MAAS clusters
 - VMware vSphere clusters
 - Connected (centrally managed) Edge Native clusters
+- Locally managed Edge Native clusters in an airgapped environment, running Canonical Kubernetes (CK8s). Configure these
+  clusters through Local UI or the Local UI API rather than through Palette. Refer to
+  [Edge Cluster Upgrade Behavior](../edge/cluster-management/upgrade-behavior.md#decoupled-control-plane-and-worker-node-upgrades).
 
 ### Cluster Profile Upgrade Behavior
 
@@ -167,9 +170,10 @@ For AWS IaaS, MAAS, and VMware vSphere clusters, scale-up is permitted. New node
 autoscaler join using the worker pool's current Kubernetes version, not the control plane version. Scale-down is not
 restricted.
 
-For connected Edge Native clusters, scale-up is not permitted while the toggle is enabled. Palette rejects scale-up
-requests on a pool with the toggle enabled, whether initiated manually or by the cluster autoscaler. To expand capacity,
-create a new worker pool and add Edge hosts to it instead.
+For Edge Native clusters, both connected and locally managed, scale-up is not permitted while the toggle is enabled.
+Scale-up requests on a pool with the toggle enabled are rejected, whether initiated manually or by the cluster
+autoscaler, because a new node cannot honor the pool's pinned Kubernetes version. To expand capacity, create a new
+worker pool and add Edge hosts to it instead.
 
 ### Upgrade a Skipped Worker Pool
 

--- a/docs/docs-content/clusters/cluster-management/platform-settings/pause-platform-upgrades.md
+++ b/docs/docs-content/clusters/cluster-management/platform-settings/pause-platform-upgrades.md
@@ -108,6 +108,9 @@ cluster outside the compatibility window might make it unhealthy, so treat the b
 notice to dismiss. Agents resume upgrading as soon as you disable the setting, which returns the cluster to a supported
 state without any further action.
 
+For background on why cluster-side components are supported two major versions behind the management plane, refer to
+[CRD API Versions](../../../architecture/crd-api-versions.md).
+
 ## Prerequisites
 
 - Cluster admin permissions or Tenant admin permissions when pausing upgrades for all clusters within tenant scope.

--- a/docs/docs-content/clusters/cluster-management/platform-settings/pause-platform-upgrades.md
+++ b/docs/docs-content/clusters/cluster-management/platform-settings/pause-platform-upgrades.md
@@ -97,6 +97,17 @@ lower scopes, and changing the setting at the lower scope will override the sett
   issues with pushing images to the local registry, and cluster deployment issues. Ensure that you enable platform
   upgrades so your agent can be upgraded to be compatible with Palette/VerteX.
 
+## Agent Version Drift Warning
+
+While agent upgrades are paused, your Palette or VerteX instance continues to advance. If the management plane moves
+more than two major versions ahead of a cluster's agents, that cluster falls outside the supported N-2 compatibility
+window and a warning banner appears on the cluster.
+
+The banner advises you to disable **Pause Agent Upgrades** so the agents can update to the latest version. Leaving a
+cluster outside the compatibility window might make it unhealthy, so treat the banner as an action to take rather than a
+notice to dismiss. Agents resume upgrading as soon as you disable the setting, which returns the cluster to a supported
+state without any further action.
+
 ## Prerequisites
 
 - Cluster admin permissions or Tenant admin permissions when pausing upgrades for all clusters within tenant scope.

--- a/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
@@ -126,27 +126,34 @@ pack, but if you want to use a different storage pack altogether, we recommend y
 
 ## Decoupled Control Plane and Worker Node Upgrades
 
-Connected (centrally managed) Edge Native clusters support upgrading the control plane independently from worker pools.
-You can enable the **Skip worker node update (Optional)** toggle on individual worker pools to defer their Kubernetes
-upgrade while the control plane advances.
+Edge Native clusters support upgrading the control plane independently from worker pools. You can enable the **Skip
+worker node update (Optional)** toggle on individual worker pools to defer their Kubernetes upgrade while the control
+plane advances. This decouples worker upgrades from control plane upgrades, which lets you apply a security patch or
+advance an LTS upgrade without repaving worker nodes, and it reduces the number of worker upgrades needed to cross
+several Kubernetes minor versions.
 
-:::info
+Support depends on how the cluster is managed.
 
-This feature is only available for connected Edge Native clusters. Locally managed Edge clusters are not supported.
+| **Cluster management**        | **Support**                                                                                                               |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Connected (centrally managed) | Supported. Configure the toggle in Palette.                                                                               |
+| Locally managed, airgapped    | Supported for clusters running Canonical Kubernetes (CK8s). Configure the toggle in Local UI or through the Local UI API. |
 
-:::
+When a cluster profile update bumps the Kubernetes version, the control plane and any worker pools that do not have
+**Skip worker node update** enabled are upgraded. Worker pools with the toggle enabled are skipped and stay at their
+current Kubernetes version. Control plane nodes are always upgraded to the Kubernetes and OS versions declared in the
+cluster profile, and are upgraded one at a time.
 
-When a cluster profile update bumps the Kubernetes version, Palette upgrades the control plane and any worker pools that
-do not have **Skip worker node update** enabled. Worker pools with the toggle enabled are skipped and stay at their
-current Kubernetes version.
+A skipped worker pool can still be updated on Day-2 for other node configuration changes, such as taints and labels. Its
+Kubernetes and OS versions stay unchanged.
 
-Palette enforces the Kubernetes [N-3 minor version skew](https://kubernetes.io/releases/version-skew-policy/). If
-enabling the toggle would cause a worker pool to fall more than three minor versions behind the control plane, Palette
-blocks the upgrade.
+The Kubernetes [N-3 minor version skew](https://kubernetes.io/releases/version-skew-policy/) is enforced. If a profile
+update would push a worker pool more than three minor versions behind the control plane, the update is rejected and the
+profile is not applied to the cluster. Disable the toggle on the affected pools first.
 
-Scale-up is not permitted while the toggle is enabled. Palette rejects scale-up requests on a pool with the toggle
-enabled, whether initiated manually or by the cluster autoscaler. To expand capacity, create a new worker pool and add
-Edge hosts to it instead.
+Scale-up is not permitted while the toggle is enabled. Scale-up requests on a pool with the toggle enabled are rejected,
+whether initiated manually or by the cluster autoscaler, because a new node cannot honor the pool's pinned Kubernetes
+version. To expand capacity, create a new worker pool and add Edge hosts to it instead.
 
 ### Upgrade a Skipped Worker Pool
 

--- a/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
@@ -128,9 +128,9 @@ pack, but if you want to use a different storage pack altogether, we recommend y
 
 Edge Native clusters support upgrading the control plane independently from worker pools. You can enable the **Skip
 worker node update (Optional)** toggle on individual worker pools to defer their Kubernetes upgrade while the control
-plane advances. This decouples worker upgrades from control plane upgrades, which lets you apply a security patch or
-advance an LTS upgrade without repaving worker nodes, and it reduces the number of worker upgrades needed to cross
-several Kubernetes minor versions.
+plane advances. This decouples worker upgrades from control plane upgrades, which lets you move the control plane
+forward, for example to apply a security patch, without repaving worker nodes. It also reduces the number of worker
+upgrades needed to cross several Kubernetes minor versions.
 
 Support depends on how the cluster is managed.
 
@@ -138,14 +138,6 @@ Support depends on how the cluster is managed.
 | ----------------------------- | ------------------------------------------------------------------------ |
 | Connected (centrally managed) | Supported. Configure the toggle in Palette.                              |
 | Locally managed, airgapped    | Supported. Configure the toggle in Local UI or through the Local UI API. |
-
-:::info
-
-A newer Kubernetes long-term support version only becomes available as an upgrade target once your Palette or VerteX
-instance itself supports it. Support for newer long-term support versions is not back-ported to earlier Palette
-long-term support releases, so upgrade your Palette or VerteX instance first, then upgrade your clusters.
-
-:::
 
 When a cluster profile update bumps the Kubernetes version, the control plane and any worker pools that do not have
 **Skip worker node update** enabled are upgraded. Worker pools with the toggle enabled are skipped and stay at their

--- a/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
@@ -126,13 +126,21 @@ pack, but if you want to use a different storage pack altogether, we recommend y
 
 ## Decoupled Control Plane and Worker Node Upgrades
 
-Edge Native clusters support upgrading the control plane independently from worker pools. You can enable the **Skip
-worker node update (Optional)** toggle on individual worker pools to defer their Kubernetes upgrade while the control
-plane advances. This decouples worker upgrades from control plane upgrades, which lets you move the control plane
-forward, for example to apply a security patch, without repaving worker nodes. It also reduces the number of worker
-upgrades needed to cross several Kubernetes minor versions.
+Edge Native clusters that use Palette eXtended Kubernetes Edge (PXK-E) or Canonical Kubernetes support upgrading the
+control plane independently from worker pools. You can enable the **Skip worker node update (Optional)** toggle on
+individual worker pools to defer their Kubernetes upgrade while the control plane advances. This decouples worker
+upgrades from control plane upgrades, which lets you move the control plane forward, for example to apply a security
+patch, without repaving worker nodes. It also reduces the number of worker upgrades needed to cross several Kubernetes
+minor versions.
 
-Support depends on how the cluster is managed.
+:::info
+
+Decoupled control plane and worker node upgrades are supported for PXK-E and Canonical Kubernetes only. K3s and RKE2
+clusters are not supported.
+
+:::
+
+Support also depends on how the cluster is managed.
 
 | **Cluster management**        | **Support**                                                              |
 | ----------------------------- | ------------------------------------------------------------------------ |

--- a/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
@@ -139,6 +139,14 @@ Support depends on how the cluster is managed.
 | Connected (centrally managed) | Supported. Configure the toggle in Palette.                                                                               |
 | Locally managed, airgapped    | Supported for clusters running Canonical Kubernetes (CK8s). Configure the toggle in Local UI or through the Local UI API. |
 
+:::info
+
+A newer Kubernetes long-term support version only becomes available as an upgrade target once your Palette or VerteX
+instance itself supports it. Support for newer long-term support versions is not back-ported to earlier Palette
+long-term support releases, so upgrade your Palette or VerteX instance first, then upgrade your clusters.
+
+:::
+
 When a cluster profile update bumps the Kubernetes version, the control plane and any worker pools that do not have
 **Skip worker node update** enabled are upgraded. Worker pools with the toggle enabled are skipped and stay at their
 current Kubernetes version. Control plane nodes are always upgraded to the Kubernetes and OS versions declared in the

--- a/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
@@ -134,10 +134,10 @@ several Kubernetes minor versions.
 
 Support depends on how the cluster is managed.
 
-| **Cluster management**        | **Support**                                                                                                               |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Connected (centrally managed) | Supported. Configure the toggle in Palette.                                                                               |
-| Locally managed, airgapped    | Supported for clusters running Canonical Kubernetes (CK8s). Configure the toggle in Local UI or through the Local UI API. |
+| **Cluster management**        | **Support**                                                              |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| Connected (centrally managed) | Supported. Configure the toggle in Palette.                              |
+| Locally managed, airgapped    | Supported. Configure the toggle in Local UI or through the Local UI API. |
 
 :::info
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/scale-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/scale-cluster.md
@@ -15,6 +15,15 @@ the cluster by removing nodes from the cluster using Local UI.
 To scale up a cluster is to add additional nodes to an active cluster. You can scale up a cluster deployed on hosts
 installed in local management mode in Local UI.
 
+:::warning
+
+You cannot scale up a worker pool that has the **Skip worker node update (Optional)** toggle enabled, because a new node
+cannot honor the pool's pinned Kubernetes version. Either disable the toggle, which repaves the pool to the control
+plane version, or create a new worker pool and add the Edge hosts to it. Refer to
+[Decoupled Control Plane and Worker Node Upgrades](../../cluster-management/upgrade-behavior.md#decoupled-control-plane-and-worker-node-upgrades).
+
+:::
+
 ### Prerequisites
 
 - You have an active cluster composed of hosts installed in local management mode. For more information, refer to

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -76,10 +76,10 @@ content bundle from the [Content](./upload-content-bundle.md) page and redeploy 
 
 ## Deferred Worker Node Upgrades
 
-On a locally managed cluster running Canonical Kubernetes (CK8s), you can defer the Kubernetes upgrade of individual
-worker pools while the control plane advances. Enable the **Skip worker node update (Optional)** toggle on a worker
-pool, and an update that raises the Kubernetes version upgrades the control plane and any pool without the toggle, while
-pools with the toggle stay at their current version.
+On a locally managed cluster, you can defer the Kubernetes upgrade of individual worker pools while the control plane
+advances. Enable the **Skip worker node update (Optional)** toggle on a worker pool, and an update that raises the
+Kubernetes version upgrades the control plane and any pool without the toggle, while pools with the toggle stay at their
+current version.
 
 This is useful when crossing several Kubernetes minor versions to reach a newer long-term support release, because it
 reduces how many times worker nodes repave.

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -74,6 +74,30 @@ content bundle from the [Content](./upload-content-bundle.md) page and redeploy 
 
    :::
 
+## Deferred Worker Node Upgrades
+
+On a locally managed cluster running Canonical Kubernetes (CK8s), you can defer the Kubernetes upgrade of individual
+worker pools while the control plane advances. Enable the **Skip worker node update (Optional)** toggle on a worker
+pool, and an update that raises the Kubernetes version upgrades the control plane and any pool without the toggle, while
+pools with the toggle stay at their current version.
+
+This is useful when crossing several Kubernetes minor versions to reach a newer long-term support release, because it
+reduces how many times worker nodes repave.
+
+Two constraints apply while the toggle is enabled.
+
+- A pool cannot fall more than three minor Kubernetes versions behind the control plane. An update that would exceed the
+  skew is rejected and is not applied to the cluster. Disable the toggle on the affected pools first.
+
+- Scale-up on that pool is rejected, because a new node cannot honor the pool's pinned Kubernetes version. To add
+  capacity, create a new worker pool and add Edge hosts to it.
+
+Disabling the toggle repaves the pool to the control plane's Kubernetes version, so make sure you are ready to repave
+before you disable it.
+
+For the full behavior, refer to
+[Decoupled Control Plane and Worker Node Upgrades](../../cluster-management/upgrade-behavior.md#decoupled-control-plane-and-worker-node-upgrades).
+
 ## Validate
 
 1. Log in to Local UI.

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -81,8 +81,7 @@ advances. Enable the **Skip worker node update (Optional)** toggle on a worker p
 Kubernetes version upgrades the control plane and any pool without the toggle, while pools with the toggle stay at their
 current version.
 
-This is useful when crossing several Kubernetes minor versions to reach a newer long-term support release, because it
-reduces how many times worker nodes repave.
+This is useful when crossing several Kubernetes minor versions, because it reduces how many times worker nodes repave.
 
 Two constraints apply while the toggle is enabled.
 

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -76,10 +76,11 @@ content bundle from the [Content](./upload-content-bundle.md) page and redeploy 
 
 ## Deferred Worker Node Upgrades
 
-On a locally managed cluster, you can defer the Kubernetes upgrade of individual worker pools while the control plane
-advances. Enable the **Skip worker node update (Optional)** toggle on a worker pool, and an update that raises the
-Kubernetes version upgrades the control plane and any pool without the toggle, while pools with the toggle stay at their
-current version.
+On a locally managed cluster that uses Palette eXtended Kubernetes Edge (PXK-E) or Canonical Kubernetes, you can defer
+the Kubernetes upgrade of individual worker pools while the control plane advances. Enable the **Skip worker node update
+(Optional)** toggle on a worker pool, and an update that raises the Kubernetes version upgrades the control plane and
+any pool without the toggle, while pools with the toggle stay at their current version. K3s and RKE2 clusters are not
+supported.
 
 This is useful when crossing several Kubernetes minor versions, because it reduces how many times worker nodes repave.
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -73,6 +73,17 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 #### Features
 
+<!-- https://spectrocloud.atlassian.net/browse/PE-9264 -->
+
+- Locally managed Edge clusters in an airgapped environment running Canonical Kubernetes (CK8s) now support decoupled
+  control plane and worker node upgrades. Enable the **Skip worker node update (Optional)** toggle on a worker pool in
+  Local UI to hold that pool at its current Kubernetes version while the control plane advances, up to the Kubernetes
+  N-3 minor version skew. This reduces how many times worker nodes repave when crossing several minor versions to reach
+  a newer long-term support release. Scale-up on a pool with the toggle enabled is rejected, and disabling the toggle
+  repaves the pool to the control plane version. Refer to
+  [Decoupled Control Plane and Worker Node Upgrades](../clusters/edge/cluster-management/upgrade-behavior.md#decoupled-control-plane-and-worker-node-upgrades)
+  for more information.
+
 #### Improvements
 
 #### Bug Fixes

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -78,9 +78,8 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 - Locally managed Edge clusters in an airgapped environment now support decoupled control plane and worker node
   upgrades. Enable the **Skip worker node update (Optional)** toggle on a worker pool in Local UI to hold that pool at
   its current Kubernetes version while the control plane advances, up to the Kubernetes N-3 minor version skew. This
-  reduces how many times worker nodes repave when crossing several minor versions to reach a newer long-term support
-  release. Scale-up on a pool with the toggle enabled is rejected, and disabling the toggle repaves the pool to the
-  control plane version. Refer to
+  reduces how many times worker nodes repave when crossing several Kubernetes minor versions. Scale-up on a pool with
+  the toggle enabled is rejected, and disabling the toggle repaves the pool to the control plane version. Refer to
   [Decoupled Control Plane and Worker Node Upgrades](../clusters/edge/cluster-management/upgrade-behavior.md#decoupled-control-plane-and-worker-node-upgrades)
   for more information.
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -75,12 +75,12 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 <!-- https://spectrocloud.atlassian.net/browse/PE-9264 -->
 
-- Locally managed Edge clusters in an airgapped environment running Canonical Kubernetes (CK8s) now support decoupled
-  control plane and worker node upgrades. Enable the **Skip worker node update (Optional)** toggle on a worker pool in
-  Local UI to hold that pool at its current Kubernetes version while the control plane advances, up to the Kubernetes
-  N-3 minor version skew. This reduces how many times worker nodes repave when crossing several minor versions to reach
-  a newer long-term support release. Scale-up on a pool with the toggle enabled is rejected, and disabling the toggle
-  repaves the pool to the control plane version. Refer to
+- Locally managed Edge clusters in an airgapped environment now support decoupled control plane and worker node
+  upgrades. Enable the **Skip worker node update (Optional)** toggle on a worker pool in Local UI to hold that pool at
+  its current Kubernetes version while the control plane advances, up to the Kubernetes N-3 minor version skew. This
+  reduces how many times worker nodes repave when crossing several minor versions to reach a newer long-term support
+  release. Scale-up on a pool with the toggle enabled is rejected, and disabling the toggle repaves the pool to the
+  control plane version. Refer to
   [Decoupled Control Plane and Worker Node Upgrades](../clusters/edge/cluster-management/upgrade-behavior.md#decoupled-control-plane-and-worker-node-upgrades)
   for more information.
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -75,11 +75,12 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 <!-- https://spectrocloud.atlassian.net/browse/PE-9264 -->
 
-- Locally managed Edge clusters in an airgapped environment now support decoupled control plane and worker node
-  upgrades. Enable the **Skip worker node update (Optional)** toggle on a worker pool in Local UI to hold that pool at
-  its current Kubernetes version while the control plane advances, up to the Kubernetes N-3 minor version skew. This
-  reduces how many times worker nodes repave when crossing several Kubernetes minor versions. Scale-up on a pool with
-  the toggle enabled is rejected, and disabling the toggle repaves the pool to the control plane version. Refer to
+- Locally managed Edge clusters in an airgapped environment that use Palette eXtended Kubernetes Edge (PXK-E) or
+  Canonical Kubernetes now support decoupled control plane and worker node upgrades. Enable the **Skip worker node
+  update (Optional)** toggle on a worker pool in Local UI to hold that pool at its current Kubernetes version while the
+  control plane advances, up to the Kubernetes N-3 minor version skew. This reduces how many times worker nodes repave
+  when crossing several Kubernetes minor versions. Scale-up on a pool with the toggle enabled is rejected, and disabling
+  the toggle repaves the pool to the control plane version. Refer to
   [Decoupled Control Plane and Worker Node Upgrades](../clusters/edge/cluster-management/upgrade-behavior.md#decoupled-control-plane-and-worker-node-upgrades)
   for more information.
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages).
- [ ] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display. _No images in this PR._
- [x] Ensure all **Vale comments** are resolved. Refer to [Vale](#vale).
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _Not required for this PR._
- [ ] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _Not applicable: targets
      `docs-rel-4-10-0`. Refer to [Backporting](#backporting)._
- [x] **Outside review:** Does this PR require review outside of Docs? **Answered.** Both questions went to Kiran
      Kilingar Nadumane, the PE-8679 assignee. One is resolved and applied; one is outstanding but non-blocking. Refer to
      [Outstanding Questions](#outstanding-questions).
- [ ] Add the `notify-slack` label once this checklist has been completed.

Good job! 👏👏👏

---

## 📝 Describe the Change

Palette 4.10.0 extends decoupled control plane and worker node upgrades to **locally managed Edge clusters in an
airgapped environment**, configured through Local UI. This unblocks multi-hop Kubernetes LTS upgrades, for example CK8s 1.36 LTS to 1.42 LTS, by letting worker pools lag the control plane instead of repaving on every minor version.

No distribution qualifier is claimed, matching what we already claim for connected Edge. Refer to [Outstanding Questions](#outstanding-questions) for the confirmation this rests on.

### This is mostly a correction, not new content

Decoupled upgrades already shipped for **connected** Edge in 4.9.b and were documented then, in commit `763aac61a` (#10559). The published Edge page therefore carries an exclusion that becomes wrong on 4.10.0:

> This feature is only available for connected Edge Native clusters. Locally managed Edge clusters are not supported.

That admonition, and the supported-cluster-types list in `node-pool.md`, are the substance of this PR. Existing prose was extended rather than duplicated, so the diff is deliberately small for a P2 feature.

### What each file does

| File | Change |
| --- | --- |
| `clusters/cluster-management/node-pool.md` | Added locally managed airgapped Edge to the supported-types list. Broadened the scale-up prohibition from connected Edge to both, with the reason (a new node cannot honor the pool's pinned Kubernetes version). |
| `clusters/edge/cluster-management/upgrade-behavior.md` | Replaced the connected-only exclusion with a support table covering both management modes. Added three behaviors from the epic that were previously undocumented: control plane nodes upgrade one at a time, a skipped pool still accepts Day-2 taint and label changes without moving its Kubernetes version, and an update that breaks the skew is rejected outright rather than partially applied. Also added the "upgrade your Palette LTS instance first" prerequisite. |
| `clusters/cluster-management/platform-settings/pause-platform-upgrades.md` | New **Agent Version Drift Warning** section, cross-linked to `architecture/crd-api-versions.md`, which already documents the same N-2 window from the architecture side. The banner itself was undocumented. |
| `clusters/edge/local-ui/cluster-management/update-cluster.md` | New **Deferred Worker Node Upgrades** section, since Local UI is the only surface for airgap. |
| `clusters/edge/local-ui/cluster-management/scale-cluster.md` | Warning that scale-up is rejected while the toggle is enabled, with the new-pool workaround. |
| `release-notes/release-notes.md` | **Edge** > **Features** entry. |

### Scope taken from the epic, not the Doc-task

[PE-8679](https://spectrocloud.atlassian.net/browse/PE-8679) is Verified and far more specific than the Doc-task, and it **strikes through two items** the Doc-task still implies are in scope:

- The "target Kubernetes version is out of the support window" profile-upgrade warning. Struck out. **Not documented.**
- Profile upgrades calling out CSI/CNI/add-on incompatibilities and failing fast. Struck out. **Not documented.**

Only the pause-agent drift banner survives from the epic's LTS UX section, and that is what this PR adds.

The epic also contradicts itself on Terraform: the acceptance criteria claim support "across all permutations, including
TF, Crossplane," while **Not in scope** states Terraform is tracked in [PE-8642](https://spectrocloud.atlassian.net/browse/PE-8642). No Terraform or Crossplane surface is documented here.

### UI strings paraphrased rather than quoted

The epic supplies exact copy for the toggle tooltip, the skew validation error, and the drift banner. All three are paraphrased here rather than quoted, on the grounds that engineering copy still moves late. If the team would rather quote them verbatim so a reader can match the string they see on screen, that is a quick change.

---

## Outstanding Questions

1. ~~**Distro scope for the airgap case.**~~ **Resolved** by Kiran Kilingar Nadumane, PE-8679 assignee, on 2026-08-18: the feature works for any distribution, and the guidance is to make the same claim we make for the connected case today. The connected case carries no distribution qualifier, so the **CK8s qualifier has been removed** from all four places that carried it. The ticket title says CK8s, but that reflects the epic that surfaced the work rather than the supported scope.
2. **Local UI navigation for the toggle.** Still open. Deliberately not written: no Local UI page documents editing this toggle, and the epic only says "worker pool config section". `scale-cluster.md` shows the surface exists at **Cluster** > **Nodes** > pool > **Pool Configuration**, so the toggle is very likely in that dialog, but "very likely" does not justify numbered steps. The new section documents behavior and links to the concept page instead. **This does not block review**, since the section is accurate as written and would only gain steps, not change meaning. If Linus has time to build and get UI access, then this will be added.

---

## Deliberately Out of Scope

**The CK8s LTS upgrade-path page.** The Doc-task asks to "update the CK8s LTS upgrade-path page (create if absent)". It is absent, and it is being tracked as a separate ticket rather than expanded into this PR.

What exists today is one substantive piece: `architecture/crd-api-versions.md` already documents the LTS N-2 compatibility window, where cluster-side agents can lag the management plane by up to two LTS major versions. This PR cross-links the new **Agent Version Drift Warning** section to it, since the two describe the same window from opposite sides. Every other LTS mention in the docs is incidental: the phrase used as motivation on `node-pool.md`, kernel-LTS troubleshooting on `troubleshooting/edge/edge.md`, and `"group": "LTS"` pack metadata.

What the new page still needs, and why it is not here:

- **Supported LTS-to-LTS hops.** The epic points at an internal wiki compatibility matrix. Transcribing a version matrix maintained elsewhere, with no signal when it changes, is how documentation goes quietly stale. Whether to summarise it inline or link it needs a product decision, not a writing decision.
- **The out-of-support intermediate-version warning.** Struck through in the epic, so it is not a shipping behavior and would not belong on the page anyway.

**One piece was pulled forward into this PR.** The prerequisite constraint is unblocked, is a real gotcha, and belongs in front of a reader planning an Edge LTS upgrade, so it ships now as an admonition on the decoupled-upgrades section: a newer Kubernetes long-term support version only becomes an available upgrade target once your Palette or VerteX instance supports it, because support is not back-ported to earlier Palette long-term support releases.

Placement note for the follow-up ticket: LTS is platform-wide, and `architecture/crd-api-versions.md` is already where the N-2 window is explained, so the page probably belongs near it rather than under Edge. The Doc-task framing it as a CK8s-on-Edge page looks like an artifact of which epic happened to surface it.

---

## Verification

Everything documented here is taken from PE-8679, which is **Verified**, so the feature is built and tested rather than
in flight. The distinction between connected and locally managed Edge support was cross-checked against the published docs and their git history to confirm the 4.9.b content describes a genuinely separate earlier delivery rather than an error.

**Not verified on an appliance.** No airgapped Edge cluster was available, so no toggle was exercised, no skew rejection was observed, and no drift banner was seen. The behavioral claims rest on the epic's acceptance criteria.

---

## Vale

Clean. Ten errors remain across the touched files and **all ten are pre-existing and outside every hunk in this PR**,
confirmed by cross-checking error line numbers against the diff hunk ranges:

- `node-pool.md` lines 29, 43, 47, 116, 165 — a repeated "the", two acronym expansions, a `kubelet` casing, and the
  `### Scaling Behavior` heading, which this PR shifted but did not author
- `upgrade-behavior.md` lines 27, 54 — acronym expansions
- `release-notes.md` lines 135, 145, 150 — the `#### OS`, `#### CNI`, `#### CSI` headings in the Packs section

`pause-platform-upgrades.md`, `update-cluster.md`, and `scale-cluster.md` report zero errors.

All four new relative links resolve, and the `#decoupled-control-plane-and-worker-node-upgrades` anchor they target is still present at `upgrade-behavior.md` line 127.

---

## Backporting

Not applicable. This PR targets `docs-rel-4-10-0` and documents a 4.10.0 capability. No `auto-backport` or
`backport-version-**` labels.

**Note on merge order:** the release-notes entry lands in the same empty **Edge** > **Features** block that
[#11707](https://github.com/spectrocloud/librarium/pull/11707) (PE-9267) also fills. Expect a conflict there; both are clean inserts, so the resolve is to keep both bullets.

---

## 💻 Changed Pages

- [Node Pools](https://deploy-preview-11709--docs-spectrocloud.netlify.app/clusters/cluster-management/node-pool#skip-worker-node-update) — supported cluster types and scaling behavior
- [Edge Cluster Upgrade Behavior](https://deploy-preview-11709--docs-spectrocloud.netlify.app/clusters/edge/cluster-management/upgrade-behavior#decoupled-control-plane-and-worker-node-upgrades) — the exclusion removed, support table added
- [Pause Agent Upgrades](https://deploy-preview-11709--docs-spectrocloud.netlify.app/clusters/cluster-management/platform-settings/pause-platform-upgrades) — new **Agent Version Drift Warning** section
- [Update Local Cluster](https://deploy-preview-11709--docs-spectrocloud.netlify.app/clusters/edge/local-ui/cluster-management/update-cluster) — new **Deferred Worker Node Upgrades** section
- [Scale a Local Cluster](https://deploy-preview-11709--docs-spectrocloud.netlify.app/clusters/edge/local-ui/cluster-management/scale-cluster) — scale-up warning
- [Release Notes](https://deploy-preview-11709--docs-spectrocloud.netlify.app/release-notes) — **Edge** > **Features** entry for 4.10.0

---

## 🎫 Jira Tickets

- [PE-9264](https://spectrocloud.atlassian.net/browse/PE-9264) — DOC - LTS upgrade path for CK8s workload clusters on edge (airgapped)
- [PE-8679](https://spectrocloud.atlassian.net/browse/PE-8679) — parent epic, Verified
- [PE-8642](https://spectrocloud.atlassian.net/browse/PE-8642) — Terraform support, explicitly out of scope


[PE-8679]: https://spectrocloud.atlassian.net/browse/PE-8679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ