### PR TITLE
DOC-3181: fail Cluster Scanner job when the scanner exits non-zero

### DIFF
--- a/.github/workflows/cluster-scanner-librarium.yaml
+++ b/.github/workflows/cluster-scanner-librarium.yaml
@@ -49,7 +49,7 @@ jobs:
           PALETTE_API_KEY: ${{ env.PALETTE_API_KEY }}
           PALETTE_HOST: ${{ env.PALETTE_HOST }}
         run: |
-          set -e
+          set -euo pipefail
           go build -o cluster-scanner
           ./cluster-scanner | tee result.log
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** for all affected pages are provided in the [Changed Pages](#-changed-pages) section. _No user-facing pages change; this is a CI workflow only._
- [x] Conduct a **self-review** for your pages using your preview links. _N/A — no rendered pages; reviewed the workflow diff instead._
- [x] **Check formatting** for your pages. _N/A — workflow file only; `.yaml` is Prettier-ignored._
- [x] Ensure all **Vale comments** are resolved. _N/A — no prose changes._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _The scanner runs only from the default branch, so no backport is needed._
- [ ] **Outside review:** Not required — Docs-owned tooling.
- [x] Add the `notify-slack` label once this checklist has been completed.

---

## 📝 Describe the Change

The Cluster Scanner's **Build and Run the App** step runs the scanner binary through a pipe: `./cluster-scanner | tee result.log`. The step used `set -e` but not `pipefail`, so a non-zero exit from `cluster-scanner` was masked by `tee`'s successful exit. The step, and therefore the whole job, reported success even when the scanner failed before it could report on any clusters. A failed scan passed silently and never triggered the job's own on-failure Slack notification, so a broken scan could go unnoticed indefinitely.

This changes `set -e` to `set -euo pipefail` in that step so the scanner's exit code propagates through the pipe. A failed scan now fails the job and fires the existing failure notification, while a successful scan behaves exactly as before. The `-u` flag additionally surfaces any unset-variable mistakes in the step. Discovered while investigating DOC-3181.

---

## 💻 Changed Pages

No user-facing changes. This PR modifies a GitHub Actions workflow (`.github/workflows/cluster-scanner-librarium.yaml`) only.

---

## 🎫 Jira Tickets

[DOC-3181](https://spectrocloud.atlassian.net/browse/DOC-3181)


[DOC-3181]: https://spectrocloud.atlassian.net/browse/DOC-3181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ