### PR TITLE
PVM-1020: Slim ISO CSI selection for VM Launchpad

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -233,6 +233,14 @@ The [Palette CLI](../automation/palette-cli/palette-cli.md) version correspondin
   Palette VMO pack, ships the log stream to Splunk. Both toggles emit filterable audit events for compliance review.
   Refer to [Metrics and Logs](../vm-management/vm-launchpad/metrics-and-logs.md) for the full configuration reference.
 
+<!-- https://spectrocloud.atlassian.net/browse/PVM-1020 -->
+
+- PaletteAI VM Launchpad now supports a new Slim ISO + Content Bundle install path that decouples appliance storage from
+  VM storage. The appliance boots on its own storage, and administrators attach a customer-chosen CSI for VM workloads
+  after the install completes. Portworx SDS and Portworx with Pure Array are validated for 4.10.0. Refer to
+  [Storage](../vm-management/vm-launchpad/infrastructure/storage.md) for the list of validated providers and
+  [Install VM Launchpad](../vm-management/vm-launchpad/install.md) for the install procedure.
+
 ### Docs and Education
 
 ### Packs

--- a/docs/docs-content/vm-management/vm-launchpad/infrastructure/storage.md
+++ b/docs/docs-content/vm-management/vm-launchpad/infrastructure/storage.md
@@ -27,6 +27,17 @@ The default appliance backend is Piraeus/LINSTOR, which provides:
 
 You can use other providers, such as host-path or Rook-Ceph, depending on the cluster configuration.
 
+### Validated Providers for VM Storage in 4.10.0
+
+In 4.10.0, the following providers are validated for VM storage on PaletteAI VM Launchpad:
+
+- Portworx SDS
+- Portworx with Pure Array
+
+Both are supported when you install the appliance using the Slim ISO and Content Bundle path, which lets the appliance
+boot on its own storage and administrators attach the customer-chosen CSI for VM workloads afterward. Refer to
+[Install VM Launchpad](../install.md) for the install procedure.
+
 ## StorageClasses
 
 StorageClasses define how VMO provisions PersistentVolumeClaims (PVCs). From **Infrastructure** > **Storage**, you can


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages).
- [x] Conduct a **self-review** for your pages using your preview links.
- [x] **Check formatting** for your pages. _Prettier + Vale clean on my added lines._
- [x] Ensure all **Vale comments** are resolved.
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _Not applicable — 4.10.0 release content only._
- [ ] **Outside review:** Sumit Tiwari (VMO Director of Engineering) to confirm the two ambiguous scope items from the Jira description before this PR is complete.
- [ ] Add the `notify-slack` label once this checklist has been completed.

## 📝 Describe the Change

**Work in progress — held pending Sumit Tiwari's scope call on two ambiguous items in the Jira description.** Currently ships the confirmed-scope portion of [PVM-1020](https://spectrocloud.atlassian.net/browse/PVM-1020) so the Slim ISO CSI selection feature has a release note and a landing spot in the storage docs before the 2026-09-04 VM Launchpad ship date, then rounds out to full coverage once the ambiguous items resolve.

Ships now:

- **Release-notes bullet** under `### PaletteAI VM Launchpad` → `#### Features`. Covers the new Slim ISO + Content Bundle install path, notes that Portworx SDS and Portworx with Pure Array are validated for 4.10.0, and flags that appliance uptime is now independent of customer CSI configuration.
- **`storage.md` subsection** (`### Validated Providers for VM Storage in 4.10.0`) listing the two validated providers with a cross-reference to `install.md` for the install procedure.

Awaits Sumit before the rest can land:

- **Full "Install with Slim ISO + Content Bundle" section on `install.md`** — needs engineering-side procedural detail (ISO artifact names, install-time prompts, Portworx attach steps). Not inventing without a source.
- **Garage (object store) for Zot HA** — Ben tagged this "may or may not belong in this Doc-task" in the description; awaiting Sumit's scope call.
- **CRD-upload path for Resource Catalog components** — Ben tagged this ambiguous; awaiting Sumit's scope call. The Resource Catalog UI itself is confirmed out of scope.
- **Cross-references from `quick-start.md` and `getting-started-wiz.md`** — depend on the `install.md` section landing first.

DM'd Sumit 2026-08-25 with the two scope questions, no reply yet; sent a follow-up DM 2026-08-29. Merging as-is would ship a release note and a storage subsection whose linked install procedure does not yet exist — hence the `do-not-merge/work-in-progress` label until the rest can join.

## 💻 Changed Pages

- Release Notes → 4.10.0 → PaletteAI VM Launchpad: [preview](https://deploy-preview-11827--docs-spectrocloud.netlify.app/release-notes#paletteai-vm-launchpad-4.10.0)
- [Storage](https://deploy-preview-11827--docs-spectrocloud.netlify.app/vm-management/vm-launchpad/infrastructure/storage#storage-providers) — new "Validated Providers for VM Storage in 4.10.0" subsection.

## 🎫 Jira Tickets

- [PVM-1020](https://spectrocloud.atlassian.net/browse/PVM-1020) — DOC - Bring-your-own CSI for VM storage after Appliance ISO install (4.10.0).



[PVM-1020]: https://spectrocloud.atlassian.net/browse/PVM-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ