### PR TITLE
Doc 3145 okta groups claim 4 10 0

### DIFF
--- a/docs/docs-content/vm-management/vmo-pack/configure-external-oidc.md
+++ b/docs/docs-content/vm-management/vmo-pack/configure-external-oidc.md
@@ -107,11 +107,14 @@ names differ.
 
    New sign-ins include the groups claim. Users with an existing session must sign out and sign in again.
 
-:::warning
+:::info
 
-Okta limits the number of groups included in a claim, with a default of 100. A broad filter combined with a user who
-belongs to many groups can produce a truncated claim. Keep the filter narrow enough that the groups you use for RBAC are
-always included.
+Okta caps the groups claim at 100 entries in the Implicit Flow. VM Launchpad's Keycloak broker uses the Authorization
+Code Flow, which does not have this cap, so an unbounded filter is safe. If you configure Keycloak to broker over the
+Implicit Flow instead, the cap applies and a user who belongs to more than 100 groups receives a truncated claim. Refer
+to
+[Error: The groups claim matched too many groups and must be configured to match fewer groups](https://support.okta.com/help/s/article/error-the-groups-claim-matched-too-many-groups-and-must-be-configured-to-match-fewer-groups?language=en_US)
+in Okta's documentation for the underlying constraint.
 
 :::
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages).
- [x] Conduct a **self-review** for your pages using your preview links.
- [x] **Check formatting** for your pages. _Byte-identical patch to #11800. Prettier + Vale clean on the master pass._
- [x] Ensure all **Vale comments** are resolved.
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _N/A. Targets `docs-rel-4-10-0` directly. The 4.9 backport rides on #11800 via `auto-backport` + `backport-version-4-9`._
- [x] **Outside review:** Not required. Kurt approved the identical patch on #11800 (2026-08-31 12:32 UTC).
- [x] Add the `notify-slack` label once this checklist has been completed.

## 📝 Describe the Change

`docs-rel-4-10-0` mirror of #11800. The change is byte-identical: rewrites the 100-group cap admonition on [Configure External OIDC](https://deploy-preview-11828--docs-spectrocloud.netlify.app/vm-management/vmo-pack/configure-external-oidc) step 4 as `:::info`, scopes the cap to Okta's Implicit Flow, and notes that VM Launchpad's default Keycloak broker (Authorization Code Flow) is exempt. Refer to #11800 for the full rationale and reviewer context; nothing else changes on this branch.

## 💻 Changed Pages

- [Configure External OIDC](https://deploy-preview-11828--docs-spectrocloud.netlify.app/vm-management/vmo-pack/configure-external-oidc): step 4 admonition rewrite.

## 🎫 Jira Tickets

- [DOC-3145](https://spectrocloud.atlassian.net/browse/DOC-3145): 4.10.0 mirror of #11800 (VMO 2.0 Okta OIDC docs expansion).


[DOC-3145]: https://spectrocloud.atlassian.net/browse/DOC-3145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ