### PR TITLE
DOC-3132: PAM enforcement for root on Edge

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/palette-canvos.md
@@ -518,10 +518,56 @@ required Edge artifacts.
     Package Tool (APT). Interactive prompts cause the image build to fail. This guidance applies to all dependencies you
     add through the `Dockerfile`.
 
-    You can also configure Pluggable Authentication Modules (PAM) policies in the `Dockerfile`. Below are examples for
-    Ubuntu 22.04 and RHEL 9.
+    You can also configure Pluggable Authentication Modules (PAM) policies in the `Dockerfile`. The following examples
+    cover SUSE, Ubuntu 22.04, and RHEL 9.
+
+    Each example sets the `enforce_for_root` option. Local UI, the TUI, and the Palette API all change passwords as
+    root, and the password quality modules exempt root by default. Without this option the check still runs and logs a
+    `BAD PASSWORD` message, but it returns success, so a password that does not meet your policy is accepted. Setting
+    `enforce_for_root` makes the check fail instead. Refer to
+    [Change User Password](../../local-ui/host-management/access-console.md#change-user-password) for the ways a
+    password can be changed.
+
+    :::warning
+
+    `pam_cracklib` does not read `/etc/security/pwquality.conf`. On SUSE, where `pam_cracklib` provides password quality
+    checks, `enforce_for_root` must be set as an argument on the module line. Writing it to `pwquality.conf` has no
+    effect.
+
+    :::
 
           <Tabs groupId="os">
+
+          <TabItem value="SUSE">
+
+    SUSE distributions, including the openSUSE base this workflow builds, use
+    [`pam_cracklib`](https://linux.die.net/man/8/pam_cracklib) for password quality checks. Do not edit
+    `/etc/pam.d/common-password` directly. That file is a symlink to `common-password-pc`, which `pam-config`
+    regenerates, so a manual edit is discarded. Use `pam-config` instead.
+
+    ```dockerfile
+    # Enable enforce_for_root for pam_cracklib
+    RUN pam-config -a --cracklib-enforce_for_root
+    ```
+
+    The resulting `/etc/pam.d/common-password-pc` is similar to the following. The other options shown reflect a
+    password policy that is already in place. The `pam-config` command adds only `enforce_for_root`.
+
+    ```text
+    password    requisite    pam_cracklib.so enforce_for_root minlen=12 dcredit=-1 ucredit=-1 lcredit=-1 minclass=4
+    password    required     pam_pwhistory.so remember=10
+    password    required     pam_unix.so use_authtok nullok shadow sha512 try_first_pass rounds=10000
+    ```
+
+    To also apply password reuse rules to root, enable the equivalent option for
+    [`pam_pwhistory`](https://linux.die.net/man/8/pam_pwhistory).
+
+    ```dockerfile
+    # Optional. Enforce password reuse rules for root as well
+    RUN pam-config -a --pwhistory-enforce_for_root
+    ```
+
+          </TabItem>
 
           <TabItem value="Ubuntu 22.04">
 
@@ -542,7 +588,9 @@ required Edge artifacts.
     ```
 
     Alternatively, you can use [`pam_pwquality`](https://linux.die.net/man/8/pam_pwquality), which is the modern
-    replacement for `pam_cracklib`, as shown in the following example.
+    replacement for `pam_cracklib`, as shown in the following example. Setting the policy in
+    `/etc/security/pwquality.conf` is preferable to editing the PAM stack, because `pam-auth-update` can rewrite
+    `/etc/pam.d/common-password` and discard changes made there.
 
     ```dockerfile
     # Install pam_pwquality
@@ -575,7 +623,9 @@ required Edge artifacts.
           <TabItem value="RHEL 9">
 
     RHEL 9 uses [`pam_pwquality`](https://linux.die.net/man/8/pam_pwquality) by default. This module enforces password
-    strength using policies defined in `/etc/security/pwquality.conf`. You only need to configure the policy.
+    strength using policies defined in `/etc/security/pwquality.conf`. You only need to configure the policy. Setting it
+    in this file rather than as arguments in `/etc/pam.d/system-auth` and `/etc/pam.d/password-auth` also means the
+    policy survives `authselect apply-changes`.
 
     ```dockerfile
     # Configure password quality policy for pam_pwquality

--- a/docs/docs-content/clusters/edge/local-ui/host-management/access-console.md
+++ b/docs/docs-content/clusters/edge/local-ui/host-management/access-console.md
@@ -78,6 +78,17 @@ You can change the password of an OS user through Local UI, through the terminal
 [TUI](../../site-deployment/site-installation/initial-setup.md) prompts for a password change when the password is
 expired and is not intended as the primary method for updating passwords.
 
+:::info
+
+Password quality rules are enforced by Pluggable Authentication Modules (PAM) on the Edge host and are configured when
+the image is built. Local UI, the TUI, and the Palette API all change passwords as root, and PAM exempts root from
+password quality checks by default. Unless the image sets the PAM `enforce_for_root` option, a password that does not
+meet your policy is accepted through these interfaces without a visible warning, even though the same password is
+rejected when a non-root user runs `passwd`. Refer to
+[Build Edge Artifacts](../../edgeforge-workflow/palette-canvos/palette-canvos.md) for how to configure PAM policies.
+
+:::
+
 :::warning
 
 If you populated the `stylus.site.users[*].passwordExpiry` field value in the user data, change the password from Local


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Documents how to make PAM password quality checks apply when Local UI, the TUI, or the Palette API changes a password. This is the docs-only resolution of engineering ticket **PE-9317**, which was closed Done with no code fix — the mechanism is a PAM root exemption, so the fix is a build-time configuration change users need to make, not code we ship.

Two files:

- **`edgeforge-workflow/palette-canvos/palette-canvos.md`** — new **SUSE** tab in the PAM section using
  `pam-config -a --cracklib-enforce_for_root`, plus a short explanation of why `enforce_for_root` is needed (Local UI, TUI, and the Palette API all change passwords as root, and `pam_cracklib` returns success for uid 0 without this option), and a warning that `pam_cracklib` does not read `pwquality.conf`. Also adds one sentence each on the existing Ubuntu and RHEL tabs noting that setting the policy in `pwquality.conf` survives `pam-auth-update` and `authselect apply-changes`.
- **`local-ui/host-management/access-console.md`** — info admonition under **Change User Password** naming the symptom: a password that violates policy is accepted through Local UI, the TUI, and the API, while the same password is rejected when a non-root user runs `passwd`. Links back to the Build Edge Artifacts guide.

### Not in this PR

No release-note entry. PE-9317 shipped no code, so nothing changed in 4.10.0 for a release note to describe.

The ticket says **SLEM**; the tab is labeled **SUSE** because the PAM section lives inside the **Advanced** workflow tab, which builds an **openSUSE** based ISO, and "SLEM" appears nowhere else in the Edge docs. `pam-config` and `pam_cracklib` are SUSE-family, so the guidance holds across openSUSE Leap, SLEM, and SLES.

### One unverified item, low-risk

The example `common-password-pc` snippet's `minlen=12 dcredit=-1 ucredit=-1 lcredit=-1 minclass=4` line came from the ticket. The prose hedges it as "is similar to the following" with a note that those options reflect a policy already in place, so if the CanvOS openSUSE base ships no cracklib policy at all, readers still know to set one themselves.

---

## 💻 Changed Pages

- [Build Edge Artifacts](https://deploy-preview-11744--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/) — Advanced workflow tab, root-exemption explanation, `pwquality.conf` warning
- [Access Local UI](https://deploy-preview-11744--docs-spectrocloud.netlify.app/clusters/edge/local-ui/host-management/access-console) — PAM enforcement admonition under Change User Password

---

## 🎫 Jira Tickets

- [DOC-3132](https://spectrocloud.atlassian.net/browse/DOC-3132) — Document steps to enable `enforce_for_root` for PAM password quality checks
- [PE-9317](https://spectrocloud.atlassian.net/browse/PE-9317) — Password complexity is not enforced when password is updated from TUI or Local UI (closed Done with no code fix; DOC-3132 is the docs-only resolution)


[DOC-3132]: https://spectrocloud.atlassian.net/browse/DOC-3132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ