### PR TITLE
DOC-3125 - Ask for the nickfury branch or tag name by name

### DIFF
--- a/.github/workflows/generate_patch_release_notes.yaml
+++ b/.github/workflows/generate_patch_release_notes.yaml
@@ -15,7 +15,7 @@ on:
         description: "The Palette patch release version (e.g., 4.9.48). Leave empty to skip the CanvOS and Palette CLI updates."
         required: false
       nickfury_ref:
-        description: "The nickfury branch or tag holding the component versions (default: v<patch_version>)"
+        description: "The nickfury branch or tag name holding the component versions. Branches are release-<version>, tags are v<version> with an optional -rc.N suffix (e.g. release-4.9 or v4.9.47-rc.2). Leave empty to try v<patch_version> then release-<patch_version>."
         required: false
       palette_cli_sha:
         description: "SHA256 checksum of the Palette CLI binary. Leave empty to derive it from the published binary."

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -348,20 +348,34 @@ that document them.
 The target prompts for the following values. Each prompt is skipped when its environment variable is already set, and
 also when there is no terminal to prompt on, so the same target runs unattended in a workflow.
 
-| **Prompt**             | **Environment Variable** | **Description**                                                                                                                                |
-| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Patch release version  | `PATCH_RELEASE_VERSION`  | The Palette patch release version, for example `4.9.48`. Leave it empty to generate the release notes body alone.                              |
-| nickfury branch or tag | `NICKFURY_REF`           | The `spectrocloud/nickfury` branch or tag that holds the component versions. Defaults to `v<version>`, then falls back to `release-<version>`. |
-| Palette CLI checksum   | `PATCH_PALETTE_CLI_SHA`  | The SHA256 checksum of the Palette CLI binary. Leave it empty to derive the checksum from the published binary, which transfers around 400 MB. |
+| **Prompt**             | **Environment Variable** | **Description**                                                                                                                                           |
+| ---------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Patch release version  | `PATCH_RELEASE_VERSION`  | The Palette patch release version, for example `4.9.48`. Leave it empty to generate the release notes body alone.                                         |
+| nickfury branch or tag | `NICKFURY_REF`           | The name of the `spectrocloud/nickfury` branch or tag that holds the component versions. Leave it empty to try `v<version>` and then `release-<version>`. |
+| Palette CLI checksum   | `PATCH_PALETTE_CLI_SHA`  | The SHA256 checksum of the Palette CLI binary. Leave it empty to derive the checksum from the published binary, which transfers around 400 MB.            |
 
 A patch ticket often names its `fixVersion` as a placeholder such as `4.9.x`, so the version you confirm at the first
-prompt both heads the new section and identifies the nickfury branch or tag to read. Leaving the prompt empty is the
-right answer while the version is still unknown. Re-running the target on the same ticket refreshes the section,
-including its heading, so you can draft the notes early and re-run once the version is confirmed.
+prompt heads the new section. Leaving the prompt empty is the right answer while the version is still unknown.
+Re-running the target on the same ticket refreshes the section, including its heading, so you can draft the notes early
+and re-run once the version is confirmed.
 
-When you supply a version, the target reads the `stylus` and `palette-cli` versions from `release/spectro_versions.txt`
-in the `spectrocloud/nickfury` repository. Reading that repository requires `GITHUB_TOKEN`. The target then compares
-those versions with the versions already recorded in the
+The second prompt asks for the nickfury branch or tag name, because a ref name does not always correspond to the patch
+release version. Release engineering hands over one of the following, so use the name you were given rather than one
+derived from the version.
+
+| **Ref**  | **Naming**          | **Example**                    |
+| -------- | ------------------- | ------------------------------ |
+| Branch   | `release-<version>` | `release-4.9`, `release-4.9.b` |
+| Tag      | `v<version>`        | `v4.9.46`                      |
+| Tag (RC) | `v<version>-rc.<N>` | `v4.9.47-rc.2`                 |
+
+Palette `4.9.47`, for example, can be built from the tag `v4.9.47-rc.2`, which no version-derived guess would find. The
+prompt accepts a name copied straight from a release ticket, including a full `refs/tags/...` or `refs/heads/...` path.
+Supplying a bare version instead of a name still works: the target tries `v<version>` and then `release-<version>`.
+
+Once the ref resolves, the target reads the `stylus` and `palette-cli` versions from `release/spectro_versions.txt` in
+the `spectrocloud/nickfury` repository. Reading that repository requires `GITHUB_TOKEN`. The target then compares those
+versions with the versions already recorded in the
 [Edge Compatibility Matrix](../docs-content/clusters/edge/edge-compatibility-matrix.md), because a patch release often
 ships the same components as the release before it. Only a component whose version moved is documented.
 

--- a/scripts/release/generate-patch-release-notes.sh
+++ b/scripts/release/generate-patch-release-notes.sh
@@ -152,16 +152,34 @@ if [[ -n "$RELEASE_PATCH_VERSION" ]]; then
   if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     echo "⚠️  GITHUB_TOKEN is not set, so $NICKFURY_REPO cannot be read. Skipping the CanvOS and Palette CLI updates." >&2
   else
+    # The release engineers hand over a branch or a tag, and neither is named after the patch
+    # release version alone: a branch is "release-<version>" and a tag is "v<version>", where a
+    # tag can also carry an "-rc.N" release candidate suffix. Ask for that name directly rather
+    # than guessing it from the version, because the two do not always correspond. For example,
+    # Palette 4.9.47 can be built from tag v4.9.47-rc.2 or from branch release-4.9.
     if [[ -z "${NICKFURY_REF:-}" && -t 0 ]]; then
-      read -p "Specify the $NICKFURY_REPO branch or tag holding the $RELEASE_PATCH component versions [v$RELEASE_PATCH]: " NICKFURY_REF
+      echo "ℹ️  Component versions come from $NICKFURY_REPO, whose refs are named:"
+      echo "      branch  release-<version>   for example, release-4.9 or release-$RELEASE_PATCH"
+      echo "      tag     v<version>          for example, v$RELEASE_PATCH or v$RELEASE_PATCH-rc.2"
+      read -p "Specify the branch or tag name holding the $RELEASE_PATCH component versions, or leave blank to try v$RELEASE_PATCH then release-$RELEASE_PATCH: " NICKFURY_REF
     fi
 
-    # nickfury names a release branch "release-<version>" and a release tag "v<version>". Try
-    # both when the ref was not given, because a patch is documented from whichever exists.
-    if [[ -n "${NICKFURY_REF:-}" ]]; then
+    # Accept a ref pasted in full, for example "refs/tags/v4.9.47-rc.2", and tolerate stray
+    # whitespace, so a value copied from a release ticket does not have to be tidied by hand.
+    NICKFURY_REF="$(printf '%s' "${NICKFURY_REF:-}" | tr -d '[:space:]')"
+    NICKFURY_REF="${NICKFURY_REF#refs/tags/}"
+    NICKFURY_REF="${NICKFURY_REF#refs/heads/}"
+
+    if [[ -z "$NICKFURY_REF" ]]; then
+      # Nothing given, so fall back to deriving both naming conventions from the version.
+      NICKFURY_REF_CANDIDATES=("v$RELEASE_PATCH" "release-$RELEASE_PATCH")
+    elif [[ "$NICKFURY_REF" == v* || "$NICKFURY_REF" == release-* ]]; then
+      # Already a ref name, so use exactly what was given.
       NICKFURY_REF_CANDIDATES=("$NICKFURY_REF")
     else
-      NICKFURY_REF_CANDIDATES=("v$RELEASE_PATCH" "release-$RELEASE_PATCH")
+      # A bare version was given rather than a ref name, so try both conventions for it.
+      echo "ℹ️  '$NICKFURY_REF' is a version rather than a ref name, so both naming conventions are tried."
+      NICKFURY_REF_CANDIDATES=("v$NICKFURY_REF" "release-$NICKFURY_REF")
     fi
 
     NICKFURY_VERSIONS=""
@@ -178,7 +196,7 @@ if [[ -n "$RELEASE_PATCH_VERSION" ]]; then
     done
 
     if [[ -z "$NICKFURY_VERSIONS" ]]; then
-      echo "⚠️  No component versions available from $NICKFURY_REPO. Skipping the CanvOS and Palette CLI updates." >&2
+      echo "⚠️  No component versions available from $NICKFURY_REPO, so the CanvOS and Palette CLI updates are skipped. Confirm the branch or tag name with the release engineers: a branch is named release-<version> and a tag v<version>, optionally with an -rc.N suffix. Then re-run with NICKFURY_REF set to that name." >&2
     else
       RELEASE_CANVOS=$(printf '%s\n' "$NICKFURY_VERSIONS" | get_keyed_value "stylus" || true)
       RELEASE_PALETTE_CLI_VERSION=$(printf '%s\n' "$NICKFURY_VERSIONS" | get_keyed_value "palette-cli" || true)


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Addendum to #11713. Script improvements only.

A nickfury ref name does not always correspond to the patch release version, so deriving it from the version is not
reliable. Palette `4.9.47`, for example, is built from the tag `v4.9.47-rc.2`; there is no `v4.9.47` tag for a
version-derived guess to find.

`make generate-patch-release-notes` now asks for the branch or tag **name** directly, and prints both naming
conventions with the current version substituted in:

```
ℹ️  Component versions come from spectrocloud/nickfury, whose refs are named:
      branch  release-<version>   for example, release-4.9 or release-4.9.47
      tag     v<version>          for example, v4.9.47 or v4.9.47-rc.2
Specify the branch or tag name holding the 4.9.47 component versions, or leave blank to try v4.9.47 then release-4.9.47:
```

Input handling:

- An explicit name (`v4.9.47-rc.2`, `release-4.9`) is used exactly as given.
- A name copied from a release ticket is tolerated, including a full `refs/tags/...` or `refs/heads/...` path and
  surrounding whitespace.
- A bare version is still accepted and expands to `v<version>` then `release-<version>`.
- Blank keeps the previous behaviour of deriving both conventions from the patch release version.

The failure message now names the conventions and the `NICKFURY_REF` override, so a wrong ref says what to supply
instead. The `nickfury_ref` workflow input description carries the same guidance.

### Testing

Every input form was resolved against the real repository: `v4.9.46`, `v4.9.47-rc.2`, `refs/tags/v4.9.47-rc.2`,
whitespace-padded input, `release-4.9`, `release-4.9.b`, `refs/heads/release-4.9`, the bare versions `4.9.46` and
`4.9` (which correctly falls through to `release-4.9`, since no `v4.9` tag exists), blank, and a non-existent name.
An interactive end-to-end run with `expect` confirmed the prompt, the resolution to `v4.9.47-rc.2`, and the
release-candidate warning firing on the resulting prerelease component versions.

---

## 💻 Changed Pages

No user-facing documentation changes. The only page touched is the contributor guide
[Release Process](https://github.com/spectrocloud/librarium/blob/DOC-3125-addendum/docs/contributing/release-process.md),
which is not published to docs.spectrocloud.com. The rest is release tooling.

---

## 🎫 Jira Tickets

[DOC-3125](https://spectrocloud.atlassian.net/browse/DOC-3125)


[DOC-3125]: https://spectrocloud.atlassian.net/browse/DOC-3125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ