### PR TITLE
Remove client quota utilization docs from the 1.0.x versioned snapshot

### DIFF
--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/clients-and-quotas.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/clients-and-quotas.md
@@ -3,24 +3,11 @@ sidebar_label: "Clients and Quotas"
 title: "Clients and Quotas"
 description:
   "An explanation of clients, API tokens, and quotas in PaletteAI Inference Launchpad: what a client is, why the
-  appliance serves many clients such as AI coding assistants, and how it meters usage, reports utilization, and limits
-  consumption."
+  appliance serves many clients such as AI coding assistants, and how it meters and limits their usage."
 hide_table_of_contents: false
 sidebar_position: 2
 tags: ["paletteai-inference-launchpad", "explanation", "clients", "quotas"]
-keywords:
-  [
-    "launchpad",
-    "ai",
-    "clients",
-    "api token",
-    "quota",
-    "rate limit",
-    "coding assistant",
-    "claude code",
-    "usage",
-    "utilization",
-  ]
+keywords: ["launchpad", "ai", "clients", "api token", "quota", "rate limit", "coding assistant", "claude code"]
 ---
 
 AI coding assistants such as Claude Code, Cursor, OpenAI Codex, and OpenCode make up many of the workloads that connect
@@ -28,8 +15,7 @@ to a PaletteAI Inference Launchpad appliance, sending their requests to the appl
 single appliance can serve many of these assistants at once, along with other workloads such as an internal chatbot or a
 nightly batch job. This page explains how the appliance tells those workloads apart, and how it meters and limits what
 each one consumes. It covers what a _client_ is, why one appliance serves many of them, and how clients, API tokens, and
-quotas fit together. Read it to understand these ideas before you create clients, issue tokens, set quotas, or review
-usage.
+quotas fit together. Read it to understand these ideas before you create clients, issue tokens, or set quotas.
 
 ## What a Client Is
 
@@ -95,13 +81,12 @@ A quota is a consumption limit attached to a client. The appliance enforces quot
 - **Tokens.** The number of tokens a client's requests process.
 - **Cost.** The computed cost of a client's requests.
 
-When you add a limit, the console offers **hour** and **day** windows. Day limits reset at midnight UTC. Hour limits
-reset at the top of each UTC hour. There is no monthly or billing-cycle window. A client that already has a per-second
-or per-minute limit still has that window enforced until you remove the row.
+The appliance measures each dimension over rolling windows of one second, one minute, one hour, and one day. There is no
+monthly or billing-cycle window.
 
-All active limits apply together. When a client reaches a limit, the appliance rejects further requests with HTTP
-`429 Too Many Requests` and names the dimension and window that tripped. It does not queue or slow the requests. It
-blocks them until the window resets and the client is back under the limit.
+When a client reaches a limit, the appliance rejects further requests with HTTP `429 Too Many Requests` and names the
+dimension and window that tripped. It does not queue or slow the requests. It blocks them until the window rolls over
+and the client is back under the limit.
 
 Above the per-client limits sits a single switch, quota enforcement, that covers the whole appliance. It decides whether
 a limit refuses a request or the appliance ignores it. A new appliance starts with enforcement on. While enforcement is
@@ -110,38 +95,8 @@ appliance limits a client: enforcement on for the appliance, and a window limit 
 setting or change it, refer to
 [Set and Manage Client Quotas](../how-to-guides/manage-client-quotas.md#check-quota-enforcement).
 
-### Utilization and Consumption
-
-**Quota Usage** on the **Usage** page shows point-in-time utilization: how much of each window the client has used right
-now, how much remains, and when that window next resets. Token utilization is the tokens counted against the client's
-token windows. Request and cost utilization use the same pattern on their own windows.
-
-Quota consumption is that used amount divided by the configured limit, shown as a percentage. On **Quota Usage**, each
-window reports its own percentage, and the table sorts the worst-used window first. On **By Client**, **Total Local
-Quota** is the configured cap for the selected data window, and **Local Quota Used** is the percentage of that cap
-consumed.
-
-A client at 100% of a limit shows **Reached limit**. Further requests are throttled until the window resets or an
-operator raises the ceiling. For every field the console reports on **Quota Usage** and the other **Usage** tabs, refer
-to [Usage Metrics Reference](../reference/usage-metrics-reference.md#quota-usage-tab).
-
-### Historical Reporting
-
-**Overview**, **By Model**, and **By Client** report consumption over a **Data window**: **Last 24h**, **Last 7 days**,
-**Last 30 days**, or a custom date range. Local versus external percentages on **Overview** are by tokens, not by
-requests or cost.
-
-**Quota Usage** does not follow that window. Its counters are the live budget, not a historical record.
-
-If the appliance has kept less history than the window you asked for, the card says so rather than filling the gap.
-
-### Limit Ceiling Increases
-
-Windows reset on the UTC clock. That is not an operator action, and it does not require a confirmation.
-
-**Increase limit** on **Quota Usage** is the operator action. It raises one window's ceiling and keeps the usage already
-counted. It cannot lower a cap. Lowering or removing a limit is an edit on **Access & Policy**. Both writes require
-permission to manage clients.
+Limits are only half the picture. The console also reports how much of a limit each client has actually spent. For the
+meters and states it uses, refer to [Usage Metrics Reference](../reference/usage-metrics-reference.md#quota-usage-tab).
 
 {/* TODO: link to a Quota & Rate Limit reference page once one exists; DOC-2941 was never created. */}
 
@@ -173,10 +128,6 @@ quotas, so it is ready to run on every request.
 
 - [Create a Client](../how-to-guides/create-a-client.md) walks through creating a client and issuing its first API
   token.
-- [Set and Manage Client Quotas](../how-to-guides/manage-client-quotas.md) walks through setting limits, turning
-  enforcement on or off, and raising a ceiling.
-- [View Client Usage](../how-to-guides/view-client-usage.md) walks through **Quota Usage**, historical data windows, and
-  per-client consumption.
 - [Use PaletteAI Inference Launchpad with Claude Code](../how-to-guides/use-claude-code.md) walks through connecting a
   coding assistant to a client with an API token.
 - [Architecture Overview](./architecture.md) explains how the appliance routes requests and where its components sit.

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/explanation.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/explanation.md
@@ -17,7 +17,7 @@ They cover design decisions, component relationships, and trade-offs rather than
 | [Architecture Overview](./architecture.md)                  | The component stack, request routing, model provisioning lifecycle, and data residency model.                     |
 | [Model Placement](./model-placement.md)                     | How a model is placed on cluster nodes, when to pin it to a subset, and how the Cluster view reports placement.   |
 | [Vision Preprocessing](./vision-preprocessing.md)           | How a text-only model answers questions about images by converting them to text first.                            |
-| [Clients and Quotas](./clients-and-quotas.md)               | What a client is, how quotas meter usage, and how utilization, consumption, and historical windows are reported.  |
+| [Clients and Quotas](./clients-and-quotas.md)               | What a client is, why the appliance serves many clients, and how API tokens and quotas govern usage.              |
 | [Model Certification](./model-certification.md)             | What certified means, how models are certified, and how to choose models for your use case.                       |
 | [Inference Engines](./inference-engines.md)                 | What an inference engine is, automatic engine selection, the supported kinds, and when to override it.            |
 | [Installation Architecture](./installation-architecture.md) | How the appliance installs across two stages, including the roles of the jumpbox and why the network uses a bond. |

--- a/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/how-to-guides.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/how-to-guides.md
@@ -22,10 +22,10 @@ you the steps to do it without teaching background concepts.
 | [Enable Vision Preprocessing](./enable-vision-preprocessing.md)   | Deploy a vision model and turn on image-to-text preprocessing for a text-only model. |
 | [Create a Client](./create-a-client.md)                           | Create a client and issue its first API token.                                       |
 | [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.               |
-| [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, raise, and remove a client's request, token, and cost limits.             |
+| [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, and remove a client's request, token, and cost limits.                    |
 | [Manage a Client's Model Access](./manage-client-model-access.md) | Route a client to models and allow it to reach external models.                      |
 | [View Token Usage](./view-token-usage.md)                         | Find token usage by model and by client, and open the metrics dashboards.            |
-| [View Client Usage](./view-client-usage.md)                       | View quota utilization, historical consumption, and per-token usage.                 |
+| [View Client Usage](./view-client-usage.md)                       | View a client's per-token consumption, requests, and cost.                           |
 | [Revoke or Delete a Client](./revoke-or-delete-a-client.md)       | Find expired keys, revoke a token, or delete a client.                               |
 | [Use Claude Code](./use-claude-code.md)                           | Connect Claude Code to the appliance so a local model serves each request.           |
 | [Use Cursor](./use-cursor.md)                                     | Connect Cursor's Ask mode to the appliance through a uniquely named model alias.     |

--- a/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/manage-client-quotas.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/manage-client-quotas.md
@@ -2,17 +2,22 @@
 sidebar_label: "Set and Manage Client Quotas"
 title: "Set and Manage Client Quotas"
 description:
-  "Step-by-step guidance for platform administrators on how to set, raise, edit, and remove usage quotas on a client on
-  a PaletteAI Inference Launchpad appliance."
+  "Step-by-step guidance for platform administrators on how to set, edit, and remove usage quotas on a client on a
+  PaletteAI Inference Launchpad appliance."
 hide_table_of_contents: false
 sidebar_position: 5
 tags: ["paletteai-inference-launchpad", "clients", "quotas", "how-to"]
 keywords: ["launchpad", "ai", "clients", "quota", "rate limit", "requests", "tokens", "cost", "429"]
 ---
 
-This guide explains how a platform administrator sets and manages usage quotas on a PaletteAI Inference Launchpad
-appliance. For what a quota is and how it interacts with clients and appliance-wide enforcement, refer to
+This guide explains how a platform administrator sets and manages usage quotas on a client on a PaletteAI Inference
+Launchpad appliance. A quota limits how much a client consumes. A quota applies to the client, so every API token that
+belongs to the client draws on the same limits. To understand how quotas fit with clients and API tokens, refer to
 [Clients and Quotas](../explanation/clients-and-quotas.md).
+
+Quotas have two layers. **Quota enforcement** is a single switch that covers the whole appliance and decides whether
+limits are enforced at all. The **quota windows** you set on each client are the limits themselves. Both must hold
+before the appliance limits a client, so confirm enforcement is on before you set a client's limits.
 
 ## Prerequisites
 
@@ -22,8 +27,11 @@ appliance. For what a quota is and how it interacts with clients and appliance-w
 
 ## Check Quota Enforcement
 
-Use these steps to read or change the appliance-wide **Quota Enforcement** switch. For what the switch does, refer to
-[Clients and Quotas: Quotas](../explanation/clients-and-quotas.md#quotas).
+Quota enforcement applies to the entire appliance, not to one client. While it is off, the appliance does not enforce
+any client's quota windows, and a client that passes its limits is not rejected. The limits you have set stay saved and
+take effect again when you turn enforcement back on.
+
+A new appliance starts with quota enforcement on.
 
 1. From the left main menu, select **Overview**.
 
@@ -63,21 +71,16 @@ clearing a backlog, and turn it back on afterward.
 
 5. Choose the dimension to limit: **requests**, **tokens**, or **cost**.
 
-6. Choose the window the limit applies over: **hour** or **day**. Day limits reset at midnight UTC. Hour limits reset at
-   the top of each UTC hour.
+6. Choose the window the limit applies over: **second**, **minute**, **hour**, or **day**.
 
 7. Enter the limit for that dimension and window.
 
-8. Repeat the previous steps for each limit you want. For example, add a tokens-per-day limit and a cost-per-day limit.
+8. Repeat the previous steps for each limit you want. For example, add a requests-per-minute limit, a tokens-per-day
+   limit, and a cost-per-day limit.
 
 9. Save the client.
 
-Each row limits one dimension over one window. A window with no row stays uncapped. All active limits apply together.
-When a window is full, new requests are blocked until it resets.
-
-Per-second and per-minute windows are not offered when you add a limit. A client that already has a second or minute
-limit still displays that row, and the appliance still enforces it. To remove such a limit, delete the row and save the
-client.
+Each row limits one dimension over one window. A window with no row stays uncapped.
 
 ## Edit or Remove a Quota
 
@@ -87,36 +90,9 @@ client.
 
 3. Select the **Quotas** section.
 
-4. Change a limit, or remove a window-limit row. Use this path when you need to lower a ceiling. **Increase limit** on
-   the **Usage** page cannot lower a cap.
+4. Change a limit, or remove a window-limit row.
 
 5. Save the client.
-
-## Increase a Limit from Usage
-
-Use these steps to raise a ceiling from **Usage** without editing the client's quota rows. For what this action does,
-refer to [Clients and Quotas: Limit Ceiling Increases](../explanation/clients-and-quotas.md#limit-ceiling-increases).
-
-1. From the left main menu, select **Usage**.
-
-2. Select the **Quota Usage** tab, and then select the client.
-
-3. On the window row, select **Increase limit**.
-
-4. Enter a value above the current limit, and then select **Increase limit** to preview the change.
-
-   :::warning
-
-   **Confirm & Apply** raises the ceiling for the current window immediately and for every window that follows. The
-   dialog does not undo the change. To lower a cap after raising it, edit the client from **Access & Policy** as
-   described in [Edit or Remove a Quota](#edit-or-remove-a-quota).
-
-   :::
-
-5. Select **Confirm & Apply**.
-
-For the full sequence, including what **Reached limit** and the preview dialog show, refer to
-[Increase a Limit from Quota Usage](./view-client-usage.md#increase-a-limit-from-quota-usage).
 
 ## Next Steps
 

--- a/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/view-client-usage.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/view-client-usage.md
@@ -2,94 +2,52 @@
 sidebar_label: "View Client Usage"
 title: "View Client Usage"
 description:
-  "Step-by-step guidance for platform administrators on how to view quota utilization, historical consumption, and
-  per-token usage on a PaletteAI Inference Launchpad appliance."
+  "Step-by-step guidance for platform administrators on how to view per-client and per-token consumption on a PaletteAI
+  Inference Launchpad appliance."
 hide_table_of_contents: false
 sidebar_position: 7
 tags: ["paletteai-inference-launchpad", "clients", "usage", "how-to"]
-keywords: ["launchpad", "ai", "clients", "usage", "tokens", "requests", "cost", "metrics", "quota", "utilization"]
+keywords: ["launchpad", "ai", "clients", "usage", "tokens", "requests", "cost", "metrics"]
 ---
 
-This guide explains how a platform administrator views a single client's quota utilization on a PaletteAI Inference
-Launchpad appliance. It covers the **Quota Usage** and **By Client** tabs of the **Usage** page. For **Overview**
-appliance-wide totals and the **By Model** breakdown, refer to [View Token Usage](./view-token-usage.md). To understand
-how usage relates to clients and quotas, refer to [Clients and Quotas](../explanation/clients-and-quotas.md). To set or
-raise a limit, refer to [Set and Manage Client Quotas](./manage-client-quotas.md).
+This guide explains how a platform administrator views consumption per client and per API token on a PaletteAI Inference
+Launchpad appliance. To understand how usage relates to clients and quotas, refer to
+[Clients and Quotas](../explanation/clients-and-quotas.md).
 
 ## Prerequisites
 
 - A running PaletteAI Inference Launchpad appliance, with the console reachable.
 - One or more clients with API tokens. To create a client, refer to [Create a Client](./create-a-client.md).
-- Console access with permission to view usage. Raising a limit from **Quota Usage** requires permission to manage
-  clients.
-
-## View Quota Usage
-
-Use these steps to check how close each client is to its request, token, and cost limits right now. For every column,
-badge, and status label on this tab, refer to
-[Usage Metrics Reference: Quota Usage Tab](../reference/usage-metrics-reference.md#quota-usage-tab).
-
-1. From the left main menu, select **Usage**.
-
-2. Select the **Quota Usage** tab.
-
-3. Select a client to open its **Quota utilization** view. Each configured window reports the percentage used, the used
-   value against the limit, the remaining amount, and when the window next resets. For every field on this view, refer
-   to
-   [Usage Metrics Reference: Client Quota Detail View](../reference/usage-metrics-reference.md#client-quota-detail-view).
-
-### Increase a Limit from Quota Usage
-
-Raise the ceiling on one window from **Quota Usage**. For what **Increase limit** does and when to use it, refer to
-[Clients and Quotas: Limit Ceiling Increases](../explanation/clients-and-quotas.md#limit-ceiling-increases).
-
-1. On the client's **Quota utilization** view, select **Increase limit** on the window row you want to raise. The
-   **Increase limit?** dialog opens. **New limit** defaults to double the current limit.
-
-2. Enter a value above the current limit. A value at or below the current limit is refused.
-
-3. Select **Increase limit** to preview the change.
-
-   :::warning
-
-   **Confirm & Apply** raises the ceiling for the current window immediately and for every window that follows. The
-   dialog does not undo the change. To lower a cap after raising it, edit the client from **Access & Policy** as
-   described in [Edit or Remove a Quota](./manage-client-quotas.md#edit-or-remove-a-quota).
-
-   :::
-
-4. Select **Confirm & Apply**.
-
-The banner and **Reached limit** marker clear when the client is back under every limit.
+- Console access with permission to view usage.
 
 ## View Usage by Client
 
-Use these steps to review one client's consumption over a chosen reporting period. For every column on this tab and tile
-on the client detail view, refer to
-[Usage Metrics Reference: By Client Tab](../reference/usage-metrics-reference.md#by-client-tab).
-
 1. From the left main menu, select **Usage**.
 
-2. Select the **By Client** tab.
+2. Select the **By client** tab.
 
-3. Set the **Data window** if you need a period other than the default. For the available windows, refer to
-   [Set the Reporting Period](./view-token-usage.md#set-the-reporting-period).
+3. Select a client.
 
-   :::info
+The client view shows:
 
-   The **By Client** table is empty until at least one client accrues usage within the current quota window. This is
-   expected on a new appliance and is not an error.
+- Per-client totals for local input tokens, local output tokens, egress tokens, and egress cost.
+- A per-token table with each token's label, prefix, status, last-used time, creation time, expiration, request count,
+  input tokens, output tokens, total tokens, and cost.
+- The percentage of each quota used, which indicates how much of each limit is still available.
+- A conversation-routing breakdown that shows which models handled the client's requests.
 
-   :::
+:::info
 
-4. Select a client to open its API keys, per-token consumption, and the models that handled its requests.
+The figures cover the period set in the **Data window** menu in the page header. When a figure cannot cover that whole
+period, the card displays a note naming the span it does cover.
+
+:::
 
 ## Further Reading
 
-- [View Token Usage](./view-token-usage.md) covers the **Overview** and **By Model** tabs, appliance-wide totals, top
-  consumers, and the Grafana dashboards.
-- [Usage Metrics Reference](../reference/usage-metrics-reference.md) defines every metric, column, quota status label,
-  and export field on the **Usage** page.
+- [View Token Usage](./view-token-usage.md) covers the rest of the **Usage** page, including per-model usage and finding
+  the top consumers.
+- [Usage Metrics Reference](../reference/usage-metrics-reference.md) defines every metric, column, and export field.
 
 ## Next Steps
 

--- a/inference-launchpad_versioned_docs/version-1.0.x/reference/glossary.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/reference/glossary.md
@@ -403,21 +403,19 @@ requirements, is one such precision.
 ### Quota
 
 A consumption limit attached to a [client](#client), enforced across three dimensions: requests (the number of calls),
-tokens (the number of tokens processed), and cost (the computed dollar spend). New limits are set per hour or per day.
-Day windows reset at midnight UTC, and hour windows reset at the top of each UTC hour. Existing per-second and
-per-minute limits remain enforced until you remove them. There is no monthly window. When a client reaches a limit, the
-appliance rejects further requests with HTTP `429 Too Many Requests` until the window resets or an operator raises the
-ceiling. **Quota Usage** shows point-in-time utilization. **By Client** shows consumption over a selected data window.
-Refer to [Manage Client Quotas](../how-to-guides/manage-client-quotas.md) and
-[View Client Usage](../how-to-guides/view-client-usage.md).
+tokens (the number of tokens processed), and cost (the computed dollar spend). Each dimension is measured over rolling
+windows of one second, one minute, one hour, and one day; there is no monthly window. When a client reaches a limit, the
+appliance rejects further requests with HTTP `429 Too Many Requests` until the window rolls over. Refer to
+[Manage Client Quotas](../how-to-guides/manage-client-quotas.md).
+
+{/* NEEDS REVIEW: per the current working assumption, quota enforcement is off by default behind a global switch. Confirm with an SME before publishing. */}
 
 ## R
 
 ### Rate Limit
 
-A [quota](#quota) on the number of requests per unit of time, such as 1,000 requests per hour. Rate limits are the
-request-dimension quotas. New limits use hour or day windows. A shorter per-second or per-minute request limit that is
-already configured still applies until you remove it.
+A [quota](#quota) on the number of requests per unit of time, such as 60 requests per minute. Rate limits are the
+request-dimension quotas enforced over short windows.
 
 ### Reasoning
 
@@ -465,7 +463,7 @@ are counted.
 
 The process of counting and tracking token consumption per request, per model, per [API token](#api-token), and per time
 window. The appliance meters input tokens, output tokens, and derived cost for every request, which is what enforces
-[quotas](#quota), gives operators usage visibility on the **Usage** page, and enables [chargeback](#chargeback).
+[quotas](#quota), gives operators usage visibility, and enables [chargeback](#chargeback).
 
 ## V
 

--- a/inference-launchpad_versioned_docs/version-1.0.x/release-notes.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/release-notes.md
@@ -56,18 +56,16 @@ conceptual introduction, refer to [What is PaletteAI Inference Launchpad?](./pal
   [Clients and Quotas](./explanation/clients-and-quotas.md) and [Create a Client](./how-to-guides/create-a-client.md)
   for more information.
 
-- Enforces per-client quotas across requests, tokens, and cost over hour and day windows, and returns HTTP `429` when a
-  limit is reached. Existing per-second and per-minute limits remain enforced. Refer to
+- Enforces per-client quotas across requests, tokens, and cost over one-second, one-minute, one-hour, and one-day
+  windows, and returns HTTP `429` when a limit is reached. Refer to
   [Manage Client Quotas](./how-to-guides/manage-client-quotas.md) for more information.
 
 - Grants every client access to all local models, and can burst to external frontier models. Refer to
   [Manage Client Model Access](./how-to-guides/manage-client-model-access.md) for more information.
 
-- Reports quota utilization and historical consumption on the **Usage** page, including a **Quota Usage** tab, 24-hour,
-  7-day, and 30-day data windows, and per-model and per-client breakdowns. Lets you raise a ceiling without zeroing
-  usage, and revoke a token or delete a client at any time. Refer to
-  [View Token Usage](./how-to-guides/view-token-usage.md), [View Client Usage](./how-to-guides/view-client-usage.md),
-  and [Revoke or Delete a Client](./how-to-guides/revoke-or-delete-a-client.md) for more information.
+- Reports per-client usage and lets you revoke a token or delete a client at any time. Refer to
+  [View Client Usage](./how-to-guides/view-client-usage.md) and
+  [Revoke or Delete a Client](./how-to-guides/revoke-or-delete-a-client.md) for more information.
 
 - Computes estimated savings by comparing locally served token volume against a configurable frontier provider reference
   rate.


### PR DESCRIPTION
## Why

The AIL-352 **client quota management and utilization** content (Quota Usage tab, Data window, Increase limit, Unlimited/Not enforced/Reached limit) leaked into \`inference-launchpad_versioned_docs/version-1.0.x/\` when this branch was cut. AIL-352 landed on master (#11690) on 2026-08-20, before the release cut on 2026-08-27, so the snapshot inherited quota-utilization edits from the 7 PAIIL-tree files that #11690 touched.

Quota utilization ships in **v1.1.1**, not 1.0.0, so it must not appear in the 1.0.x archive.

This mirrors the master-side revert in #11807 and coordinates with the v1.1.1 tracking PR #11781.

## What this changes

For each of the 7 PAIIL-tree files that AIL-352 (#11690) touched, the AIL-352 additions are removed from the versioned snapshot. AIL-352 was reverse-applied with \`git apply -R --3way\`, so unrelated 1.0.0 content that landed alongside — AIL-424 (deploy on selected nodes) — stays in place.

Conflict resolutions during the reverse-apply:

- **\`explanation/explanation.md\`** — kept the current table (Model Placement row from AIL-424, pre-AIL-419 wording for Installation Architecture from the prior revert); reverted only the "Clients and Quotas" description to pre-AIL-352 wording.
- **\`how-to-guides/how-to-guides.md\`** — kept the current post-revert table (no BYOM, no Replace a Model, no Register External Endpoint, no Manage Cluster Infrastructure, no Upgrade the Platform); reverted only the "Set and Manage Client Quotas" and "View Client Usage" descriptions to pre-AIL-352 wording.
- **\`how-to-guides/view-client-usage.md\`** — took the pre-AIL-352 form of the "View Usage by Client" step continuation. Dropped the DOC-3054 \`:::info\` block about the empty By Client table (\`934b7b927\`) — that block was written for the AIL-352 rewrite.

## What is NOT changed

The shared partial \`_partials/paletteai-inference-launchpad/_request-routing-and-quotas.mdx\` on this branch is intentionally not touched. That partial ships with v1.1.1 from this branch — its AIL-352 wording (client-scoped quotas rather than API-token-scoped) must stay for the v1.1.1 release. The partial lives outside the versioned tree, so the 1.0.x snapshot renders using whatever is at the current path.

The \`docs/products/paletteai-inference-launchpad/\` tree on this branch is NOT touched — that tree is the current/next-release tree that ships with v1.1.1 and must retain AIL-352 content.

\`reference/usage-metrics-reference.md\` on the versioned snapshot is not touched. That page was added by DOC-2925 (#11706), not by AIL-352, so it is out of scope for this revert.

## Test plan

- [ ] Confirm the diff only touches \`inference-launchpad_versioned_docs/version-1.0.x/**\` — the same 7 PAIIL-tree files.
- [ ] Confirm the versioned Netlify preview shows pre-AIL-352 wording on \`clients-and-quotas.md\`, \`manage-client-quotas.md\`, \`view-client-usage.md\`, glossary Quota / Rate Limit entries, and 1.0.0 release notes.
- [ ] Confirm no Quota Usage tab, Increase limit, Reached limit, Not enforced, or Data-window vocabulary appears outside \`usage-metrics-reference.md\` in the versioned snapshot.
- [ ] Confirm the partial rendering on the 4 coding-tool how-tos still shows the v1.1.1 (client-scoped) wording — the partial is shared, not versioned.