### PR TITLE
DOC-3125 - Resolve the GitHub token before prompting in the patch notes script

### DIFF
--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -293,11 +293,16 @@ page.
 
 #### Issue Tracker and Super API
 
-| **Environment Variable** | **Description**          | **Example Value**       |
-| ------------------------ | ------------------------ | ----------------------- |
-| `JIRA_EMAIL`             | Issue tracker email.     | `name@spectrocloud.com` |
-| `JIRA_API_TOKEN`         | Issue tracker API token. | `XXX`                   |
-| `SUPER_API_TOKEN`        | Super API token.         | `XXX`                   |
+| **Environment Variable** | **Description**                                                                  | **Example Value**       |
+| ------------------------ | -------------------------------------------------------------------------------- | ----------------------- |
+| `JIRA_EMAIL`             | Issue tracker email.                                                             | `name@spectrocloud.com` |
+| `JIRA_API_TOKEN`         | Issue tracker API token.                                                         | `XXX`                   |
+| `SUPER_API_TOKEN`        | Super API token.                                                                 | `XXX`                   |
+| `GITHUB_TOKEN`           | GitHub token with read access to the private `spectrocloud/nickfury` repository. | `XXX`                   |
+
+`GITHUB_TOKEN` is only needed to look up component versions. Set it in your `.env` file, the same as the other tokens.
+When it is not set, the scripts fall back to the token the GitHub CLI already holds, so a machine that has run
+`gh auth login` against the organisation needs no `.env` entry at all. The scripts say which of the two they used.
 
 Super API keys are personal, and Super only accepts a key while its owner has a current SSO session. When the owner has
 not signed in to [Super](https://app.super.work) recently, Super rejects the key with an HTTP 401 error. Because Super
@@ -373,11 +378,14 @@ Palette `4.9.47`, for example, can be built from the tag `v4.9.47-rc.2`, which n
 prompt accepts a name copied straight from a release ticket, including a full `refs/tags/...` or `refs/heads/...` path.
 Supplying a bare version instead of a name still works: the target tries `v<version>` and then `release-<version>`.
 
+The ref prompt only appears when a GitHub token is available, because without one there is nothing to read. The target
+reports which token it is using before it prompts for anything, so a missing token is clear before you answer the
+version prompt rather than after.
+
 Once the ref resolves, the target reads the `stylus` and `palette-cli` versions from `release/spectro_versions.txt` in
-the `spectrocloud/nickfury` repository. Reading that repository requires `GITHUB_TOKEN`. The target then compares those
-versions with the versions already recorded in the
-[Edge Compatibility Matrix](../docs-content/clusters/edge/edge-compatibility-matrix.md), because a patch release often
-ships the same components as the release before it. Only a component whose version moved is documented.
+the `spectrocloud/nickfury` repository. The target then compares those versions with the versions already recorded in
+the [Edge Compatibility Matrix](../docs-content/clusters/edge/edge-compatibility-matrix.md), because a patch release
+often ships the same components as the release before it. Only a component whose version moved is documented.
 
 | **Component**             | **nickfury Key** | **Pages Updated When the Version Moves**                                                                                                                          |
 | ------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/scripts/release/generate-patch-release-notes.sh
+++ b/scripts/release/generate-patch-release-notes.sh
@@ -120,9 +120,30 @@ fi
 echo "ℹ️  Extracted release date: $RELEASE_DATE."
 echo "ℹ️  Extracted release patch: $RELEASE_PATCH."
 
-# Confirm the patch release version, so the CanvOS and Palette CLI versions this patch ships can
-# be read from nickfury. Both the branch and the tag that nickfury uses for a release are named
-# after the version, and the documentation pages are keyed on it too. Leaving it blank generates
+# Reading nickfury needs a token that can see a private repository. Resolve it before prompting for
+# anything, so the run states up front whether the component versions can be looked up at all,
+# rather than asking for a version and then quietly ignoring it.
+#
+# GITHUB_TOKEN comes from .env for a local run and from the workflow environment in CI. When it is
+# absent, fall back to the token the GitHub CLI already holds, which is usually signed in to the
+# organisation on a writer's machine.
+if [[ -z "${GITHUB_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
+  GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+
+  if [[ -n "$GITHUB_TOKEN" ]]; then
+    export GITHUB_TOKEN
+    echo "ℹ️  GITHUB_TOKEN is not set, so the GitHub CLI token from 'gh auth token' is used to read $NICKFURY_REPO."
+  fi
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "⚠️  No GitHub token is available, so $NICKFURY_REPO cannot be read and the CanvOS and Palette CLI versions are not looked up. Add 'export GITHUB_TOKEN=<token>' to your .env file, or run 'gh auth login', then re-run this script. 'make init-release' adds the .env placeholder." >&2
+else
+  echo "ℹ️  Component versions will be read from $NICKFURY_REPO."
+fi
+
+# Confirm the patch release version. It heads the new release notes section, and it is the key the
+# documentation pages record the CanvOS and Palette CLI versions against. Leaving it blank generates
 # the release notes alone, which is the right answer while the version is still unknown.
 #
 # Every prompt below is skipped when its environment variable is already set, and when there is no
@@ -130,6 +151,13 @@ echo "ℹ️  Extracted release patch: $RELEASE_PATCH."
 RELEASE_PATCH_VERSION="${PATCH_RELEASE_VERSION:-}"
 
 if [[ -z "$RELEASE_PATCH_VERSION" && -t 0 ]]; then
+  echo "ℹ️  The patch release version heads the new release notes section."
+
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    echo "    A follow-up prompt then asks for the $NICKFURY_REPO branch or tag that holds the CanvOS"
+    echo "    and Palette CLI versions for it. The version and that ref name are separate values."
+  fi
+
   read -p "Specify the Palette patch release version (for example, 4.9.48), or leave blank to skip the CanvOS and Palette CLI updates: " RELEASE_PATCH_VERSION
 fi
 
@@ -149,9 +177,8 @@ RELEASE_CANVOS=""
 RELEASE_PALETTE_CLI_VERSION=""
 
 if [[ -n "$RELEASE_PATCH_VERSION" ]]; then
-  if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-    echo "⚠️  GITHUB_TOKEN is not set, so $NICKFURY_REPO cannot be read. Skipping the CanvOS and Palette CLI updates." >&2
-  else
+  # A missing token was already reported above, so this only has to skip the lookup quietly.
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
     # The release engineers hand over a branch or a tag, and neither is named after the patch
     # release version alone: a branch is "release-<version>" and a tag is "v<version>", where a
     # tag can also carry an "-rc.N" release candidate suffix. Ask for that name directly rather


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Follow-up to #11713 and #11719. Script improvements only.

Two problems surfaced on the first real run. `GITHUB_TOKEN` was checked only *after* the patch release version prompt,
so with no token in `.env` the version was accepted and then silently ignored, the branch-or-tag prompt never appeared,
and the warning did not say where to set the token.

- **The token is resolved before any prompt**, and the run states which token it is using. When `GITHUB_TOKEN` is
  unset, the script falls back to the GitHub CLI token from `gh auth token`, so a machine that has run `gh auth login`
  needs no `.env` entry. CI is unaffected, because the workflow always sets `GITHUB_TOKEN` explicitly.
- **The missing-token warning is actionable**, naming `.env`, `gh auth login`, and `make init-release`.
- **The version prompt says a follow-up prompt asks for the branch or tag name**, and that the two are separate values.
  That line only appears when a token is available, since without one there is no ref prompt to come.
- `GITHUB_TOKEN` is now documented in the environment variable table, where it was missing.

Before:

```
Specify the Palette patch release version (for example, 4.9.48), or leave blank to skip the CanvOS and Palette CLI updates: 4.9.47
ℹ️  Using confirmed patch release version: 4.9.47.
⚠️  GITHUB_TOKEN is not set, so spectrocloud/nickfury cannot be read. Skipping the CanvOS and Palette CLI updates.
```

After, on the same machine with no `.env` entry:

```
ℹ️  GITHUB_TOKEN is not set, so the GitHub CLI token from 'gh auth token' is used to read spectrocloud/nickfury.
ℹ️  Component versions will be read from spectrocloud/nickfury.
ℹ️  The patch release version heads the new release notes section.
    A follow-up prompt then asks for the spectrocloud/nickfury branch or tag that holds the CanvOS
    and Palette CLI versions for it. The version and that ref name are separate values.
Specify the Palette patch release version (for example, 4.9.48), or leave blank to skip the CanvOS and Palette CLI updates: 4.9.47
ℹ️  Using confirmed patch release version: 4.9.47.
ℹ️  Component versions come from spectrocloud/nickfury, whose refs are named:
      branch  release-<version>   for example, release-4.9 or release-4.9.47
      tag     v<version>          for example, v4.9.47 or v4.9.47-rc.2
Specify the branch or tag name holding the 4.9.47 component versions, or leave blank to try v4.9.47 then release-4.9.47: v4.9.47-rc.2
ℹ️  Sourced component versions from spectrocloud/nickfury@v4.9.47-rc.2 (stylus=4.9.38-rc.1, palette-cli=4.9.20-rc.1).
```

### Testing

Three paths exercised interactively with `expect`, against a copy of a real `.env` that has no `GITHUB_TOKEN`:

- **No `GITHUB_TOKEN`** — falls back to the CLI token, announces it, both prompts appear, versions resolve.
- **No token and no `gh` on `PATH`** — emits the actionable warning and skips the lookup without prompting for a ref.
- **`GITHUB_TOKEN` set explicitly** — no fallback message, versions resolve. This is the CI path.

---

## 💻 Changed Pages

No user-facing documentation changes. The only page touched is the contributor guide
[Release Process](https://github.com/spectrocloud/librarium/blob/DOC-3125-token-and-prompts/docs/contributing/release-process.md),
which is not published to docs.spectrocloud.com. The rest is release tooling.

---

## 🎫 Jira Tickets

[DOC-3125](https://spectrocloud.atlassian.net/browse/DOC-3125)


[DOC-3125]: https://spectrocloud.atlassian.net/browse/DOC-3125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ