### PR TITLE
[version-4-7] fixing broken links for aug 24, 2026 (#11763)

### DIFF
--- a/_partials/self-hosted/_setup-steps.mdx
+++ b/_partials/self-hosted/_setup-steps.mdx
@@ -19,7 +19,7 @@ partial_name: setup-steps
 
   - [Apache HTTP Server](https://httpd.apache.org/)
 
-  - [Nginx](https://www.nginx.com/)
+  - [Nginx](https://www.f5.com/products/nginx)
 
   - [Caddy](https://caddyserver.com/)
 

--- a/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
+++ b/docs/docs-content/vm-management/create-manage-vm/advanced-topics/migrate-vm-kubevirt.md
@@ -97,10 +97,9 @@ This migration method uses the [Palette CLI](../../../automation/palette-cli/pal
   - The Palette CLI must have access to both the VMO cluster and the machines to be migrated.
 - The kubectl command-line tool should also be installed. Refer to the
   [kubectl installation](https://kubernetes.io/docs/tasks/tools/install-kubectl/) guide to learn more.
-- We recommend providing a
-  [VMware Virtual Disk Development Kit (VDDK) image](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/latest)
-  for the migration. This will significantly speed up the migration. The migration engine uses VDDK on the destination
-  VMO cluster to read virtual disks from the source environment, transfer the data, and write it to the target storage.
+- We recommend providing a VMware Virtual Disk Development Kit (VDDK) image for the migration. This will significantly
+  speed up the migration. The migration engine uses VDDK on the destination VMO cluster to read virtual disks from the
+  source environment, transfer the data, and write it to the target storage.
 
   - You must build and host the VDDK image in your own image registry, which must be accessible to the destination VMO
     cluster for migrations.
@@ -109,8 +108,8 @@ This migration method uses the [Palette CLI](../../../automation/palette-cli/pal
     <details>
     <summary> Example steps to build and upload VDDK image </summary>
 
-    1. Download the VDDK image from the
-       [Broadcom Developer Portal](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/latest).
+    1. Download the VDDK image from the [Broadcom Developer Portal](https://developer.broadcom.com/). An account is
+       required.
 
     2. Decompress the downloaded image.
 

--- a/docs/docs-content/vm-management/vm-migration-assistant/create-source-providers.md
+++ b/docs/docs-content/vm-management/vm-migration-assistant/create-source-providers.md
@@ -56,10 +56,9 @@ Machines (VMs) that need to be migrated.
     [Changed Block Tracking](https://knowledge.broadcom.com/external/article/315370/enabling-or-disabling-changed-block-trac.html)
     must be enabled on your VMs.
 
-- We recommend providing a
-  [VMware Virtual Disk Development Kit (VDDK) image](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/latest)
-  for the migration. This will significantly speed up the migration. The migration engine uses VDDK on the destination
-  VMO cluster to read virtual disks from the source environment, transfer the data, and write it to the target storage.
+- We recommend providing a VMware Virtual Disk Development Kit (VDDK) image for the migration. This will significantly
+  speed up the migration. The migration engine uses VDDK on the destination VMO cluster to read virtual disks from the
+  source environment, transfer the data, and write it to the target storage.
 
   - You must build and host the VDDK image in your own image registry, which must be accessible to the destination VMO
     cluster for migrations.
@@ -74,8 +73,8 @@ Machines (VMs) that need to be migrated.
 
     <TabItem label="Non-Airgap" value="non-airgap">
 
-    1. Download the VDDK image from the
-       [Broadcom Developer Portal](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/latest).
+    1. Download the VDDK image from the [Broadcom Developer Portal](https://developer.broadcom.com/). An account is
+       required.
 
     2. Decompress the downloaded image.
 
@@ -114,8 +113,8 @@ Machines (VMs) that need to be migrated.
 
     <TabItem label="Airgap" value="airgap">
 
-    1.  Download the VDDK image from the
-        [Broadcom Developer Portal](https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/latest).
+    1.  Download the VDDK image from the [Broadcom Developer Portal](https://developer.broadcom.com/). An account is
+        required.
 
     2.  Copy or move the VDDK image to another Linux environment inside your airgap environment. Use any approved method
         to transfer the binary to the airgap environment.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-7`:
 - [fixing broken links for aug 24, 2026 (#11763)](https://github.com/spectrocloud/librarium/pull/11763)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
