### PR TITLE
PEM-11809 - Correct JFrog OCI pack registry configuration examples

### DIFF
--- a/_partials/_oci-packs-registry-configuration-by-provider.mdx
+++ b/_partials/_oci-packs-registry-configuration-by-provider.mdx
@@ -3,7 +3,7 @@ partial_category: oci-registry-configuration
 partial_name: oci-packs-registry-configuration-by-provider
 ---
 
-When configuring OCI pack registries in Palette through the UI or Helm values, ensure that the configuration values align with the expected URL structure of the registry. This is especially important for registries that do not adhere to the standard Docker V2 API structure, such as JFrog Artifactory.
+When configuring OCI pack registries in Palette through the UI, API, or Helm values, ensure that the configuration values align with the expected URL structure of the registry. This is especially important for registries that do not adhere to the standard Docker V2 API structure, such as JFrog Artifactory.
 
 The following sections provide key rules and example configurations for some of the supported OCI pack registry providers.
 
@@ -12,17 +12,19 @@ The following sections provide key rules and example configurations for some of 
 - Palette resolves pack URL locations using the following pattern.
 
   ```text
-  <endpoint>/<baseContentPath>/spectro-packs
+  <endpoint>/<basePath>/<baseContentPath>/spectro-packs
   ```
 
-  If `<baseContentPath>` is empty, Palette uses the following pattern instead.
+  Both `<basePath>` and `<baseContentPath>` are optional, and Palette omits any segment that you leave empty. If you
+  leave both empty, Palette uses the following pattern instead.
 
   ```text
   <endpoint>/spectro-packs
   ```
 
-- The `spectro-packs` path is appended automatically so you should not include it in the values for `<endpoint>` or
-  `<baseContentPath>`. Palette expects packs to be stored under the `spectro-packs` repository path in the OCI registry.
+- The `spectro-packs` path is appended automatically so you should not include it in the values for `<endpoint>`,
+  `<basePath>`, or `<baseContentPath>`. Palette expects packs to be stored under the `spectro-packs` repository path in
+  the OCI registry.
 
 - In general practice, set `<baseContentPath>` to the path segment that sits between the `<endpoint>` and
   `spectro-packs`. Leave empty if `spectro-packs` is at the repository root.
@@ -30,10 +32,13 @@ The following sections provide key rules and example configurations for some of 
   For example, if your OCI registry URL is `https://harbor.example.com/registry/palette-packs/spectro-packs`, set
   `<endpoint>` to `https://harbor.example.com` and `<baseContentPath>` to `registry/palette-packs`.
 
+- Palette syncs only the content stored directly in the directory that `<baseContentPath>` specifies. Content stored at
+  the repository root or in child directories nested below the specified path is not synced.
+
 - For registries with a non-standard API path like
-  [JFrog Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/jfrog-artifactory), include the full API
-  path in the `<endpoint>` value. For standard Docker V2 registries like [Harbor](https://goharbor.io/), use the
-  hostname only.
+  [JFrog Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/jfrog-artifactory), specify the API path
+  in `<basePath>`, which is the **Endpoint Suffix** field in the Palette UI. For standard Docker V2 registries like
+  [Harbor](https://goharbor.io/), use the hostname only for `<endpoint>` and leave `<basePath>` empty.
 
 - Self-hosted registries require a base64-encoded PEM CA certificate in `<caCert>`.
 
@@ -45,28 +50,48 @@ The following examples demonstrate how to configure OCI pack registries for diff
 
 <TabItem value="example-jfrog-artifactory" label="Example JFrog Artifactory">
 
-- The full Docker V2 API path is required for the JFrog Artifactory `<endpoint>`.
-- The [repository key](https://jfrog.com/help/r/artifactory-rest-apis/list-docker-repositories) is included in the
-  `<endpoint>` value, which is `spectro-packs-repo` in this example.
+:::info
+
+JFrog Artifactory pack registries are supported at the tenant scope only. Add them using the Palette UI or API. The
+`ociPackRegistry` Helm values of the self-hosted Palette and Palette VerteX charts do not support JFrog Artifactory.
+
+:::
+
+- The `<endpoint>` is the JFrog Artifactory hostname only.
+- The full Docker V2 API path is required, and it includes the
+  [repository key](https://jfrog.com/help/r/artifactory-rest-apis/list-docker-repositories). Specify this path in the
+  **Endpoint Suffix** field, which corresponds to `<basePath>` in the API. The repository key is `spectro-packs-repo` in
+  this example.
 - The `<baseContentPath>` is the directory in the JFrog repository where the packs are stored, which is `sample-dir` in
-  this example. Palette syncs only the content stored directly in the specified directory. Content stored at the
-  repository root or in child directories nested below the specified path is not synced.
+  this example.
 
 ```text hideClipboard title="UI values example"
-Endpoint: https://artifactory.example.com/artifactory/api/docker/spectro-packs-repo
+Endpoint: https://artifactory.example.com
+Endpoint Suffix: artifactory/api/docker/spectro-packs-repo
 Base Content Path: sample-dir
 ```
 
-```yaml hideClipboard title="Helm values example"
-config:
-  ociPackRegistry:
-    endpoint: "https://artifactory.example.com/artifactory/api/docker/spectro-packs-repo"
-    baseContentPath: "sample-dir"
-    name: "Artifactory OCI Packs"
-    username: "<username>"
-    password: "<base64-encoded-password>"
-    insecureSkipVerify: false
-    caCert: "<base64-encoded-ca-cert>"
+```json hideClipboard title="API values example"
+{
+  "spec": {
+    "endpoint": "https://artifactory.example.com",
+    "basePath": "artifactory/api/docker/spectro-packs-repo",
+    "baseContentPath": "sample-dir",
+    "providerType": "pack",
+    "isPrivate": false,
+    "isSyncSupported": true,
+    "auth": {
+      "type": "basic",
+      "username": "<username>",
+      "password": "<password>",
+      "tls": {
+        "ca": "<pem-ca-certificate>",
+        "enabled": true,
+        "insecureSkipVerify": false
+      }
+    }
+  }
+}
 ```
 
 This configuration resolves to the following URL for `spectro-packs`.

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-helm.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-helm.md
@@ -151,20 +151,25 @@ directory as a separate base content path.
 
 8. Provide the registry URL in the **Endpoint** field.
 
-9. If **Synchronization** is enabled, in the **Base Content Path** field, enter the base path to the repository in the
-   registry where the Helm charts are stored. You can specify multiple base paths by pressing the **ENTER** key after
-   each path. Providing multiple base paths is useful when Helm charts are stored in different directories or projects.
+9. If **Synchronization** is enabled and your registry requires a suffix to be appended to the endpoint, specify it in
+   the **Endpoint Suffix** field. This field is optional and applies to registries that do not use a standard Docker V2
+   API path. For example, JFrog Artifactory requires the API path and the repository key, such as
+   `artifactory/api/docker/spectro-charts-repo`.
 
-10. Fill out the **Username** and **Password** fields with the credentials to access the registry. If the registry does
+10. If **Synchronization** is enabled, in the **Base Content Path** field, enter the base path to the repository in the
+    registry where the Helm charts are stored. You can specify multiple base paths by pressing the **ENTER** key after
+    each path. Providing multiple base paths is useful when Helm charts are stored in different directories or projects.
+
+11. Fill out the **Username** and **Password** fields with the credentials to access the registry. If the registry does
     not require authentication, leave the **Username** and **Password** fields empty.
 
     <PartialsComponent category="registries-and-packs" name="acr-tip-oci" />
 
-11. If your OCI registry server is using a self-signed certificate, select **Upload file** to upload the certificate. If
+12. If your OCI registry server is using a self-signed certificate, select **Upload file** to upload the certificate. If
     the server certificate is not signed by a trusted CA, select **Insecure Skip TLS Verify** to skip verifying the x509
     certificate.
 
-12. Select **Confirm** to add the registry.
+13. Select **Confirm** to add the registry.
 
 </TabItem>
 

--- a/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-packs.md
+++ b/docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-packs.md
@@ -112,21 +112,26 @@ registry you are adding.
 
 8. Provide the registry URL in the **Endpoint** field.
 
-9. Specify the **Base Content Path**. This is the path to the OCI registry where the OCI Packs are stored. For example,
-   if the OCI registry URL is `https://registry.example.com` and the OCI Packs are stored in the `internal` repository,
-   the base content path is `internal`. You can specify multiple base paths by pressing the Enter key after each path.
-   Providing multiple base paths is useful when Helm Charts are stored in different directories or projects, such as
-   multiple projects in a Harbor registry.
+9. If your registry requires a suffix to be appended to the endpoint, specify it in the **Endpoint Suffix** field. This
+   field is optional and applies to registries that do not use a standard Docker V2 API path. For example, JFrog
+   Artifactory requires the API path and the repository key, such as `artifactory/api/docker/spectro-packs-repo`. Refer
+   to [OCI Packs Registry Configuration by Provider](./oci-registry.md#oci-packs-registry-configuration-by-provider) for
+   provider-specific examples.
 
-10. Fill out the **Username** and **Password** fields with the credentials to access the registry.
+10. Specify the **Base Content Path**. This is the path to the OCI registry where the OCI packs are stored. For example,
+    if the OCI registry URL is `https://registry.example.com` and the OCI packs are stored in the `internal` repository,
+    the base content path is `internal`. Palette syncs only the packs stored directly in this directory. Packs stored at
+    the repository root or in child directories nested below it are not synced.
+
+11. Fill out the **Username** and **Password** fields with the credentials to access the registry.
 
     <PartialsComponent category="registries-and-packs" name="acr-tip-oci" />
 
-11. If your OCI registry server is using a self-signed certificate or if the server certificate is not signed by a
+12. If your OCI registry server is using a self-signed certificate or if the server certificate is not signed by a
     trusted CA, check the **Insecure Skip TLS Verify** box to skip verifying the x509 certificate, and click **Upload
     file** to upload the certificate.
 
-12. Click **Confirm** to complete adding the registry.
+13. Click **Confirm** to complete adding the registry.
 
 </TabItem>
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

This PR corrects the JFrog Artifactory configuration guidance for OCI pack registries, and documents the **Endpoint
Suffix** field.

The premise of PEM-11809 changed while it was open. It was originally raised because the docs presented JFrog as an OCI
pack registry example when JFrog was only verified for OCI Helm. PEM-11808 has since been completed and verified, so
JFrog **is** now supported for OCI packs at the tenant scope. The fix is therefore to correct the field values rather
than to remove JFrog.

Engineering confirmed the following mapping on PEM-11809, and supplied a
[verified create request](https://spectrocloud.atlassian.net/browse/PEM-11808?focusedCommentId=283070):

| UI field          | API field         | JFrog value                                  |
| ----------------- | ----------------- | -------------------------------------------- |
| Endpoint          | `endpoint`        | Hostname only                                |
| Endpoint Suffix   | `basePath`        | `artifactory/api/docker/<repository-key>`    |
| Base Content Path | `baseContentPath` | Directory inside that repository             |

Engineering also confirmed that JFrog pack registries are tenant scope only and can be added through the UI or API only.
They are not supported through the `ociPackRegistry` Helm values of the self-hosted charts, which is tracked separately
under PEM-10274.

### Changes

**`_partials/_oci-packs-registry-configuration-by-provider.mdx`**

- Updated the pack URL resolution pattern to `<endpoint>/<basePath>/<baseContentPath>/spectro-packs`, and noted that
  both middle segments are optional.
- Replaced the key rule that instructed readers to include the full API path in `<endpoint>` with guidance to use
  `<basePath>` / **Endpoint Suffix**.
- Moved the sync scoping rule out of the JFrog tab and into the key rules, because Engineering confirmed it applies to
  both pack and Helm registries. This wording originally arrived under DOC-2996, whose acceptance criteria were about
  OCI Helm sync, and it landed in the packs partial by mistake.
- Rewrote the JFrog tab with the corrected values, added an admonition covering the tenant scope and UI/API-only
  constraints, and replaced the unsupported `ociPackRegistry` Helm snippet with an API example.

**`docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-packs.md`**

- Added a step for the **Endpoint Suffix** field, which was previously undocumented.
- Corrected the **Base Content Path** step, which described entering multiple paths with the Enter key and referred to
  Helm charts. That behaviour is Helm-only; for pack registries the field is a single value.

**`docs/docs-content/registries-and-packs/registries/oci-registry/add-oci-helm.md`**

- Added the equivalent **Endpoint Suffix** step to the Basic tab. JFrog OCI Helm registries need this field too, and it
  previously appeared only in the GHCR tab, where readers are told to leave it blank.

### Notes for reviewers

- This PR targets the `DOC-3138` branch, which covers the upcoming 4.9.x patch release that contains PEM-11808. A
  separate PR will take `DOC-3138` to `master`, and the backport labels belong on that PR rather than this one.
- No release note entry is included here. That belongs with DOC-3138 once the patch version and date are confirmed.
- Vale reports one pre-existing `heading-all-caps` error on the `#### STS` heading in `add-oci-packs.md`. It is present
  on `master`, is outside the scope of this change, and has been left alone.
- Engineering review is worth having on this one, since the field mapping and the tenant-scope constraint came from
  PEM-11809 and PEM-11808 rather than from a published source.

---

## 💻 Changed Pages

Directly edited pages:

- [Add OCI Packs Registry](https://deploy-preview-11771--docs-spectrocloud.netlify.app/registries-and-packs/registries/oci-registry/add-oci-packs/)
  — new **Endpoint Suffix** step, and the corrected **Base Content Path** step.
- [Add OCI Helm Registry](https://deploy-preview-11771--docs-spectrocloud.netlify.app/registries-and-packs/registries/oci-registry/add-oci-helm/)
  — new **Endpoint Suffix** step in the Basic tab.

Pages that render the edited partial:

- [OCI Registries](https://deploy-preview-11771--docs-spectrocloud.netlify.app/registries-and-packs/registries/oci-registry/#oci-packs-registry-configuration-by-provider)
- [Palette Helm Chart Reference](https://deploy-preview-11771--docs-spectrocloud.netlify.app/enterprise-version/install-palette/install-on-kubernetes/palette-helm-ref/#oci-packs-registry-configuration-by-provider)
- [Palette VerteX Helm Chart Reference](https://deploy-preview-11771--docs-spectrocloud.netlify.app/vertex/install-palette-vertex/install-on-kubernetes/vertex-helm-ref/#oci-packs-registry-configuration-by-provider)

The two Helm chart reference pages are worth particular attention. The JFrog tab now carries an admonition stating that
JFrog is not supported through the `ociPackRegistry` Helm values, which is the approach taken instead of splitting the
partial so that the JFrog example does not appear on those pages at all.

---

## 🎫 Jira Tickets

[PEM-11809](https://spectrocloud.atlassian.net/browse/PEM-11809)

Related: [PEM-11808](https://spectrocloud.atlassian.net/browse/PEM-11808) (the implementation epic) and
[DOC-3138](https://spectrocloud.atlassian.net/browse/DOC-3138) (the patch release notes ticket this branch targets).


[PEM-11809]: https://spectrocloud.atlassian.net/browse/PEM-11809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ