### PR TITLE
fix: correct partial path for AWS CloudFormation stack permissions in permissions map

### DIFF
--- a/scripts/permissions-map.json
+++ b/scripts/permissions-map.json
@@ -7,7 +7,7 @@
   "aws/MinimumIaaSDynamicPermissions.json": "_partials/permissions/_aws-iaas-dynamic-permissions.mdx",
   "aws/MinimumEKSDynamicPermissions.json": "_partials/permissions/_aws-eks-dynamic-permissions.mdx",
   "aws/MinimumEKSStaticPermissions.json": "_partials/permissions/_aws-eks-static-permissions.mdx",
-  "aws/MinimumAWSCloudFormationStackPermissions.json": "_partials/permissions/_aws-cloud-formation-stack-permissions.mdx",
+  "aws/MinimumAWSCloudFormationStackPermissions.json": "_partials/permissions/_aws-cloudformation-stack-permissions.mdx",
   "aws/AWSPaletteCloudFormationInputTemplate.yaml": "_partials/permissions/_aws-palette-cloud-formation-input-template.mdx",
   "aws/AmazonEBSCSIDriverPolicy.yaml": "_partials/permissions/_aws-ebs-csi-driver-policy.mdx",
   "aws/ControllersEKSPolicy.json": "_partials/permissions/_aws-eks-controller-policy.mdx",


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [x] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

This PR fixes a broken path in `scripts/permissions-map.json`, the map that drives the weekly [Permissions Update](https://github.com/spectrocloud/librarium/blob/master/.github/workflows/permissions-update.yaml) workflow.

The entry for `aws/MinimumAWSCloudFormationStackPermissions.json` pointed at `_partials/permissions/_aws-cloud-formation-stack-permissions.mdx`, but the partial is named `_aws-cloudformation-stack-permissions.mdx` — no hyphen between "cloud" and "formation". Both the partial and the map entry were introduced together in #9514 (PCP-5892) with the names already diverged.

`scripts/permissions-sync.sh` warns and skips when either side of a mapping is missing:

```bash
if [[ ! -f "$repo_permissions/$source_file" || ! -f "$repo_librarium/$mdx_file" ]]; then
    echo "Warning: '$source_file' or '$mdx_file' missing. Skipping..."
    continue
fi
```

So this entry has never been compared. The workflow reported a clean run for it no matter what the source content said, meaning a change to the CloudFormation stack permissions in `required-permissions-data` would not have raised a docs PR.

The partial's name is authoritative on three counts — the file on disk, the `partial_name` in its frontmatter, and the `PartialsComponent` reference in `minimum-permissions-policies.md` — so the map path is corrected rather than the file renamed. Renaming the partial would break that page.

### Verification

Replicating the sync script's `awk` extraction read-only against `required-permissions-data` on `main`, all 24 map entries now resolve on both sides and all 24 match byte for byte. In particular, `MinimumAWSCloudFormationStackPermissions.json` is currently identical to its partial, so the silent skip had not yet let real drift through — this is a latent gap being closed, not an outstanding permissions discrepancy.

I also validated every map entry against every supported branch from `version-4-6` up. This was the only broken mapping on any branch.

### Backports

`version-4-9` and `version-4-8` carry the same bad path and are labelled for backport. `version-4-7` and `version-4-6` do not have this entry at all, since it arrived with #9514, so they need no change.

---

## 💻 Changed Pages

No user-facing changes. This PR only touches the build/tooling map used by the Permissions Update workflow, so there are no page previews to review.

---

## 🎫 Jira Tickets

No corresponding Jira ticket. This was found incidentally while scoping [DOC-3161](https://spectrocloud.atlassian.net/browse/DOC-3161) (tracking the backup location S3 IAM policy in `required-permissions-data`) and fixed directly, as the change is a one-line path correction.


[DOC-3161]: https://spectrocloud.atlassian.net/browse/DOC-3161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ