### PR TITLE
AIL-494: Document how the tier map and semantic router combine

### DIFF
--- a/_partials/paletteai-inference-launchpad/_request-routing-and-quotas.mdx
+++ b/_partials/paletteai-inference-launchpad/_request-routing-and-quotas.mdx
@@ -9,5 +9,7 @@ local one. Quotas apply to the client, so every API token that belongs to the cl
 client exhausts a quota, the appliance returns an HTTP `429` response.
 
 To understand what a client is and how API keys and quotas govern usage, refer to
-[Clients and Quotas](/paletteai-inference-launchpad/explanation/clients-and-quotas).
-{/* TODO: link to the intelligent routing how-to and the token quotas and metering reference once they exist */}
+[Clients and Quotas](/paletteai-inference-launchpad/explanation/clients-and-quotas). To understand how the Tier map and
+the semantic router combine to pick a model for each request, refer to
+[Routing Behavior](/paletteai-inference-launchpad/explanation/routing-behavior).
+{/* TODO: link to the token quotas and metering reference once it exists */}

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -69,10 +69,14 @@ then deploying the replacement. Removing the model from one node leaves it servi
 
 ## Request Routing
 
-The gateway routes each request to a model. A request that names a model uses that model, and a request that does not
-name a model falls back to the default model. When you change the default model, the gateway rebuilds its router in
-place. The gateway does not restart, and it does not drain requests that are in progress. Requests that the gateway
-already routed continue on their assigned model, and the new default applies only to later requests.
+The gateway routes each request to a model in two stages: the Tier map rewrites a client-supplied model name to a model
+the appliance serves, and any request the Tier map does not settle passes to the semantic router, which picks a model
+from a category and a complexity band. For the full picture of how the two controls combine and where each rule lives on
+the box and per client, refer to [Routing Behavior](./routing-behavior.md).
+
+When you change the routing configuration the gateway follows, it rebuilds its router in place. The gateway does not
+restart, and it does not drain requests that are in progress. Requests that the gateway already routed continue on their
+assigned model, and the new configuration applies only to later requests.
 
 Before it routes a request, the gateway authenticates the calling client from its API token and enforces that client's
 quotas. When routing policy sends a request off the appliance, the gateway can reach a built-in frontier provider or a

--- a/docs/products/paletteai-inference-launchpad/explanation/explanation.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/explanation.md
@@ -18,6 +18,7 @@ They cover design decisions, component relationships, and trade-offs rather than
 | [Model Placement](./model-placement.md)                     | How a model is placed on cluster nodes, when to pin it to a subset, and how the Cluster view reports placement.  |
 | [Vision Preprocessing](./vision-preprocessing.md)           | How a text-only model answers questions about images by converting them to text first.                           |
 | [Clients and Quotas](./clients-and-quotas.md)               | What a client is, how quotas meter usage, and how utilization, consumption, and historical windows are reported. |
+| [Routing Behavior](./routing-behavior.md)                   | How the Tier map and the semantic router combine to pick the model that answers each request.                    |
 | [Model Certification](./model-certification.md)             | What certified means, how models are certified, and how to choose models for your use case.                      |
 | [Inference Engines](./inference-engines.md)                 | What an inference engine is, automatic engine selection, the supported kinds, and when to override it.           |
 | [Installation Architecture](./installation-architecture.md) | How the appliance installs, why the network uses a bond, and how day-two upgrades stay in Local UI.              |

--- a/docs/products/paletteai-inference-launchpad/explanation/routing-behavior.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/routing-behavior.md
@@ -1,0 +1,219 @@
+---
+sidebar_label: "Routing Behavior"
+title: "Routing Behavior"
+description:
+  "An explanation of how PaletteAI Inference Launchpad decides which model answers each request: the Tier map, the
+  semantic router, how the two combine, and the traps operators should know about."
+hide_table_of_contents: false
+sidebar_position: 7
+tags: ["paletteai-inference-launchpad", "explanation", "routing", "semantic-routing", "tier-map"]
+keywords:
+  [
+    "launchpad",
+    "ai",
+    "routing",
+    "semantic routing",
+    "tier map",
+    "complexity threshold",
+    "coding",
+    "everything else",
+    "simple",
+    "complex",
+    "choose per request",
+    "decision recording",
+  ]
+---
+
+Every request to a PaletteAI Inference Launchpad appliance runs through two controls before it reaches a model: the
+**Tier map** and the **Semantic routing** card. They sit next to each other in the console, but they act on different
+requests: the **Tier map** handles requests that name a model, and the **Semantic routing** card handles the ones that
+do not. This page explains how the appliance walks the two controls in order, which requests reach the semantic router,
+how the semantic router chooses a model from a category and a complexity band, and where inheritance sits between the
+box-wide setting and each client. Read it to understand these ideas before you author routing rules, so the rules you
+write match the requests your clients actually send.
+
+## The Two-Stage Routing Decision
+
+The appliance decides which model answers a request in two stages, in this order.
+
+- **Stage 1: Tier map.** The Tier map rewrites a model name the client sent to a model the appliance serves. If a Tier
+  map row matches, the appliance uses the row's Model, attaches its Thinking directive, and the semantic router does not
+  run.
+- **Stage 2: Semantic routing.** For requests that Stage 1 does not settle, the semantic router picks a model from a
+  category and a complexity band. Only some requests reach this stage; which requests those are is the source of the
+  most common misconfiguration on the appliance.
+
+Both stages have a per-client overlay under **Access & Policy** > **Clients** > **Routing**. A client that leaves a
+value untouched follows the appliance-wide setting on **Settings** > **Configurations**.
+
+## The Tier Map
+
+The Tier map answers this question: when a client asks for a model by name, which model on the appliance actually
+answers?
+
+Each Tier map row has three columns.
+
+- **Alias prefix.** The name the client sends, matched by prefix. Presets are `claude-opus-`, `claude-sonnet-`, and
+  `claude-haiku-`. You can also add a custom prefix.
+- **Model.** A model the appliance serves, or the special picker value **Choose per request**. When Model is a served
+  model, the Tier map settles the request in Stage 1. When Model is **Choose per request**, the alias is handed to the
+  semantic router in Stage 2.
+- **Thinking.** A directive attached to the chosen model, one of `off`, `on`, `budget` (with a token count), or `effort`
+  (with a level: low, medium, high, max). The directive follows the request onto whichever model answers, even when the
+  semantic router picks that model.
+
+A client that names a model no row matches, and no other rule catches, falls back to the box's **Fallback for unmatched
+requests**. When that fallback is off, the appliance returns HTTP `404`.
+
+## What Reaches the Semantic Router
+
+A request reaches the semantic router in exactly three cases.
+
+- The request sends `auto` as the model.
+- The request sends no model field, or sends an empty one. This behaves the same as `auto`.
+- The request names an alias whose Tier map row is set to **Choose per request**. The alias contributes its Thinking
+  directive to the picked model.
+
+Any other request is settled by the Tier map or by the box fallback and never reaches the semantic router.
+
+:::warning
+
+A client that sends `auto` bypasses the Tier map entirely. The most common misconfiguration on the appliance is an
+operator who adds a Tier map row for a client such as Cursor, expecting that row to steer the request. Cursor sends
+`auto`, so it never matches a Tier map row. The request lands directly on the client's **Semantic routing** card
+instead. To steer this traffic, author a **Semantic routing** rule, not a Tier map row.
+
+:::
+
+## Categories and Complexity Bands
+
+The semantic router keys every rule on two axes.
+
+- **Category.** A label the appliance derives for the prompt. The console shows two categories today: **Coding** and
+  **Everything else**.
+
+<!-- vale off -->
+
+- **Complexity band.** A label the appliance derives from a complexity score. When the score reaches the **Complexity
+  threshold**, the band is **Complex**. Otherwise the band is **Simple**.
+
+<!-- vale on -->
+
+The category vocabulary is owned by the appliance and may change in a later release. Do not assume any category label
+other than the two shown in the console.
+
+### How the Lookup Works
+
+For a routed request, the appliance looks up a rule in this order.
+
+1. If a scenario hint is present on the request, that hint pins the model and the lookup ends.
+2. Otherwise, the appliance reads the category and the complexity score for the prompt, and looks up an exact rule for
+   `<category>/<band>`, such as `Coding/Complex`.
+3. If no banded rule matches, the appliance looks up a rule for the bare category, such as `Coding`. This backstop rule
+   catches requests when no score arrives, for example when the classifier could not answer for the prompt.
+4. If no bare-category rule matches, the appliance uses the box's **Fallback for unmatched requests**.
+
+A rule keyed on a banded key applies only when the classifier returned a score. A rule keyed on the bare category is the
+backstop for prompts that arrive without a score.
+
+:::warning
+
+Missing a bare-category backstop drops that traffic silently to the box fallback. If you author a rule for
+`Coding/Complex` but not one for `Coding`, a coding prompt the classifier cannot score does not use your **Coding**
+rule. It uses the box fallback. Author a bare-category rule for every category you care about.
+
+:::
+
+A category rule may name a model the appliance serves locally, or a frontier or external target once egress is set up
+for the client. The default-deny egress gate still applies to the client, so a rule that names an off-box target only
+works for a client with egress enabled.
+
+### Four Worked Examples
+
+The four category and band combinations, with a rule for each on a small appliance that serves the certified coding
+models.
+
+| **Category and band**         | **Rule**                   | **What happens**                                                                                                                                                    |
+| ----------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Coding` / `Complex`          | Route to `deepseek-v4-pro` | A refactoring agent sends `auto`. The classifier labels the prompt `Coding` with a score at or above the Complexity threshold. The router picks `deepseek-v4-pro`.  |
+| `Coding` / `Simple`           | Route to `gemma-4`         | A shell tab-completion tool sends `auto`. The classifier labels the prompt `Coding` with a score below the Complexity threshold. The router picks `gemma-4`.        |
+| `Everything else` / `Complex` | Route to `kimi-2.7`        | A long document summarization sends `auto`. The classifier labels the prompt `Everything else` with a score at or above the threshold. The router picks `kimi-2.7`. |
+| `Everything else` / `Simple`  | Route to `glm-5.2`         | A short chat reply sends `auto`. The classifier labels the prompt `Everything else` with a score below the threshold. The router picks `glm-5.2`.                   |
+
+The rules above are illustrative. Choose your own rules for the models your appliance serves.
+
+## The Complexity Threshold
+
+The Complexity threshold is the boundary between the **Simple** and the **Complex** band. The console shows it as a
+percentage. `0` is the simplest prompt and `1` is the most complex, so a lower threshold sends more traffic to the
+**Complex** rule.
+
+The box-wide Complexity threshold lives on the **Semantic routing** card under **Settings** > **Configurations**. Every
+client starts by following it.
+
+### Per-Client Inheritance
+
+Each client's **Semantic routing** card holds its own Complexity threshold. An empty value there means the client
+follows the box. This is not the same as authoring today's box value into the client.
+
+- A client with an **empty** threshold follows the box. If an operator raises the box threshold from `0.4` to `0.6`, the
+  client moves with it.
+- A client **pinned** at `0.4` stays at `0.4` even if the box moves to `0.6`. It stays pinned until an operator changes
+  the client's value or clears it back to inheritance.
+
+The same inheritance rule applies to category rules on the per-client **Semantic routing** card. The card is seeded from
+the box setting the client currently follows.
+
+## Fallback for Unmatched Requests
+
+The box's **Fallback for unmatched requests** catches every request no other control settles. It answers the request
+when the Tier map does not match, when the semantic router finds no rule for the category, and when a client asks for a
+model the appliance does not serve. When the fallback is off, the appliance returns HTTP `404` for these requests.
+
+The fallback is a safety net. It is not a substitute for a bare-category backstop on the semantic router. A request that
+falls to the fallback does not appear on the **Semantic routing** panel of the **Usage** page, because that panel only
+reports traffic the semantic router classified.
+
+## Usage Reporting
+
+The **Usage** page reports the traffic the semantic router classified on its **Semantic routing** panel. The panel has
+one row per category and model, and reports the request count, total tokens, estimated cost, and the classifier's
+average confidence for the row as a percentage.
+
+For the exact column names and definitions, refer to [Usage Metrics Reference](../reference/usage-metrics-reference.md).
+
+<!-- vale off -->
+
+{/* NEEDS REVIEW: the AIL-494 brief described per-row complexity band, per-row routing reason, and an `unknown` confidence value on the Usage page's Semantic routing panel, but the shipped panel exposes only Category, Model, Requests, Total tok, Cost, and Avg conf. A subject-matter expert should reconcile the brief with the shipped panel before this page publishes. */}
+
+<!-- vale on -->
+
+## Decision Recording
+
+Decision recording writes one row per classification to a CSV file, so an operator can tune the categories and the
+Complexity threshold against the traffic the appliance actually sees.
+
+- Recording is off by default. Each client has a **Decision recording** section in **Access & Policy** > **Clients**.
+- The switch survives a restart. Turning recording on once keeps it on across appliance upgrades and node reboots until
+  an operator turns it off.
+- The console offers **Download** and **Delete** actions for the recorded CSV. **Delete** asks for confirmation.
+- Prompts in recorded rows are truncated. Files rotate as they fill, so recording does not consume unbounded disk.
+- If a write to the CSV fails, the appliance disables recording rather than fail the request. Serving a client's request
+  always takes priority over writing a decision row.
+
+Recorded rows are for operator tuning. They are not a compliance audit log, and they are not shipped off the appliance.
+
+## Metrics and Dashboards
+
+The appliance ships a Grafana dashboard, **Semantic prompt classification and routing**, loaded through the same
+dashboards mount as the other appliance dashboards. The dashboard leads with the share of traffic the classifier
+answered for, so an operator can know at a glance how much of a client's traffic the semantic router is choosing.
+
+## Resources
+
+- [Configure Semantic Routing](../how-to-guides/configure-semantic-routing.md) walks through setting the Complexity
+  threshold, authoring category rules, overriding both per client, and enabling Decision recording.
+- [Manage a Client's Model Access](../how-to-guides/manage-client-model-access.md) walks through the Tier map and
+  through allowing a client to reach external models.
+- [Usage Metrics Reference](../reference/usage-metrics-reference.md) defines every field the **Usage** page reports.
+- [Glossary](../reference/glossary.md) defines the routing terms used throughout this page.

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/configure-semantic-routing.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/configure-semantic-routing.md
@@ -1,0 +1,144 @@
+---
+sidebar_label: "Configure Semantic Routing"
+title: "Configure Semantic Routing"
+description:
+  "Step-by-step guidance for platform administrators on how to set the Complexity threshold, author category rules,
+  override both for a client, and turn on Decision recording on a PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 2.2
+tags: ["paletteai-inference-launchpad", "routing", "semantic-routing", "how-to"]
+keywords:
+  [
+    "launchpad",
+    "ai",
+    "semantic routing",
+    "complexity threshold",
+    "coding",
+    "everything else",
+    "simple",
+    "complex",
+    "decision recording",
+  ]
+---
+
+This guide explains how a platform administrator sets and overrides the appliance's semantic routing rules on a
+PaletteAI Inference Launchpad appliance. For what the semantic router does, how it combines with the Tier map, and how a
+client inherits from the box, refer to [Routing Behavior](../explanation/routing-behavior.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+- Console access with permission to edit routing settings.
+- One or more served models to route requests to. To deploy a model, refer to [Deploy a Model](./deploy-a-model.md).
+- _(Per-client steps only)_ An existing client. To create one, refer to [Create a Client](./create-a-client.md).
+- _(Off-box category rules only)_ Egress enabled for the client that uses the rule. To enable egress, refer to
+  [Manage a Client's Model Access](./manage-client-model-access.md#allow-a-client-to-reach-external-models).
+
+## Set the Box-Wide Complexity Threshold
+
+Use these steps to set the boundary between the **Simple** and the **Complex** band for every client that follows the
+box.
+
+1. From the left main menu, select **Settings**.
+
+2. Select the **Configurations** tab.
+
+3. On the **Semantic routing** card, enter a value for **Complexity threshold**. The value is between `0` and `1` and is
+   shown as a percentage. A lower value sends more traffic to the **Complex** rule.
+
+4. Select **Save**.
+
+## Author Category Rules on the Box
+
+Use these steps to choose which model answers each combination of category and complexity band for every client that
+follows the box.
+
+1. From the left main menu, select **Settings**.
+
+2. Select the **Configurations** tab.
+
+3. On the **Semantic routing** card, find the **Coding** row and the **Everything else** row.
+
+4. For each row, choose a model for the **Simple** band and a model for the **Complex** band. To answer requests the
+   classifier could not score, also choose a model for the bare category row.
+
+5. _(External target only)_ To route a category to a frontier or external target, choose that target in the row. The
+   default-deny egress gate still applies to each client that uses the rule.
+
+6. Select **Apply** to apply the pending changes.
+
+## Override the Complexity Threshold for a Client
+
+Use these steps to give one client its own boundary between **Simple** and **Complex**. An empty value means the client
+follows the box.
+
+1. From the left main menu, select **Access & Policy** > **Clients**.
+
+2. Select the client to open its detail panel.
+
+3. In the **Routing** section, find the **Semantic routing** card.
+
+4. Enter a value for **Complexity threshold**. Leave the field empty to follow the box.
+
+5. Select **Save**.
+
+## Override Category Rules for a Client
+
+Use these steps to give one client its own model for each category and band. Any row you leave as the box set it stays
+inherited from the box.
+
+1. From the left main menu, select **Access & Policy** > **Clients**.
+
+2. Select the client to open its detail panel.
+
+3. In the **Routing** section, find the **Semantic routing** card. The rows are seeded from the box setting the client
+   currently follows.
+
+4. For each row you want the client to override, choose a model for the **Simple** band and a model for the **Complex**
+   band. To answer requests the classifier could not score, also choose a model for the bare category row.
+
+5. Select **Apply** to apply the pending changes.
+
+:::info
+
+The **Semantic routing** card governs every request from this client that sends `auto`, and every request whose alias is
+set to **Choose per request** in the client's Tier map. To hand an alias to the semantic router, edit the Tier map row
+and set its **Model** column to **Choose per request**.
+
+:::
+
+## Turn On Decision Recording
+
+Use these steps to record one CSV row per classification for a client, so you can tune the categories and the Complexity
+threshold against real traffic.
+
+1. From the left main menu, select **Access & Policy** > **Clients**.
+
+2. Select the client to open its detail panel.
+
+3. In the **Decision recording** section, turn recording on. The switch survives an appliance restart.
+
+4. Let the appliance run long enough to record traffic that represents your workload.
+
+## Download the Recorded CSV
+
+1. From the left main menu, select **Access & Policy** > **Clients**.
+
+2. Select the client to open its detail panel.
+
+3. In the **Decision recording** section, select **Download**.
+
+## Delete the Recorded CSV
+
+1. From the left main menu, select **Access & Policy** > **Clients**.
+
+2. Select the client to open its detail panel.
+
+3. In the **Decision recording** section, select **Delete**.
+
+4. In the confirmation dialog, confirm the deletion.
+
+## Next Steps
+
+- [Manage a Client's Model Access](./manage-client-model-access.md)
+- [View Client Usage](./view-client-usage.md)

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -13,26 +13,27 @@ you the steps to do it without teaching background concepts.
 
 ## Contents
 
-| **Guide**                                                                               | **What you do**                                                                      |
-| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Install the Appliance](./install-the-appliance.md)                                     | Flash the installer ISO, boot the hardware, and bring up the appliance console.      |
-| [Manage Cluster Infrastructure](./manage-cluster-infrastructure.md)                     | Index the Local UI tasks for day-two cluster infrastructure operations.              |
-| [Upgrade the Platform](./upgrade-the-platform.md)                                       | Upload a newer content bundle from Artifact Studio and apply **Update** in Local UI. |
-| [Deploy a Model](./deploy-a-model.md)                                                   | Deploy an LLM, choose which nodes run it, and verify it is serving.                  |
-| [Replace a Model](./replace-a-model.md)                                                 | Remove a model from a node, then deploy a newer version or a different model.        |
-| [Upload a Model](./upload-a-model.md)                                                   | Download a model on a jumpbox and upload it to the appliance.                        |
-| [Bring Your Own Model](./bring-your-own-model.md)                                       | Author metadata for a model that is not certified, then upload and deploy it.        |
-| [Switch the Default Model](./set-the-default-model.md)                                  | Switch the default model when the current default becomes unavailable.               |
-| [Enable Vision Preprocessing](./enable-vision-preprocessing.md)                         | Deploy a vision model and turn on image-to-text preprocessing for a text-only model. |
-| [Create a Client](./create-a-client.md)                                                 | Create a client and issue its first API token.                                       |
-| [Generate an API Token](./generate-an-api-token.md)                                     | Create an API token that clients use to authenticate to the appliance.               |
-| [Set and Manage Client Quotas](./manage-client-quotas.md)                               | Set, edit, raise, and remove a client's request, token, and cost limits.             |
-| [Manage a Client's Model Access](./manage-client-model-access.md)                       | Route a client to models and allow it to reach external models.                      |
-| [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md) | Register an OpenAI-compatible host, authorize a client, and route to its models.     |
-| [View Token Usage](./view-token-usage.md)                                               | Find token usage by model and by client, and open the metrics dashboards.            |
-| [View Client Usage](./view-client-usage.md)                                             | View quota utilization, historical consumption, and per-token usage.                 |
-| [Revoke or Delete a Client](./revoke-or-delete-a-client.md)                             | Find expired keys, revoke a token, or delete a client.                               |
-| [Use Claude Code](./use-claude-code.md)                                                 | Connect Claude Code to the appliance so a local model serves each request.           |
-| [Use Cursor](./use-cursor.md)                                                           | Connect Cursor's Ask mode to the appliance through a uniquely named model alias.     |
-| [Use OpenAI Codex](./use-codex.md)                                                      | Connect the OpenAI Codex CLI to the appliance with a custom model provider.          |
-| [Use OpenCode](./use-opencode.md)                                                       | Connect the OpenCode terminal agent to the appliance through a custom provider.      |
+| **Guide**                                                                               | **What you do**                                                                                                |
+| --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Install the Appliance](./install-the-appliance.md)                                     | Flash the installer ISO, boot the hardware, and bring up the appliance console.                                |
+| [Manage Cluster Infrastructure](./manage-cluster-infrastructure.md)                     | Index the Local UI tasks for day-two cluster infrastructure operations.                                        |
+| [Upgrade the Platform](./upgrade-the-platform.md)                                       | Upload a newer content bundle from Artifact Studio and apply **Update** in Local UI.                           |
+| [Deploy a Model](./deploy-a-model.md)                                                   | Deploy an LLM, choose which nodes run it, and verify it is serving.                                            |
+| [Replace a Model](./replace-a-model.md)                                                 | Remove a model from a node, then deploy a newer version or a different model.                                  |
+| [Upload a Model](./upload-a-model.md)                                                   | Download a model on a jumpbox and upload it to the appliance.                                                  |
+| [Bring Your Own Model](./bring-your-own-model.md)                                       | Author metadata for a model that is not certified, then upload and deploy it.                                  |
+| [Switch the Default Model](./set-the-default-model.md)                                  | Switch the default model when the current default becomes unavailable.                                         |
+| [Configure Semantic Routing](./configure-semantic-routing.md)                           | Set the Complexity threshold, author category rules, override both per client, and turn on Decision recording. |
+| [Enable Vision Preprocessing](./enable-vision-preprocessing.md)                         | Deploy a vision model and turn on image-to-text preprocessing for a text-only model.                           |
+| [Create a Client](./create-a-client.md)                                                 | Create a client and issue its first API token.                                                                 |
+| [Generate an API Token](./generate-an-api-token.md)                                     | Create an API token that clients use to authenticate to the appliance.                                         |
+| [Set and Manage Client Quotas](./manage-client-quotas.md)                               | Set, edit, raise, and remove a client's request, token, and cost limits.                                       |
+| [Manage a Client's Model Access](./manage-client-model-access.md)                       | Route a client to models and allow it to reach external models.                                                |
+| [Register an External Inference Endpoint](./register-an-external-inference-endpoint.md) | Register an OpenAI-compatible host, authorize a client, and route to its models.                               |
+| [View Token Usage](./view-token-usage.md)                                               | Find token usage by model and by client, and open the metrics dashboards.                                      |
+| [View Client Usage](./view-client-usage.md)                                             | View quota utilization, historical consumption, and per-token usage.                                           |
+| [Revoke or Delete a Client](./revoke-or-delete-a-client.md)                             | Find expired keys, revoke a token, or delete a client.                                                         |
+| [Use Claude Code](./use-claude-code.md)                                                 | Connect Claude Code to the appliance so a local model serves each request.                                     |
+| [Use Cursor](./use-cursor.md)                                                           | Connect Cursor's Ask mode to the appliance through a uniquely named model alias.                               |
+| [Use OpenAI Codex](./use-codex.md)                                                      | Connect the OpenAI Codex CLI to the appliance with a custom model provider.                                    |
+| [Use OpenCode](./use-opencode.md)                                                       | Connect the OpenCode terminal agent to the appliance through a custom provider.                                |

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/manage-client-model-access.md
@@ -51,9 +51,9 @@ Use a client's tier map to route the client's model aliases to the models you ch
 6. Save the client.
 
 The tier map applies to the selected client. Requests from other clients follow their own tier maps, so they are not
-routed to that model unless you configure their tier maps as well.
-
-<!--TODO: once published, add a sentence here linking to Configure Intelligent Routing and Semantic Domains (DOC-2926) for routing that goes beyond client-level model selection, such as semantic domains.-->
+routed to that model unless you configure their tier maps as well. For requests the tier map does not settle, such as a
+request that sends `auto`, refer to [Configure Semantic Routing](./configure-semantic-routing.md). For how the two
+controls combine, refer to [Routing Behavior](../explanation/routing-behavior.md).
 
 {/* NEEDS REVIEW: the tier map governs which model handles a client's requests by default. It is a routing overlay, not a hard access gate for local models. Confirm the operator-facing framing with an SME. */}
 

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/use-claude-code.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/use-claude-code.md
@@ -98,5 +98,7 @@ session uses, run the `/status` command in Claude Code and review the **Anthropi
 
 To look up any configuration value, refer to [Claude Code Configuration](../reference/claude-code-reference.md). To
 deploy another model to the appliance, refer to [Deploy a Model](./deploy-a-model.md). To let the appliance answer
-questions about pasted screenshots, refer to [Enable Vision Preprocessing](./enable-vision-preprocessing.md).
-{/* TODO: add direction to the client and API token management, token quotas and metering, and intelligent routing pages once they exist */}
+questions about pasted screenshots, refer to [Enable Vision Preprocessing](./enable-vision-preprocessing.md). To
+understand how the Tier map and the semantic router pick a model for each request, refer to
+[Routing Behavior](../explanation/routing-behavior.md).
+{/* TODO: add direction to the client and API token management, and token quotas and metering pages once they exist */}

--- a/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -104,7 +104,7 @@ Whatever brought you here, these are the fastest paths in.
   • [Deploy your first model](./how-to-guides/deploy-a-model.md)
 - **Understand the product**: [Architecture](./explanation/architecture.md) •
   [Model Placement](./explanation/model-placement.md) • [Vision Preprocessing](./explanation/vision-preprocessing.md) •
-  [Clients and Quotas](./explanation/clients-and-quotas.md) •
+  [Clients and Quotas](./explanation/clients-and-quotas.md) • [Routing Behavior](./explanation/routing-behavior.md) •
   [Model Certification](./explanation/model-certification.md) • [Inference Engines](./explanation/inference-engines.md)
 - **Connect your coding tools**: [Claude Code](./how-to-guides/use-claude-code.md) •
   [Cursor](./how-to-guides/use-cursor.md) • [OpenAI Codex](./how-to-guides/use-codex.md) •
@@ -113,6 +113,7 @@ Whatever brought you here, these are the fastest paths in.
   [Upgrade the platform](./how-to-guides/upgrade-the-platform.md) •
   [Replace a model](./how-to-guides/replace-a-model.md) •
   [Enable vision preprocessing](./how-to-guides/enable-vision-preprocessing.md) •
+  [Configure semantic routing](./how-to-guides/configure-semantic-routing.md) •
   [Create a client](./how-to-guides/create-a-client.md) • [Set client quotas](./how-to-guides/manage-client-quotas.md) •
   [Register an external inference endpoint](./how-to-guides/register-an-external-inference-endpoint.md) •
   [View client usage](./how-to-guides/view-client-usage.md) •

--- a/docs/products/paletteai-inference-launchpad/reference/claude-code-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/claude-code-reference.md
@@ -51,4 +51,4 @@ If the token's quota is exhausted, the appliance returns an HTTP `429` response 
 - [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md)
 - User and API token management {/* TODO: link once page exists */}
 - Token quotas and metering {/* TODO: link once page exists */}
-- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- [Routing Behavior](../explanation/routing-behavior.md)

--- a/docs/products/paletteai-inference-launchpad/reference/codex-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/codex-reference.md
@@ -80,5 +80,5 @@ If the token's quota is exhausted, the appliance returns an HTTP `429` response 
 - [Use PaletteAI Inference Launchpad with OpenAI Codex](../how-to-guides/use-codex.md)
 - [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md)
 - [Use PaletteAI Inference Launchpad with Cursor](../how-to-guides/use-cursor.md)
-- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- [Routing Behavior](../explanation/routing-behavior.md)
 - Token quotas and metering {/* TODO: link once page exists */}

--- a/docs/products/paletteai-inference-launchpad/reference/cursor-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/cursor-reference.md
@@ -66,5 +66,5 @@ If the token's quota is exhausted, the appliance returns an HTTP `429` response 
 
 - [Use PaletteAI Inference Launchpad with Cursor](../how-to-guides/use-cursor.md)
 - [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md)
-- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- [Routing Behavior](../explanation/routing-behavior.md)
 - Token quotas and metering {/* TODO: link once page exists */}

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -89,6 +89,13 @@ makes chargeback possible.
 
 {/* NEEDS REVIEW: chargeback is defined in the source glossary but does not yet appear in any shipped PAIIL doc. Confirm the term and framing with an SME before publishing. */}
 
+### Choose per Request
+
+The special picker value on a [Tier map](#tier-map) row's Model column that hands the alias to the
+[semantic routing](#semantic-routing) card instead of settling the request in the Tier map. The alias contributes its
+Thinking directive to whichever model the semantic router picks. Refer to
+[Routing Behavior](../explanation/routing-behavior.md).
+
 ### Client
 
 The identity the appliance uses to recognize who is sending a request, and the unit of both access and accounting. The
@@ -115,6 +122,18 @@ An AI development tool, such as Claude Code, Cursor, OpenAI Codex, or OpenCode, 
 Coding assistants are the primary workloads the appliance is tuned for; each one connects to the appliance as a
 [client](#client) instead of to a cloud provider.
 
+### Complex
+
+The [semantic routing](#semantic-routing) band applied to a prompt whose complexity score reaches the
+[Complexity threshold](#complexity-threshold). Refer to [Routing Behavior](../explanation/routing-behavior.md).
+
+### Complexity Threshold
+
+The boundary between the [Simple](#simple) band and the [Complex](#complex) band on the
+[semantic routing](#semantic-routing) card. The console shows the value as a percentage. `0` is the simplest prompt and
+`1` is the most complex, so a lower threshold sends more traffic to the **Complex** rule. Refer to
+[Routing Behavior](../explanation/routing-behavior.md).
+
 ### Content Bundle
 
 A compressed archive, larger than 20 GB, containing the appliance's platform and application software. Operators upload
@@ -128,6 +147,14 @@ The maximum number of tokens a model can process in a single request, counting t
 Different models have different context window sizes.
 
 ## D
+
+### Decision Recording
+
+An operator-tuning feature that writes one CSV row per classification the [semantic router](#semantic-routing) makes, so
+the recorded prompts can be used to tune the categories and the [Complexity threshold](#complexity-threshold) against
+real traffic. The switch is off by default, survives a restart, and the console offers **Download** and **Delete**
+actions on the CSV. Refer to
+[Configure Semantic Routing](../how-to-guides/configure-semantic-routing.md#turn-on-decision-recording).
 
 ### Default Model
 
@@ -162,6 +189,13 @@ models appear in a client's routing picker, and traffic to it is metered as egre
 [Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md).
 
 ## F
+
+### Fallback for Unmatched Requests
+
+The box-wide model that answers any request no other control settles: a request no [Tier map](#tier-map) row matches, a
+request the [semantic router](#semantic-routing) finds no rule for, or a request that names a model the appliance does
+not serve. When the fallback is off, the appliance returns HTTP `404` for these requests. Refer to
+[Switch the Default Model](../how-to-guides/set-the-default-model.md).
 
 ### FIPS
 
@@ -449,6 +483,24 @@ does this is called a reasoning model, and the depth of that effort can sometime
 
 ## S
 
+### Semantic Routing
+
+The appliance's on-box path that picks a model for a request when no [Tier map](#tier-map) row settles it. The router
+keys every rule on two axes: a category the appliance derives for the prompt, such as **Coding** or **Everything else**,
+and a [complexity band](#complex), either [Simple](#simple) or [Complex](#complex). The card lives on the box-wide
+**Semantic routing** card under **Settings** > **Configurations**, and on each client's **Routing** section for
+per-client overrides. Refer to [Routing Behavior](../explanation/routing-behavior.md) and
+[Configure Semantic Routing](../how-to-guides/configure-semantic-routing.md).
+
+<!-- vale off -->
+
+### Simple
+
+The [semantic routing](#semantic-routing) band applied to a prompt whose complexity score is below the
+[Complexity threshold](#complexity-threshold). Refer to [Routing Behavior](../explanation/routing-behavior.md).
+
+<!-- vale on -->
+
 ### Slim ISO
 
 The small (approximately 1.5 GB) bootable installer image that contains the appliance's operating system, provisioning
@@ -472,9 +524,12 @@ Defense deployments.
 
 ### Tier Map
 
-A routing overlay that governs which model handles a client's requests by default, mapping an incoming model name or
-alias to a served model. It selects the default target for a client's requests rather than acting as a hard access gate
-for local models. Refer to [Manage Client Model Access](../how-to-guides/manage-client-model-access.md).
+A routing overlay that governs which model handles a client's requests when the request names a model by name or alias.
+The card lives in the client drawer under **Routing**, alongside the [semantic routing](#semantic-routing) card. Each
+row maps an alias prefix to a Model and attaches a Thinking directive. A row whose Model is set to
+[Choose per Request](#choose-per-request) hands the alias to the semantic router instead of settling it in the Tier map.
+Refer to [Routing Behavior](../explanation/routing-behavior.md) and
+[Manage a Client's Model Access](../how-to-guides/manage-client-model-access.md).
 
 ### Token and Tokenization
 

--- a/docs/products/paletteai-inference-launchpad/reference/opencode-reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/opencode-reference.md
@@ -86,5 +86,5 @@ If the token's quota is exhausted, the appliance returns an HTTP `429` response 
 - [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md)
 - [Use PaletteAI Inference Launchpad with Cursor](../how-to-guides/use-cursor.md)
 - [Use PaletteAI Inference Launchpad with OpenAI Codex](../how-to-guides/use-codex.md)
-- Intelligent routing and tier maps {/* TODO: link once page exists */}
+- [Routing Behavior](../explanation/routing-behavior.md)
 - Token quotas and metering {/* TODO: link once page exists */}

--- a/docs/products/paletteai-inference-launchpad/release-notes.md
+++ b/docs/products/paletteai-inference-launchpad/release-notes.md
@@ -37,6 +37,16 @@ and platform security.
   egress. Refer to [Register an External Inference Endpoint](./how-to-guides/register-an-external-inference-endpoint.md)
   for more information.
 
+<!-- vale off -->
+
+- **Semantic routing.** The appliance now routes every request through an on-box semantic router that picks a model from
+  a category, **Coding** or **Everything else**, and a complexity band, **Simple** or **Complex**. The Tier map and the
+  **Semantic routing** card remain separate controls in the console, and both accept per-client overrides. Refer to
+  [Routing Behavior](./explanation/routing-behavior.md) and
+  [Configure Semantic Routing](./how-to-guides/configure-semantic-routing.md) for more information.
+
+<!-- vale on -->
+
 - **Typed editor for JSON-valued engine arguments.** When an engine argument's value is a JSON document, the **Deploy
   model** panel now shows a typed editor with live validation, per-field type badges, byte sizes in readable units, and
   a one-select fix when a value is a quoted boolean or a quoted number. KV cache offloading is the first engine argument


### PR DESCRIPTION
## Summary

Documents the on-box semantic router that ships in PaletteAI Inference Launchpad 1.1.1 and how it combines with the Tier map. Ticket: [AIL-494](https://spectrocloud.atlassian.net/browse/AIL-494). Parent epic: [AIL-261](https://spectrocloud.atlassian.net/browse/AIL-261).

**Retargeted 2026-08-28**: this PR now merges into `paiil-cut-1.0.x`, not `master`. Semantic routing has not shipped in 1.0.x, so the changes land only under `docs/products/paletteai-inference-launchpad/` and the `inference-launchpad_versioned_docs/version-1.0.x/` snapshot is left untouched. Same pattern as [#11797](https://github.com/spectrocloud/librarium/pull/11797) (AIL-543) and the recent revert wave on master.

- Adds `explanation/routing-behavior.md` — a Concept page walking the two-stage decision (Tier map first, then the semantic router), the three entry points into the router (`auto`, empty model field, `Choose per request`), the two axes (category and complexity band), inheritance for the per-client Complexity threshold, the `auto`-bypasses-Tier-map trap that catches Cursor operators out, four worked examples covering every category/band combination, Decision recording, and the `Semantic prompt classification and routing` Grafana dashboard.
- Adds `how-to-guides/configure-semantic-routing.md` — a Task page for setting the box-wide Complexity threshold, authoring category rules, overriding both per client, and turning on Decision recording.
- Updates the how-to index, the landing page (Understand-the-product and Operate-day-to-day sections), and the glossary (Tier Map updated + seven new entries: Semantic Routing, Complexity Threshold, Simple, Complex, Choose per Request, Fallback for Unmatched Requests, Decision Recording).
- Adds a New Features bullet to the 1.1.1 release notes section.

## Notes for the reviewer

- Every UI label is copied from the ticket's verified table (`origin/main` at commit `b66f5256` in `launchpad-ai`). Please spot-check against a live appliance if one is at hand.
- The classifier is described by outcome only (a category and a complexity score). It is not named. The retired third-party router, `ExtProc`, the retired category set (`chat`, `code`, `math`, `reasoning`), and internal identifiers are not mentioned.
- The **Usage Reporting** section was rewritten during the review gate to match the shipped `usage-metrics-reference.md` (columns `Category | Model | Requests | Total tok | Cost | Avg conf`). A `NEEDS REVIEW` MDX comment flags that the AIL-494 brief described per-row complexity band, per-row routing reason, and an `unknown` confidence value that are not present in the shipped panel — a SME should reconcile the brief with the shipped panel before publish.
- The worked-example model names are illustrative and are called out as such on the page.

## Test plan

- [ ] Netlify preview builds
- [ ] Sidebar renders the new how-to at position 2.2 (between Switch the Default Model and Enable Vision Preprocessing)
- [ ] Landing page links to Routing Behavior and Configure Semantic Routing resolve
- [ ] Glossary anchors resolve from the routing-behavior page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIL-494]: https://spectrocloud.atlassian.net/browse/AIL-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIL-261]: https://spectrocloud.atlassian.net/browse/AIL-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ