### PR TITLE
DOC-3035: trim Dependabot workflow env block to what build-ci reads

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -13,21 +13,35 @@ concurrency:
   group: dependabot-ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Dependabot-triggered runs read from the Dependabot secrets scope, which GitHub configures
+# separately from the Actions secrets scope. Secrets that are absent from the Dependabot scope
+# resolve to an empty string with no warning, so this block is deliberately narrower than the env
+# blocks in release.yaml and pull_request.yaml: it lists only what `make build-ci` actually consumes.
+#
+# Keep this list in sync with the Dependabot secrets configured on the repository.
+#
+# Deliberately omitted. Do not re-add these for parity with the other build workflows:
+#   AWS_*                          Only used by the S3 sync steps in release.yaml.
+#   APPZI_TOKEN, SEERS_CMP_KEY     Interpolated into <script> tags. Only matter for a deployed site.
+#   FULLSTORY_ORGID                Not read by the build at all. The org ID is hardcoded in
+#                                  static/scripts/fullstory.js.
+#   ALGOLIA_ADMIN_KEY              Only used by the Algolia crawler, not by the build.
+#   DISABLE_PACKS_INTEGRATIONS     Unset behaves as false, which is what this workflow wants.
+#   DISABLE_SECURITY_INTEGRATIONS  Unset behaves as false. Must stay unset while DSO_AUTH_TOKEN is
+#                                  set, otherwise CVE checks are skipped entirely.
+#   SHOW_LAST_UPDATE_TIME          Unset behaves as false. Must stay unset: last-update times need
+#                                  full git history, and this workflow checks out shallow.
 env:
+  # Auto-provided by Actions. The fallback actions below receive it explicitly via `gh-token`.
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_KEY }}
-  AWS_DEFAULT_REGION: us-east-1
-  APPZI_TOKEN: ${{ secrets.APPZI_TOKEN }}
-  FULLSTORY_ORGID: ${{ secrets.FULLSTORY_ORGID }}
-  ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
+  # The Docusaurus Algolia theme validates all three as required in docusaurus.config.js.
   ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
   ALGOLIA_SEARCH_KEY: ${{ secrets.ALGOLIA_SEARCH_KEY }}
   ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
+  # Pack data fetches. A 401 exits 5, which routes to the cached-packs fallback below.
   PALETTE_API_KEY: ${{ secrets.PALETTE_API_KEY }}
-  DISABLE_PACKS_INTEGRATIONS: ${{ secrets.DISABLE_PACKS_INTEGRATIONS }}
-  DISABLE_SECURITY_INTEGRATIONS: ${{ secrets.DISABLE_SECURITY_INTEGRATIONS }}
-  SHOW_LAST_UPDATE_TIME: ${{ secrets.SHOW_LAST_UPDATE_TIME }}
+  # CVE data fetches. utils/cves/requests.js throws at module load when this is unset, which exits 1
+  # and bypasses the cached-CVEs fallback. Only exit 7 reaches that fallback, so this must be set.
   DSO_AUTH_TOKEN: ${{ secrets.DSO_AUTH_TOKEN }}
   NODE_VERSION: "24"
 

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -21,7 +21,7 @@ concurrency:
 # Keep this list in sync with the Dependabot secrets configured on the repository.
 #
 # Deliberately omitted. Do not re-add these for parity with the other build workflows:
-#   AWS_*                          Only used by the S3 sync steps in release.yaml.
+#   AWS_*                          Only used by the S3 sync steps in release.yaml and other workflows.
 #   APPZI_TOKEN, SEERS_CMP_KEY     Interpolated into <script> tags. Only matter for a deployed site.
 #   FULLSTORY_ORGID                Not read by the build at all. The org ID is hardcoded in
 #                                  static/scripts/fullstory.js.


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

This PR trims the `env:` block in `.github/workflows/dependabot.yaml` from 15 entries to 7. The retained set is exactly what the Dependabot pre-merge build (`make build-ci`) actually consumes:

| Retained var | Where it's used | What breaks if missing |
| --- | --- | --- |
| `GITHUB_TOKEN` | Auto-provided by Actions | Cached-packs and cached-CVEs fallback actions receive it via their `gh-token` input, not via workflow `env`. Kept for parity with the other build workflows. |
| `ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_KEY`, `ALGOLIA_INDEX_NAME` | `docusaurus.config.js` | Docusaurus Algolia plugin validates all three; missing values fail config load. |
| `PALETTE_API_KEY` | `plugins/packs-integrations.js`, `src/services/api/index.js` | Pack fetches 401 → `process.exit(5)` → cached-packs fallback. |
| `DSO_AUTH_TOKEN` | `utils/cves/requests.js`, `utils/pack-cves/requests.js` | Module throws at load with a non-7 exit code; the cached-CVEs fallback never triggers. Only `process.exit(7)` from a failed API call (token present, API down) routes through the fallback. |
| `NODE_VERSION` | Runner setup | Node install step needs the version. |

Each removed entry was traced against the `make build-ci` dependency chain (`generate-api-docs → pack-cves → cves → generate-partials → docusaurus build`) and confirmed inert. Removed entries carry inline comments in the workflow file explaining why they must not be re-added for parity with `release.yaml`.

### Five implementation notes worth recording

**1. AC #2 is already satisfied — no secret changes needed.** The Dependabot secrets scope on the repo holds exactly the 5 required entries: `ALGOLIA_APP_ID`, `ALGOLIA_INDEX_NAME`, `ALGOLIA_SEARCH_KEY`, `DSO_AUTH_TOKEN`, `PALETTE_API_KEY`. That is precisely the trimmed list, so the two lists were not actually drifting. Re-verified 2026-08-24 before opening this PR — still 5 entries, no drift since 2026-08-04.

**2. This change is a runtime no-op.** Because the other 8 secrets are absent from the Dependabot scope, GitHub already substitutes empty strings for them, silently and without a warning. The build has therefore been running without their values all along. Run `30866402516` (brace-expansion 1.1.11 → 1.1.18, 2026-08-04) succeeded on the direct build path, with both the cached-packs and cached-CVEs fallback steps skipped. Removed vars shift `${process.env.X}` from `""` to `undefined`, which changes one throwaway `<script>` interpolation (`APPZI_TOKEN` into a dead tag) but does not affect config validation. Confirmed by a local `make build-ci` on 2026-08-04 with only the 7 retained vars — reached `BUILD_EXIT_CODE=0` and generated 3,165 HTML files.

**3. The `GITHUB_TOKEN` rationale in the ticket description was incorrect.** The description listed it as required by the cached-packs and cached-CVEs fallback actions; those actions do not read it from the workflow `env`. Both receive the token through their `gh-token` input and set `GH_TOKEN` on their own steps. Nothing in the build chain reads `process.env.GITHUB_TOKEN`. Kept anyway because it is auto-provided by Actions and every other build workflow declares it. Conclusion stands; reason does not.

**4. The block was not a superset of `release.yaml`'s.** `SEERS_CMP_KEY` is declared in `release.yaml` and nine other build workflows, and is consumed at `docusaurus.config.js:105` as the cookie-consent `data-key`, but it was never present in `dependabot.yaml`. Left out here for the same reason as `APPZI_TOKEN`: interpolated into a `<script>` tag, only meaningful for a deployed site. Recorded so the divergence reads as deliberate.

**5. `FULLSTORY_ORGID` is not merely tolerant of an empty value — it is not read at all.** The ticket description says it is string-interpolated into `utils/scripts/fullstory-script.js`. True, but the module has no importer anywhere in the repo: a repo-wide search for `fullstory-script`, `fullStoryScript`, and `fullstoryScript` returns only the declaration and the `module.exports` inside the file itself. The FullStory snippet that actually ships is the tracked static file `static/scripts/fullstory.js`, loaded at `docusaurus.config.js:93`, which hardcodes the org ID. `git log -S "fullstory-script" -- docusaurus.config.js` returns zero commits, so the Docusaurus config has never referenced the templated module. The FullStory integration is live and working — only the environment variable and that one orphaned module are unused. Split out as [DOC-3140](https://spectrocloud.atlassian.net/browse/DOC-3140) rather than folded in here.

### Backport

Not required. Dependabot only ever targets `master`: `.github/dependabot.yml` sets `target-branch: master` for both the npm and github-actions ecosystems. The workflow also filters on `branches: ["master"]`, which matches a pull request's base branch. The file is present on `version-4-2` through `version-4-9`, but those copies carry the same filter and are inert. Backporting would be cosmetic-only, and per the docs-team convention (`backport-floor-version-4-2` policy) we do not cosmetic-backport.

### Notes for review

- Vale is clean on the workflow file (`.yaml` is not in Vale's scan set, so no direct check applies — the change is workflow YAML only).
- No new vocabulary or accept-list changes required.
- Follow-up filed as [DOC-3140](https://spectrocloud.atlassian.net/browse/DOC-3140): FULLSTORY_ORGID is referenced in 11 workflows but not consumed by the build. Option A (delete the orphan) vs Option B (wire the templated module back) is captured on the ticket. Out of scope for this PR.

---

## 💻 Changed Pages

No user-facing changes. This PR modifies `.github/workflows/dependabot.yaml` only. There is no Netlify preview to review.

---

## 🎫 Jira Tickets

- [DOC-3035](https://spectrocloud.atlassian.net/browse/DOC-3035) — Remove unused environment variables from Dependabot workflow


[DOC-3035]: https://spectrocloud.atlassian.net/browse/DOC-3035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOC-3140]: https://spectrocloud.atlassian.net/browse/DOC-3140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ