### PR TITLE
fixing broken links for aug 24, 2026

### DIFF
--- a/_partials/self-hosted/_setup-steps.mdx
+++ b/_partials/self-hosted/_setup-steps.mdx
@@ -19,7 +19,7 @@ partial_name: setup-steps
 
   - [Apache HTTP Server](https://httpd.apache.org/)
 
-  - [Nginx](https://www.nginx.com/)
+  - [Nginx](https://www.f5.com/products/nginx)
 
   - [Caddy](https://caddyserver.com/)
 

--- a/docs/docs-content/vm-management/vm-migration-assistant/create-source-providers.md
+++ b/docs/docs-content/vm-management/vm-migration-assistant/create-source-providers.md
@@ -48,10 +48,9 @@ Machines (VMs) that need to be migrated.
     [Changed Block Tracking](https://knowledge.broadcom.com/external/article/315370/enabling-or-disabling-changed-block-trac.html)
     must be enabled on your VMs.
 
-- A
-  [VMware Virtual Disk Development Kit (VDDK) image](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/8.0)
-  is required for migrations. The migration engine uses VDDK on the destination VMO cluster to read virtual disks from
-  the source environment, transfer the data, and write it to the target storage.
+- A VMware Virtual Disk Development Kit (VDDK) image is required for migrations. The migration engine uses VDDK on the
+  destination VMO cluster to read virtual disks from the source environment, transfer the data, and write it to the
+  target storage.
 
   - The VDDK version used must be **8.0.2.1** or earlier.
 
@@ -68,8 +67,8 @@ Machines (VMs) that need to be migrated.
 
     <TabItem label="Non-Airgap" value="non-airgap">
 
-    1. Download the VDDK image from the
-       [Broadcom Developer Portal](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/8.0).
+    1. Download the VDDK image from the [Broadcom Developer Portal](https://developer.broadcom.com/). An account is
+       required.
 
     2. Decompress the downloaded image.
 
@@ -108,8 +107,8 @@ Machines (VMs) that need to be migrated.
 
     <TabItem label="Airgap" value="airgap">
 
-    1. Download the VDDK image from the
-       [Broadcom Developer Portal](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/8.0).
+    1. Download the VDDK image from the [Broadcom Developer Portal](https://developer.broadcom.com/). An account is
+       required.
 
     2. Copy or move the VDDK image to another Linux environment inside your airgap environment.
 

--- a/docs/docs-content/vm-management/vmo-pack/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
+++ b/docs/docs-content/vm-management/vmo-pack/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
@@ -97,10 +97,9 @@ This migration method uses the [Palette CLI](../../../../automation/palette-cli/
   - The Palette CLI must have access to both the VMO cluster and the machines to be migrated.
 - The kubectl command-line tool should also be installed. Refer to the
   [kubectl installation](https://kubernetes.io/docs/tasks/tools/install-kubectl/) guide to learn more.
-- We recommend providing a
-  [VMware Virtual Disk Development Kit (VDDK) image](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/latest)
-  for the migration. This will significantly speed up the migration. The migration engine uses VDDK on the destination
-  VMO cluster to read virtual disks from the source environment, transfer the data, and write it to the target storage.
+- We recommend providing a VMware Virtual Disk Development Kit (VDDK) image for the migration. This will significantly
+  speed up the migration. The migration engine uses VDDK on the destination VMO cluster to read virtual disks from the
+  source environment, transfer the data, and write it to the target storage.
 
   - You must build and host the VDDK image in your own image registry, which must be accessible to the destination VMO
     cluster for migrations.
@@ -109,8 +108,8 @@ This migration method uses the [Palette CLI](../../../../automation/palette-cli/
     <details>
     <summary> Example steps to build and upload VDDK image </summary>
 
-    1. Download the VDDK image from the
-       [Broadcom Developer Portal](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/latest).
+    1. Download the VDDK image from the [Broadcom Developer Portal](https://developer.broadcom.com/). An account is
+       required.
 
     2. Decompress the downloaded image.
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

---

## 📝 Describe the Change

This PR fixes the real broken links from the 2026-08-24 weekly Broken External Docs Links report. Of the 7 URLs the linkinator run flagged, verification against a modern browser UA found only 2 real breaks (both Broadcom-gated VDDK SDK pages) plus 1 silent redirect (nginx.com → f5.com after F5's acquisition). This PR addresses those 3 real issues across 3 source files. The remaining 4 URLs in the report were confirmed as false positives (3 Red Hat pages that 403 to non-browser HTTP clients — same pattern as DOC-1877 / DOC-1884 / DOC-3126) or self-resolved before the fix window (the `software.spectrocloud.com/palette-cli/v4.9.19` object was uploaded 27 seconds before verification; the docs row from PR #11745 landed ahead of the CDN upload).

### Broadcom Developer Portal — real breaks (5 links, 2 files)

Broadcom has removed the anonymously-browsable `/sdks/vmware-virtual-disk-development-kit-vddk/{latest|8.0}` pages. The path segment now returns a clean 404 for anonymous clients; the SDK itself now sits behind a Broadcom account on `developer.broadcom.com`. Rather than point at the version-specific SDK sub-page, the docs now point at the Broadcom Developer Portal root (`https://developer.broadcom.com/`) with a note that an account is required to download. The **8.0.2.1 or earlier** version requirement is preserved in the prose (previously carried only by the URL fragment).

### www.nginx.com — silent redirect (1 link, 1 file)

Post-F5 acquisition, `https://www.nginx.com/` 301-redirects to `https://www.f5.com/products/nginx`. The redirect is transparent and the link technically works, but pointing at the current URL directly is cleaner and avoids the linkinator false-positive-ish signal.


### Backport scope

The weekly URL checker only crawls master's build (`versioned-url-checker.sh`'s "versioned" refers to relative link validation inside master, not to crawling the `version-4-*` branches). So the same broken URLs have been undetected on every live-supported version branch. Verified footprint on the version branches before labeling:

| File | 4-9 | 4-8 | 4-7 | 4-6 |
| --- | --- | --- | --- | --- |
| `_partials/self-hosted/_setup-steps.mdx` (nginx.com) | 1 hit | 1 | 1 | 1 |
| `vmo-pack/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md` (2 VDDK) | 2 hits | file absent | absent | absent |
| `vm-migration-assistant/create-source-providers.md` (3 VDDK) | 3 hits | 3 | 3 | 3 |

Auto-backport should apply cleanly on all four labeled branches. Where `migrate-vm-kubevirt.md` does not exist (4-8, 4-7, 4-6), the bot skips that file and applies the remaining two.

### Notes for review

- No new vocabulary or accept-list changes required. Vale is clean (0 errors on both edited `.md` files at `error` level).
- No images added or changed.
- The pre-existing markdownlint MD033 warnings on inline HTML (Docusaurus `Tabs`/`TabItem`/`details`/`summary`/`VersionedLink`) and one MD001 heading increment warning in `create-source-providers.md` are not on the edited lines and are unchanged from master.
- The 3 Red Hat false positives in this week's report are a fifth-round recurrence of the linkinator user-agent issue (DOC-1877, DOC-1884, DOC-3126). DOC-3126 is already open with the fix scoped; nothing to file. Not addressed here.


---

## 💻 Changed Pages

- [Migrate a VM to a VMO cluster using the Palette CLI](https://deploy-preview-11763--docs-spectrocloud.netlify.app/vm-management/vmo-pack/create-manage-vm/advanced-topics/migrate-vm-kubevirt) — VDDK reference + download step
- [Create Source Providers](https://deploy-preview-11763--docs-spectrocloud.netlify.app/vm-management/vm-migration-assistant/create-source-providers) — VDDK reference + Non-Airgap and Airgap tab download steps
- [Environment Setup for Palette Enterprise (VMware airgap)](https://deploy-preview-11763--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-vmware/airgap-install/environment-setup/env-setup-vm) — nginx.com entry in the airgap file-server list (via `_partials/self-hosted/_setup-steps.mdx`)
- [Environment Setup for VerteX (VMware airgap)](https://deploy-preview-11763--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-vmware/airgap-install/environment-setup/env-setup-vm-vertex) — same partial, VerteX consumer

---

## 🎫 Jira Tickets

No Jira ticket for the fixes in this PR itself. Source is the 2026-08-24 automated Broken External Docs Links weekly report posted by the `Docs & Education Bot` in `#private-team-docs` ([thread link](https://spectrocloud.slack.com/archives/C048YDW2J7P/p1787581526644429)). The 3 Red Hat false positives in this week's report are already scoped by [DOC-3126](https://spectrocloud.atlassian.net/browse/DOC-3126) (open, assigned to Linus) — root cause is the spoofed Chrome/79 user agent in both `linkinator/linkinator.config.json` and `linkinator/linkinator-ci.config.json`.



[DOC-3126]: https://spectrocloud.atlassian.net/browse/DOC-3126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ