### PR TITLE
PE-9265: Kairos v4.1.2 and kairos-init v0.16.x (4.10.0)

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -75,6 +75,11 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 #### Improvements
 
+<!-- https://spectrocloud.atlassian.net/browse/PE-9265 -->
+
+- Edge workflows have been updated to Kairos v4.1.2 with `kairos-init` v0.16.x. Day-1 and Day-2 upgrades from earlier
+  Kairos builds are supported.
+
 #### Bug Fixes
 
 ### VerteX


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages).
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable). _One list item added to an existing section; no
        tables or admonitions._
  - [x] Verify all images display. _No images in this PR._
- [x] Ensure all **Vale comments** are resolved.
  - [x] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _Not required. Refer to [Vale](#vale)._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _Not applicable. Refer to
      [Backporting](#backporting)._
- [x] **Outside review:** Does this PR require review outside of Docs? **Yes, ideally.** One open question with
      Engineering, which does not block merge. Refer to [Open question](#open-question).
- [x] Add the `notify-slack` label once this checklist has been completed.

Good job! 👏👏👏

---

## 📝 Describe the Change

Adds the 4.10.0 release-note entry for the Kairos base image bump: **Kairos v4.1.2 with `kairos-init` v0.16.x**, replacing kairos-init 0.8.12 on kairos v4.0.3.

One list item under **Edge > Improvements**. That is the whole change.

### Why there is nothing else to document

**No Kairos version is referenced anywhere in the documentation.** A search for Kairos version patterns across every `.md` and `.mdx` file returns no support matrix, no compatibility table, and no version-bearing page. The only versioned mentions are historical records in `known-issues.md`. So this component bump has no downstream page to update, which confirms the cross-check in PE-9265: `docs/docs-content/component/` redirects to the CLI Downloads page and carries no Kairos row.

### Why the entry does not list the OS matrix

PE-9265 enumerates nine operating systems. The entry deliberately names none for two reasons.

**Precedent.** The previous Kairos bump shipped in 4.9.5 and enumerated no OS matrix either:

> Edge workflows have been updated to Kairos v4.0.3. Due to upstream changes, this update does not apply to
> [UKI-based Trusted Boot images], which remain on Kairos v3.5.9. This does not impact functionality.

**One OS in that matrix is undocumented.** "SLE Micro" appears exactly **once** in the entire repository, in
`docs/docs-content/unlisted/cve-reports.md`, and never as a supported Edge operating system. Naming it in a release note would introduce a platform our docs do not otherwise present as supported. Raised with Engineering separately, because if SLE Micro is supported then we have a documentation gap larger than this ticket.

### Deliberately omitted

PE-9265's scope says reset behavior preserves prior GRUB options. That claim is not in the entry, because it is unverified and because "nothing broke" is not usually release-note material. Asked as a question rather than published as a fact. If Engineering confirms the previous bump *did* disturb GRUB options and this restores them, it is worth adding, and `clusters/edge/cluster-management/reset-host.md` would be the page for any behavioral detail.



## 💻 Changed Pages

- [Release Notes](https://deploy-preview-11731--docs-spectrocloud.netlify.app/release-notes/) — new entry under **4.10.0 > Edge > Improvements**

---

## 🎫 Jira Tickets

[PE-9265](https://spectrocloud.atlassian.net/browse/PE-9265) — DOC - Kairos v4.1.2 / kairos-init v0.16.x upgrade (4.10.0)

Related:

- [PE-8393](https://spectrocloud.atlassian.net/browse/PE-8393) — the `multipath-tools` known issue whose Kairos v3.5.9 attribution this bump calls into question


[PE-9265]: https://spectrocloud.atlassian.net/browse/PE-9265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ