### PR TITLE
DOC-3114 - Document CanvOS and Palette CLI versions for 4.9 patch releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,9 +413,9 @@ init-release:
 	grep -q "^export RELEASE_VERSION=" .env || echo "export RELEASE_VERSION=" >> .env
 	grep -q "^export RELEASE_DATE=" .env || echo "export RELEASE_DATE=" >> .env
 	grep -q "^export RELEASE_CANVOS=" .env || echo "export RELEASE_CANVOS=" >> .env
+	grep -q "^export RELEASE_PALETTE_CLI_VERSION=" .env || echo "export RELEASE_PALETTE_CLI_VERSION=" >> .env
 	grep -q "^export RELEASE_TERRAFORM_VERSION=" .env || echo "export RELEASE_TERRAFORM_VERSION=" >> .env
 	grep -q "^# COMPONENT UPDATES" .env || echo "\n# COMPONENT UPDATES" >> .env
-	grep -q "^export RELEASE_PALETTE_CLI_VERSION=" .env || echo "export RELEASE_PALETTE_CLI_VERSION=" >> .env
 	grep -q "^export RELEASE_PALETTE_CLI_SHA=" .env || echo "export RELEASE_PALETTE_CLI_SHA=" >> .env
 	grep -q "^export RELEASE_REGISTRY_VERSION=" .env || echo "export RELEASE_REGISTRY_VERSION=" >> .env
 	grep -q "^export RELEASE_SPECTRO_CLI_VERSION=" .env || echo "export RELEASE_SPECTRO_CLI_VERSION=" >> .env

--- a/docs/docs-content/automation/palette-cli/install-palette-cli.md
+++ b/docs/docs-content/automation/palette-cli/install-palette-cli.md
@@ -68,7 +68,7 @@ palette version
 <!-- palette-cli-version-output -->
 
 ```shell hideClipboard
-Palette CLI version: 4.9.15
+Palette CLI version: 4.9.19
 ```
 
 ## Next Steps

--- a/docs/docs-content/clusters/edge/edge-compatibility-matrix.md
+++ b/docs/docs-content/clusters/edge/edge-compatibility-matrix.md
@@ -21,22 +21,31 @@ CanvOS, Stylus, and the Edge host version refer to the same Edge host software r
 
 ## Compatibility Matrix
 
-| Palette Release                   | CanvOS / Stylus / Edge Host Version | Palette CLI Version | Palette Edge CLI Status                              |
-| --------------------------------- | ----------------------------------- | ------------------- | ---------------------------------------------------- |
-| <!-- edge-compat-4.9.c --> 4.9.38 | 4.9.34                              | 4.9.15              | Deprecated. Use Palette CLI for supported workflows. |
-| <!-- edge-compat-4.9.b --> 4.9.22 | 4.9.19                              | 4.9.8               | Deprecated. Use Palette CLI for supported workflows. |
-| 4.9.14                            | 4.9.10                              | 4.9.5               | Deprecated. Use Palette CLI for supported workflows. |
-| 4.9.5                             | 4.9.4                               | 4.9.2               | 4.9.4                                                |
-| 4.8.47                            | 4.8.18                              | 4.8.10              | 4.8.18                                               |
-| 4.8.33                            | 4.8.10                              | 4.8.7               | 4.8.10                                               |
-| 4.8.21                            | 4.8.8                               | 4.8.5               | 4.8.8                                                |
-| 4.8.6                             | 4.8.1                               | 4.8.2               | 4.8.1                                                |
-| 4.7.27                            | 4.7.16                              | 4.7.4               | 4.7.16                                               |
-| 4.7.20                            | 4.7.13                              | 4.7.2               | 4.7.13                                               |
-| 4.7.13                            | 4.7.9                               | 4.7.1               | 4.7.9                                                |
-| 4.7.3                             | 4.7.2                               | 4.7.0               | 4.7.2                                                |
-| 4.6.40                            | 4.6.24                              | 4.6.8               | 4.6.24                                               |
-| 4.6.32                            | 4.6.21                              | 4.6.6               | 4.6.21                                               |
+| Palette Release                    | CanvOS / Stylus / Edge Host Version | Palette CLI Version | Palette Edge CLI Status                              |
+| ---------------------------------- | ----------------------------------- | ------------------- | ---------------------------------------------------- |
+| <!-- edge-compat-4.9.46 --> 4.9.46 | 4.9.37                              | 4.9.19              | Deprecated. Use Palette CLI for supported workflows. |
+| <!-- edge-compat-4.9.43 --> 4.9.43 | 4.9.36                              | 4.9.18              | Deprecated. Use Palette CLI for supported workflows. |
+| <!-- edge-compat-4.9.c --> 4.9.38  | 4.9.34                              | 4.9.16              | Deprecated. Use Palette CLI for supported workflows. |
+| <!-- edge-compat-4.9.27 --> 4.9.27 | 4.9.22                              | 4.9.10              | Deprecated. Use Palette CLI for supported workflows. |
+| <!-- edge-compat-4.9.24 --> 4.9.24 | 4.9.21                              | 4.9.10              | Deprecated. Use Palette CLI for supported workflows. |
+| <!-- edge-compat-4.9.23 --> 4.9.23 | 4.9.20                              | 4.9.9               | Deprecated. Use Palette CLI for supported workflows. |
+| <!-- edge-compat-4.9.b --> 4.9.22  | 4.9.19                              | 4.9.8               | Deprecated. Use Palette CLI for supported workflows. |
+| <!-- edge-compat-4.9.18 --> 4.9.18 | 4.9.13                              | 4.9.7               | Deprecated. Use Palette CLI for supported workflows. |
+| <!-- edge-compat-4.9.16 --> 4.9.16 | 4.9.11                              | 4.9.6               | Deprecated. Use Palette CLI for supported workflows. |
+| 4.9.14                             | 4.9.10                              | 4.9.5               | Deprecated. Use Palette CLI for supported workflows. |
+| <!-- edge-compat-4.9.8 --> 4.9.8   | 4.9.7                               | 4.9.2               | 4.9.7                                                |
+| <!-- edge-compat-4.9.6 --> 4.9.6   | 4.9.6                               | 4.9.2               | 4.9.6                                                |
+| 4.9.5                              | 4.9.4                               | 4.9.2               | 4.9.4                                                |
+| 4.8.47                             | 4.8.18                              | 4.8.10              | 4.8.18                                               |
+| 4.8.33                             | 4.8.10                              | 4.8.7               | 4.8.10                                               |
+| 4.8.21                             | 4.8.8                               | 4.8.5               | 4.8.8                                                |
+| 4.8.6                              | 4.8.1                               | 4.8.2               | 4.8.1                                                |
+| 4.7.27                             | 4.7.16                              | 4.7.4               | 4.7.16                                               |
+| 4.7.20                             | 4.7.13                              | 4.7.2               | 4.7.13                                               |
+| 4.7.13                             | 4.7.9                               | 4.7.1               | 4.7.9                                                |
+| 4.7.3                              | 4.7.2                               | 4.7.0               | 4.7.2                                                |
+| 4.6.40                             | 4.6.24                              | 4.6.8               | 4.6.24                                               |
+| 4.6.32                             | 4.6.21                              | 4.6.6               | 4.6.21                                               |
 
 ## Palette Edge CLI Deprecation
 

--- a/docs/docs-content/downloads/cli-tools.md
+++ b/docs/docs-content/downloads/cli-tools.md
@@ -27,8 +27,14 @@ The Palette CLI is supported on Linux operating systems running on AMD64 (x86_64
 
 | Palette Release <!-- palette-cli-version-table --> | Recommended CLI Version          | Download URL                                                            | Checksum (SHA256)                                                  |
 | -------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| <!-- cli-4.9.c --> 4.9.38                          | 4.9.15                           | https://software.spectrocloud.com/palette-cli/v4.9.15/linux/cli/palette | `945fe6419002c4e96f792395ebf2f41118178717ab02122aa8a4c6211692979d` |
+| <!-- cli-4.9.46 --> 4.9.46                         | 4.9.19                           | https://software.spectrocloud.com/palette-cli/v4.9.19/linux/cli/palette | `472aa53dc5dd2a7161aff367415e08b75a2efd666a900bef95315804b4103132` |
+| <!-- cli-4.9.43 --> 4.9.43                         | 4.9.18                           | https://software.spectrocloud.com/palette-cli/v4.9.18/linux/cli/palette | `999819c7520d14f4a7ff20a569d979b9aa1b9c2da30ba40a21b7cb1c6733231c` |
+| <!-- cli-4.9.c --> 4.9.38                          | 4.9.16                           | https://software.spectrocloud.com/palette-cli/v4.9.16/linux/cli/palette | `7032e347e97df641c22c5c30ad3ec94614380d28e546b80f94fb747a33ac9b48` |
+| <!-- cli-4.9.24 --> 4.9.24                         | 4.9.10                           | https://software.spectrocloud.com/palette-cli/v4.9.10/linux/cli/palette | `8eb9f8575b1b6b2a82389350dd0b8c86867181c6a489f4cd10b51048c61589ed` |
+| <!-- cli-4.9.23 --> 4.9.23                         | 4.9.9                            | https://software.spectrocloud.com/palette-cli/v4.9.9/linux/cli/palette  | `13a0beb305e8cf197f541c5981518f7b4bb179fbe7159fea59324289d57cb128` |
 | <!-- cli-4.9.b --> 4.9.22                          | 4.9.8                            | https://software.spectrocloud.com/palette-cli/v4.9.8/linux/cli/palette  | `cdaf494b40791b9b9d04228ad8981387c350e246d1cd77a4f3b1c84d78ba6c10` |
+| <!-- cli-4.9.18 --> 4.9.18                         | 4.9.7                            | https://software.spectrocloud.com/palette-cli/v4.9.7/linux/cli/palette  | `ced80618604938e3786b46eb0f7f45cfd97346184a5cb9d5ff855f2db210849c` |
+| <!-- cli-4.9.16 --> 4.9.16                         | 4.9.6                            | https://software.spectrocloud.com/palette-cli/v4.9.6/linux/cli/palette  | `cbdb5b3c0f66194f5523676b78b98cacc3bd1a6b109e13fc987554fc2e326ad2` |
 | <!-- cli-4.9.a --> 4.9.14                          | 4.9.5                            | https://software.spectrocloud.com/palette-cli/v4.9.5/linux/cli/palette  | `41427f5d4d58f85933f7cce8ab6b38c9899ec83b74285c15338c2dc0ec55e44a` |
 | <!-- cli-4.9.0 --> 4.9.5                           | 4.9.2                            | https://software.spectrocloud.com/palette-cli/v4.9.2/linux/cli/palette  | `5d1e004aa4b124029fedcc3eebe442af20a8a447cd95a4aad9e7357d0b28e516` |
 | <!-- cli-4-8-c --> 4.8.47                          | 4.8.10                           | https://software.spectrocloud.com/palette-cli/v4.8.10/linux/cli/palette | `06e3d139fcfec018830ab2a9e03ee0c760dfc8cd8b0283eca93a43c86ae68b24` |
@@ -72,6 +78,8 @@ information.
 
 | Palette Release <!-- edge-version-table --> | CLI Version                | Download URL                                                            | Checksum (SHA256)                                                  |
 | ------------------------------------------- | -------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| <!-- edge-4.9.8 --> 4.9.8                   | 4.9.7                      | https://software.spectrocloud.com/stylus/v4.9.7/cli/linux/palette-edge  | `6e6245b97a8a6600189a93c49a4dbda2176b10caab41e73cc2d1f1f3a2ee4697` |
+| <!-- edge-4.9.6 --> 4.9.6                   | 4.9.6                      | https://software.spectrocloud.com/stylus/v4.9.6/cli/linux/palette-edge  | `474d977dbbb9098fb3dbb0caf39c24f93416dfb4e003f997c9648f7fea361191` |
 | <!-- edge-4.9.0 --> 4.9.5                   | 4.9.4                      | https://software.spectrocloud.com/stylus/v4.9.4/cli/linux/palette-edge  | `28c6ec3fe7b065d28554d738bcc5d87e655b4862bf3196ec30c3f527b8736321` |
 | <!-- edge-4-8-c --> 4.8.47                  | 4.8.18                     | https://software.spectrocloud.com/stylus/v4.8.18/cli/linux/palette-edge | `54f69d28e9cfd0f651c451ae2d008366cdb9da4be90ce2bcaccb743b488b3c73` |
 | <!-- edge-4.8.b --> 4.8.33                  | 4.8.10                     | https://software.spectrocloud.com/stylus/v4.8.10/cli/linux/palette-edge | `bc635479233dde1f5b966bb5d776a5f1fdeb9babe200666a8c8a1306546ce471` |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -48,6 +48,23 @@ tags: ["release-notes"]
   stopping the upgrade. Refer to [Troubleshooting the VMO Pack](../vm-management/vmo-pack/troubleshooting.md) for the
   manual procedure that applies when you upgrade to a pack version that predates this fix.
 
+### Edge
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.9.46 Palette release is 4.9.37.
+
+:::
+
+### Automation
+
+:::info
+
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.46 Palette release is
+4.9.19. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+
+:::
+
 ## August 14, 2026 - Component Updates {#component-updates-2026-33}
 
 <!-- COMPONENT UPDATES TICKET: DOC-3104 -->
@@ -176,6 +193,23 @@ The following component updates are applicable to this release:
 - Fixed vSphere PCG deployments behind a whitelist proxy hanging at `WaitingForKubeadmInit` due to the proxy CA
   certificate never being written to the control-plane VM, which caused containerd image pull failures with an x509
   certificate verification error.
+
+### Edge
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.9.43 Palette release is 4.9.36.
+
+:::
+
+### Automation
+
+:::info
+
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.43 Palette release is
+4.9.18. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+
+:::
 
 ## August 7, 2026 - Component Updates {#component-updates-2026-32}
 
@@ -732,7 +766,8 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 :::info
 
-Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible version of the Palette CLI.
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.38 Palette release is
+4.9.16. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
 
 :::
 
@@ -1029,6 +1064,14 @@ The following component updates are applicable to this release:
 - Fixed an issue that caused the Palette Edge Interactive Installer TUI to incorrectly select the installer boot media
   for disk-wiping when booting an Edge host from a physical USB drive flashed with the installer ISO.
 
+### Edge
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.9.27 Palette release is 4.9.22.
+
+:::
+
 ## July 3, 2026 - Component Updates {#component-updates-2026-27}
 
 <!-- COMPONENT UPDATES TICKET: DOC-2962 -->
@@ -1145,6 +1188,23 @@ The following component updates are applicable to this release:
   even when [agent upgrades](../clusters/cluster-management/platform-settings/pause-platform-upgrades.md) were paused,
   leaving the cluster with mismatched agent versions across nodes and causing continuous pod restarts.
 
+### Edge
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.9.24 Palette release is 4.9.21.
+
+:::
+
+### Automation
+
+:::info
+
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.24 Palette release is
+4.9.10. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+
+:::
+
 ## June 29, 2026 - Release 4.9.23
 
 The following component updates are applicable to this release:
@@ -1161,6 +1221,23 @@ The following component updates are applicable to this release:
 - Fixed a bug that caused the Edge Agent version 4.9.19 to incorrectly enforce password strength validation on profile
   variables for non-VMO Edge clusters, blocking cluster updates when weak passwords were present. Password strength
   checks are now restricted to VMO profile variables only, restoring the update behavior from previous Palette versions.
+
+### Edge
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.9.23 Palette release is 4.9.20.
+
+:::
+
+### Automation
+
+:::info
+
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.23 Palette release is
+4.9.9. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+
+:::
 
 ## June 28, 2026 - Release 4.9.22 {#release-notes-4.9.22}
 
@@ -1565,7 +1642,8 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 :::info
 
-Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible version of the Palette CLI.
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.22 Palette release is
+4.9.8. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
 
 :::
 
@@ -1821,6 +1899,23 @@ The following component updates are applicable to this release:
 - Fixed redundant cluster status cache broadcasts by limiting eviction to cluster state changes, significantly reducing
   unnecessary cache reloads.
 
+### Edge
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.9.18 Palette release is 4.9.13.
+
+:::
+
+### Automation
+
+:::info
+
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.18 Palette release is
+4.9.7. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+
+:::
+
 ## June 8, 2026 - Release 4.9.16
 
 The following component updates are applicable to this release:
@@ -1881,6 +1976,23 @@ The following component updates are applicable to this release:
   initiating the upgrade. Refer to
   [Scenario - Custom Certificate Handling During Upgrade](../troubleshooting/palette-upgrade.md#scenario---custom-certificate-replaced-after-upgrade)
   for more information.
+
+### Edge
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.9.16 Palette release is 4.9.11.
+
+:::
+
+### Automation
+
+:::info
+
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.16 Palette release is
+4.9.6. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+
+:::
 
 ## June 5, 2026 - Component Updates {#component-updates-2026-23}
 
@@ -2231,7 +2343,8 @@ information.
 
 :::info
 
-Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible version of the Palette CLI.
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.14 Palette release is
+4.9.5. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
 
 :::
 
@@ -2454,6 +2567,14 @@ The following component updates are applicable to this release:
 - Fixed an issue that caused [EKS clusters](../clusters/public-cloud/aws/eks.md) configured with static placement or
   private endpoint access to fail to deploy due to EC2 permission errors.
 
+### Edge
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.9.8 Palette release is 4.9.7.
+
+:::
+
 ## May 11, 2026 - Release 4.9.6
 
 The following component updates are applicable to this release:
@@ -2507,6 +2628,14 @@ The following component updates are applicable to this release:
 
 - The dependencies of the Palette agent were updated to the latest versions, ensuring that it has the latest security
   patches.
+
+### Edge
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.9.6 Palette release is 4.9.6.
+
+:::
 
 ## May 8, 2026 - Component Updates {#component-updates-2026-19}
 
@@ -2890,7 +3019,8 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 :::info
 
-Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible version of the Palette CLI.
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.5 Palette release is 4.9.2.
+Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
 
 :::
 

--- a/scripts/release/generate-release-notes.sh
+++ b/scripts/release/generate-release-notes.sh
@@ -9,10 +9,14 @@ RELEASE_NOTES_HEADING_TEMPLATE_FILE="scripts/release/templates/release-notes-hea
 RELEASE_NOTES_PARAMETERISED_FILE="scripts/release/release-notes-output.md"
 RELEASE_NOTES_HEADING_PARAMETERISED_FILE="scripts/release/release-notes-heading-output.md"
 
-if ! check_env "RELEASE_DATE" || 
-   ! check_env "RELEASE_NAME" ||  
-   ! check_env "RELEASE_CANVOS" ||  
-   ! check_env "RELEASE_TERRAFORM_VERSION" ||  
+# RELEASE_CANVOS and RELEASE_PALETTE_CLI_VERSION fill the Edge and Automation callouts. Both are
+# required, because generate_parameterised_file substitutes an unset variable with an empty string
+# and would leave a sentence that names no version rather than a visible placeholder.
+if ! check_env "RELEASE_DATE" ||
+   ! check_env "RELEASE_NAME" ||
+   ! check_env "RELEASE_CANVOS" ||
+   ! check_env "RELEASE_PALETTE_CLI_VERSION" ||
+   ! check_env "RELEASE_TERRAFORM_VERSION" ||
    ! check_env "RELEASE_VERSION" ; then
     echo "‼️  Skipping generate $RELEASE_NOTES_FILE due to missing environment variables. ‼️"
     exit 0

--- a/scripts/release/templates/release-notes.md
+++ b/scripts/release/templates/release-notes.md
@@ -38,7 +38,7 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 :::info
 
-Check out the [CLI Tools](/downloads/cli-tools/) page to find the compatible version of the Palette CLI.
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the {{RELEASE_VERSION}} Palette release is {{RELEASE_PALETTE_CLI_VERSION}}. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
 
 :::
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

This PR backfills the CanvOS (stylus) and Palette CLI versions for the 4.9 patch releases that shipped a new version of
either component, and fixes the template gap that let the Palette CLI version go unrecorded.

- **Release notes** — adds an `### Edge` and/or `### Automation` callout to 4.9.46, 4.9.43, 4.9.27, 4.9.24, 4.9.23,
  4.9.18, 4.9.16, 4.9.8, and 4.9.6. Nothing is added for 4.9.41 or 4.9.44, which shipped the same components as the
  release before them.
- **Edge Compatibility Matrix and CLI Tools** — adds the corresponding rows, with each Palette CLI checksum derived
  from the published binary. Also adds the two Palette Edge CLI rows (4.9.8, 4.9.6) that the matrix now points at.
- **Corrects 4.9.38** from Palette CLI 4.9.15 to 4.9.16. The published value came from tag `v4.9.38-rc.1`, which
  carried the prerelease `palette-cli 4.9.15-rc.3`; the final `v4.9.38` tag reports `4.9.16`.
- **Tooling** — the named-release template's Edge callout already interpolated `RELEASE_CANVOS`, but its Automation
  callout was hardcoded prose that named no version, so `make generate-release-notes` has never recorded the Palette
  CLI version. It now interpolates `RELEASE_PALETTE_CLI_VERSION`, which is guarded in `generate-release-notes.sh` and
  seeded under the `.env` RELEASE NOTES heading beside `RELEASE_CANVOS`.

Versions come from `nickfury`'s `release/spectro_versions.txt` at each final release tag.

**One follow-up outside this PR:**

1. `spectrocloud/CanvOS` has no `v4.9.11` tag, even though stylus 4.9.11 shipped in Palette 4.9.16. The 4.9.16 entry
   uses 4.9.11 on the stated convention that CanvOS tracks stylus; @benradstone is confirming with Santhosh Daivajna
   whether that tag needs cutting or the value needs changing. Every other version documented here has a matching
   CanvOS tag.

---

## 💻 Changed Pages

Preview links to be added once Netlify has built. Affected pages:

- [Install](https://deploy-preview-11745--docs-spectrocloud.netlify.app/automation/palette-cli/install-palette-cli) — sample version output updated to 4.9.19
- [Edge Compatibility Matrix](https://deploy-preview-11745--docs-spectrocloud.netlify.app/clusters/edge/edge-compatibility-matrix)
- [CLI Tools](https://deploy-preview-11745--docs-spectrocloud.netlify.app/downloads/cli-tools)
- [Release Notes](https://deploy-preview-11745--docs-spectrocloud.netlify.app/release-notes)

---

## 🎫 Jira Tickets

[DOC-3114](https://spectrocloud.atlassian.net/browse/DOC-3114)


[DOC-3114]: https://spectrocloud.atlassian.net/browse/DOC-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ