### PR TITLE
PE-9349: Document Palette TUI setup-required signpost (4.10.0)

### DIFF
--- a/docs/docs-content/clusters/edge/site-deployment/site-installation/initial-setup.md
+++ b/docs/docs-content/clusters/edge/site-deployment/site-installation/initial-setup.md
@@ -98,6 +98,18 @@ more information about EdgeForge and site user data, refer to
 
    :::
 
+   Starting with Palette version 4.10.0, the landing page signposts whether the Edge host has a login user configured
+   for the OS and Local UI:
+
+   - If no login user exists, the landing page displays the yellow warning **Setup required: press F2 to create login
+     user for ssh and LocalUI**, and the footer reads **`<F2> Create login`**. Pressing **F2** opens the **Create User**
+     page directly.
+
+   - If a login user already exists, the landing page displays its standard message and the footer reads
+     **`<F2> Customize`**. Pressing **F2** opens the customize flow described in the following steps.
+
+   The warning and the footer label automatically revert once a login user is created.
+
 3. Press **F2** to customize your settings.
 
 4. If you configured a user in your `user-data` file in the EdgeForge step, the TUI displays the **User Login** page.

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -122,6 +122,16 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 - Edge workflows have been updated to Kairos v4.1.2 with `kairos-init` v0.16.x. Day-1 and Day-2 upgrades from earlier
   Kairos builds are supported.
 
+<!-- https://spectrocloud.atlassian.net/browse/PE-8675 -->
+
+- The Palette TUI landing page now signposts initial user setup. When no login user exists on the Edge host, the landing
+  page displays the yellow warning **Setup required: press F2 to create login user for ssh and LocalUI**, and the footer
+  reads **`<F2> Create login`** instead of **`<F2> Customize`**. Both revert automatically once a login user is created.
+  Previously, the landing page did not indicate that a user account was missing, so the F2 shortcut for creating the
+  initial login was not discoverable. Refer to
+  [Initial Edge Host Configuration with Palette TUI](../clusters/edge/site-deployment/site-installation/initial-setup.md)
+  for more information.
+
 #### Bug Fixes
 
 ### VerteX


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

This PR documents the new Palette TUI landing-page signpost shipping in Palette 4.10.0 ([PE-8675](https://spectrocloud.atlassian.net/browse/PE-8675), verified).

**Before 4.10.0.** The Palette TUI landing page always displayed its standard system-information message, with **`<F2> Customize`** in the footer, regardless of whether a login user existed. On an appliance where no user had been configured through `user-data`, an operator reaching the landing page had no visible cue that a user account was still required for OS and Local UI access — the F2 shortcut for creating the initial login was not discoverable. This is the pattern Romain Decker hit during a VMO TUI install in May 2026, which drove the epic.

**In 4.10.0.** The landing page now signposts the missing-user state:

- When no login user exists, the landing page displays the yellow warning **Setup required: press F2 to create login user for ssh and LocalUI**, and the footer reads **`<F2> Create login`** instead of **`<F2> Customize`**. Pressing **F2** opens the **Create User** page directly.
- When a login user already exists, the landing page and footer behave as today.
- Both the warning and the footer label automatically revert once a login user is created.

### Changes

| Ticket | Page | Change |
| --- | --- | --- |
| PE-8675 | `docs/docs-content/release-notes/release-notes.md` | New bullet under 4.10.0 → Edge → Improvements, sourced from the PE-8675 epic + Yogeshwar Pawade's 2026-07-20 comment on PE-8675 (final wording of the landing message and footer label) |
| PE-8675 | `docs/docs-content/clusters/edge/site-deployment/site-installation/initial-setup.md` | Added a 4.10.0 signposting note between step 2 and step 3 of _Set up Edge Host_. Covers both "no user" and "user exists" landing-page states, the footer label variance, and the auto-revert behavior once a user is created. |

### Sources

- Ticket description (PE-9349) supplies the landing-page and footer text verbatim.
- Yogeshwar Pawade on [PE-8675](https://spectrocloud.atlassian.net/browse/PE-8675) (comment 268980, 2026-07-20) documented the final wording and the auto-revert behavior; Chris Paap confirmed the wording on 2026-07-21.
- Yogeshwar Pawade on PE-8675 (2026-07-21) confirmed that when an account already exists nothing changes: the existing "To provision this device please login to Local UI console" message stays and the footer keeps **`<F2> Customize`**.
- The behavior lives in the TUI code path shared across Edge appliances, so the docs describe it as a Palette TUI change rather than scoping it to VMO. PE-8675's epic is scoped to VMO standalone but the fix generalizes.

### Notes for review

- No new vocabulary or accept-list changes required.
- No images added or changed. If Product wants a landing-page screenshot to accompany the release-note bullet, drop it in `static/assets/docs/images/` and I'll wire it in.
- Vale (`error` level) is clean on both hunks. Six pre-existing errors elsewhere in the files (all-caps headings, `TUI` / `DNS` / `CPU` acronym-expand) are unchanged from `docs-rel-4-10-0`.

---

## 💻 Changed Pages

- [Release Notes — 4.10.0](https://deploy-preview-11757--docs-spectrocloud.netlify.app/release-notes#release-notes-4.10.0) — PE-8675 Improvements bullet
- [Initial Edge Host Configuration with Palette TUI](https://deploy-preview-11757--docs-spectrocloud.netlify.app/clusters/edge/site-deployment/site-installation/initial-setup) — landing-page signposting note

---

## 🎫 Jira Tickets

- [PE-9349](https://spectrocloud.atlassian.net/browse/PE-9349) — Doc: TUI message when users do not exist on landing screen (4.10.0)
- [PE-8675](https://spectrocloud.atlassian.net/browse/PE-8675) — Epic: VMO TUI install: user creation not signposted; proposed warning fix misses Local UI dependency


[PE-8675]: https://spectrocloud.atlassian.net/browse/PE-8675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ