### PR TITLE
DOC-3172: document VMO Pack StorageClass label for VM workloads (4.10.0 mirror PR)

### DIFF
--- a/docs/docs-content/vm-management/vmo-pack/create-vmo-profile.md
+++ b/docs/docs-content/vm-management/vmo-pack/create-vmo-profile.md
@@ -72,6 +72,14 @@ We recommend using Ubuntu 22.04 as the OS image for Edge clusters deployed in
 
 </Tabs>
 
+Regardless of environment, if you pre-provision StorageClasses that VM workloads should use (for example, through
+GitOps, Terraform, or an imperative script), label each class with `vmo-manager.spectrocloud.com/vm-workload: "true"`.
+Without the label, the class appears in the VMO UI but the **Allow for VMs** checkbox is not pre-checked, so the class
+is not available for VM workloads until an administrator edits it on the **Home** > **Storage** > **Storage Classes**
+page. Refer to
+[Custom StorageClass Not Appearing as VM-eligible](./troubleshooting.md#scenario---custom-storageclass-not-appearing-as-vm-eligible)
+for the fix on an existing class.
+
 ## Create the Profile
 
 <Tabs groupId="environment">

--- a/docs/docs-content/vm-management/vmo-pack/troubleshooting.md
+++ b/docs/docs-content/vm-management/vmo-pack/troubleshooting.md
@@ -433,3 +433,57 @@ The Job and the script apply the label `app.kubernetes.io/managed-by: Helm` and 
 | RoleBinding        | Golden images namespace | `vmo-cdi-clone-source`   |
 
 <!-- vale on -->
+
+## Scenario - Custom StorageClass Not Appearing as VM-eligible
+
+The VMO UI shows a StorageClass on the **Home** > **Storage** > **Storage Classes** page, but the **VM WORKLOADS**
+column reports `Not configured` and the **Allow for VMs** checkbox on the edit dialog is not pre-checked. VMs cannot use
+the class until an administrator enables it.
+
+This condition applies when a StorageClass is created out-of-band from the VMO UI, such as through GitOps, Terraform, or
+`kubectl apply`, without the label VMO reads to determine VM eligibility.
+
+### Debug Steps
+
+VMO decides which StorageClass is VM-eligible by looking for the label
+`vmo-manager.spectrocloud.com/vm-workload: "true"` on the class. A class that does not carry the label is not surfaced
+to VM workloads, regardless of its Container Storage Interface (CSI) provisioner.
+
+To confirm the state on a specific class, issue the following command. Replace `<class-name>` with the name of your
+StorageClass.
+
+```shell
+kubectl get storageclass <class-name> --output jsonpath='{.metadata.labels}'
+```
+
+The output should include `"vmo-manager.spectrocloud.com/vm-workload":"true"`. If the label is missing, VMO treats the
+class as not VM-eligible.
+
+### Resolution
+
+Add the label to the StorageClass. Issue the following command, replacing `<class-name>` with the name of your
+StorageClass.
+
+```shell
+kubectl label storageclass <class-name> vmo-manager.spectrocloud.com/vm-workload=true
+```
+
+Refresh the **Storage Classes** page in the VMO UI. The **VM WORKLOADS** column reports `Healthy` and the **Allow for
+VMs** checkbox is pre-checked on the edit dialog. Existing VMs and new VM workloads can now use the class.
+
+To bake the label into a StorageClass manifest so it is present at creation time, include the label under
+`metadata.labels`.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: <class-name>
+  labels:
+    vmo-manager.spectrocloud.com/vm-workload: "true"
+provisioner: <your-csi-provisioner>
+# ... rest of your StorageClass definition
+```
+
+The label is CSI-agnostic. It applies to Piraeus, Rook-Ceph, Portworx, and any other CSI provisioner. VMO reads the
+label only, not the CSI or the class name.


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages).
- [x] Conduct a **self-review** for your pages using your preview links.
- [x] **Check formatting** for your pages. _Byte-identical patch to #11831. Prettier clean on the master pass._
- [x] Ensure all **Vale comments** are resolved.
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _N/A. Targets `docs-rel-4-10-0` directly. The 4.9 backport rides on #11831 via `auto-backport` + `backport-version-4-9`._
- [ ] **Outside review:** Not required. The fix is engineering-confirmed on [SCS-5216](https://spectrocloud.atlassian.net/browse/SCS-5216) by John Hoffer and Tony Windebank.
- [ ] Add the `notify-slack` label once this checklist has been completed.

## 📝 Describe the Change

`docs-rel-4-10-0` mirror of #11831. The change is byte-identical: adds a Prerequisites paragraph on [Create a VMO Profile](https://deploy-preview-11832--docs-spectrocloud.netlify.app/vm-management/vmo-pack/create-vmo-profile) that instructs customers pre-provisioning StorageClasses to stamp each class with `vmo-manager.spectrocloud.com/vm-workload: "true"`, and adds a new [Custom StorageClass Not Appearing as VM-eligible](https://deploy-preview-11832--docs-spectrocloud.netlify.app/vm-management/vmo-pack/troubleshooting#scenario---custom-storageclass-not-appearing-as-vm-eligible) troubleshooting scenario for existing deployments. Refer to #11831 for the full rationale and Loves customer context. Nothing else changes on this branch.

Docs need to be on `docs-rel-4-10-0` for the 2026-09-06 VMO Pack 4.10.0 ship. Loves is already on a 4.10.1 lab per SCS-5216.

## 💻 Changed Pages

- [Create a VMO Profile](https://deploy-preview-11832--docs-spectrocloud.netlify.app/vm-management/vmo-pack/create-vmo-profile): new Prerequisites paragraph after the Tabs on the label requirement.
- [Troubleshooting the VMO Pack](https://deploy-preview-11832--docs-spectrocloud.netlify.app/vm-management/vmo-pack/troubleshooting#scenario---custom-storageclass-not-appearing-as-vm-eligible): new scenario, "Custom StorageClass Not Appearing as VM-eligible".

## 🎫 Jira Tickets

- [DOC-3172](https://spectrocloud.atlassian.net/browse/DOC-3172): 4.10.0 mirror of #11831.
- [SCS-5216](https://spectrocloud.atlassian.net/browse/SCS-5216): Loves customer support ticket, the source of the request.


[SCS-5216]: https://spectrocloud.atlassian.net/browse/SCS-5216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ