### PR TITLE
DOC-3126: add docs.redhat.com to linkinator skip list

### DIFF
--- a/linkinator/linkinator-ci.config.json
+++ b/linkinator/linkinator-ci.config.json
@@ -22,6 +22,7 @@
     "https://dev.mysql.com/doc/.*$$",
     "^https://github.com.*$$",
     "^https://developers.redhat.com.*$$",
+    "^https://docs.redhat.com.*$$",
     "^https://www.intel.com.*$$",
     "^https://developer.hashicorp.com.*$$",
     "^https://www.packer.io.*$$",

--- a/linkinator/linkinator.config.json
+++ b/linkinator/linkinator.config.json
@@ -22,6 +22,7 @@
     "https://dev.mysql.com/doc/.*$$",
     "^https://github.com.*$$",
     "^https://developers.redhat.com.*$$",
+    "^https://docs.redhat.com.*$$",
     "^https://www.intel.com.*$$",
     "^https://developer.hashicorp.com.*$$",
     "^https://www.packer.io.*$$",


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _CI configuration only — no user-facing pages change._
- [x] Conduct a **self-review** for your pages using your preview links. _Not applicable._
- [x] **Check formatting** for your pages. _JSON validated; Prettier reports both configs unchanged._
- [x] Ensure all **Vale comments** are resolved. _Not applicable._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. `auto-backport` + `backport-version-4-6/-4-7/-4-8/-4-9`, matching PR #11815.
- [ ] **Outside review:** Not required.
- [ ] Add the `notify-slack` label once this checklist has been completed.

## 📝 Describe the Change

Follow-up to [PR #11815](https://github.com/spectrocloud/librarium/pull/11815) (drop spoofed Chrome/79 UA). Adds `docs.redhat.com` to the linkinator skip list on both configs, next to the existing `developers.redhat.com` entry. Two 1-line additions.

Testing PR #11815 on 2026-08-29 showed `docs.redhat.com` now returns **403 for every request**, including no-UA and Chrome/128 with browser-like Accept headers. The 403 body comes from `errors.edgesuite.net` with `x-rh-edge-*` headers — Akamai Bot Manager fingerprinting, which linkinator has no way to satisfy:

| Date | Test | `docs.redhat.com` |
| --- | --- | --- |
| 2026-08-19 | `curl` no UA | 200 |
| 2026-08-24 | `curl -A "Chrome/128"` | 200 |
| 2026-08-29 | any UA + browser headers | **403 (Akamai edge)** |

The remaining path is to skip the domain, matching how `developers.redhat.com` has been handled since DOC-1877.

## 💻 Changed Pages

None — CI configuration only.

## 🎫 Jira Tickets

- [DOC-3126](https://spectrocloud.atlassian.net/browse/DOC-3126) — Broken URL check reports false positives because of its spoofed user agent.


[DOC-3126]: https://spectrocloud.atlassian.net/browse/DOC-3126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ