### PR TITLE
DOC-3054: document empty state on By Client tab

### DIFF
--- a/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/view-client-usage.md
@@ -75,6 +75,13 @@ on the client detail view, refer to
 3. Set the **Data window** if you need a period other than the default. For the available windows, refer to
    [Set the Reporting Period](./view-token-usage.md#set-the-reporting-period).
 
+   :::info
+
+   The **By Client** table is empty until at least one client accrues usage within the current quota window. This is
+   expected on a new appliance and is not an error.
+
+   :::
+
 4. Select a client to open its API keys, per-token consumption, and the models that handled its requests.
 
 ## Further Reading


### PR DESCRIPTION
For [DOC-3054](https://spectrocloud.atlassian.net/browse/DOC-3054).

- Adds a single `:::info` admonition under step 3 of **View Usage by Client** so operators who open the **By Client** tab on a new appliance recognize the empty table as expected behavior, not a broken feature.
- 
## Test plan

- [x] Netlify deploy preview renders the `:::info` admonition correctly on the **View Client Usage** page.
- [x] Vale, prettier, and link-check pass on the changed file.
- [x] `npm run build` from `docs/` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-3054]: https://spectrocloud.atlassian.net/browse/DOC-3054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ