### PR TITLE
[version-4-6] fixing broken links and addressing false positives (#11714)

### DIFF
--- a/docs/contributing/checks-and-ci.md
+++ b/docs/contributing/checks-and-ci.md
@@ -36,8 +36,7 @@ We leverage [Vale](https://vale.sh/) to help us enforce our writing style progra
 mistakes. The writing checks are executed upon a pull request. You may also conduct a writing check locally by using the
 Vale CLI. Follow the steps below to install the Vale CLI and execute the writing checks.
 
-Start by installing Vale by following the [installation steps](https://vale.sh/docs/vale-cli/installation/) in the Vale
-documentation.
+Start by installing Vale by following the [installation steps](https://vale.sh/docs/install) in the Vale documentation.
 
 Next, download the required Vale plugins.
 

--- a/docs/docs-content/tutorials/getting-started/palette/aws/deploy-manage-k8s-cluster-tf.md
+++ b/docs/docs-content/tutorials/getting-started/palette/aws/deploy-manage-k8s-cluster-tf.md
@@ -559,9 +559,8 @@ kubectl port-forward --namespace kubecost deployment/cost-analyzer-cost-analyzer
 ```
 
 Open your browser window and navigate to `http://localhost:9090`. The Kubecost UI provides you with a variety of cost
-information about your cluster. Read more about
-[Navigating the Kubecost UI](https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui) to make the most of
-the cost analyzer pack.
+information about your cluster. Read more about [Navigating the Kubecost UI](https://www.ibm.com/docs/en/kubecost) to
+make the most of the cost analyzer pack.
 
 ![Image that shows the Kubecost UI](/getting-started/aws/getting-started_deploy-manage-k8s-cluster_kubecost.webp)
 

--- a/docs/docs-content/tutorials/getting-started/palette/azure/deploy-manage-k8s-cluster-tf.md
+++ b/docs/docs-content/tutorials/getting-started/palette/azure/deploy-manage-k8s-cluster-tf.md
@@ -567,9 +567,8 @@ kubectl port-forward --namespace kubecost deployment/cost-analyzer-cost-analyzer
 ```
 
 Open your browser window and navigate to `http://localhost:9090`. The Kubecost UI provides you with a variety of cost
-information about your cluster. Read more about
-[Navigating the Kubecost UI](https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui) to make the most of
-the cost analyzer pack.
+information about your cluster. Read more about [Navigating the Kubecost UI](https://www.ibm.com/docs/en/kubecost) to
+make the most of the cost analyzer pack.
 
 ![Image that shows the Kubecost UI](/getting-started/azure/getting-started_deploy-manage-k8s-cluster_kubecost.webp)
 

--- a/docs/docs-content/tutorials/getting-started/palette/gcp/deploy-manage-k8s-cluster-tf.md
+++ b/docs/docs-content/tutorials/getting-started/palette/gcp/deploy-manage-k8s-cluster-tf.md
@@ -556,9 +556,8 @@ kubectl port-forward --namespace kubecost deployment/cost-analyzer-cost-analyzer
 ```
 
 Open your browser window and navigate to `http://localhost:9090`. The Kubecost UI provides you with a variety of cost
-information about your cluster. Read more about
-[Navigating the Kubecost UI](https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui) to make the most of
-the cost analyzer pack.
+information about your cluster. Read more about [Navigating the Kubecost UI](https://www.ibm.com/docs/en/kubecost) to
+make the most of the cost analyzer pack.
 
 ![Image that shows the Kubecost UI](/getting-started/gcp/getting-started_deploy-manage-k8s-cluster_kubecost.webp)
 

--- a/docs/docs-content/tutorials/getting-started/palette/vmware/deploy-manage-k8s-cluster-tf.md
+++ b/docs/docs-content/tutorials/getting-started/palette/vmware/deploy-manage-k8s-cluster-tf.md
@@ -611,8 +611,8 @@ To use Kubecost in VMware vSphere clusters, you must enable the
 [custom pricing](https://docs.kubecost.com/architecture/pricing-sources-matrix#cloud-provider-on-demand-api) option in
 the Kubecost UI and manually set the monthly cluster costs.
 
-Read more about [Navigating the Kubecost UI](https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui) to
-make the most of the cost analyzer pack.
+Read more about [Navigating the Kubecost UI](https://www.ibm.com/docs/en/kubecost) to make the most of the cost analyzer
+pack.
 
 ![Image that shows the Kubecost UI](/getting-started/vmware/getting-started_deploy-manage-k8s-cluster_kubecost.webp)
 

--- a/docs/docs-content/vm-management/vm-migration-assistant/additional-configuration.md
+++ b/docs/docs-content/vm-management/vm-migration-assistant/additional-configuration.md
@@ -174,7 +174,7 @@ A dedicated migration network can improve performance and reduce risks to the VM
 ### Networks Tab
 
 The **Networks** tab displays a table of
-[NetworkAttachmentDefinitions](https://docs.openshift.com/container-platform/4.8/rest_api/network_apis/networkattachmentdefinition-k8s-cni-cncf-io-v1.html)
+[NetworkAttachmentDefinitions](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/network_apis/networkattachmentdefinition-k8s-cni-cncf-io-v1)
 from the cluster. This tab is only visible on host clusters.
 
 You can select a default migration network for the cluster to improve disk transfer performance. If no network is


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-6`:
 - [fixing broken links and addressing false positives (#11714)](https://github.com/spectrocloud/librarium/pull/11714)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

---

### Note on scope

Raised manually because the automated backport hit merge conflicts on this branch.

**The two `linkinator/` config files from #11714 are deliberately excluded.** The upstream change appended two skip
regexes immediately after a `docs.ansible.com` entry that does not exist on this branch, so the hunk has no context to
apply against. That is the entire conflict; all six documentation files apply cleanly.

The config files are omitted rather than hand-merged because GitHub Actions `schedule` triggers only fire on the
default branch, so the weekly Broken URL check never runs here. A skip entry on this branch would only affect a local
`make verify-url-links`. The configs have also already drifted from master independently, and DOC-3126 will rewrite the
skip list wholesale when the spoofed user agent is removed.

This PR therefore contains only the six documentation fixes, verified to match master's doc-only diff exactly:
**6 files changed, 10 insertions(+), 14 deletions(-)**.
