### PR TITLE
AIL-543: Document KV cache offloading operator surface

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
@@ -48,6 +48,29 @@ PaletteAI Inference Launchpad supports the following engine kinds.
 Serving features can vary by kind. For example, some kinds support reasoning and tool-calling for models that provide
 them, while others do not. The automatic option accounts for these differences when it matches an engine to a model.
 
+## Engine Arguments
+
+Engine behavior can be adjusted through engine-specific arguments, which the model's recipe carries alongside its launch
+configuration. The **Deploy model** panel shows those arguments in the **Extra arguments** subsection of the **Serving
+overrides** card, so you can review or override them for a single deploy without editing the recipe.
+
+Where an argument's value is a JSON document, the panel replaces the plain text input with a typed editor that validates
+the JSON on every keystroke and offers a form view labeled by field type. The editor is triggered by the shape of the
+value, not by a list of known argument names, so any current or future engine argument whose value is a JSON object or
+array is edited the same way. The editor validates that the text parses as JSON, not the values the engine will accept.
+Where the engine rejects a value at startup, the deploy fails on the model row after you confirm, rather than showing an
+inline error in the dialog.
+
+KV cache offloading is the first engine argument that uses this editor. The offloading strategy travels with the model's
+recipe, which the appliance ships alongside a supported model, so the operator does not enable or disable offloading
+from a switch on the deploy panel; the editor exists only to let the operator review or adjust the recipe's JSON value
+for a single deploy. A common trap the editor catches is a quoted boolean: engines read any non-empty text as `true`, so
+a field holding `"false"` as a string is silently read as `true`. The editor detects that and offers a one-select fix to
+rewrite the value as an actual boolean.
+
+Refer to
+[Review or Change an Engine Argument That Uses JSON](../how-to-guides/deploy-a-model.md#review-or-change-an-engine-argument-that-uses-json).
+
 ## Manual Engine Selection
 
 Leave the engine on the automatic option unless you have a specific reason to pin a model to a particular engine, such

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md
@@ -55,7 +55,7 @@ dialog. For why you would pin a model to some nodes and not others, refer to
    snapshot. A node you add to the cluster later does not receive this model until you add it, as described in
    [Add a Model to More Nodes](#add-a-model-to-more-nodes).
 
-7. Select **Deploy**, review the deployment preview, and then select **Confirm & apply**.
+7. Select **Deploy**, review the deployment preview, and then select **Confirm & Apply**.
 
 The appliance writes nothing until you confirm. It then brings the model through gate, provision, smoke-test, and ready
 stages on each chosen node. For that lifecycle, refer to
@@ -98,6 +98,43 @@ during deployment and clears once the model finishes coming online, at which poi
 For why a model becomes routable only after it passes its smoke test, refer to
 [Model Provisioning Lifecycle](../explanation/architecture.md#model-provisioning-lifecycle).
 
+## Review or Change an Engine Argument That Uses JSON
+
+When a `{ } JSON` chip appears on an **Extra arguments** row in the **Deploy model** panel, use the JSON argument editor
+to review or change the value for this deploy. For background on when the recipe carries a JSON-valued argument, refer
+to [Engine Arguments](../explanation/inference-engines.md#engine-arguments).
+
+1. On the **Cluster** page, select the **Models** tab, and then select **Deploy New Model**. The **Deploy model** panel
+   opens.
+
+2. Choose the model in the **Model** drop-down menu, then expand the **Serving overrides** card.
+
+3. Under **Extra arguments**, locate a row whose value is a `{ } JSON` chip followed by a one-line preview of its
+   top-level fields.
+
+4. Select **Edit JSON** on that row. The dialog opens with the argument's flag in its title, for example
+   `Edit --kv-transfer-config`, and the sub-line `Changes apply to this deploy only. Field names come from the engine.`
+
+5. On the **Form** tab, change values in place. Every field carries its type as a badge: `string`, `number`, `boolean`,
+   or `null`. A boolean field renders as a `true` / `false` button pair. A number field rejects non-numeric text with
+   `Enter a number.` A byte field shows its size in readable units, such as `64 GiB.` A per-rank byte field also shows
+   the node total for the model's tensor-parallel width. A `null` field is not editable on this tab and reads
+   `Set a value on the Raw JSON tab.`
+
+   To add or remove a field, switch to the **Raw JSON** tab. A note at the top of the **Form** tab makes this explicit:
+   `Add or remove fields on the Raw JSON tab. The form edits values only, so a typo cannot invent a key the engine ignores.`
+
+6. On the **Raw JSON** tab, review the whole document, or add and remove fields. The tab validates on every keystroke.
+   When the text does not parse, the error appears as `Line N: [message]`, **Apply** is unavailable, and the **Form**
+   tab is unavailable with the tooltip `Fix the JSON error first.` Correct the parse error to re-enable both.
+
+7. If the editor shows the warning
+   `[key] is the text '[value]', not the boolean [value]. Engines read any non-empty text as true.`, select **Convert to
+   boolean [value]**. If it shows the softer nudge for a quoted number, select **Convert to number [value]**.
+
+8. Select **Apply** to keep the change, or **Cancel** to discard it. **Apply** writes the argument back for this deploy
+   only.
+
 ## Add a Model to More Nodes
 
 To run an already deployed model on additional nodes, deploy it again and select the extra nodes. Nodes that already
@@ -110,7 +147,7 @@ serve the model stay selected and show **Already deployed**.
 3. Select the same model. In **Nodes**, already serving nodes are locked with **Already deployed**. Select each
    additional eligible node.
 
-4. Select **Deploy**, review the preview, and then select **Confirm & apply**.
+4. Select **Deploy**, review the preview, and then select **Confirm & Apply**.
 
 The appliance creates an engine on each newly chosen node and leaves the existing engines and the model's endpoint
 alone. Traffic continues on the nodes that were already serving.
@@ -157,9 +194,7 @@ reasons and how the appliance behaves when a node degrades between selection and
 
 ## Next Steps
 
-To change which model handles requests that do not name a model explicitly, refer to
-[Switch the Default Model](./set-the-default-model.md). To put a newer version or a different model on a node, refer to
-[Replace a Model](./replace-a-model.md). For why you would pin a model to some nodes and not others, refer to
-[Model Placement](../explanation/model-placement.md). To let a text-only model answer questions about images, refer to
-[Enable Vision Preprocessing](./enable-vision-preprocessing.md). To bring a model that is not in the certified catalog,
-refer to [Bring Your Own Model](./bring-your-own-model.md).
+To put a newer version or a different model on a node, refer to [Replace a Model](./replace-a-model.md). For why you
+would pin a model to some nodes and not others, refer to [Model Placement](../explanation/model-placement.md). To let a
+text-only model answer questions about images, refer to [Enable Vision Preprocessing](./enable-vision-preprocessing.md).
+To bring a model that is not in the certified catalog, refer to [Bring Your Own Model](./bring-your-own-model.md).

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -245,6 +245,14 @@ The key-value cache that an [inference engine](#inference-engine) keeps in GPU a
 response, holding the intermediate state for the tokens processed so far. Its size drives much of the appliance's memory
 and fast-storage requirements.
 
+### KV Cache Offloading
+
+A memory-management strategy in which an [inference engine](#inference-engine) keeps part of the [KV cache](#kv-cache)
+outside GPU memory, in host RAM or on fast local storage, and swaps it back to the GPU when the tokens it holds are
+needed again. Offloading lets a model serve longer contexts, or more concurrent requests, than would fit in GPU memory
+alone. Refer to
+[Review or Change an Engine Argument That Uses JSON](../how-to-guides/deploy-a-model.md#review-or-change-an-engine-argument-that-uses-json).
+
 ## L
 
 ### Large Language Model (LLM)

--- a/docs/products/paletteai-inference-launchpad/release-notes.md
+++ b/docs/products/paletteai-inference-launchpad/release-notes.md
@@ -37,6 +37,13 @@ and platform security.
   egress. Refer to [Register an External Inference Endpoint](./how-to-guides/register-an-external-inference-endpoint.md)
   for more information.
 
+- **Typed editor for JSON-valued engine arguments.** When an engine argument's value is a JSON document, the **Deploy
+  model** panel now shows a typed editor with live validation, per-field type badges, byte sizes in readable units, and
+  a one-select fix when a value is a quoted boolean or a quoted number. KV cache offloading is the first engine argument
+  that uses this editor. Refer to
+  [Review or Change an Engine Argument That Uses JSON](./how-to-guides/deploy-a-model.md#review-or-change-an-engine-argument-that-uses-json)
+  for more information.
+
 ### Improvements
 
 - **Model upgrade through replacement.** You can now upgrade a deployed model's weights or swap it for a different model


### PR DESCRIPTION
## Summary

Documents how PaletteAI Inference Launchpad 1.1.1 exposes KV cache offloading to an operator through the **Deploy model** panel's JSON argument editor. Targets the `paiil-cut-1.0.x` branch (the 1.1 dev line) — no changes to `inference-launchpad_versioned_docs/version-1.0.x/`, because KV cache offloading is a 1.1.1 feature and does not belong in the 1.0.x snapshot.

- New H2 subsection in `docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md` — [Review or Change an Engine Argument That Uses JSON](https://github.com/spectrocloud/librarium/blob/docs/ail-543-kvcache-offloading/docs/products/paletteai-inference-launchpad/how-to-guides/deploy-a-model.md#review-or-change-an-engine-argument-that-uses-json) — walks through the `{ } JSON` chip, the **Edit JSON** dialog, the Form and Raw JSON tabs, the this-deploy-only scope of **Apply**, and the one-select fix for a quoted boolean.
- New **Engine Arguments** H2 in `explanation/inference-engines.md` explains the mechanism, names KV cache offloading as the first argument that uses the editor, and covers the JSON-vs-engine-value validation boundary.
- **Glossary** gains a sibling **KV Cache Offloading** entry next to **KV Cache** that defines the concept for a customer and links to the same subsection.
- **Release Notes** picks up a new bullet under **1.1.1 > New Features** for the typed JSON editor.
- Two collateral fixes on `deploy-a-model.md`: `Confirm & Apply` casing correction on the two deploy-panel steps, and removal of the **Switch the Default Model** link from **Next Steps**. The remove-a-model flow keeps its lowercase `Confirm & apply`.

## Ticket

- Doc-task: [AIL-543](https://spectrocloud.atlassian.net/browse/AIL-543)
- Parent Epic: [AIL-251](https://spectrocloud.atlassian.net/browse/AIL-251)

## Test plan

- [ ] Netlify preview builds successfully against the `paiil-cut-1.0.x` base.
- [ ] The **Review or Change an Engine Argument That Uses JSON** anchor resolves from the **Inference Engines** page, the **KV Cache Offloading** glossary entry, and the 1.1.1 release note bullet.
- [ ] `inference-launchpad_versioned_docs/version-1.0.x/` shows no diff on this PR — KV cache offloading is a 1.1.1 feature and must not appear in the 1.0.x snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AIL-543]: https://spectrocloud.atlassian.net/browse/AIL-543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ