### PR TITLE
DOC-3108 follow-up: unbreak the visual report publish gate

### DIFF
--- a/.github/workflows/visual-comparison.yaml
+++ b/.github/workflows/visual-comparison.yaml
@@ -401,27 +401,39 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
           REPO_URL: https://github.com/${{ github.repository }}.git
+        # The sentinels below are deliberately `present`/`absent` and NOT `true`/`false`.
+        # Several secrets in this workflow's top-level `env:` block hold the literal
+        # string `true` or `false` (DISABLE_PACKS_INTEGRATIONS, DISABLE_SECURITY_INTEGRATIONS,
+        # SHOW_LAST_UPDATE_TIME). Actions registers every secret value as a mask for the
+        # whole job, then refuses to set any job output containing a masked value:
+        #   ##[warning]Skip output 'branch_present' since it may contain secret.
+        # The output then arrives at `publish_report` as an empty string, the `if` is
+        # false, and the publish silently skips while the run stays green. That is
+        # exactly what happened to every run between DOC-3108 merging and this fix.
+        # Do not "tidy" these back to booleans. See DOC-3108.
         run: |
           set -euo pipefail
 
           if [ -z "$HEAD_REF" ]; then
             echo "::notice::Empty head_ref; skipping publish."
-            printf 'branch_present=false\n' >> "$GITHUB_OUTPUT"
+            printf 'branch_present=absent\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/$HEAD_REF" >/dev/null 2>&1; then
-            printf 'branch_present=true\n' >> "$GITHUB_OUTPUT"
+            printf 'branch_present=present\n' >> "$GITHUB_OUTPUT"
           else
             echo "::notice::Head branch '$HEAD_REF' no longer exists on origin; skipping publish to avoid orphaning reports/<sanitised>. The scheduled sweep in reconcile-orphan-reports.yaml will not have to fix this one."
-            printf 'branch_present=false\n' >> "$GITHUB_OUTPUT"
+            printf 'branch_present=absent\n' >> "$GITHUB_OUTPUT"
           fi
 
 
   publish_report:
     name: Publish HTML Report
     needs: [run-ci, take-screenshots, merge-reports, head_ref_check]
-    if: needs.head_ref_check.outputs.branch_present == 'true'
+    # `present`/`absent` rather than `true`/`false` is load-bearing — see the sentinel
+    # comment in head_ref_check's check step before changing this comparison.
+    if: needs.head_ref_check.outputs.branch_present == 'present'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Pushes the report to gh-pages and posts the report URL comment on the PR.


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [ ] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [ ] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [ ] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

> **Notes on the unchecked items:** this PR touches only `.github/workflows/visual-comparison.yaml`, so there are no pages to self-review, no formatting or images to verify, and no prose for Vale to lint. No outside review is needed; this is Docs-owned CI. CI and `notify-slack` are left for the author. See [Backport](#-backport) for why no backport labels are set.

---

## 📝 Describe the Change

This PR fixes the `Publish HTML Report` job in the visual comparison workflow, which has been **silently skipping on every run** since [#11746](https://github.com/spectrocloud/librarium/pull/11746) (DOC-3108) merged on 2026-08-24. No visual report has published to GitHub Pages since that date, and no PR has received its report URL comment.

### Root cause

DOC-3108 added a `head_ref_check` job that confirms the PR head branch still exists on origin, and gated the publish on its output:

```yaml
if: needs.head_ref_check.outputs.branch_present == 'true'
```

The check itself works correctly. The output never arrives.

This workflow's top-level `env:` block exposes several repository secrets whose values are the literal strings `true` and `false` — `DISABLE_PACKS_INTEGRATIONS`, `DISABLE_SECURITY_INTEGRATIONS` and `SHOW_LAST_UPDATE_TIME`. GitHub Actions registers every secret value as a mask for the entire job, then refuses to set any **job output** whose value contains a masked string. From the `Confirm Head Branch Still Exists` job log on [run 32955933625](https://github.com/spectrocloud/librarium/actions/runs/32955933625):

```
Evaluate and set job outputs
##[warning]Skip output 'branch_present' since it may contain secret.
```

The masking is visible in the same log, where the workflow's own script text is redacted before it is even run:

```
printf 'branch_present=***\n' >> "$GITHUB_OUTPUT"
```

With the output dropped, `needs.head_ref_check.outputs.branch_present` evaluates to the empty string, `'' == 'true'` is false, and `publish_report` skips. Because a skip is not a failure, the run still reports green — which is why this went unnoticed for two days.

### The fix

Emit `present` / `absent` instead of `true` / `false`. No boolean-valued secret can collide with those, so the output is set normally. The gate on `publish_report` is updated to match, and both ends carry a comment explaining why the sentinels are not booleans, so the next reader does not "tidy" them back and silently reintroduce the bug.

### Alternatives considered

Narrowing the top-level `env:` block so those three secrets are only exposed to the jobs that actually build the site would also fix it. It is a larger, riskier change to a workflow that several jobs depend on, and it is not durable — the masking returns the moment someone re-adds a boolean secret to a job that emits an output. The sentinel change is immune to that regardless of what the secrets hold.

### Scope check

`branch_present` is the only job-level boolean output in the repository that has these secrets in scope. Other workflows that write `true` / `false` to `$GITHUB_OUTPUT` (`clean-up-report.yaml`, `gitleaks.yaml`, `versions_robot.yaml`, `GHA-ready-for-review.yaml`, `update_component_updates.yaml`, `update_patch_release_notes.yaml`) are unaffected: they are either **step** outputs consumed inside the same job, which this masking does not apply to, or they run in workflows that do not expose the boolean secrets.

### 🔀 Backport

No backport labels are set. `visual-comparison.yaml` does exist on the `version-*` branches, but the copies there are inert: the workflow is gated on `branches-ignore: ["version-*", "docs-rel-*"]`, which filters on the PR's base branch, so a PR into a release branch never triggers it. The gate is identical on those branches.

There is also precedent. Looking at this file's history on `version-4-9`, the only changes that have ever travelled are Dependabot action bumps and security sweeps (doc-2879, ps-2034, doc-2629). Every behavioural fix to this workflow stayed on `master` — DOC-3101, DOC-3103, the DOC-3103 addendum, the apt orphan-lock fix (#11732) and DOC-3108 itself are all absent from the release branches. The last functional change to reach `version-4-9` was in June 2026. Backporting this one would be the anomaly, not the norm.

`docs-rel-4-10-0` does currently carry the broken gate, but it inherited it by merging `master` (last merge 2026-08-25) rather than by backport, and it is inert there for the same reason. This fix will reach it on the next `master` merge with no action needed.

Flagging for the reviewer: if the rationale behind the earlier security backports was "keep this file consistent across branches" rather than "those branches are exposed", the same argument could be made here. I do not think it applies to a behavioural fix to a workflow that cannot run on those branches, but it is a reviewer's call rather than mine.

### Verifying this after merge

A skipped publish leaves the run green, so the run-level status is not evidence. Check that the `Publish HTML Report` job on the next labelled PR reaches `success` and that the report URL comment appears on the PR.

---

## 💻 Changed Pages

No user-facing changes. This PR modifies CI configuration only — one workflow file, no docs content.

---

## 🎫 Jira Tickets

No dedicated ticket. This is a follow-up defect fix to [DOC-3108](https://spectrocloud.atlassian.net/browse/DOC-3108), whose implementation introduced the gate; happy to file a separate ticket if the team would prefer one for tracking.


[DOC-3108]: https://spectrocloud.atlassian.net/browse/DOC-3108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ