### PR TITLE
DOC-3179 - Patch release notes for 4.9.53

### DIFF
--- a/docs/docs-content/automation/palette-cli/install-palette-cli.md
+++ b/docs/docs-content/automation/palette-cli/install-palette-cli.md
@@ -68,7 +68,7 @@ palette version
 <!-- palette-cli-version-output -->
 
 ```shell hideClipboard
-Palette CLI version: 4.9.19
+Palette CLI version: 4.9.21
 ```
 
 ## Next Steps

--- a/docs/docs-content/clusters/edge/edge-compatibility-matrix.md
+++ b/docs/docs-content/clusters/edge/edge-compatibility-matrix.md
@@ -23,6 +23,7 @@ CanvOS, Stylus, and the Edge host version refer to the same Edge host software r
 
 | Palette Release                    | CanvOS / Stylus / Edge Host Version | Palette CLI Version | Palette Edge CLI Status                              |
 | ---------------------------------- | ----------------------------------- | ------------------- | ---------------------------------------------------- |
+| <!-- edge-compat-4.9.53 --> 4.9.53 | 4.9.39                              | 4.9.21              | Deprecated. Use Palette CLI for supported workflows. |
 | <!-- edge-compat-4.9.51 --> 4.9.51 | 4.9.39                              | 4.9.19              | Deprecated. Use Palette CLI for supported workflows. |
 | <!-- edge-compat-4.9.48 --> 4.9.48 | 4.9.38                              | 4.9.19              | Deprecated. Use Palette CLI for supported workflows. |
 | <!-- edge-compat-4.9.46 --> 4.9.46 | 4.9.37                              | 4.9.19              | Deprecated. Use Palette CLI for supported workflows. |

--- a/docs/docs-content/downloads/cli-tools.md
+++ b/docs/docs-content/downloads/cli-tools.md
@@ -27,6 +27,7 @@ The Palette CLI is supported on Linux operating systems running on AMD64 (x86_64
 
 | Palette Release <!-- palette-cli-version-table --> | Recommended CLI Version          | Download URL                                                            | Checksum (SHA256)                                                  |
 | -------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| <!-- cli-4.9.53 --> 4.9.53                         | 4.9.21                           | https://software.spectrocloud.com/palette-cli/v4.9.21/linux/cli/palette | `ad6e3e6b86db3aefa73a32f2bbbd89e8db70dcfca6b105e3db30844440d13154` |
 | <!-- cli-4.9.46 --> 4.9.46                         | 4.9.19                           | https://software.spectrocloud.com/palette-cli/v4.9.19/linux/cli/palette | `472aa53dc5dd2a7161aff367415e08b75a2efd666a900bef95315804b4103132` |
 | <!-- cli-4.9.43 --> 4.9.43                         | 4.9.18                           | https://software.spectrocloud.com/palette-cli/v4.9.18/linux/cli/palette | `999819c7520d14f4a7ff20a569d979b9aa1b9c2da30ba40a21b7cb1c6733231c` |
 | <!-- cli-4.9.c --> 4.9.38                          | 4.9.16                           | https://software.spectrocloud.com/palette-cli/v4.9.16/linux/cli/palette | `7032e347e97df641c22c5c30ad3ec94614380d28e546b80f94fb747a33ac9b48` |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,30 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## September 2, 2026 - Release 4.9.x
+
+<!-- PATCH RELEASE TICKET: DOC-3179 -->
+<!-- PATCH RELEASE VERSION: 4.9.x -->
+
+### Breaking Changes {#breaking-changes-4-9-x}
+
+<!-- https://spectrocloud.atlassian.net/browse/PEM-11891 -->
+
+- The `GET /v1/spectroclusters/{uid}/assets/manifest` [Palette API](/api/introduction/) endpoint is now restricted to
+  the Palette cluster management agent. Requests made with a user access token or an API key return a forbidden
+  response. The cluster asset manifest contains sensitive material, such as the admin kubeconfig, certificates, and
+  secrets, that only the agent requires for cluster management operations. Update any automation that retrieves the
+  cluster asset manifest with a user access token or an API key.
+
+### Bug Fixes
+
+<!-- https://spectrocloud.atlassian.net/browse/PEM-11891 -->
+
+- Fixed an issue where the cluster asset manifest endpoint authorized requests against the `cluster.get` permission
+  alone. As a result, users with read-only cluster access, such as those assigned the
+  [Cluster Viewer](../user-management/palette-rbac/project-scope-roles-permissions.md) role, could retrieve sensitive
+  cluster material that their role otherwise denies them.
+
 ## August 27, 2026 - Release 4.9.52
 
 <!-- PATCH RELEASE TICKET: DOC-3162 -->

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,12 +11,12 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
-## September 2, 2026 - Release 4.9.x
+## September 3, 2026 - Release 4.9.53
 
 <!-- PATCH RELEASE TICKET: DOC-3179 -->
-<!-- PATCH RELEASE VERSION: 4.9.x -->
+<!-- PATCH RELEASE VERSION: 4.9.53 -->
 
-### Breaking Changes {#breaking-changes-4-9-x}
+### Breaking Changes {#breaking-changes-4-9-53}
 
 <!-- https://spectrocloud.atlassian.net/browse/PEM-11891 -->
 
@@ -34,6 +34,22 @@ tags: ["release-notes"]
   alone. As a result, users with read-only cluster access, such as those assigned the
   [Cluster Viewer](../user-management/palette-rbac/project-scope-roles-permissions.md) role, could retrieve sensitive
   cluster material that their role otherwise denies them.
+
+<!-- https://spectrocloud.atlassian.net/browse/PLT-2346 -->
+
+- Fixed an issue where the Palette CLI generated a cert-manager manifest with empty image tags and a malformed container
+  argument. As a result, [Private Cloud Gateway (PCG)](../clusters/pcg/pcg.md) installation failed during the bootstrap
+  phase with the error
+  `cannot unmarshal object into Go struct field Container.spec.template.spec.containers.args of type string`.
+
+### Automation
+
+:::info
+
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.53 Palette release is
+4.9.21. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+
+:::
 
 ## August 27, 2026 - Release 4.9.52
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Adds the 4.9.53 patch release notes and the component version updates that ship with them.

Two fixes are covered. The cluster asset manifest endpoint is now restricted to the Palette cluster management agent, documented as both a **Breaking Change** (automation using a user access token or API key now gets a forbidden response) and a **Bug Fix** (the endpoint previously authorized against `cluster.get` alone, exposing sensitive cluster material to read-only roles). Separately, the Palette CLI generated a cert-manager manifest with empty image tags and a malformed container argument, which broke PCG installation during bootstrap.

The version and date are now confirmed — 4.9.53, September 3, 2026 — replacing the earlier `4.9.x` placeholder in the heading, the anchor, and the `PATCH RELEASE VERSION` marker.

**Component versions**, read from `nickfury/release/spectro_versions.txt` at the final `v4.9.53` tag:

| Component | At v4.9.53 | Last documented | Outcome |
| --- | --- | --- | --- |
| CanvOS / Stylus | 4.9.39 | 4.9.39 (at 4.9.51) | Unchanged — no Edge section, per the "only document what moved" rule |
| Palette CLI | 4.9.21 | 4.9.19 (at 4.9.46) | Moved — Automation callout, matrix row, CLI Tools row, install page |

The CLI moving is consistent with the second fix being a CLI defect. The matrix row is written even though CanvOS held steady, because the row records both components.

Two things worth a reviewer's attention:

- **The CLI checksum was derived by streaming the published binary**, not taken from ReTool. It is worth a cross-check against ReTool before merge, since a wrong checksum is worse than no row. The binary itself is confirmed published (HTTP 200).
- The Edge Compatibility Matrix, CLI Tools, and install page edits were produced by running the repo's own generator scripts with the resolved versions passed in, rather than by hand, so the table format and insert-or-replace behaviour match `make generate-release`.

Not included: given the nature of the access-control exposure, a security advisories entry may also be warranted. That needs the security team's draft as input, so it is not in this PR.

---

## 💻 Changed Pages

- [Release Notes](https://deploy-preview-11852--docs-spectrocloud.netlify.app/release-notes/#september-3-2026---release-4953) — new 4.9.53 section ([Breaking Changes](https://deploy-preview-11852--docs-spectrocloud.netlify.app/release-notes/#breaking-changes-4-9-53))
- [Edge Compatibility Matrix](https://deploy-preview-11852--docs-spectrocloud.netlify.app/clusters/edge/edge-compatibility-matrix/#compatibility-matrix) — new 4.9.53 row
- [CLI Tools](https://deploy-preview-11852--docs-spectrocloud.netlify.app/downloads/cli-tools/#palette-cli) — new 4.9.53 row with download URL and checksum
- [Install Palette CLI](https://deploy-preview-11852--docs-spectrocloud.netlify.app/automation/palette-cli/install-palette-cli/#validate) — version output updated to 4.9.21

---

## 🎫 Jira Tickets

[DOC-3179](https://spectrocloud.atlassian.net/browse/DOC-3179)

Source engineering tickets: PEM 11891 and PLT 2346. The release notes wording for PEM 11891 was reviewed and approved on the ticket by the engineering owner.

_Related Jira keys are written unhyphenated and unlinked on purpose. The merge automation scans this body for issue keys and resolves every one it finds, including keys inside a `browse/<KEY>` URL, so only the ticket this PR resolves is linked._


[DOC-3179]: https://spectrocloud.atlassian.net/browse/DOC-3179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ