### PR TITLE
PE-8648: addendum for clarification of Edge appliance

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -228,10 +228,10 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 <!-- https://spectrocloud.atlassian.net/browse/PE-8314 -->
 <!-- https://spectrocloud.atlassian.net/browse/PE-8648 -->
 
-- Upgrading an existing connected Edge cluster on an operating system with systemd version 255 or later requires a
-  provider image built with **CanvOS 4.10.x** that sets `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Reference the image
-  through `system.uri` in the BYOOS pack for the first upgrade after you adopt **CanvOS 4.10.x**. This upgrade aligns
-  the Palette Edge node agent on the host with the Palette release. Subsequent Kubernetes upgrades do not need a
+- Upgrading an existing appliance mode connected Edge cluster on an operating system with systemd version 255 or later
+  requires a provider image built with **CanvOS 4.10.x** that sets `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Reference
+  the image through `system.uri` in the BYOOS pack for the first upgrade after you adopt **CanvOS 4.10.x**. This upgrade
+  aligns the Palette Edge node agent on the host with the Palette release. Subsequent Kubernetes upgrades do not need a
   provider image, so set `system.uri: NA` in the BYOOS pack. For Unified Kernel Image (UKI) deployments, sign the new
   provider image and the systemd extensions with the same keys that you used to sign the installer. Refer to
   [Upgrade an Existing Cluster](../clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md#upgrade-an-existing-cluster)
@@ -266,12 +266,12 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 <!-- https://spectrocloud.atlassian.net/browse/PE-8314 -->
 <!-- https://spectrocloud.atlassian.net/browse/PE-8648 -->
 
-- Connected Edge clusters can now use systemd extensions to deliver Kubernetes and Palette Agent binaries at runtime,
-  instead of embedding those binaries in the provider image. On operating systems running systemd version 255 or later,
-  provider images built with CanvOS 4.10.x exclude the binaries by default, and Stylus (Palette Edge node agent) 4.10.x
-  delivers them through systemd extensions. Set `system.uri: NA` in the BYOOS pack for standard upgrades. The new
-  `BUNDLE_K8S_AND_AGENT_PROVIDER` flag in the CanvOS `.arg` file overrides the default when a specific flow requires the
-  binaries embedded. Refer to
+- Appliance mode connected Edge clusters can now use systemd extensions to deliver Kubernetes and Palette Agent binaries
+  at runtime, instead of embedding those binaries in the provider image. On operating systems running systemd version
+  255 or later, provider images built with CanvOS 4.10.x exclude the binaries by default, and Stylus (Palette Edge node
+  agent) 4.10.x delivers them through systemd extensions. Set `system.uri: NA` in the BYOOS pack for standard upgrades.
+  The new `BUNDLE_K8S_AND_AGENT_PROVIDER` flag in the CanvOS `.arg` file overrides the default when a specific flow
+  requires the binaries embedded. Refer to
   [Deliver Kubernetes and Agent Binaries via systemd Extensions](../clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md#bundle-k8s-and-agent-provider-flag)
   for build and upgrade guidance.
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** for all affected pages are provided in the [Changed Pages](#-changed-pages) section.
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages. _Prettier clean; no tables or images changed._
- [x] Ensure all **Vale comments** are resolved. _No new findings; the pre-existing `heading-all-caps` alert on the `BUNDLE_K8S_AND_AGENT_PROVIDER` inline code is unchanged by this PR._
- [ ] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _Targets `docs-rel-4-10-0`; the feature is new in 4.10.0, so no earlier-version backport applies._
- [x] **Outside review:** Scope was confirmed with Edge engineering on PE-8648 (appliance mode). No further outside review required.
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

---

## 📝 Describe the Change

The two PE-8648 entries in the 4.10.0 release notes (the Edge breaking change and the systemd-extensions feature) described the systemd-extensions delivery of Kubernetes and Palette Agent binaries as applying to "connected Edge clusters." Engineering confirmed the capability is scoped to **appliance mode** Edge, not Agent mode. This PR changes both entries to "appliance mode connected Edge cluster(s)" so the scope is accurate and consistent with how the linked build guide and other Edge pages describe the deployment mode.

Only the two release-note bullets change; no steps, tables, or images are affected.

---

## 💻 Changed Pages

- [Release Notes → Release 4.10.0 → Edge Breaking Changes and Features:](https://deploy-preview-11862--docs-spectrocloud.netlify.app/release-notes/release-notes/#edge-breaking-changes-4.10.0)

---

## 🎫 Jira Tickets

[PE-8648](https://spectrocloud.atlassian.net/browse/PE-8648)


[PE-8648]: https://spectrocloud.atlassian.net/browse/PE-8648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ