### PR TITLE
chore: bump docusaurus-plugin-sass to silence Dart Sass legacy JS API warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "clsx": "^2.1.1",
         "docusaurus-plugin-image-zoom": "^2.0.0",
         "docusaurus-plugin-openapi-docs": "^4.7.1",
-        "docusaurus-plugin-sass": "^0.2.5",
+        "docusaurus-plugin-sass": "^0.2.6",
         "docusaurus-theme-openapi-docs": "^4.7.1",
         "feed": "^5.2.1",
         "fuse.js": "^7.1.0",
@@ -50,9 +50,9 @@
         "@playwright/test": "^1.61.1",
         "@semantic-release/changelog": "^7.0.0",
         "@semantic-release/exec": "^7.1.0",
-        "@semantic-release/git": "*",
-        "@semantic-release/github": "*",
-        "@semantic-release/npm": "*",
+        "@semantic-release/git": "latest",
+        "@semantic-release/github": "latest",
+        "@semantic-release/npm": "latest",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@tsconfig/docusaurus": "^2.0.9",
@@ -87,7 +87,7 @@
         "xml2js": "^0.6.2"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=24.15.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -18575,10 +18575,12 @@
       }
     },
     "node_modules/docusaurus-plugin-sass": {
-      "version": "0.2.5",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-sass/-/docusaurus-plugin-sass-0.2.6.tgz",
+      "integrity": "sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==",
       "license": "MIT",
       "dependencies": {
-        "sass-loader": "^10.1.1"
+        "sass-loader": "^16.0.2"
       },
       "peerDependencies": {
         "@docusaurus/core": "^2.0.0-beta || ^3.0.0-alpha",
@@ -18628,46 +18630,6 @@
         "docusaurus-plugin-sass": "^0.2.3",
         "react": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/docusaurus-theme-openapi-docs/node_modules/sass-loader": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.6.tgz",
-      "integrity": "sha512-sglGzId5gmlfxNs4gK2U3h7HlVRfx278YK6Ono5lwzuvi1jxig80YiuHkaDBVsYIKFhx8wN7XSCI0M2IDS/3qA==",
-      "license": "MIT",
-      "dependencies": {
-        "neo-async": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-        "sass": "^1.3.0",
-        "sass-embedded": "*",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "node-sass": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -28337,13 +28299,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/ky": {
@@ -41803,32 +41758,29 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.5.2.tgz",
-      "integrity": "sha512-vMUoSNOUKJILHpcNCCyD23X34gve1TS7Rjd9uXHeKqhvBG39x6XbswFDtpbTElj6XdMFezoWhkh5vtKudf2cgQ==",
+      "version": "16.0.8",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.8.tgz",
+      "integrity": "sha512-hcov4ZwZJIGbEuyNr9EmiTmZueyrxSToE6GOzoZnq5JM7ecRO7ttyvilPn+VmRsqiP16+VYZzVnGZj/hzZgKBA==",
       "license": "MIT",
       "dependencies": {
-        "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.2"
+        "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "fibers": ">= 3.1.0",
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
-        "webpack": "^4.36.0 || ^5.0.0"
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "fibers": {
+        "@rspack/core": {
           "optional": true
         },
         "node-sass": {
@@ -41836,48 +41788,13 @@
         },
         "sass": {
           "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/sass-loader/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/sass-loader/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/sass-loader/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
-    "node_modules/sass-loader/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/sass/node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "clsx": "^2.1.1",
     "docusaurus-plugin-image-zoom": "^2.0.0",
     "docusaurus-plugin-openapi-docs": "^4.7.1",
-    "docusaurus-plugin-sass": "^0.2.5",
+    "docusaurus-plugin-sass": "^0.2.6",
     "docusaurus-theme-openapi-docs": "^4.7.1",
     "feed": "^5.2.1",
     "fuse.js": "^7.1.0",


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._ — No Jira ticket; see that section.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._ — No user-facing changes; see that section.
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy. — N/A,
      no content changes. Verified instead by a full `make build`.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable). — N/A, no content changes. `package.json` and
        `package-lock.json` both pass `prettier --check`.
  - [x] Verify all images display. — N/A, no content changes.
- [x] Ensure all **Vale comments** are resolved. — N/A, no prose changed.
  - [x] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._ — Not required.
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._ — Open question, see below.
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.) — Not expected; this is docs-repo build tooling only.
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

This PR silences the repeated Dart Sass deprecation warning that appears throughout every `make build` and
`make start`:

```
DEPRECATION WARNING [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
```

**Cause.** `docusaurus-plugin-sass@0.2.5` depends on `sass-loader@^10`, which only speaks Dart Sass's legacy
`render()` JS API. Paired with `sass@1.97.x`, that produced the warning on every `.scss` compile. The split was
visible in the dependency tree, where the OpenAPI theme was already on a modern loader:

```
├─┬ docusaurus-plugin-sass@0.2.5
│ └── sass-loader@10.5.2          ← legacy API, the warning
└─┬ docusaurus-theme-openapi-docs@4.7.1
  └── sass-loader@16.0.6          ← modern API, silent
```

**Fix.** Bump `docusaurus-plugin-sass` to `^0.2.6`, which changes its dependency to `sass-loader@^16`. That
version defaults to `api: "modern-compiler"`.

**Why this is low risk.** The plugin's own source is byte-identical between 0.2.5 and 0.2.6 — the only change in
the release is the `sass-loader` range. Its peer range is likewise unchanged
(`"@docusaurus/core": "^2.0.0-beta || ^3.0.0-alpha"`), so nothing about Docusaurus compatibility moves. The plugin
touches exactly one Docusaurus API, `utils.getStyleLoaders` from the `configureWebpack` hook, which is still
provided by our `@docusaurus/core@3.9.2`. `sass-loader@16` requires Node >= 18.12 and webpack ^5, both already
satisfied, and the OpenAPI theme has been running 16.x in this same build all along.

**Side effect on the lockfile.** `sass-loader` now dedupes to a single hoisted `16.0.8` shared by both consumers,
which drops the legacy loader's private `ajv` / `schema-utils` subtree. That accounts for the lopsided diff
(25 insertions, 108 deletions) — it is removal of duplicated transitive packages, not a broad dependency change.

Both `package.json` and `package-lock.json` were updated so the manifest floor and the lockfile agree; raising the
range to `^0.2.6` (rather than relying on the lockfile alone) keeps a future lockfile regeneration from silently
resolving back to 0.2.5 and reintroducing the warning.

**Verification.** `make build` exits `0` with `[SUCCESS] Generated static files in "build"`, the full log contains
zero `legacy-js-api` occurrences (previously many per build), and `build/assets/css/styles.*.css` still compiles
from `custom.scss` at the expected ~188K with the expected selectors present.

**Open question for reviewers:** should this be backported to the `version-4-*` branches? Those branches run the
same build tooling and would emit the same warning, but this is a developer-experience fix with no user-facing
effect, so I have not added backport labels. Happy to add `auto-backport` plus the relevant `backport-version-**`
labels if the team wants it.

---

## 💻 Changed Pages

**No user-facing changes.** This PR touches only build tooling (`package.json` and `package-lock.json`). No
documentation pages are added, removed, or modified, so there are no preview links to review.

---

## 🎫 Jira Tickets

**No corresponding Jira ticket.** This is an unticketed developer-experience cleanup of build output noise, raised
off the back of noticing the warning during a local build.
