### PR TITLE
docs: restore August 28 component updates removed in error

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -309,8 +309,6 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 <!-- END PACKS LIST BODY: DOC-3115. DO NOT DELETE. -->
 
-#### Pack Notes
-
 ## August 17, 2026 - Release 4.9.46
 
 <!-- PATCH RELEASE TICKET: DOC-3113 -->

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -51,6 +51,57 @@ The [Palette CLI](../automation/palette-cli/palette-cli.md) version correspondin
 
 :::
 
+## August 28, 2026 - Component Updates {#component-updates-2026-35}
+
+<!-- COMPONENT UPDATES TICKET: DOC-3139 -->
+<!-- RELEASE DATE: August 28, 2026 -->
+<!-- RELEASE MANAGEMENT APPLIANCE: 4.9.51 -->
+<!-- RELEASE ARTIFACT STUDIO: 4.9.22 -->
+<!-- RELEASE TERRAFORM VERSION: NA -->
+
+The following components have been updated for Palette version 4.9.5 - 4.9.52.
+
+| Component                                                                                             | Version |
+| ----------------------------------------------------------------------------------------------------- | ------- |
+| [Artifact Studio](../downloads/artifact-studio.md)                                                    | 4.9.22  |
+| [Palette Management Appliance](../enterprise-version/install-palette/palette-management-appliance.md) | 4.9.51  |
+| [VerteX Management Appliance](../vertex/install-palette-vertex/vertex-management-appliance.md)        | 4.9.51  |
+
+<!-- BEGIN COMPONENT UPDATES BODY: DOC-3139. DO NOT DELETE. -->
+
+### Improvements
+
+<!-- https://spectrocloud.atlassian.net/browse/PCOM-995 -->
+
+- Artifact Studio now publishes downloadable model metadata for all verified PaletteAI Inference Launchpad models,
+  enabling users to download unified GPU-vendor metadata directly from the Show Artifacts view.
+
+<!-- END COMPONENT UPDATES BODY: DOC-3139. DO NOT DELETE. -->
+
+### Packs
+
+<!-- BEGIN PACKS LIST BODY: DOC-3139. DO NOT DELETE. -->
+<!-- prettier-ignore-start -->
+
+| Pack Name | Layer | Non-FIPS | FIPS | New Version |
+| --------- | ----- | -------- | ---- | ----------- |
+| <VersionedLink text="argo-cd" url="/integrations/packs/?pack=argo-cd" /> | `addon` | :white_check_mark: | :x: | 10.4.0 |
+| <VersionedLink text="cni-aws-vpc-eks-helm" url="/integrations/packs/?pack=cni-aws-vpc-eks-helm" /> | `cni` | :x: | :white_check_mark: | 1.22.3 |
+| <VersionedLink text="csi-azure" url="/integrations/packs/?pack=csi-azure" /> | `csi` | :x: | :white_check_mark: | 1.34.5 |
+| <VersionedLink text="csi-local-path-provisioner" url="/integrations/packs/?pack=csi-local-path-provisioner" /> | `csi` | :x: | :white_check_mark: | 0.0.37 |
+| <VersionedLink text="csi-local-path-provisioner-addon" url="/integrations/packs/?pack=csi-local-path-provisioner-addon" /> | `addon` | :x: | :white_check_mark: | 0.0.37 |
+| <VersionedLink text="csi-longhorn" url="/integrations/packs/?pack=csi-longhorn" /> | `csi` | :x: | :white_check_mark: | 1.11.2 |
+| <VersionedLink text="csi-longhorn-addon" url="/integrations/packs/?pack=csi-longhorn-addon" /> | `addon` | :x: | :white_check_mark: | 1.11.2 |
+| <VersionedLink text="piraeus-operator" url="/integrations/packs/?pack=piraeus-operator" /> | `csi` | :white_check_mark: | :white_check_mark: | 2.11.0 |
+| <VersionedLink text="piraeus-operator-addon" url="/integrations/packs/?pack=piraeus-operator-addon" /> | `addon` | :white_check_mark: | :white_check_mark: | 2.11.0 |
+| <VersionedLink text="prometheus-agent" url="/integrations/packs/?pack=prometheus-agent" /> | `addon` | :white_check_mark: | :x: | 29.27.0 |
+| <VersionedLink text="prometheus-operator" url="/integrations/packs/?pack=prometheus-operator" /> | `addon` | :white_check_mark: | :x: | 88.5.4 |
+| <VersionedLink text="zot-registry" url="/integrations/packs/?pack=zot-registry" /> | `addon` | :white_check_mark: | :white_check_mark: | 0.1.122 |
+
+<!-- prettier-ignore-end -->
+
+<!-- END PACKS LIST BODY: DOC-3139. DO NOT DELETE. -->
+
 ## August 27, 2026 - Release 4.9.52
 
 <!-- PATCH RELEASE TICKET: DOC-3162 -->


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Restores the `August 28, 2026 - Component Updates` section (week 35), which was published to `master` and then deleted in error eight hours later.

| When | PR | Effect |
| --- | --- | --- |
| Aug 28, 16:16 UTC | #11813 → `master` | Added the section |
| Aug 28, 16:31 UTC | #11814 → `version-4-9` | Backported it (this copy survives) |
| Aug 29, 00:23 UTC | #11781 → `master` | **Removed it** — `-53/+0` on this file |

#11781 was a PaletteAI Inference Launchpad release and archive cut. Its only change to `release-notes.md` was the deletion, with zero insertions, and it touched no other Palette content — so it almost certainly branched before #11813 merged and carried a stale copy of the file that silently reverted it. Confirmed unintentional.

The section content is taken verbatim from that removal commit and is **byte-identical** to the copy still live on `version-4-9`, with one deliberate exception: its empty `#### Pack Notes` heading has been dropped, since it had no content under it. It is reinserted in chronological position, between the 4.9.53 and 4.9.52 sections.

A follow-up commit removes the one other empty `#### Pack Notes` heading on the page, in the August 21 section (week 34). A scan confirms these were the only two empty instances; the other six all have content and are untouched. The diff is `+51/-2`, both deletions being those headings.

**No backport labels.** `version-4-9` already has this section — it is the copy that survived — so backporting would duplicate it. This restore is `master`-only.

**One Vale error is expected on CI** at the "Artifact Studio now publishes downloadable model metadata..." line: `Use 'inference' instead of 'Inference'`. It fires on the product name *PaletteAI Inference Launchpad*, so it is a false positive. I have left the restored text unaltered rather than corrupting a product name to satisfy the rule — this content already sat on `master` in exactly this form. The accept list may be worth updating separately.

---

## 💻 Changed Pages

- [Release Notes](https://deploy-preview-11858--docs-spectrocloud.netlify.app/release-notes/#august-28-2026---component-updates) — restored week 35 Component Updates section

---

## 🎫 Jira Tickets

No corresponding Jira ticket — this is a repair of an accidental deletion, found while backporting a separate change.

The restored section carries the original component updates ticket reference, DOC 3139, in its HTML comment markers.

_Related Jira keys are written unhyphenated and unlinked on purpose. The merge automation scans this body for issue keys and resolves every one it finds, including keys inside a `browse/<KEY>` URL._
