### PR TITLE
PE-8648: systemd extensions for provider images

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -300,7 +300,7 @@ steps.
    Agent binaries when systemd extensions are available.
 2. If a provider image is required for operating system upgrades or patches, build the image from **CanvOS 4.10.x or
    later**.
-3. When Stylus is pinned to an earlier release such as `4.9.a`, supply a provider image. Provider images built from
+3. When Stylus is pinned to an earlier release such as `4.9.14`, supply a provider image. Provider images built from
    CanvOS 4.10.x must set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Provider images built from older CanvOS releases
    might work but are not recommended.
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -90,8 +90,8 @@ guide when you do not require [specialized configurations](#specialized-build-gu
     ```
 
 4.  Check out the CanvOS tag that corresponds to your Palette release. Refer to the
-    [Edge Compatibility Matrix](/clusters/edge/edge-compatibility-matrix/) to identify the correct CanvOS, Stylus, and
-    Edge host version. This guide uses the tag **v4.4.12** as an example.
+    [Edge Compatibility Matrix](/clusters/edge/edge-compatibility-matrix/) to identify the correct CanvOS, Palette Edge
+    agent, and Edge host version. This guide uses the tag **v4.4.12** as an example.
 
     ```shell
     git checkout v4.4.12
@@ -264,7 +264,7 @@ guide when you do not require [specialized configurations](#specialized-build-gu
    docker.io/[DOCKER-ID]/ubuntu          k3s-1.28.2-v4.4.12-palette-learn       075134ad5d4b   10 minutes ago   4.11GB
    ```
 
-## systemd Extensions and the `BUNDLE_K8S_AND_AGENT_PROVIDER` Flag {#bundle-k8s-and-agent-provider-flag}
+## Deliver Kubernetes and Agent Binaries via systemd Extensions {#bundle-k8s-and-agent-provider-flag}
 
 Starting with **CanvOS 4.10**, connected Edge clusters can use systemd extensions to deliver Kubernetes and Palette
 Agent binaries at runtime instead of embedding them in the provider image. This reduces provider image size and lets a
@@ -273,10 +273,11 @@ only.
 
 ### Support Requirements
 
-- **Stylus 4.10.x** or later on the cluster. Older Stylus releases fall back to the pre-systemd-extensions behavior.
+- **Palette Edge agent 4.10.0** or later on the cluster. Earlier releases fall back to the pre-systemd-extensions
+  behavior.
 - An operating system with **systemd version 255 or later**. Operating systems on earlier systemd versions continue to
   follow the existing flow, where Kubernetes and Palette Agent binaries are embedded in the provider image.
-- **CanvOS 4.10.x** or later to build provider images that opt in or out of the extensions path.
+- **CanvOS 4.10.0** or later to build provider images that opt in or out of the extensions path.
 
 ### `BUNDLE_K8S_AND_AGENT_PROVIDER` Flag Behavior
 
@@ -288,8 +289,8 @@ provider binaries are embedded in the provider image.
 | systemd 255 or later     | Excluded (delivered by systemd extensions)        | Set the flag to `true` when a specific flow requires the binaries embedded in the provider image. |
 | systemd earlier than 255 | Included                                          | Setting the flag has no effect. Binaries are always embedded on these operating systems.          |
 
-The flag is new in CanvOS 4.10. Earlier CanvOS releases do not recognize it and continue to operate with the existing
-behavior.
+The flag is a CanvOS 4.10 addition. Earlier CanvOS releases do not recognize it and continue to operate with the
+existing behavior.
 
 ### New Clusters
 
@@ -298,31 +299,33 @@ steps.
 
 1. Set `system.uri: NA` in the BYOOS pack. Palette does not need a provider image to deliver Kubernetes and Palette
    Agent binaries when systemd extensions are available.
-2. If a provider image is required for operating system upgrades or patches, build the image from **CanvOS 4.10.x or
-   later**.
-3. When Stylus is pinned to a release prior to 4.10.x, supply a provider image. Provider images built from CanvOS 4.10.x
-   must set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Provider images built from older CanvOS releases might work but
-   are not recommended.
+2. If a provider image is required for operating system upgrades or patches, build the image from a supported CanvOS
+   release. Refer to [Support Requirements](#support-requirements) for the minimum version.
+3. When the Palette Edge agent is pinned to an earlier release, supply a provider image. Provider images built from a
+   supported CanvOS release must set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Provider images built from older CanvOS
+   releases might work but are not recommended.
 
-### Upgrade an Existing Cluster on an Operating System with systemd 255 or Later
+### Upgrade an Existing Cluster
 
-The first upgrade after adopting CanvOS 4.10.x requires a provider image that ships the aligned Palette Agent version.
+The first upgrade after adopting CanvOS 4.10.0 requires a provider image that ships the aligned Palette Agent version.
 Subsequent Kubernetes upgrades run without a provider image.
 
-1. Build a provider image with **CanvOS 4.10.x or later** and set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true` in the
+1. Build a provider image with a supported CanvOS release and set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true` in the
    `.arg` file. Set `system.uri: <provider-image>` in the BYOOS pack for the initial upgrade. This upgrade replaces the
-   `kairos-agent` on the system with the 4.10.x-aligned version.
+   `kairos-agent` on the system with the aligned Palette Agent version. Refer to
+   [Support Requirements](#support-requirements) for the minimum CanvOS release.
 2. For subsequent Kubernetes upgrades, set `system.uri: NA` in the BYOOS pack. Palette delivers Kubernetes binaries
    through systemd extensions and does not require a provider image. A provider image can still be supplied for each
    repave, in which case `BUNDLE_K8S_AND_AGENT_PROVIDER` is not required.
-3. If Stylus remains pinned to a release earlier than 4.10.x, systemd extensions are not available on this cluster.
-   Build provider images from **CanvOS 4.10.x or later** with `BUNDLE_K8S_AND_AGENT_PROVIDER` set to `true` for every
+3. If the Palette Edge agent remains pinned to an earlier release, systemd extensions are not available on this cluster.
+   Build provider images from a supported CanvOS release with `BUNDLE_K8S_AND_AGENT_PROVIDER` set to `true` for every
    upgrade.
 
 ### Upgrade Operating System Packages
 
-Operating system package upgrades require a provider image built with **CanvOS 4.10.x or later**. Reference the image
-through `system.uri` in the BYOOS pack.
+Operating system package upgrades require a provider image built from a supported CanvOS release. Reference the image
+through `system.uri` in the BYOOS pack, and refer to [Support Requirements](#support-requirements) for the minimum
+version.
 
 ### Unified Kernel Image (UKI) Considerations
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -300,9 +300,9 @@ steps.
    Agent binaries when systemd extensions are available.
 2. If a provider image is required for operating system upgrades or patches, build the image from **CanvOS 4.10.x or
    later**.
-3. When Stylus is pinned to a release prior to 4.10.x, supply a provider image. Provider images built from
-   CanvOS 4.10.x must set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Provider images built from older CanvOS releases
-   might work but are not recommended.
+3. When Stylus is pinned to a release prior to 4.10.x, supply a provider image. Provider images built from CanvOS 4.10.x
+   must set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Provider images built from older CanvOS releases might work but
+   are not recommended.
 
 ### Upgrade an Existing Cluster on an Operating System with systemd 255 or Later
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -300,7 +300,7 @@ steps.
    Agent binaries when systemd extensions are available.
 2. If a provider image is required for operating system upgrades or patches, build the image from **CanvOS 4.10.x or
    later**.
-3. When Stylus is pinned to an earlier release such as `4.9.14`, supply a provider image. Provider images built from
+3. When Stylus is pinned to a release prior to 4.10.x, supply a provider image. Provider images built from
    CanvOS 4.10.x must set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Provider images built from older CanvOS releases
    might work but are not recommended.
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -264,6 +264,76 @@ guide when you do not require [specialized configurations](#specialized-build-gu
    docker.io/[DOCKER-ID]/ubuntu          k3s-1.28.2-v4.4.12-palette-learn       075134ad5d4b   10 minutes ago   4.11GB
    ```
 
+## systemd Extensions and the `BUNDLE_K8S_AND_AGENT_PROVIDER` Flag {#bundle-k8s-and-agent-provider-flag}
+
+Starting with **CanvOS 4.10**, connected Edge clusters can use systemd extensions to deliver Kubernetes and Palette
+Agent binaries at runtime instead of embedding them in the provider image. This reduces provider image size and lets a
+single provider image serve multiple Kubernetes versions on the same host. This capability applies to connected clusters
+only.
+
+### Support Requirements
+
+- **Stylus 4.10.x** or later on the cluster. Older Stylus releases fall back to the pre-systemd-extensions behavior.
+- An operating system with **systemd version 255 or later**. Operating systems on earlier systemd versions continue to
+  follow the existing flow, where Kubernetes and Palette Agent binaries are embedded in the provider image.
+- **CanvOS 4.10.x** or later to build provider images that opt in or out of the extensions path.
+
+### `BUNDLE_K8S_AND_AGENT_PROVIDER` Flag Behavior
+
+The `BUNDLE_K8S_AND_AGENT_PROVIDER` flag in the CanvOS `.arg` file controls whether Kubernetes and Palette Agent
+provider binaries are embedded in the provider image.
+
+| **Operating System**     | **Default `BUNDLE_K8S_AND_AGENT_PROVIDER` Value** | **Notes**                                                                                         |
+| ------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| systemd 255 or later     | Excluded (delivered by systemd extensions)        | Set the flag to `true` when a specific flow requires the binaries embedded in the provider image. |
+| systemd earlier than 255 | Included                                          | Setting the flag has no effect. Binaries are always embedded on these operating systems.          |
+
+The flag is new in CanvOS 4.10. Earlier CanvOS releases do not recognize it and continue to operate with the existing
+behavior. This is a non-breaking change.
+
+### New Clusters
+
+When you provision a new connected Edge cluster on an operating system with systemd 255 or later, take the following
+steps.
+
+1. Set `system.uri: NA` in the BYOOS pack. Palette does not need a provider image to deliver Kubernetes and Palette
+   Agent binaries when systemd extensions are available.
+2. If a provider image is required for operating system upgrades or patches, build the image from **CanvOS 4.10.x or
+   later**.
+3. When Stylus is pinned to an earlier release such as `4.9.a`, supply a provider image. Provider images built from
+   CanvOS 4.10.x must set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Provider images built from older CanvOS releases
+   might work but are not recommended.
+
+### Upgrade an Existing Cluster on an Operating System with systemd 255 or Later
+
+The first upgrade after adopting CanvOS 4.10.x requires a provider image that ships the aligned Palette Agent version.
+Subsequent Kubernetes upgrades run without a provider image.
+
+1. Build a provider image with **CanvOS 4.10.x or later** and set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true` in the
+   `.arg` file. Set `system.uri: <provider-image>` in the BYOOS pack for the initial upgrade. This upgrade replaces the
+   `kairos-agent` on the system with the 4.10.x-aligned version.
+2. For subsequent Kubernetes upgrades, set `system.uri: NA` in the BYOOS pack. Palette delivers Kubernetes binaries
+   through systemd extensions and does not require a provider image. A provider image can still be supplied for each
+   repave, in which case `BUNDLE_K8S_AND_AGENT_PROVIDER` is not required.
+3. If Stylus remains pinned to a release earlier than 4.10.x, systemd extensions are not available on this cluster.
+   Build provider images from **CanvOS 4.10.x or later** with `BUNDLE_K8S_AND_AGENT_PROVIDER` set to `true` for every
+   upgrade.
+
+### Upgrade Operating System Packages
+
+Operating system package upgrades require a provider image built with **CanvOS 4.10.x or later**. Reference the image
+through `system.uri` in the BYOOS pack.
+
+### Unified Kernel Image (UKI) Considerations
+
+For Edge hosts using [Unified Kernel Images](../../../trusted-boot/trusted-boot.md), signing keys must line up in both
+directions.
+
+- New provider images must be signed with the same keys used to sign the installer. A mismatch causes the host to reject
+  the image at boot.
+- systemd extensions delivered outside of the provider image must be signed with the same keys used to sign the
+  installer.
+
 ## Next Steps
 
 Provider images are only one the artifacts you need to provision an Edge deployment. You also need to build the Edge

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -289,7 +289,7 @@ provider binaries are embedded in the provider image.
 | systemd earlier than 255 | Included                                          | Setting the flag has no effect. Binaries are always embedded on these operating systems.          |
 
 The flag is new in CanvOS 4.10. Earlier CanvOS releases do not recognize it and continue to operate with the existing
-behavior. This is a non-breaking change.
+behavior.
 
 ### New Clusters
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -109,6 +109,17 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
   chunked upload support. Refer to
   [Upload Content Bundle](../clusters/edge/local-ui/cluster-management/upload-content-bundle.md) for more information.
 
+<!-- https://spectrocloud.atlassian.net/browse/PE-8648 -->
+
+- Connected Edge clusters can now use systemd extensions to deliver Kubernetes and Palette Agent binaries at runtime,
+  instead of embedding those binaries in the provider image. On operating systems running systemd version 255 or later,
+  provider images built with CanvOS 4.10.x exclude the binaries by default, and Stylus 4.10.x delivers them through
+  systemd extensions. Set `system.uri: NA` in the BYOOS pack for standard upgrades. The new
+  `BUNDLE_K8S_AND_AGENT_PROVIDER` flag in the CanvOS `.arg` file overrides the default when a specific flow requires the
+  binaries embedded. Refer to
+  [systemd Extensions and the `BUNDLE_K8S_AND_AGENT_PROVIDER` Flag](../clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md#bundle-k8s-and-agent-provider-flag)
+  for build and upgrade guidance.
+
 #### Improvements
 
 <!-- https://spectrocloud.atlassian.net/browse/PE-9268 -->


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Documents systemd extensions as the new delivery mechanism for Kubernetes and Palette Agent binaries on connected Edge clusters in 4.10.0, and the `BUNDLE_K8S_AND_AGENT_PROVIDER` flag introduced in CanvOS 4.10 that controls whether those binaries are embedded in the provider image.

**`build-provider-images.md`** — new top-level section _systemd Extensions and the `BUNDLE_K8S_AND_AGENT_PROVIDER` Flag_ (explicit anchor `#bundle-k8s-and-agent-provider-flag`) covering:

- Support requirements (Stylus 4.10.x, systemd 255 or later, CanvOS 4.10.x)
- Flag behavior table (default excluded on systemd 255+, included otherwise, no-op on unsupported OSes, non-breaking)
- New cluster flow (`system.uri: NA` in the BYOOS pack, provider-image expectations, Stylus-pinning caveat)
- Existing-cluster upgrade flow on systemd 255+ (initial upgrade requires a provider image with the flag set; subsequent Kubernetes upgrades run without one)
- OS package upgrade note
- Unified Kernel Image signing constraints (provider image and systemd extensions must be signed with the same keys as the installer)

**`release-notes.md`** — new 4.10.0 Edge Features bullet for PE-8648, linking to the section above.

### Notes for review

- No backport labels — feature is 4.10.0-only (CanvOS 4.10 flag, Stylus 4.10.x requirement).
- Vale clean on both edited files. Six pre-existing all-caps heading errors on the release notes' `#### OS` / `#### CNI` / `#### CSI` pack-notes headings are unchanged.
- Ticket scope is _connected clusters_. If airgapped Edge has an equivalent flow, a separate ticket covers it — nothing in PE-8648 spelled out an airgap counterpart.

## 💻 Changed Pages

- [Build Provider Images — systemd Extensions and the `BUNDLE_K8S_AND_AGENT_PROVIDER` Flag](https://deploy-preview-11782--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/#bundle-k8s-and-agent-provider-flag)
- [Release Notes — 4.10.0 Edge Features](https://deploy-preview-11782--docs-spectrocloud.netlify.app/release-notes#release-notes-4.10.0)

## 🎫 Jira Tickets

- [PE-8648](https://spectrocloud.atlassian.net/browse/PE-8648) — Doc: k8s systemd-extensions as provider-images for connected clusters


[PE-8648]: https://spectrocloud.atlassian.net/browse/PE-8648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ