### PR TITLE
PE-9338: Document multi-minor Kubernetes upgrade and post-upgrade downgrade blocks

### DIFF
--- a/docs/docs-content/cluster-templates/modify-cluster-templates.md
+++ b/docs/docs-content/cluster-templates/modify-cluster-templates.md
@@ -79,6 +79,15 @@ each variable before attempting the upgrade again.
 
 :::
 
+:::info
+
+A scheduled or template-driven update that would upgrade a cluster's Kubernetes version across more than one minor
+version at a time is refused on the server, and the cluster is not advanced. This is consistent with interactive cluster
+updates. Update the linked cluster profile to advance the Kubernetes version one minor version at a time. For more
+information, refer to the [Kubernetes Upgrades](../integrations/kubernetes-support.md#kubernetes-upgrades) section.
+
+:::
+
 ### Policies Tab
 
 Use the **Policies** tab to perform the following actions:

--- a/docs/docs-content/clusters/cluster-management/cluster-updates.md
+++ b/docs/docs-content/clusters/cluster-management/cluster-updates.md
@@ -25,9 +25,10 @@ repave schedule and methodology. Refer to
 
 :::warning
 
-Once you upgrade your cluster to a new Kubernetes version, you will not be able to downgrade. We recommend that, before
-upgrading, you review the information provided in the
-[Kubernetes Upgrades](../../integrations/kubernetes-support.md#kubernetes-upgrades) section.
+After a cluster successfully upgrades to a new Kubernetes minor version, Palette blocks any attempt to downgrade it to a
+lower minor version than the one it is currently running, and displays an error banner. This block applies to
+user-initiated downgrades; a downgrade that occurs as part of a cluster profile rollback is exempt. Before upgrading,
+review the [Kubernetes Upgrades](../../integrations/kubernetes-support.md#kubernetes-upgrades) section.
 
 :::
 
@@ -37,8 +38,13 @@ upgrading, you review the information provided in the
   instead. For more information about creating an Edge cluster, refer to
   [Create Cluster Definition](../edge/site-deployment/cluster-deployment.md).
 
-- Avoid skipping minor versions when upgrading the Kubernetes version of a cluster. Refer to the documentation of your
-  Kubernetes distribution for upgrade guidance and follow the recommended upgrade paths.
+- You cannot skip minor versions when upgrading the Kubernetes version of a cluster. Palette prevents a Kubernetes
+  upgrade that skips one or more minor versions. If you attempt a multi-minor upgrade in the review-changes editor,
+  Palette disables the **Update** button and displays a banner. Upgrade one minor version at a time instead. For more
+  information, refer to the [Kubernetes Upgrades](../../integrations/kubernetes-support.md#kubernetes-upgrades) section.
+  This restriction applies to all Kubernetes distributions, but it does not apply to imported (brownfield) clusters,
+  whose Kubernetes lifecycle Palette does not manage. For distribution-specific upgrade guidance, refer to the
+  documentation of your Kubernetes distribution.
 
   - For PXK and PXK-E, refer to
     [Upgrade Kubeadm Clusters](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).

--- a/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
+++ b/docs/docs-content/clusters/edge/cluster-management/upgrade-behavior.md
@@ -124,6 +124,24 @@ pack, but if you want to use a different storage pack altogether, we recommend y
 
 :::
 
+## Kubernetes Minor Version Upgrades
+
+Edge clusters follow the same sequential Kubernetes upgrade rules as management-plane clusters. Palette blocks a
+control-plane upgrade that skips one or more Kubernetes minor versions. After a cluster successfully upgrades, Palette
+also blocks a downgrade to a minor version lower than the one the cluster runs. These blocks apply to all Edge
+Kubernetes distributions, and you cannot override them. For the full behavior and the exact messages that Palette
+displays, refer to the [Kubernetes Upgrades](../../../integrations/kubernetes-support.md#kubernetes-upgrades) section.
+
+How Palette applies the block depends on how you manage the cluster.
+
+- For connected (centrally managed) Edge clusters, the management plane validates both interactive and scheduled or
+  cluster-template updates before it pushes the updated profile down to the Edge host. Palette refuses an upgrade that
+  skips a minor version before the cluster advances.
+
+- For locally managed Edge clusters, the Edge host manager validates interactive updates in the Edge Local UI. It
+  rejects an upgrade that skips a minor version and blocks the update action. For more information, refer to
+  [Update Local Cluster](../local-ui/cluster-management/update-cluster.md).
+
 ## Decoupled Control Plane and Worker Node Upgrades
 
 Connected (centrally managed) Edge Native clusters support upgrading the control plane independently from worker pools.

--- a/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
+++ b/docs/docs-content/clusters/edge/local-ui/cluster-management/update-cluster.md
@@ -30,6 +30,23 @@ content bundle from the [Content](./upload-content-bundle.md) page and redeploy 
 
 ## Update Local Cluster
 
+:::warning
+
+Palette enforces sequential Kubernetes minor version upgrades on locally managed Edge clusters, in both connected and
+air-gapped modes. If the cluster profile version you upload skips one or more Kubernetes minor versions, the Edge host
+manager rejects the update, and you cannot select **Confirm Changes** or **Update**. Upgrade one minor version at a time
+instead. Palette displays the following message.
+
+> Kubernetes upgrades across multiple minor versions are not supported. Please update your cluster profile to
+> sequentially upgrade the Kubernetes pack across each minor version.
+
+Similarly, after the cluster successfully upgrades to a new Kubernetes minor version, the Edge host manager rejects an
+update that downgrades it to a lower minor version than the one it runs today, unless the downgrade is part of a cluster
+profile rollback. For more information, refer to the
+[Kubernetes Upgrades](../../../../integrations/kubernetes-support.md#kubernetes-upgrades) section.
+
+:::
+
 1. Log into Local UI by visiting the 5080 port of your Edge device's IP address or domain name. For more information,
    refer to [Access Local UI](../host-management/access-console.md).
 

--- a/docs/docs-content/integrations/kubernetes-support.md
+++ b/docs/docs-content/integrations/kubernetes-support.md
@@ -62,18 +62,58 @@ about our deprecation process in the [Pack Deprecation](./maintenance-policy.md#
 
 ## Kubernetes Upgrades
 
-:::warning
+Kubernetes supports sequential minor version upgrades only, one minor version at a time. For example, if you are using
+Kubernetes version 1.30, you upgrade to 1.31 before upgrading to 1.32. Skipping a minor version leaves control-plane
+components in an inconsistent, often unrecoverable state. You can learn more about the official Kubernetes upgrade
+guidelines on the [Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/) page.
 
-Once you upgrade your cluster to a new Kubernetes version, you will not be able to downgrade. We recommend that, before
-upgrading, you review the information provided in this section.
+To protect your clusters, Palette enforces this sequential upgrade path. The restrictions described in this section
+apply uniformly to all Kubernetes distributions, including CNCF Kubernetes, PXK, PXK-E, K3s, RKE2, MicroK8s, and
+cloud-managed distributions such as Amazon EKS, Azure AKS, and Google GKE, with no per-distribution exceptions. The
+restrictions apply to both management-plane clusters, which you manage through the Palette UI, API, or Terraform, and
+Edge clusters, which you manage through the Edge Local UI in both connected and air-gapped modes.
+
+### Palette Blocks Multi-Minor Upgrades
+
+Palette blocks any Kubernetes upgrade that skips one or more minor versions. For example, an upgrade from 1.30 to 1.32
+is not allowed. To reach 1.32 from 1.30, upgrade one minor version at a time, first to 1.31 and then to 1.32. Changes
+within the same minor version, such as a patch upgrade from 1.30.4 to 1.30.8, remain allowed.
+
+When you attempt a multi-minor upgrade, Palette disables the update action in the review editor and displays the
+following message.
+
+> Kubernetes upgrades across multiple minor versions are not supported. Please update your cluster profile to
+> sequentially upgrade the Kubernetes pack across each minor version.
+
+Palette enforces this restriction on the server, so it applies across every upgrade path, including the Palette UI, the
+API, Terraform and Crossplane (where the block surfaces as a plan or apply diagnostic), and scheduled or
+cluster-template updates. Palette refuses a scheduled or template-driven update that skips a minor version and does not
+advance the cluster.
+
+### Palette Blocks Downgrades After an Upgrade
+
+After a cluster successfully upgrades to a new Kubernetes minor version, Palette blocks any attempt to downgrade it to a
+minor version lower than the one it is currently running. When you attempt such a downgrade, Palette displays the
+following message.
+
+> Kubernetes downgrades are not supported after a successful upgrade. Please update your cluster profile to a Kubernetes
+> version equal to or newer than the currently running version.
+
+This block applies only to reverting a Kubernetes version that the cluster has already successfully reached. Deploying a
+lower Kubernetes minor version to a cluster that has not already upgraded to a higher one is not affected.
+
+:::info
+
+A Kubernetes downgrade that occurs as part of a cluster profile rollback, such as restoring an earlier cluster profile
+version or revision, is exempt from this block. The block applies to a user-initiated downgrade, not to a profile
+rollback or revision restore.
 
 :::
 
-The official guidelines for Kubernetes upgrades recommend upgrading one minor version at a time. For example, if you are
-using Kubernetes version 1.26, you should upgrade to 1.27, before upgrading to version 1.28. You can learn more about
-the official Kubernetes upgrade guidelines in the
-[Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/) page. We recommend following the official
-guidelines for all Kubernetes upgrades, including PXK and PXK-E.
+### Imported Clusters
+
+The multi-minor upgrade block and the downgrade block do not apply to imported (brownfield) clusters. Palette does not
+manage the Kubernetes lifecycle of imported clusters, so it does not enforce these restrictions on them.
 
 :::tip
 

--- a/docs/docs-content/profiles/cluster-profiles/modify-cluster-profiles/update-cluster-profile.md
+++ b/docs/docs-content/profiles/cluster-profiles/modify-cluster-profiles/update-cluster-profile.md
@@ -235,9 +235,15 @@ Ensure you follow these practices when updating to a new pack version.
 - You should not copy the pack configuration from one version to another, as the newer version often contains
   customizations. Instead, you should integrate your changes manually in the new version. Use the **Keep** button to
   copy the lines from the current configuration to the new version.
-- Update to a newer Kubernetes version incrementally, one minor version at a time.
+- Update to a newer Kubernetes version incrementally, one minor version at a time. Palette prevents an upgrade of the
+  Kubernetes pack that skips one or more minor versions. When you review the changes, Palette disables **Apply Changes /
+  Update** and displays a banner if the update would skip a minor version.
 - Select a specific target version instead of a group that ends in `.x`
-- We do not recommend downgrading packs to the previous version.
+- We do not recommend downgrading packs to the previous version. For the Kubernetes pack specifically, after a cluster
+  successfully upgrades to a new Kubernetes minor version, Palette blocks a downgrade to a lower minor version than the
+  one the cluster is currently running. This block does not apply to a downgrade that occurs as part of a cluster
+  profile rollback. For more information, refer to the
+  [Kubernetes Upgrades](../../../integrations/kubernetes-support.md#kubernetes-upgrades) section.
 
 :::
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,21 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+{/* PROVISIONAL ENTRY. The release date and version below are placeholders pending the PE-9338 target release (Solution Design Open Question 5). Move this entry under the correct release heading, or regenerate it with `make generate-release-notes`, at release cut. */}
+
+## TBD, 2026 - Release TBD
+
+### Improvements
+
+<!-- https://spectrocloud.atlassian.net/browse/PE-9338 -->
+
+- Palette now enforces sequential Kubernetes minor version upgrades. Palette blocks an upgrade that skips one or more
+  Kubernetes minor versions, and after a cluster successfully upgrades, it blocks a downgrade to a minor version lower
+  than the one the cluster runs. The restrictions apply to management-plane and Edge clusters, in both connected and
+  air-gapped modes, across all Kubernetes distributions. Imported clusters are exempt, and a downgrade performed as part
+  of a cluster profile rollback is exempt. Refer to
+  [Kubernetes Upgrades](../integrations/kubernetes-support.md#kubernetes-upgrades) for more information.
+
 ## August 27, 2026 - Release 4.9.52
 
 <!-- PATCH RELEASE TICKET: DOC-3162 -->


### PR DESCRIPTION
Closes spectrocloud/librarium#11850

Parent: spectrocloud/luma#168 · JIRA: [PE-9338](https://spectrocloud.atlassian.net/browse/PE-9338)

## Summary

Palette now enforces sequential Kubernetes minor version upgrades platform-wide. This PR documents the two enforced, server-side blocks and their exact user-facing banners:

- **Multi-minor upgrade block** — an upgrade that skips one or more minor versions (for example 1.30 → 1.32) is refused.
- **Downgrade-after-successful-upgrade block** — after a cluster successfully upgrades, downgrading it below the minor version it is currently running is refused. General/fresh lower-version deploys are **not** affected, and a downgrade performed as part of a **cluster profile rollback / revision restore is exempt**.

Scope documented: uniform `+1` rule across **all distros** (PXK/kubeadm, PXK-E, k3s, rke2, MicroK8s/ck8s, cloud-managed EKS/AKS/GKE); **imported/brownfield clusters exempt**; management plane (UI/API/Terraform, where Terraform/Crossplane surface it as a plan/apply diagnostic) **and** Edge (connected **and** air-gapped); interactive **and** scheduled/cluster-template paths.

## Files changed (canonical page + consistent cross-linked edits)

| Page | Change |
|------|--------|
| `integrations/kubernetes-support.md` | Canonical **Kubernetes Upgrades** section rewritten: enforced sequential path, multi-minor block + verbatim banner, downgrade-after-upgrade block + verbatim banner + rollback exemption, imported-cluster exemption, all-distro/all-path scope. |
| `clusters/cluster-management/cluster-updates.md` | Limitations bullet → enforced block + disabled **Update** button; downgrade warning → enforced downgrade-after-upgrade + rollback exemption. |
| `profiles/.../update-cluster-profile.md` | Update-the-Pack-Version warning → enforced single-minor + review-editor disable + downgrade note for the k8s pack. |
| `clusters/edge/local-ui/cluster-management/update-cluster.md` | Local UI update flow: multi-minor and downgrade rejected by the Edge host manager, **connected and air-gapped** (`.tgz` upload = GEHC repro). |
| `clusters/edge/cluster-management/upgrade-behavior.md` | New **Kubernetes Minor Version Upgrades** section: control-plane block, connected (central) vs locally managed (edge-manager) validation. |
| `cluster-templates/modify-cluster-templates.md` | Scheduled/template multi-minor update refused server-side. |
| `release-notes/release-notes.md` | Provisional PE-9338 entry with JIRA marker + docs cross-link (see note below). |

## Verbatim banner copy (not paraphrased)

- Multi-minor (SD §9.1, verbatim): *"Kubernetes upgrades across multiple minor versions are not supported. Please update your cluster profile to sequentially upgrade the Kubernetes pack across each minor version."*
- Downgrade (`api-contracts.md` finalized 2026-09-01, verbatim): *"Kubernetes downgrades are not supported after a successful upgrade. Please update your cluster profile to a Kubernetes version equal to or newer than the currently running version."*

## Notes for reviewers

- **Release-notes entry is provisional.** The target release is TBD (SD Open Question 5) and the feature must ship first. The entry sits under a `## TBD, 2026 - Release TBD` heading with a `{/* PROVISIONAL … */}` marker; move it under the correct release heading (or regenerate via `make generate-release-notes`) at release cut. It does not modify any already-shipped release section.
- **Rollback exemption** is documented per the epic direction (SD §12 Q18 tracked it as open; the orchestrated feature spec confirms rollback/revision-restore downgrades are exempt while user-initiated downgrades are blocked).
- **Airgap downgrade** is documented because `api-contracts.md` Contract 2 resolves SD R-1 (stylus derives the last-successfully-reconciled version live from the local kubelet — airgap-safe).

## Definition of Done

- [x] **Branch `PE-9338` created off `master`.** Commit `4faf027c` on branch `PE-9338`; base `master`.
- [x] **Docs build / MDX + internal-link integrity.** Full Docusaurus (3.9.2) client+server bundle **compiled with no MDX errors** across all pages, including every changed page. The build then ran `onBrokenLinks:"throw"` / `onBrokenAnchors:"throw"`. In this sandbox the only hard failure was broken links, and **every** broken link targets an ungenerated `/api/*` reference page (the API-docs pipeline needs network/specs not present here) — **none originate from a PE-9338 edit**. Independent link check: **all 8 internal links added by this PR resolve to existing files and the `#kubernetes-upgrades` anchor exists (0 problems).** Authoritative full build = the **Netlify deploy preview** on this PR (has Algolia keys + generated API/packs/CVE content) — please confirm it renders the changed pages.
- [x] **BDD / edge automated test gates — N/A.** librarium is a static docs site with no application code paths exercised by BDD/edge suites. The substance (edge upgrade+downgrade for connected and airgap) is satisfied by content — see the next box.
- [x] **Edge upgrade + downgrade documented for BOTH connected and airgap.** `update-cluster.md` (Local UI incl. airgap `.tgz` upload = GEHC repro) and `upgrade-behavior.md` (connected central-plane validation vs interactive edge-manager) both state the multi-minor block; downgrade documented for edge incl. airgap (R-1 resolved via live-kubelet derivation).
- [x] **No broken links / MDX errors.** See build box. `verify-url-links` (external URLs): **no new external URLs added** — the only external link in the diff (`kubernetes.io/releases/version-skew-policy`) pre-existed; nothing new for linkinator to fail.
- [x] **Lint/style pass, no NEW warnings.** Vale 3.19.0 (Google + write-good + alex + spectrocloud-docs-internal) on added lines: **0 errors**. The 2 remaining warnings are `write-good.TooWordy: 'multiple'` occurring **inside the verbatim UI banner quote** ("across multiple minor versions…"), which must not be altered. Prettier (`--check`, proseWrap always / 120): **clean on all 7 files**.
- [x] **All applicable distros covered** on `kubernetes-support.md`: PXK (kubeadm/CNCF), PXK-E, k3s, rke2, MicroK8s/ck8s, and cloud-managed EKS/AKS/GKE — uniform `+1`, no per-distro carve-outs.
- [x] **Imported/brownfield exemption documented** on `kubernetes-support.md` and `cluster-updates.md`.
- [x] **Release-notes entry added** — dated (provisional) entry in `release-notes.md` with the `<!-- …/PE-9338 -->` marker and a docs cross-link; see provisional note above.
- [x] **User-facing error messages accurate.** Multi-minor quoted verbatim from SD §9.1; downgrade quoted verbatim from the finalized `api-contracts.md` copy (2026-09-01). Neither invented/paraphrased.
- [x] **Downgrade rule not overstated.** Only post-successful-upgrade reversal is described as blocked; general/fresh lower-version deploys are explicitly not affected; rollback exempt.
- [x] **PR opened against `master`** with this DoD checklist + evidence. CI (Vale, Prettier, build, link check) and the Netlify deploy preview to be confirmed green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PE-9338]: https://spectrocloud.atlassian.net/browse/PE-9338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ