### PR TITLE
[version-4-9] DOC-3179 - Patch release notes for 4.9.53 (#11852)

### DIFF
--- a/docs/docs-content/automation/palette-cli/install-palette-cli.md
+++ b/docs/docs-content/automation/palette-cli/install-palette-cli.md
@@ -68,7 +68,7 @@ palette version
 <!-- palette-cli-version-output -->
 
 ```shell hideClipboard
-Palette CLI version: 4.9.19
+Palette CLI version: 4.9.21
 ```
 
 ## Next Steps

--- a/docs/docs-content/clusters/edge/edge-compatibility-matrix.md
+++ b/docs/docs-content/clusters/edge/edge-compatibility-matrix.md
@@ -23,6 +23,7 @@ CanvOS, Stylus, and the Edge host version refer to the same Edge host software r
 
 | Palette Release                    | CanvOS / Stylus / Edge Host Version | Palette CLI Version | Palette Edge CLI Status                              |
 | ---------------------------------- | ----------------------------------- | ------------------- | ---------------------------------------------------- |
+| <!-- edge-compat-4.9.53 --> 4.9.53 | 4.9.39                              | 4.9.21              | Deprecated. Use Palette CLI for supported workflows. |
 | <!-- edge-compat-4.9.51 --> 4.9.51 | 4.9.39                              | 4.9.19              | Deprecated. Use Palette CLI for supported workflows. |
 | <!-- edge-compat-4.9.48 --> 4.9.48 | 4.9.38                              | 4.9.19              | Deprecated. Use Palette CLI for supported workflows. |
 | <!-- edge-compat-4.9.46 --> 4.9.46 | 4.9.37                              | 4.9.19              | Deprecated. Use Palette CLI for supported workflows. |

--- a/docs/docs-content/downloads/cli-tools.md
+++ b/docs/docs-content/downloads/cli-tools.md
@@ -27,6 +27,7 @@ The Palette CLI is supported on Linux operating systems running on AMD64 (x86_64
 
 | Palette Release <!-- palette-cli-version-table --> | Recommended CLI Version          | Download URL                                                            | Checksum (SHA256)                                                  |
 | -------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| <!-- cli-4.9.53 --> 4.9.53                         | 4.9.21                           | https://software.spectrocloud.com/palette-cli/v4.9.21/linux/cli/palette | `ad6e3e6b86db3aefa73a32f2bbbd89e8db70dcfca6b105e3db30844440d13154` |
 | <!-- cli-4.9.46 --> 4.9.46                         | 4.9.19                           | https://software.spectrocloud.com/palette-cli/v4.9.19/linux/cli/palette | `472aa53dc5dd2a7161aff367415e08b75a2efd666a900bef95315804b4103132` |
 | <!-- cli-4.9.43 --> 4.9.43                         | 4.9.18                           | https://software.spectrocloud.com/palette-cli/v4.9.18/linux/cli/palette | `999819c7520d14f4a7ff20a569d979b9aa1b9c2da30ba40a21b7cb1c6733231c` |
 | <!-- cli-4.9.c --> 4.9.38                          | 4.9.16                           | https://software.spectrocloud.com/palette-cli/v4.9.16/linux/cli/palette | `7032e347e97df641c22c5c30ad3ec94614380d28e546b80f94fb747a33ac9b48` |

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,46 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## September 3, 2026 - Release 4.9.53
+
+<!-- PATCH RELEASE TICKET: DOC-3179 -->
+<!-- PATCH RELEASE VERSION: 4.9.53 -->
+
+### Breaking Changes {#breaking-changes-4-9-53}
+
+<!-- https://spectrocloud.atlassian.net/browse/PEM-11891 -->
+
+- The `GET /v1/spectroclusters/{uid}/assets/manifest` [Palette API](/api/introduction/) endpoint is now restricted to
+  the Palette cluster management agent. Requests made with a user access token or an API key return a forbidden
+  response. The cluster asset manifest contains sensitive material, such as the admin kubeconfig, certificates, and
+  secrets, that only the agent requires for cluster management operations. Update any automation that retrieves the
+  cluster asset manifest with a user access token or an API key.
+
+### Bug Fixes
+
+<!-- https://spectrocloud.atlassian.net/browse/PEM-11891 -->
+
+- Fixed an issue where the cluster asset manifest endpoint authorized requests against the `cluster.get` permission
+  alone. As a result, users with read-only cluster access, such as those assigned the
+  [Cluster Viewer](../user-management/palette-rbac/project-scope-roles-permissions.md) role, could retrieve sensitive
+  cluster material that their role otherwise denies them.
+
+<!-- https://spectrocloud.atlassian.net/browse/PLT-2346 -->
+
+- Fixed an issue where the Palette CLI generated a cert-manager manifest with empty image tags and a malformed container
+  argument. As a result, [Private Cloud Gateway (PCG)](../clusters/pcg/pcg.md) installation failed during the bootstrap
+  phase with the error
+  `cannot unmarshal object into Go struct field Container.spec.template.spec.containers.args of type string`.
+
+### Automation
+
+:::info
+
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.9.53 Palette release is
+4.9.21. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+
+:::
+
 ## August 28, 2026 - Component Updates {#component-updates-2026-35}
 
 <!-- COMPONENT UPDATES TICKET: DOC-3139 -->

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -309,8 +309,6 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 <!-- END PACKS LIST BODY: DOC-3115. DO NOT DELETE. -->
 
-#### Pack Notes
-
 ## August 17, 2026 - Release 4.9.46
 
 <!-- PATCH RELEASE TICKET: DOC-3113 -->

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -102,8 +102,6 @@ The following components have been updated for Palette version 4.9.5 - 4.9.52.
 
 <!-- END PACKS LIST BODY: DOC-3139. DO NOT DELETE. -->
 
-#### Pack Notes
-
 ## August 27, 2026 - Release 4.9.52
 
 <!-- PATCH RELEASE TICKET: DOC-3162 -->


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-9`:
 - [DOC-3179 - Patch release notes for 4.9.53 (#11852)](https://github.com/spectrocloud/librarium/pull/11852)

Raised by hand because the auto-backport bot hit a merge conflict.

**Conflict and resolution.** Both sides add a section immediately after `<ReleaseNotesVersions />`: this branch has `## August 28, 2026 - Component Updates` (week 35), which `master` does not, and the backport adds `## September 3, 2026 - Release 4.9.53`. Both were kept, newest first, matching the page's reverse-chronological order. The cherry-picked commit reproduces the source commit exactly — `43 insertions(+), 1 deletion(-)`, adding one H2 and removing none — with the single deletion being the intended Palette CLI `4.9.19` to `4.9.21` bump on the install page.

**Follow-up commits.** Two further commits remove empty `#### Pack Notes` headings — one in the August 28 section (week 35), one in the August 21 section (week 34). Both had no content under them. A scan of the whole page confirms these were the only two empty instances; the other six all have content and are untouched. The branch total against `version-4-9` is therefore `43 insertions(+), 5 deletions(-)`, the deletions being those two headings and the intended Palette CLI version bump.

Worth noting separately: week 35 is missing from `master` because an unrelated PR removed it there after it had already been backported here. #11858 restores it, and drops the same empty heading.

<!--- Backport version: manual -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
