### PR TITLE
docs: backfill Component Updates back-links for 2026-32 and 2026-33

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -174,6 +174,10 @@ The following component updates are applicable to this release:
 
 ## August 11, 2026 - Release 4.9.43
 
+The following component updates are applicable to this release:
+
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
+
 <!-- PATCH RELEASE TICKET: DOC-3099 -->
 
 ### Improvements
@@ -301,6 +305,7 @@ The following components have been updated for Palette version 4.9.5 - 4.9.41.
 The following component updates are applicable to this release:
 
 - [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 <!-- PATCH RELEASE TICKET: DOC-3088 -->
 
@@ -321,6 +326,7 @@ The following component updates are applicable to this release:
 The following component updates are applicable to this release:
 
 - [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 <!-- COMPONENT UPDATES TICKETS: DOC-3029, DOC-3020 -->
 <!-- RELEASE DATE: July 30, 2026 -->
@@ -1027,7 +1033,7 @@ The following components have been updated for Palette version 4.9.5 - 4.9.27.
 <!-- RELEASE ARTIFACT STUDIO: 4.9.11 -->
 <!-- RELEASE TERRAFORM VERSION: 0.29.6 -->
 
-The following components have been updated for Palette version 4.9.5 - 4.9.24.
+The following components have been updated for Palette version 4.9.5 - 4.9.27.
 
 | Component                                          | Version |
 | -------------------------------------------------- | ------- |
@@ -1079,6 +1085,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 <!-- PATCH RELEASE TICKET: DOC-2985 -->
 
@@ -1191,6 +1199,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 <!-- PATCH RELEASE TICKET: DOC-2957 -->
 
@@ -1243,6 +1253,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 ### Bug Fixes
 
@@ -1277,6 +1289,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 ### Security Notices
 
@@ -1884,6 +1898,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 <!-- PATCH RELEASE TICKET: DOC-2887 -->
 
@@ -1956,6 +1972,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 ### Breaking Changes {#breaking-changes-4-9-16}
 
@@ -2105,6 +2123,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 ### Security Notices
 
@@ -2563,6 +2583,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 <!-- PATCH RELEASE TICKET: DOC-2824 -->
 
@@ -2618,6 +2640,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 ### Improvements
 
@@ -2761,6 +2785,8 @@ The following component updates are applicable to this release:
 - [July 10, 2026 - Component Updates](#component-updates-2026-28) <!-- omit in toc -->
 - [July 17, 2026 - Component Updates](#component-updates-2026-29) <!-- omit in toc -->
 - [July 24, 2026 - Component Updates](#component-updates-2026-30) <!-- omit in toc -->
+- [August 7, 2026 - Component Updates](#component-updates-2026-32) <!-- omit in toc -->
+- [August 14, 2026 - Component Updates](#component-updates-2026-33) <!-- omit in toc -->
 
 ### Security Notices
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _This PR has no
      dedicated Jira ticket — it is retrospective housekeeping across many releases. Context tickets are listed in that
      section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages).
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable). _Prettier clean; all additions are list items in
        existing lists._
  - [x] Verify all images display. _No images in this PR._
- [x] Ensure all **Vale comments** are resolved. _No prose was authored — additions are anchor links reusing the
      existing wording._
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _Not required for this PR._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _Needs a decision — see
      [Backporting](#backporting)._
- [ ] **Outside review:** Does this PR require review outside of Docs? _No. Docs-only cross-referencing._
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Backfills the retrospective **"The following component updates are applicable to this release"** back-links for the two
most recent Component Updates sections — **August 7 (`2026-32`)** and **August 14 (`2026-33`)** — into every earlier
`4.9.x` release section that predates them. Each release section should list the component updates published *after* it
shipped, and these two weeks had not yet been propagated backwards.

### Back-links added

| Release section | Added |
| --- | --- |
| August 11, 2026 - Release 4.9.43 | `2026-33` (+ the list block itself) |
| August 6, 2026 - Release 4.9.41 | `2026-33` |
| July 30, 2026 - Release 4.9.38 | `2026-33` |
| July 9, 2026 - Release 4.9.27 | `2026-32`, `2026-33` |
| July 1, 2026 - Release 4.9.24 | `2026-32`, `2026-33` |
| June 29, 2026 - Release 4.9.23 | `2026-32`, `2026-33` |
| June 28, 2026 - Release 4.9.22 | `2026-32`, `2026-33` |
| June 11, 2026 - Release 4.9.18 | `2026-32`, `2026-33` |
| June 8, 2026 - Release 4.9.16 | `2026-32`, `2026-33` |
| May 31, 2026 - Release 4.9.14 | `2026-32`, `2026-33` |
| May 14, 2026 - Release 4.9.8 | `2026-32`, `2026-33` |
| May 11, 2026 - Release 4.9.6 | `2026-32`, `2026-33` |
| May 3, 2026 - Release 4.9.5 | `2026-32`, `2026-33` |

Two cases are deliberately asymmetric and worth a reviewer's attention:

- **Release 4.9.43 gains the list block itself**, having had none at all. It links only `2026-33`, because `2026-32`
  (August 7) *predates* the August 11 release and so is not applicable to it.
- **Week `2026-31` is absent throughout, and that is correct.** That batch was wrapped into the
  **July 30, 2026 - Release 4.9.38** section rather than published under its own heading, so no
  `{#component-updates-2026-31}` anchor exists to link to. This happens when a Component Updates batch is scheduled in
  the same week as a Palette release. The same is true of weeks `2026-22` and `2026-26`, folded into Releases 4.9.14 and
  4.9.22 respectively — the three missing anchors in the file are exactly the three weeks that contained a release.

### Unrelated fix in the same file

The **July 10, 2026 - Component Updates** section stated its components applied to _"Palette version 4.9.5 - 4.9.24"_.
Corrected to **`4.9.5 - 4.9.27`**: Release 4.9.27 shipped July 9, the day before that update, and every other Component
Updates section states the latest release on or before its own date. Verified against all ten sections that carry the
sentence.

---

## 💻 Changed Pages

- [Release Notes](https://deploy-preview-11754--docs-spectrocloud.netlify.app/release-notes) — the only page changed.
  Worth spot-checking that each added back-link resolves to its Component Updates heading rather than 404-ing on the
  anchor.

---

## 🎫 Jira Tickets

No dedicated ticket — this is retrospective cross-referencing triggered by the publication of the two Component Updates
sections below, which are already merged.

- [DOC-3087](https://spectrocloud.atlassian.net/browse/DOC-3087) — Platform Solutions Week 32 Update (`2026-32`)
- [DOC-3104](https://spectrocloud.atlassian.net/browse/DOC-3104) — Platform Solutions Week 33 Update (`2026-33`)

---

## Backporting

**Needs a decision.** `release-notes.md` is maintained on `master` and the `version-4-*` branches carry their own
copies, so whether these back-links need to propagate depends on team convention for retrospective release-notes edits.
No `auto-backport` or `backport-version-**` labels have been applied — please add them if this should land on the
version branches.


[DOC-3087]: https://spectrocloud.atlassian.net/browse/DOC-3087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ