### PR TITLE
PCP-7362 - Document day-2 repave behavior for SSH keys and NTP on Canonical K8s

### DIFF
--- a/docs/docs-content/clusters/data-center/maas/architecture.md
+++ b/docs/docs-content/clusters/data-center/maas/architecture.md
@@ -100,6 +100,11 @@ Configuring **SSH Keys** through Palette does not remove or modify default or ex
 example, the built-in `ubuntu` user on Ubuntu MAAS images. Palette preserves those users, along with any keys that MAAS
 or the machine image configured for them.
 
+On a Canonical Kubernetes cluster, changing **SSH Keys** after the cluster is deployed repaves the cluster nodes. Refer
+to
+[Day-2 SSH Key and NTP Changes on Canonical Kubernetes Clusters](#day-2-ssh-key-and-ntp-changes-on-canonical-kubernetes-clusters)
+for more information.
+
 ### SSH Access on OpenShift Workload Clusters
 
 OpenShift workload clusters hosted by a HyperShift host cluster are provisioned through HyperShift's `HostedCluster` and
@@ -122,11 +127,48 @@ If you remove every server from the list on a Canonical Kubernetes cluster, its 
 of the node operating system, for example `0.ubuntu.pool.ntp.org` through `3.ubuntu.pool.ntp.org`. They do not return to
 the NTP server that MAAS provides.
 
+On a Canonical Kubernetes cluster, changing **NTP Servers** after the cluster is deployed repaves the cluster nodes.
+Refer to
+[Day-2 SSH Key and NTP Changes on Canonical Kubernetes Clusters](#day-2-ssh-key-and-ntp-changes-on-canonical-kubernetes-clusters)
+for more information.
+
 ### NTP on OpenShift Workload Clusters
 
 OpenShift workload clusters hosted by a HyperShift host cluster do not consume the cluster's **NTP Servers** field.
 Their nodes are provisioned through HyperShift's `HostedCluster` and `NodePool` custom resources on RHCOS rather than
 through Palette's cloud-init path, so time synchronization on those nodes is governed by OpenShift and RHCOS mechanisms.
+
+## Day-2 SSH Key and NTP Changes on Canonical Kubernetes Clusters
+
+Palette injects the **SSH Keys** and **NTP Servers** values from a cluster's cloud configuration into the bootstrap
+configuration of each Canonical Kubernetes (CK8s) node. When you change either value on a deployed CK8s cluster, the
+node configuration that Palette generates no longer matches the configuration of the running nodes, and Palette repaves
+the cluster to reconcile the difference.
+
+The repave replaces the control plane nodes and the nodes in every worker pool. Palette replaces nodes one at a time so
+that the cluster remains available for the duration of the operation. As with any repave, Palette requires your approval
+before the operation starts. Refer to
+[Repave Behavior and Configuration](../../cluster-management/node-pool.md#repave-behavior-and-configuration) to learn
+how repaves proceed and how to approve them.
+
+:::warning
+
+Plan **SSH Keys** and **NTP Servers** changes on a deployed Canonical Kubernetes cluster in the same way you plan a
+Kubernetes version upgrade. Every node in the cluster is replaced.
+
+:::
+
+Palette does not repave the cluster in the following cases:
+
+- You save the cloud configuration without changing the **SSH Keys** or **NTP Servers** values. Palette compares the
+  node configuration it generates against the configuration of the running nodes and takes no action when the two match.
+
+- You use an auto-generated SSH key and do not regenerate it. Palette reuses the stored public key each time it
+  evaluates the cluster, so the node configuration remains unchanged. Regenerating the key produces a new public key,
+  which does repave the cluster.
+
+- You have not configured **SSH Keys** or **NTP Servers** on the cluster. Palette repaves the cluster only in response
+  to a change in these values.
 
 ## Custom API Server Endpoint for MAAS Clusters
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -50,7 +50,7 @@ tags: ["release-notes"]
   cluster's cloud configuration during cluster creation and on Day-2 through the Palette UI, API, Terraform provider,
   and Crossplane provider, on both Palette and Palette VerteX. Palette injects the keys into the `spectro` user's
   `~/.ssh/authorized_keys` on every control plane and worker node, and preserves any users that MAAS or the machine
-  image already configured. Refer to
+  image already configured. Changing the keys on a deployed CK8s cluster repaves the cluster nodes. Refer to
   [SSH Keys on MAAS Cluster Nodes](../clusters/data-center/maas/architecture.md#ssh-keys-on-maas-cluster-nodes) for more
   information.
 
@@ -59,7 +59,8 @@ tags: ["release-notes"]
 - Canonical Kubernetes (CK8s) clusters on MAAS now support Network Time Protocol (NTP) server configuration. You can
   configure **NTP Servers** on the cluster's cloud configuration during cluster creation and on Day-2 through the
   Palette UI, API, Terraform provider, and Crossplane provider, on both Palette and Palette VerteX. The servers you
-  specify replace the NTP configuration that MAAS provides to each control plane and worker node. Refer to
+  specify replace the NTP configuration that MAAS provides to each control plane and worker node. Changing the servers
+  on a deployed CK8s cluster repaves the cluster nodes. Refer to
   [NTP Servers on MAAS Cluster Nodes](../clusters/data-center/maas/architecture.md#ntp-servers-on-maas-cluster-nodes)
   for more information.
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Documents the node repave that a day-2 **SSH Keys** or **NTP Servers** change triggers on a Canonical Kubernetes (CK8s) cluster on MAAS.

The two sibling doc tasks for this epic — PCP 7415 (SSH) and PCP 7381 (NTP) — each explicitly deferred this behavior here and told the other not to duplicate it, so it is the one part of the 4.10.0 CK8s SSH/NTP story with no coverage on the release branch today. Both of their architecture sections are already merged, and all five MAAS create pages already link into them, so this change is confined to `architecture.md` plus the two release note entries.

### What changed

- **`architecture.md`** — new `## Day-2 SSH Key and NTP Changes on Canonical Kubernetes Clusters` section covering the repave scope (control plane plus every worker pool, one node at a time), the cluster-level approval gate, and the three cases that do not repave. A pointer to it is added at the end of the existing **SSH Keys on MAAS Cluster Nodes** and **NTP Servers on MAAS Cluster Nodes** sections.
- **`release-notes.md`** — one sentence added to each of the two 4.10.0 entries. Both previously said the values are configurable "on Day-2" with no indication that doing so replaces every node.

---

## 💻 Changed Pages

- [Architecture](https://deploy-preview-11796--docs-spectrocloud.netlify.app/clusters/data-center/maas/architecture) — the CK8s SSH and CK8s NTP entries
- [Release Notes](https://deploy-preview-11796--docs-spectrocloud.netlify.app/release-notes) — new Day-2 section, plus pointers in the SSH Keys and NTP Servers sections

---

## 🎫 Jira Tickets

[PCP-7362](https://spectrocloud.atlassian.net/browse/PCP-7362)

Related, for context only: PCP 6899 (parent epic, SSH key management for CK8s on MAAS), PCP 7415 (SSH doc task), PCP 7381 (NTP doc task).

_Related ticket keys above are written with a space and left unlinked on purpose. The merge automation resolves every hyphenated key it finds in this body, including one inside a `browse/<KEY>` URL, so linking them would silently close tickets this PR does not resolve._


[PCP-7362]: https://spectrocloud.atlassian.net/browse/PCP-7362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ