### PR TITLE
PVM-1019: otel probe scope addendum

### DIFF
--- a/docs/docs-content/vm-management/vm-launchpad/metrics-and-logs.md
+++ b/docs/docs-content/vm-management/vm-launchpad/metrics-and-logs.md
@@ -78,8 +78,10 @@ configuration change.
 
 1. Open your VMO cluster profile in Palette and select the **Virtual Machine Orchestrator** pack.
 
-2. Under `charts.vmo-manager.deployment.extraEnv`, add the two variables with your extra namespaces and workload names.
-   Both fields take comma-separated values and trim whitespace.
+2. Under `charts.vmo-manager.deployment.extraEnv`, add the two environment variables `VMO_OTEL_EXTRA_NAMESPACES` and
+   `VMO_OTEL_EXTRA_NAMES` with your extra namespaces and workload names. Use these exact variable names, which VMO reads
+   literally; only the values in the following example are placeholders. Both fields take comma-separated values and
+   trim whitespace.
 
    ```yaml title="Example YAML values"
    charts:

--- a/docs/docs-content/vm-management/vm-launchpad/metrics-and-logs.md
+++ b/docs/docs-content/vm-management/vm-launchpad/metrics-and-logs.md
@@ -35,13 +35,69 @@ events after 30 days, forwarding appliance logs to a central system is how you k
 
 ## Page Visibility
 
-The **Metrics and Logs** page appears in the VMO UI only when VMO detects an external OpenTelemetry Collector Deployment
-or DaemonSet in the cluster. VMO checks at runtime through a capability probe, and the page stays hidden until at least
-one such workload exists.
+The **Metrics and Logs** page appears in the VMO UI only when VMO detects an OpenTelemetry Collector Deployment or
+DaemonSet in the cluster. VMO checks at runtime through a capability probe that scans a built-in set of namespaces for
+workloads with a built-in set of names. The page stays hidden until at least one match exists.
 
-If **Metrics and Logs** does not appear under **Settings** > **Configuration**, deploy an OpenTelemetry Collector on the
-cluster. Refer to [Configure the OpenTelemetry Collector addon](#configure-the-opentelemetry-collector-addon) for the
-Palette VMO pack addon path.
+By default, the probe searches the following namespaces:
+
+- `kube-system`
+- `opentelemetry`
+- `monitoring`
+- `otel`
+
+for a Deployment or DaemonSet with any of the following names:
+
+- `otel-collector-agent`
+- `opentelemetry-collector`
+- `otel-collector`
+
+The `kube-system` namespace covers the OpenTelemetry Collector that the Palette VMO pack addon deploys. The other three
+cover community Helm charts and manual installs into a dedicated namespace.
+
+If **Metrics and Logs** does not appear under **Settings** > **Configuration**, either deploy an OpenTelemetry Collector
+into one of the default locations or extend the probe as described in
+[Extend the OpenTelemetry Collector Probe](#extend-the-opentelemetry-collector-probe). Refer to
+[Configure the OpenTelemetry Collector addon](#configure-the-opentelemetry-collector-addon) for the Palette VMO pack
+addon path.
+
+:::info
+
+If the probe cannot reach the Kubernetes API server for any check because of a network error, RBAC denial, or 5xx
+response, VMO leaves the **Metrics and Logs** page visible rather than hiding a working feature. Confirm the
+OpenTelemetry Collector is present before relying on page visibility as a signal.
+
+:::
+
+### Extend the OpenTelemetry Collector Probe
+
+If your OpenTelemetry Collector runs under a non-default namespace or workload name, such as one deployed by a custom
+Helm chart or a service mesh sidecar, extend the probe by setting two environment variables on the `vmo-manager`
+container through the VMO pack values. VMO appends the extras to the defaults, so existing installs keep working with no
+configuration change.
+
+1. Open your VMO cluster profile in Palette and select the **Virtual Machine Orchestrator** pack.
+
+2. Under `charts.vmo-manager.deployment.extraEnv`, add the two variables with your extra namespaces and workload names.
+   Both fields take comma-separated values and trim whitespace.
+
+   ```yaml
+   charts:
+     vmo-manager:
+       deployment:
+         extraEnv:
+           - name: VMO_OTEL_EXTRA_NAMESPACES
+             value: "my-observability,mesh-obs"
+           - name: VMO_OTEL_EXTRA_NAMES
+             value: "my-otel-agent"
+   ```
+
+3. Save the profile and apply the update. Palette re-renders the Deployment, the `vmo-manager` pods restart with the new
+   environment, and the next capability probe picks up the extras within 60 seconds. The **Metrics and Logs** page
+   appears in the sidebar once a matching workload is found.
+
+The extension is additive. Removing the environment variables reverts the probe to the built-in defaults on the next pod
+restart.
 
 ## How Forwarding Works
 

--- a/docs/docs-content/vm-management/vm-launchpad/metrics-and-logs.md
+++ b/docs/docs-content/vm-management/vm-launchpad/metrics-and-logs.md
@@ -81,7 +81,7 @@ configuration change.
 2. Under `charts.vmo-manager.deployment.extraEnv`, add the two variables with your extra namespaces and workload names.
    Both fields take comma-separated values and trim whitespace.
 
-   ```yaml
+   ```yaml title="Example YAML values"
    charts:
      vmo-manager:
        deployment:


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Addendum to #11684. Yin (via Slack, 2026-08-31 19:29) flagged that the current **Page Visibility** section on the VM Launchpad **Metrics and Logs** page under-describes what VMO's OpenTelemetry Collector probe actually checks. This PR corrects that and documents the new `extraEnv` extension mechanism that ships in the same vmo-manager release.

Changes to `docs/docs-content/vm-management/vm-launchpad/metrics-and-logs.md`:

- Expand **Page Visibility** to list the four default namespaces (`kube-system`, `opentelemetry`, `monitoring`, `otel`) and three default workload names (`otel-collector-agent`, `opentelemetry-collector`, `otel-collector`) the probe searches for a Deployment or DaemonSet.
- Add an `:::info` callout that documents the probe's fail-open behavior — on a network error, RBAC denial, or 5xx from the Kubernetes API server, the page stays visible rather than hiding a working feature.
- Add a new **Extend the OpenTelemetry Collector Probe** subsection covering the two new env vars (`VMO_OTEL_EXTRA_NAMESPACES`, `VMO_OTEL_EXTRA_NAMES`) set through `charts.vmo-manager.deployment.extraEnv` on the VMO pack. Extras are additive, comma-separated, whitespace-trimmed, and picked up on the next capability probe (≤60 s) after a pod restart.

## 🔗 Changed Pages

- [VM Launchpad: Metrics and Logs -- Page Visibility section](https://deploy-preview-11836--docs-spectrocloud.netlify.app/vm-management/vm-launchpad/metrics-and-logs#page-visibility)

## 🧪 Jira Tickets

- [PVM-1019](https://spectrocloud.atlassian.net/browse/PVM-1019)


[PVM-1019]: https://spectrocloud.atlassian.net/browse/PVM-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ