### PR TITLE
docs: document the Thinking directive on the 1.0.x Tier Map

### DIFF
--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/explanation.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/explanation.md
@@ -19,3 +19,4 @@ They cover design decisions, component relationships, and trade-offs rather than
 | [Model Certification](./model-certification.md)             | What certified means, how models are certified, and how to choose models for your use case.                       |
 | [Inference Engines](./inference-engines.md)                 | What an inference engine is, automatic engine selection, the supported kinds, and when to override it.            |
 | [Installation Architecture](./installation-architecture.md) | How the appliance installs across two stages, including the roles of the jumpbox and why the network uses a bond. |
+| [The Thinking Directive](./thinking-directive.md)           | What the Thinking directive controls, why off is disabled for some models, and how a budget is interpreted.       |

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/thinking-directive.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/thinking-directive.md
@@ -1,0 +1,76 @@
+---
+sidebar_label: "The Thinking Directive"
+title: "The Thinking Directive"
+description:
+  "How the Thinking directive on the Tier Map controls reasoning depth, why the off option is disabled for some
+  providers, and how a token budget is interpreted across engines."
+hide_table_of_contents: false
+sidebar_position: 6
+tags: ["paletteai-inference-launchpad", "routing", "tier-map", "thinking", "explanation"]
+keywords: ["launchpad", "ai", "thinking", "reasoning", "budget", "tier map"]
+---
+
+The Thinking directive is a per-tier setting on the [Tier Map](../reference/glossary.md#tier-map) that tells the
+tier's resolved model how much reasoning to do before it answers. Each Tier Map row carries its own Thinking
+directive, so different tiers on the same appliance can reason at different depths.
+
+Reasoning is a hidden generation phase that a reasoning-capable model runs before it produces the visible answer. The
+hidden phase costs tokens and adds latency. Setting the Thinking directive is how a platform administrator trades that
+cost against answer quality for each tier. To perform this task, refer to
+[Set the Thinking Directive for a Tier](../how-to-guides/set-tier-thinking.md). For the exact values each mode
+carries, refer to [Thinking Directive Modes](../reference/thinking-modes.md).
+
+## How Each Mode Is Interpreted
+
+The console offers three modes: **off**, **on**, and **budget**. The tier's engine and its resolved model together
+decide what the mode does at request time.
+
+- **off** turns reasoning off. On a reasoning-capable model, the model skips the hidden phase and answers directly.
+
+- **on** turns reasoning on with no explicit budget. The model reasons at the depth its own defaults choose.
+
+- **budget** turns reasoning on with a token-budget hint. The value is a hint, not a hard cap. Refer to
+  [Budget Is a Hint, Not a Cap](#budget-is-a-hint-not-a-cap) below for what each engine family does with it.
+
+## Model-Aware Off
+
+Some frontier providers do not expose a switch that turns reasoning off. For these providers, a Thinking value of
+**off** has no meaning at the wire, so the console does not offer it. The Tier Map's Thinking selector disables
+**off** whenever the tier resolves to one of the following models.
+
+- OpenAI o-series models.
+
+- OpenAI GPT-5 family models.
+
+For a tier that resolves to one of these models, the selector offers only **on** and **budget**.
+
+## When the Engine Has No Thinking Surface
+
+Some engines have no reasoning surface at all. A small chat model that ships without a reasoning phase is the common
+case. When the tier's resolved model runs on such an engine, the appliance accepts the Thinking directive and the
+engine ignores it, because there is no phase for the directive to act on.
+
+To make this state visible, the Tier Map row renders the **Thinking** column in a grey chip that reads
+`ignored — no thinking surface`. The gateway passes the request through unchanged, so the request does not fail. The
+directive takes effect the moment a reasoning-capable model serves the tier.
+
+## Budget Is a Hint, Not a Cap
+
+The `budget:<n>` value is a hint. How each engine family treats the value is described below.
+
+- **Anthropic frontier models, version 4.6 and earlier**. The provider treats the value as a target it aims for, not
+  as a limit. The provider's own documentation describes it as a target.
+
+- **Anthropic frontier models, version 5 and later**. The value has no observable effect. Reasoning runs to the full
+  output allowance regardless of the number set.
+
+- **Local models**. No chat template that ships with the appliance reads the value. Local models ignore the budget on
+  every family tested.
+
+:::warning
+
+Do not rely on `budget:<n>` to bound spend or response length. Use
+[client quotas](../how-to-guides/manage-client-quotas.md) for spend, and the request's own output-token limit for
+response length.
+
+:::

--- a/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/how-to-guides.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/how-to-guides.md
@@ -18,6 +18,7 @@ you the steps to do it without teaching background concepts.
 | [Install the Appliance](./install-the-appliance.md)               | Flash the installer ISO, boot the hardware, and bring up the appliance console.  |
 | [Deploy a Model](./deploy-a-model.md)                             | Deploy an LLM to the cluster and verify it is serving.                           |
 | [Upload a Model](./upload-a-model.md)                             | Download a model on a jumpbox and upload it to the appliance.                    |
+| [Set the Thinking Directive for a Tier](./set-tier-thinking.md)   | Choose off, on, or a budget hint per tier on the Tier map.                       |
 | [Create a Client](./create-a-client.md)                           | Create a client and issue its first API token.                                   |
 | [Generate an API Token](./generate-an-api-token.md)               | Create an API token that clients use to authenticate to the appliance.           |
 | [Set and Manage Client Quotas](./manage-client-quotas.md)         | Set, edit, and remove a client's request, token, and cost limits.                |

--- a/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/set-tier-thinking.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/how-to-guides/set-tier-thinking.md
@@ -1,0 +1,53 @@
+---
+sidebar_label: "Set the Thinking Directive for a Tier"
+title: "Set the Thinking Directive for a Tier"
+description:
+  "Step-by-step guidance for platform administrators on how to set the Thinking directive for a tier on the Tier map of
+  a PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 2
+tags: ["paletteai-inference-launchpad", "routing", "tier-map", "thinking", "how-to"]
+keywords:
+  ["launchpad", "ai", "thinking", "reasoning", "tier map", "budget", "routing"]
+---
+
+This guide explains how to set the Thinking directive for a tier on the
+[Tier Map](../reference/glossary.md#tier-map) of a PaletteAI Inference Launchpad appliance. For what the directive
+does and how each mode is interpreted, refer to [The Thinking Directive](../explanation/thinking-directive.md). For
+the value each mode carries at request time, refer to [Thinking Directive Modes](../reference/thinking-modes.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+
+- Console access with permission to edit routing settings.
+
+- At least one tier with a resolved model on the Tier map. To place a model on the appliance, refer to
+  [Deploy a Model](./deploy-a-model.md).
+
+## Set the Thinking Directive
+
+1. From the left main menu, select **Routing**.
+
+2. On the **Tier map** card, find the row for the tier you want to change and select **edit**.
+
+3. In the **Thinking** selector, choose **off**, **on**, or **budget**.
+
+4. _(**budget** only)_ In the field next to the selector, enter a positive token count, such as `4096`.
+
+5. Select **Apply tier** and confirm the plan card.
+
+## Validate
+
+- The **Tier map** row shows the new directive in the **Thinking** column, formatted as `on`, `off`, or `budget:<n>`.
+
+- Send a request through the tier and open its trace. On a reasoning-capable model, the response reports a non-zero
+  reasoning-token count.
+
+## Next Steps
+
+- [The Thinking Directive](../explanation/thinking-directive.md)
+
+- [Thinking Directive Modes](../reference/thinking-modes.md)
+
+- [Manage a Client's Model Access](./manage-client-model-access.md)

--- a/inference-launchpad_versioned_docs/version-1.0.x/reference/reference.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/reference/reference.md
@@ -21,6 +21,7 @@ is configured, not how to accomplish a task.
 | [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration.                |
 | [Model Upload Reference](./model-upload-reference.md)             | Palette CLI model download and upload flags, and the model metadata file fields.               |
 | [Usage Metrics Reference](./usage-metrics-reference.md)           | Every filter, metric, table column, and export field on the Usage page.                        |
+| [Thinking Directive Modes](./thinking-modes.md)                   | The Thinking directive modes on the Tier map and how each engine treats a token budget.        |
 | [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.                    |
 | [Cursor Configuration](./cursor-reference.md)                     | Settings and values for pointing Cursor at the appliance.                                      |
 | [OpenAI Codex Configuration](./codex-reference.md)                | Configuration file fields and values for pointing Codex at the appliance.                      |

--- a/inference-launchpad_versioned_docs/version-1.0.x/reference/thinking-modes.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/reference/thinking-modes.md
@@ -1,0 +1,40 @@
+---
+sidebar_label: "Thinking Directive Modes"
+title: "Thinking Directive Modes"
+description:
+  "Reference of the Thinking directive modes on the Tier map, the value each mode carries at request time, the console
+  states that override the setting, and how each engine family interprets a token budget."
+hide_table_of_contents: false
+sidebar_position: 4.8
+tags: ["paletteai-inference-launchpad", "routing", "tier-map", "thinking", "reference"]
+keywords: ["launchpad", "ai", "thinking", "reasoning", "budget", "tier map"]
+---
+
+This reference lists the Thinking directive modes on the Tier map of a PaletteAI Inference Launchpad appliance, the
+value each mode carries at request time, the console states that override the setting, and how each engine family
+interprets a token budget. For the concept behind the directive, refer to
+[The Thinking Directive](../explanation/thinking-directive.md). For the steps to set the directive, refer to
+[Set the Thinking Directive for a Tier](../how-to-guides/set-tier-thinking.md).
+
+## Modes
+
+| **Mode**   | **Authored value** | **What the model does**                                                                          |
+| ---------- | ------------------ | ------------------------------------------------------------------------------------------------ |
+| **off**    | `off`              | The model does not reason. It answers each request directly.                                     |
+| **on**     | `on`               | The model reasons at the depth its own defaults choose. No token budget is set.                  |
+| **budget** | `budget:<n>`       | The model reasons with a token-budget hint of `<n>` tokens. The value is a hint, not a hard cap. |
+
+## Per-Engine Interpretation of Budget
+
+| **Engine family**                           | **How the value is treated**                                                                   |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Anthropic frontier, version 4.6 and earlier | A target the provider aims for, not a limit.                                                   |
+| Anthropic frontier, version 5 and later     | No observable effect. Reasoning runs to the full output allowance.                             |
+| Local models                                | Not read. No chat template that ships with the appliance reads the value on any family tested. |
+
+## Console States That Override the Setting
+
+| **State**                                         | **When it appears**                                                                     | **Effect**                                                        |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `off` is disabled                                 | The tier resolves to an OpenAI o-series or GPT-5 family model.                          | The selector does not offer **off** for that tier.                |
+| Grey chip reading `ignored — no thinking surface` | The tier's resolved model runs on an engine that has no reasoning surface.              | The engine ignores the directive; the request is served normally. |


### PR DESCRIPTION
## Summary

Documents the Thinking directive on the Tier Map for the v1.0.x archive of the PaletteAI Inference Launchpad docs. Ships as three pages in strict Diátaxis — a task-only how-to, a concept-and-behavior explanation, and a lookup-only reference — plus a Contents row on each category's landing page.

## Content

**How-to** — `how-to-guides/set-tier-thinking.md`. Prerequisites, a four-step procedure to set the directive on a Tier Map row, and a Validate section. The first prose mention of Tier Map links to the glossary entry.

**Explanation** — `explanation/thinking-directive.md`. What the directive controls per tier, how each of the three shipped modes (`off`, `on`, `budget:<n>`) is interpreted, the model-aware `off` disablement for OpenAI o-series and GPT-5, the ignored-chip state on engines with no reasoning surface, and the budget-hint accuracy across engine families. The warning admonition against using budget as a spend bound links out to the client quotas how-to.

**Reference** — `reference/thinking-modes.md`. Three lookup tables: mode values, per-engine budget interpretation, and console states that override the setting.

**Landing pages** — `how-to-guides.md`, `explanation.md`, `reference.md` each get one Contents row for the new page.

## Accuracy call-out on budget mode

Per Chinmay Gabel's comment on the ticket (2026-09-02), the ticket's original phrasing "budget as hard cap or mapped level" is wrong. Live testing shows the value has never behaved as a hard cap on any tested engine — Anthropic 4.6 and earlier treat it as a target (as the provider's own docs describe), Anthropic 5 and later show no observable effect, and every local chat template that ships with the appliance ignores the value. The docs describe it as a hint, and the warning admonition steers operators to client quotas for spend limits and the request's own output-token limit for response length.

## Ticket

[AIL-638 — Document Thinking directive](https://spectrocloud.atlassian.net/browse/AIL-638)

## Test plan

- [ ] Netlify preview renders all three pages under `/paletteai-inference-launchpad/v1.0.x/…`.
- [ ] Sidebar autogeneration places **Set the Thinking Directive for a Tier** between "Upload a Model" and "Create a Client".
- [ ] Sidebar autogeneration adds **The Thinking Directive** to the explanation section at position 6.
- [ ] Sidebar autogeneration adds **Thinking Directive Modes** to the reference section at position 4.8.
- [ ] Each Diátaxis category's landing page shows the new row in its Contents table.
- [ ] The linked Tier Map glossary anchor resolves in both the how-to and the explanation.
- [ ] The linked client quotas how-to resolves from the explanation's warning admonition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
