### PR TITLE
DOC-3125 - Order and tighten the patch release notes workflow fields

### DIFF
--- a/.github/workflows/generate_patch_release_notes.yaml
+++ b/.github/workflows/generate_patch_release_notes.yaml
@@ -5,23 +5,25 @@ on:
   workflow_dispatch:
     inputs:
       jira_ticket:
-        description: "The Jira ticket for the patch release (e.g., DOC-2815)"
+        description: "Jira ticket for the patch release, for example DOC-2815."
         required: true
       base_branch:
-        description: "The base branch for the patch release PR (default: master)"
+        description: "Base branch for the pull request."
         required: true
         default: "master"
       patch_version:
-        description: "The Palette patch release version (e.g., 4.9.48), or a placeholder such as 4.9.x. Leave empty to use the version from the candidates JQL."
-        required: false
-      nickfury_ref:
-        description: "The nickfury branch or tag name holding the component versions. Branches are release-<version>, tags are v<version> with an optional -rc.N suffix (e.g. release-4.9 or v4.9.47-rc.2). Leave empty to try v<patch_version> then release-<patch_version>."
-        required: false
-      palette_cli_sha:
-        description: "SHA256 checksum of the Palette CLI binary, from ReTool. Leave empty to record it as pending."
+        description: "Palette patch release version, for example 4.9.48. Use a placeholder such as 4.9.x while it is undecided. Empty takes the version from the candidates JQL."
         required: false
       component_updates:
-        description: "Set to true when this patch adds a new CanvOS or Palette CLI version, or both. Leave empty to generate the release notes body only."
+        description: "Tick when this patch adds a new CanvOS or Palette CLI version, or both. Leave clear to generate the release notes body only, in which case the two fields below are ignored."
+        required: false
+        type: boolean
+        default: false
+      nickfury_ref:
+        description: "nickfury branch or tag holding those versions, for example release-4.9 or v4.9.47-rc.2. Empty records the versions as PENDING."
+        required: false
+      palette_cli_sha:
+        description: "Palette CLI SHA256 checksum, from ReTool. Enter derive to read it from the published binary. Empty records it as PENDING."
         required: false
 
 env:

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -364,7 +364,9 @@ The Palette CLI checksum is published in ReTool, so look it up there and paste i
 published binary instead, which streams around 400 MB and only works once the release is out.
 
 An unattended run answers from the environment variables alone. It generates the release notes body only, unless
-`NICKFURY_REF` or `PATCH_PALETTE_CLI_SHA` is supplied, which is taken to mean the component versions are wanted.
+`NICKFURY_REF` or `PATCH_PALETTE_CLI_SHA` is supplied, which is taken to mean the component versions are wanted. The
+**Generate Patch Release Notes** workflow presents the same values as form fields, in the same order, and its component
+version tick box has to be set for the branch or tag and checksum fields to be used.
 
 A patch ticket often names its `fixVersion` as a placeholder such as `4.9.x`, so the version you confirm at the first
 prompt heads the new section. A placeholder is a valid answer, and pressing Enter accepts the one the candidates JQL

--- a/scripts/release/generate-patch-release-notes.sh
+++ b/scripts/release/generate-patch-release-notes.sh
@@ -209,6 +209,12 @@ fi
 
 if [[ "$COMPONENT_UPDATES" == false ]]; then
   echo "ℹ️  No new CanvOS or Palette CLI versions, so only the release notes body is generated."
+
+  # A branch, tag, or checksum supplied alongside a "no" answer is a mismatch worth naming, because
+  # the workflow form makes it easy to fill those fields in and leave the tick box clear.
+  if [[ -n "${NICKFURY_REF:-}" || -n "${PATCH_PALETTE_CLI_SHA:-}" ]]; then
+    echo "⚠️  A branch or tag, or a checksum, was supplied but no new component versions were requested, so it is ignored. Answer yes to the component version question, or set PATCH_COMPONENT_UPDATES=true, to use it." >&2
+  fi
 elif [[ -z "${GITHUB_TOKEN:-}" ]]; then
   echo "⚠️  No GitHub token is available, so $NICKFURY_REPO cannot be read and the component versions are recorded as pending. Add 'export GITHUB_TOKEN=<token>' to your .env file, or run 'gh auth login', to look them up. 'make init-release' adds the .env placeholder." >&2
 fi


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Follow-up to #11733. Workflow form and one warning only.

The **Generate Patch Release Notes** form listed the component version field **last**, after the two fields that only
apply when it is set, and the branch or tag description still said an empty value derives a ref from the version. That
stopped being true in #11733, where an empty answer began recording the versions as pending.

The fields are now ordered as the terminal asks for them, so the form and the interview match:

| Order | Field | Terminal question |
| --- | --- | --- |
| 1 | `jira_ticket` | Specify ticket to generate patch release notes for |
| 2 | `base_branch` | n/a |
| 3 | `patch_version` | Do you know the Palette patch release version? |
| 4 | `component_updates` | Does this patch release add a new CanvOS or Palette CLI version, or both? |
| 5 | `nickfury_ref` | Do you know the nickfury branch or tag name? |
| 6 | `palette_cli_sha` | The Palette CLI checksum |

Other changes:

- `component_updates` is now `type: boolean`, so it is a tick box rather than a value to type `true` into.
- Every description is shortened, and the stale ref-derivation claim is corrected. `palette_cli_sha` now mentions
  `derive`, which was only documented in the terminal prompt.
- The script warns when a branch, tag, or checksum is supplied without asking for component versions. The form makes
  that easy to do, and the value was previously ignored in silence.

### Testing

Simulated both workflow paths non-interactively:

- **Tick box clear, `NICKFURY_REF` supplied** — the new warning fires and only `release-notes.md` is written.
- **Tick box set, same ref** — versions resolve from `v4.9.46` and all four pages are written.

YAML validates, and the field order was diffed against the `confirm` calls in the script to confirm they line up.

---

## 💻 Changed Pages

No user-facing documentation changes. The only page touched is the contributor guide
[Release Process](https://github.com/spectrocloud/librarium/blob/DOC-3125-workflow-fields/docs/contributing/release-process.md),
which is not published to docs.spectrocloud.com. The rest is release tooling.

---

## 🎫 Jira Tickets

[DOC-3125](https://spectrocloud.atlassian.net/browse/DOC-3125)


[DOC-3125]: https://spectrocloud.atlassian.net/browse/DOC-3125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ