### PR TITLE
DOC-3162 - Patch release notes for 4.9.52

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,20 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## August 27, 2026 - Release 4.9.52
+
+<!-- PATCH RELEASE TICKET: DOC-3162 -->
+<!-- PATCH RELEASE VERSION: 4.9.52 -->
+
+### Improvements
+
+<!-- https://spectrocloud.atlassian.net/browse/PEM-11815 -->
+
+- You can now add a JFrog Artifactory OCI packs registry through the Palette UI. Specify the JFrog Docker V2 API path
+  and repository key in the **Endpoint Suffix** field when you add the registry. In Palette 4.9.51, this configuration
+  was available only through the API and Terraform. Refer to
+  [Add OCI Packs Registry](../registries-and-packs/registries/oci-registry/add-oci-packs.md) for more information.
+
 ## August 26, 2026 - Release 4.9.51
 
 <!-- PATCH RELEASE TICKET: DOC-3138 -->
@@ -25,8 +39,8 @@ tags: ["release-notes"]
 
 <!-- https://spectrocloud.atlassian.net/browse/PEM-11808 -->
 
-- JFrog Artifactory OCI pack registries are now supported at the tenant scope. Add the registry through the Palette UI
-  or API, and specify the JFrog Docker V2 API path and repository key in the **Endpoint Suffix** field. Refer to
+- JFrog Artifactory OCI pack registries are now supported at the tenant scope. Add the registry through the API or
+  Terraform, and specify the JFrog Docker V2 API path and repository key as the registry `basePath`. Refer to
   [OCI Packs Registry Configuration by Provider](../registries-and-packs/registries/oci-registry/oci-registry.md#oci-packs-registry-configuration-by-provider)
   for configuration examples.
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [x] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

This PR adds the release notes section for the Palette 4.9.52 patch release.

DOC-3162 does not follow the usual patch ticket format. It carries no "List of candidates" link and no due date, and it names a single issue rather than a candidate set, so `make generate-patch-release-notes` cannot run against it. The section was produced by hand following what that script would have done, including its marker comments, so a later run of the script can still find and update the section.

Values that the script would normally derive from the candidates JQL were sourced as follows:

- **Release date (August 27, 2026)** — from SRE 3863 (CR: Update Production to Release 4.9.52). The 4.9.51 CR was raised on the evening of the 25th and completed after midnight on the 26th, which is the date its section carries; SRE 3863 was raised on the evening of the 26th and is still in review.
- **Release version (4.9.52)** — from the DOC-3162 summary and SRE 3863. The ticket's own fixVersion is the generic `4.9.x` placeholder.
- **Candidate issue (PEM 11815)** — the ticket that shipped the UI change in this patch. PEM 11808 is the parent epic and is already cited in the 4.9.51 section, so reusing it would duplicate the marker.

**No component version changes.** `nickfury@release-4.9` reports `stylus=4.9.39` and `palette-cli=4.9.19`, both identical to what 4.9.51 already documents, so there is no Edge or Automation section and no rows are added to the Edge Compatibility Matrix or the CLI Tools table. SRE 3863 confirms `optic` 4.9.10 → 4.9.12 is the only service that moved.

**Correction to the 4.9.51 entry.** That entry stated that a JFrog Artifactory OCI pack registry could be added "through the Palette UI or API" using the **Endpoint Suffix** field. Per DOC-3162 and SRE 3863, the UI field did not ship until 4.9.52, so the 4.9.51 entry now describes only the API and Terraform paths and refers to the registry `basePath`. Without this, the two adjacent sections contradict each other.

---

## 💻 Changed Pages

- [Release Notes](https://deploy-preview-11794--docs-spectrocloud.netlify.app/release-notes) — add the 4.9.52 section, correct the 4.9.51 JFrog entry

---

## 🎫 Jira Tickets

[DOC-3162](https://spectrocloud.atlassian.net/browse/DOC-3162)

Related: PEM 11815, PEM 11808, SRE 3863
