### PR TITLE
DOC-3065: clarify vLLM as the only supported inference engine

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
@@ -47,8 +47,8 @@ listed here once they are supported.
 | llama.cpp | CPU          | Coming soon | Lightweight CPU-based serving for smaller models on nodes without a GPU. |
 
 Because vLLM is the only supported kind today, the automatic option and any manual selection both resolve to a vLLM
-engine. The **Deploy model** dialog may list other kinds if a future release adds them, but you should not select a
-kind marked as coming soon until its release notes announce support.
+engine. The **Deploy model** dialog may list other kinds if a future release adds them, but you should not select a kind
+marked as coming soon until its release notes announce support.
 
 ## Engine Arguments
 

--- a/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
@@ -7,7 +7,7 @@ description:
 hide_table_of_contents: false
 sidebar_position: 4
 tags: ["paletteai-inference-launchpad", "models", "explanation"]
-keywords: ["launchpad", "ai", "inference", "engine", "vLLM", "SGLang", "Ollama"]
+keywords: ["launchpad", "ai", "inference", "engine", "vLLM"]
 ---
 
 This page explains what an inference engine is in PaletteAI Inference Launchpad, how the appliance selects one
@@ -32,21 +32,23 @@ engine to the model and the chosen nodes for you.
 
 The engines you can choose from depend on how your appliance is configured. The **Deploy model** dialog lists the
 automatic option first, followed by any named engines the appliance exposes, each labeled with its kind, such as
-`default · sglang`.
+`default · vllm`.
 
 ## Supported Engine Kinds
 
-PaletteAI Inference Launchpad supports the following engine kinds.
+PaletteAI Inference Launchpad currently supports one engine kind, vLLM. Additional kinds are on the roadmap and will be
+listed here once they are supported.
 
-| **Kind**  | **Hardware** | **Summary**                                                              |
-| --------- | ------------ | ------------------------------------------------------------------------ |
-| vLLM      | GPU          | High-throughput GPU serving for large models.                            |
-| SGLang    | GPU          | High-throughput GPU serving with support for advanced serving features.  |
-| Ollama    | CPU          | CPU-based serving for smaller models on nodes without a GPU.             |
-| llama.cpp | CPU          | Lightweight CPU-based serving for smaller models on nodes without a GPU. |
+| **Kind**  | **Hardware** | **Status**  | **Summary**                                                              |
+| --------- | ------------ | ----------- | ------------------------------------------------------------------------ |
+| vLLM      | GPU          | Supported   | High-throughput GPU serving for large models.                            |
+| SGLang    | GPU          | Coming soon | High-throughput GPU serving with support for advanced serving features.  |
+| Ollama    | CPU          | Coming soon | CPU-based serving for smaller models on nodes without a GPU.             |
+| llama.cpp | CPU          | Coming soon | Lightweight CPU-based serving for smaller models on nodes without a GPU. |
 
-Serving features can vary by kind. For example, some kinds support reasoning and tool-calling for models that provide
-them, while others do not. The automatic option accounts for these differences when it matches an engine to a model.
+Because vLLM is the only supported kind today, the automatic option and any manual selection both resolve to a vLLM
+engine. The **Deploy model** dialog may list other kinds if a future release adds them, but you should not select a
+kind marked as coming soon until its release notes announce support.
 
 ## Engine Arguments
 

--- a/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
@@ -36,13 +36,9 @@ automatic option first, followed by any named engines the appliance exposes, eac
 
 ## Supported Engine Kinds
 
-PaletteAI Inference Launchpad supports one engine kind, vLLM.
-
-| **Kind** | **Hardware** | **Summary**                                   |
-| -------- | ------------ | --------------------------------------------- |
-| vLLM     | GPU          | High-throughput GPU serving for large models. |
-
-Because vLLM is the only supported kind, the automatic option and any manual selection both resolve to a vLLM engine.
+PaletteAI Inference Launchpad supports one engine kind, vLLM, which provides high-throughput GPU serving for large
+models. Because it is the only supported kind, the automatic option and any manual selection both resolve to a vLLM
+engine.
 
 ## Engine Arguments
 

--- a/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/inference-engines.md
@@ -36,19 +36,13 @@ automatic option first, followed by any named engines the appliance exposes, eac
 
 ## Supported Engine Kinds
 
-PaletteAI Inference Launchpad currently supports one engine kind, vLLM. Additional kinds are on the roadmap and will be
-listed here once they are supported.
+PaletteAI Inference Launchpad supports one engine kind, vLLM.
 
-| **Kind**  | **Hardware** | **Status**  | **Summary**                                                              |
-| --------- | ------------ | ----------- | ------------------------------------------------------------------------ |
-| vLLM      | GPU          | Supported   | High-throughput GPU serving for large models.                            |
-| SGLang    | GPU          | Coming soon | High-throughput GPU serving with support for advanced serving features.  |
-| Ollama    | CPU          | Coming soon | CPU-based serving for smaller models on nodes without a GPU.             |
-| llama.cpp | CPU          | Coming soon | Lightweight CPU-based serving for smaller models on nodes without a GPU. |
+| **Kind** | **Hardware** | **Summary**                                   |
+| -------- | ------------ | --------------------------------------------- |
+| vLLM     | GPU          | High-throughput GPU serving for large models. |
 
-Because vLLM is the only supported kind today, the automatic option and any manual selection both resolve to a vLLM
-engine. The **Deploy model** dialog may list other kinds if a future release adds them, but you should not select a kind
-marked as coming soon until its release notes announce support.
+Because vLLM is the only supported kind, the automatic option and any manual selection both resolve to a vLLM engine.
 
 ## Engine Arguments
 

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -235,8 +235,7 @@ locally rather than by a cloud provider.
 
 The runtime that loads a model and serves its requests behind the model's endpoint. It determines how a model runs,
 which hardware it can use, and which serving features are available. The appliance selects an engine automatically by
-default. [vLLM](#vllm) is the only currently supported kind; other kinds may be added in future releases. Refer to
-[Inference Engines](../explanation/inference-engines.md).
+default. [vLLM](#vllm) is the only supported kind. Refer to [Inference Engines](../explanation/inference-engines.md).
 
 ### Intelligent Routing
 

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -235,8 +235,8 @@ locally rather than by a cloud provider.
 
 The runtime that loads a model and serves its requests behind the model's endpoint. It determines how a model runs,
 which hardware it can use, and which serving features are available. The appliance selects an engine automatically by
-default. Refer to [Inference Engines](../explanation/inference-engines.md) for the supported kinds, such as
-[vLLM](#vllm), SGLang, Ollama, and llama.cpp.
+default. [vLLM](#vllm) is the only currently supported kind; other kinds may be added in future releases. Refer to
+[Inference Engines](../explanation/inference-engines.md).
 
 ### Intelligent Routing
 

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -570,6 +570,6 @@ model. Refer to [Vision Preprocessing](../explanation/vision-preprocessing.md) a
 
 ### vLLM
 
-An open source, high-throughput [inference engine](#inference-engine) for large language models. vLLM is one of the
-GPU-serving engines the appliance can run, exposing an [OpenAI-compatible endpoint](#openai-compatible-api) on the
+An open source, high-throughput [inference engine](#inference-engine) for large language models. vLLM is the
+GPU-serving engine the appliance currently runs, exposing an [OpenAI-compatible endpoint](#openai-compatible-api) on the
 Kubernetes cluster.

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -570,6 +570,6 @@ model. Refer to [Vision Preprocessing](../explanation/vision-preprocessing.md) a
 
 ### vLLM
 
-An open source, high-throughput [inference engine](#inference-engine) for large language models. vLLM is the
-GPU-serving engine the appliance currently runs, exposing an [OpenAI-compatible endpoint](#openai-compatible-api) on the
-Kubernetes cluster.
+An open source, high-throughput [inference engine](#inference-engine) for large language models. vLLM is the GPU-serving
+engine the appliance currently runs, exposing an [OpenAI-compatible endpoint](#openai-compatible-api) on the Kubernetes
+cluster.

--- a/docs/products/paletteai-inference-launchpad/release-notes.md
+++ b/docs/products/paletteai-inference-launchpad/release-notes.md
@@ -116,9 +116,9 @@ conceptual introduction, refer to [What is PaletteAI Inference Launchpad?](./pal
 - Replaces a serving model by removing it from a node and then deploying a newer version or a different model. Refer to
   [Replace a Model](./how-to-guides/replace-a-model.md) for more information.
 
-- Exposes each model as an OpenAI-compatible endpoint and supports four engine kinds, vLLM, SGLang, Ollama, and
-  llama.cpp, selected automatically or pinned per model. Refer to
-  [Inference Engines](./explanation/inference-engines.md) for more information.
+- Exposes each model as an OpenAI-compatible endpoint served by vLLM, the only supported engine kind, selected
+  automatically or pinned per model. Refer to [Inference Engines](./explanation/inference-engines.md) for more
+  information.
 
 - Serves many clients from one appliance, each identified by API tokens prefixed `lpai_`. Refer to
   [Clients and Quotas](./explanation/clients-and-quotas.md) and [Create a Client](./how-to-guides/create-a-client.md)

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/inference-engines.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/inference-engines.md
@@ -35,19 +35,13 @@ first, followed by any named engines the appliance exposes, each labeled with it
 
 ## Supported Engine Kinds
 
-PaletteAI Inference Launchpad currently supports one engine kind, vLLM. Additional kinds are on the roadmap and will be
-listed here once they are supported.
+PaletteAI Inference Launchpad supports one engine kind, vLLM.
 
-| **Kind**  | **Hardware** | **Status**  | **Summary**                                                              |
-| --------- | ------------ | ----------- | ------------------------------------------------------------------------ |
-| vLLM      | GPU          | Supported   | High-throughput GPU serving for large models.                            |
-| SGLang    | GPU          | Coming soon | High-throughput GPU serving with support for advanced serving features.  |
-| Ollama    | CPU          | Coming soon | CPU-based serving for smaller models on nodes without a GPU.             |
-| llama.cpp | CPU          | Coming soon | Lightweight CPU-based serving for smaller models on nodes without a GPU. |
+| **Kind** | **Hardware** | **Summary**                                   |
+| -------- | ------------ | --------------------------------------------- |
+| vLLM     | GPU          | High-throughput GPU serving for large models. |
 
-Because vLLM is the only supported kind today, the automatic option and any manual selection both resolve to a vLLM
-engine. The deploy panel may list other kinds if a future release adds them, but you should not select a kind marked as
-coming soon until its release notes announce support.
+Because vLLM is the only supported kind, the automatic option and any manual selection both resolve to a vLLM engine.
 
 ## Manual Engine Selection
 

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/inference-engines.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/inference-engines.md
@@ -7,7 +7,7 @@ description:
 hide_table_of_contents: false
 sidebar_position: 4
 tags: ["paletteai-inference-launchpad", "models", "explanation"]
-keywords: ["launchpad", "ai", "inference", "engine", "vLLM", "SGLang", "Ollama"]
+keywords: ["launchpad", "ai", "inference", "engine", "vLLM"]
 ---
 
 This page explains what an inference engine is in PaletteAI Inference Launchpad, how the appliance selects one
@@ -31,21 +31,23 @@ model. Leaving the setting on automatic is the recommended choice for most deplo
 the engine to the model and the target node for you.
 
 The engines you can choose from depend on how your appliance is configured. The deploy panel lists the automatic option
-first, followed by any named engines the appliance exposes, each labeled with its kind, such as `default · sglang`.
+first, followed by any named engines the appliance exposes, each labeled with its kind, such as `default · vllm`.
 
 ## Supported Engine Kinds
 
-PaletteAI Inference Launchpad supports the following engine kinds.
+PaletteAI Inference Launchpad currently supports one engine kind, vLLM. Additional kinds are on the roadmap and will be
+listed here once they are supported.
 
-| **Kind**  | **Hardware** | **Summary**                                                              |
-| --------- | ------------ | ------------------------------------------------------------------------ |
-| vLLM      | GPU          | High-throughput GPU serving for large models.                            |
-| SGLang    | GPU          | High-throughput GPU serving with support for advanced serving features.  |
-| Ollama    | CPU          | CPU-based serving for smaller models on nodes without a GPU.             |
-| llama.cpp | CPU          | Lightweight CPU-based serving for smaller models on nodes without a GPU. |
+| **Kind**  | **Hardware** | **Status**  | **Summary**                                                              |
+| --------- | ------------ | ----------- | ------------------------------------------------------------------------ |
+| vLLM      | GPU          | Supported   | High-throughput GPU serving for large models.                            |
+| SGLang    | GPU          | Coming soon | High-throughput GPU serving with support for advanced serving features.  |
+| Ollama    | CPU          | Coming soon | CPU-based serving for smaller models on nodes without a GPU.             |
+| llama.cpp | CPU          | Coming soon | Lightweight CPU-based serving for smaller models on nodes without a GPU. |
 
-Serving features can vary by kind. For example, some kinds support reasoning and tool-calling for models that provide
-them, while others do not. The automatic option accounts for these differences when it matches an engine to a model.
+Because vLLM is the only supported kind today, the automatic option and any manual selection both resolve to a vLLM
+engine. The deploy panel may list other kinds if a future release adds them, but you should not select a kind marked as
+coming soon until its release notes announce support.
 
 ## Manual Engine Selection
 

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/inference-engines.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/inference-engines.md
@@ -35,13 +35,9 @@ first, followed by any named engines the appliance exposes, each labeled with it
 
 ## Supported Engine Kinds
 
-PaletteAI Inference Launchpad supports one engine kind, vLLM.
-
-| **Kind** | **Hardware** | **Summary**                                   |
-| -------- | ------------ | --------------------------------------------- |
-| vLLM     | GPU          | High-throughput GPU serving for large models. |
-
-Because vLLM is the only supported kind, the automatic option and any manual selection both resolve to a vLLM engine.
+PaletteAI Inference Launchpad supports one engine kind, vLLM, which provides high-throughput GPU serving for large
+models. Because it is the only supported kind, the automatic option and any manual selection both resolve to a vLLM
+engine.
 
 ## Manual Engine Selection
 

--- a/inference-launchpad_versioned_docs/version-1.0.x/reference/glossary.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/reference/glossary.md
@@ -192,8 +192,7 @@ locally rather than by a cloud provider.
 
 The runtime that loads a model and serves its requests behind the model's endpoint. It determines how a model runs,
 which hardware it can use, and which serving features are available. The appliance selects an engine automatically by
-default. [vLLM](#vllm) is the only currently supported kind; other kinds may be added in future releases. Refer to
-[Inference Engines](../explanation/inference-engines.md).
+default. [vLLM](#vllm) is the only supported kind. Refer to [Inference Engines](../explanation/inference-engines.md).
 
 ### Intelligent Routing
 

--- a/inference-launchpad_versioned_docs/version-1.0.x/reference/glossary.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/reference/glossary.md
@@ -192,8 +192,8 @@ locally rather than by a cloud provider.
 
 The runtime that loads a model and serves its requests behind the model's endpoint. It determines how a model runs,
 which hardware it can use, and which serving features are available. The appliance selects an engine automatically by
-default. Refer to [Inference Engines](../explanation/inference-engines.md) for the supported kinds, such as
-[vLLM](#vllm), SGLang, Ollama, and llama.cpp.
+default. [vLLM](#vllm) is the only currently supported kind; other kinds may be added in future releases. Refer to
+[Inference Engines](../explanation/inference-engines.md).
 
 ### Intelligent Routing
 

--- a/inference-launchpad_versioned_docs/version-1.0.x/reference/glossary.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/reference/glossary.md
@@ -466,6 +466,6 @@ drive or USB stick. Virtual media is the fallback for booting the [slim ISO](#sl
 
 ### vLLM
 
-An open source, high-throughput [inference engine](#inference-engine) for large language models. vLLM is one of the
-GPU-serving engines the appliance can run, exposing an [OpenAI-compatible endpoint](#openai-compatible-api) on the
+An open source, high-throughput [inference engine](#inference-engine) for large language models. vLLM is the
+GPU-serving engine the appliance currently runs, exposing an [OpenAI-compatible endpoint](#openai-compatible-api) on the
 Kubernetes cluster.

--- a/inference-launchpad_versioned_docs/version-1.0.x/release-notes.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/release-notes.md
@@ -44,8 +44,8 @@ conceptual introduction, refer to [What is PaletteAI Inference Launchpad?](./pal
 - Deploys a model to the cluster and places it on the best-fit node automatically, after a guarded preview, gate,
   provision, and smoke-test sequence. Refer to [Deploy a Model](./how-to-guides/deploy-a-model.md) for more information.
 
-- Exposes each model as an OpenAI-compatible endpoint and supports four engine kinds, vLLM, SGLang, Ollama, and
-  llama.cpp, selected automatically or pinned per model. Refer to
+- Exposes each model as an OpenAI-compatible endpoint served by vLLM, the only supported engine kind, selected
+  automatically or pinned per model. Refer to
   [Inference Engines](./explanation/inference-engines.md) for more information.
 
 - Serves many clients from one appliance, each identified by API tokens prefixed `lpai_`. Refer to


### PR DESCRIPTION
## Summary

- Rewrites the **Supported Engine Kinds** section on the PAIIL Inference Engines explanation page so it names vLLM as the only currently supported kind and marks SGLang, Ollama, and llama.cpp as **Coming soon** in a new **Status** column.
- Updates the surrounding prose so the automatic-selection example (`default · sglang` → `default · vllm`) and the paragraph after the table no longer imply multiple engines are available today.
- Syncs the wording in the PAIIL glossary (both the `Inference Engine` and `vLLM` entries) and the v1.0.0 release-notes bullet that used to say "supports four engine kinds."
- Applies every change to both `docs/products/paletteai-inference-launchpad/` (master/Next) and `inference-launchpad_versioned_docs/version-1.0.x/` so the version dropdown stays consistent.

Jira: [DOC-3065](https://spectrocloud.atlassian.net/browse/DOC-3065)

## Test plan

- [ ] Netlify preview renders the updated **Supported Engine Kinds** table with the new **Status** column and the "Coming soon" values.
- [ ] Netlify preview shows the same wording on the version dropdown's `v1.0.x` copy.
- [ ] `Inference Engine` and `vLLM` glossary entries no longer imply multiple supported GPU engines.
- [ ] v1.0.0 release-notes bullet reads "…served by vLLM, the only supported engine kind…".

[DOC-3065]: https://spectrocloud.atlassian.net/browse/DOC-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ