### PR TITLE
DOC-3097: correct the self-hosted upgrade path tables and cross-check Kubernetes minors

### DIFF
--- a/_partials/self-hosted/management-appliance/_upgrade-palette-upgrade-notes.mdx
+++ b/_partials/self-hosted/management-appliance/_upgrade-palette-upgrade-notes.mdx
@@ -3,11 +3,6 @@ partial_category: self-hosted
 partial_name: upgrade-palette-upgrade-notes
 ---
 
-- **(4.8.x to 4.9.23+)** Direct upgrades of {props.version} from any `4.8.x` release to `4.9.23` or later are not
-  supported, because they skip a Kubernetes minor version. The `4.8.x` series ships Kubernetes `1.32.9`, and `4.9.23`
-  and later ship Kubernetes `1.34.6`. To reach `4.9.23` or later from `4.8.x`, first upgrade to a `4.9.x` release on
-  Kubernetes `1.33.10` (we recommend `4.9.14`), then upgrade to your target `4.9.23` or later release.
-
 - **(4.7.27 to 4.7.29+)** If upgrading from version **4.7.27**, you must run an additional script before upgrading
   {props.version}. This script ensures the `linstor-lvm-storage` StorageClass has correct parameters and safely
   recreates the PVC while preserving data.

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -71,7 +71,7 @@ The following table lists the Kubernetes version bundled with each recent Palett
 
 | Palette Release                                | EC Binary | Palette Management Appliance |
 | :--------------------------------------------- | :-------: | :--------------------------: |
-| 4.7.40, 4.7.43                                 |  1.31.8   |        Not documented        |
+| 4.7.40, 4.7.43                                 |  1.31.8   |        Not applicable        |
 | 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61, 4.8.62 |  1.32.9   |            1.33.9            |
 | 4.9.5, 4.9.8, 4.9.14                           |  1.33.10  |            1.34.6            |
 | 4.9.23 and later                               |  1.34.6   |            1.34.9            |

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -32,10 +32,9 @@ Refer to the following tables for the supported self-hosted Palette upgrade path
 [Kubernetes](../install-palette/install-on-kubernetes/install-on-kubernetes.md), and
 [Palette Management Appliance](../install-palette/palette-management-appliance.md) installations.
 
-In the following tables, :white_check_mark: indicates a validated direct upgrade path and :x: indicates an unsupported
-path. A [:question:](#kubernetes-version-constraint) indicates a path that self-hosted Palette supports only as a
-staggered upgrade through an intermediate release. Refer to
-[Kubernetes Version Constraint](#kubernetes-version-constraint) for the intermediate release to use.
+In the following tables, :white_check_mark: indicates a validated upgrade path and :x: indicates a path that is not
+supported. Refer to [Kubernetes Version Constraint](#kubernetes-version-constraint) for why some upgrades from a `4.8.x`
+release are not supported, and for the two-step route to use instead.
 
 :::danger
 
@@ -58,30 +57,34 @@ health status of MongoDB ReplicaSet members, refer to our
 
 ### Kubernetes Version Constraint
 
-This constraint applies to Enterprise Cluster (EC) binary and Palette Management Appliance installations, which bundle a
-specific Kubernetes version with each Palette release. It does not apply to Palette installed with Helm on a
-customer-managed Kubernetes cluster, where you manage the Kubernetes version independently of Palette. The paths in the
-**Kubernetes** tab are not subject to this constraint.
-
 Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette upgrade cannot cross more
 than one Kubernetes minor version. An upgrade that would skip a Kubernetes minor version may fail mid-run and leave the
 management cluster in an unrecoverable state.
 
+This constraint applies to Enterprise Cluster (EC) binary and Palette Management Appliance installations, which bundle a
+specific Kubernetes version with each Palette release. The two installation types do not bundle the same Kubernetes
+version for a given release, so compare the versions for the installation type you use. The constraint does not apply to
+Palette installed with Helm on a customer-managed Kubernetes cluster, where you manage the Kubernetes version
+independently of Palette. The paths in the **Kubernetes** tab are not subject to it.
+
 The following table lists the Kubernetes version bundled with each recent Palette release.
 
-| Palette Release                        | Kubernetes Version |
-| :------------------------------------- | :----------------: |
-| 4.7.40, 4.7.43                         |       1.31.8       |
-| 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
-| 4.9.5, 4.9.8, 4.9.14                   |      1.33.10       |
-| 4.9.23 and later                       |       1.34.6       |
+| Palette Release                                | EC Binary | Palette Management Appliance |
+| :--------------------------------------------- | :-------: | :--------------------------: |
+| 4.7.40, 4.7.43                                 |  1.31.8   |        Not documented        |
+| 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61, 4.8.62 |  1.32.9   |            1.33.9            |
+| 4.9.5, 4.9.8, 4.9.14                           |  1.33.10  |            1.34.6            |
+| 4.9.23 and later                               |  1.34.6   |            1.34.9            |
 
-Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
-`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. The upgrade path tables mark these
-paths with :question: rather than :white_check_mark:. To reach `4.9.23` or later from `4.8.x`, upgrade in two steps.
+On EC binary installations, direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x`
+series ships Kubernetes `1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. The upgrade
+path tables mark these paths with :x:. To reach `4.9.23` or later from `4.8.x`, upgrade in two steps.
 
-1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
+1. Upgrade to `4.9.14`, which ships Kubernetes `1.33.10`.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
+
+Palette Management Appliance installations are not affected, because they ship Kubernetes `1.33.9` on `4.8.x` and
+`1.34.9` on `4.9.24` and later, which crosses a single minor version.
 
 Before you start any Palette upgrade, compare the Kubernetes version of your current release with that of the target
 release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the missing
@@ -94,30 +97,51 @@ minor.
 
 <!-- upgrade-paths:vmware-4.9:start -->
 
-| **Source Version** | **Target Version** |                 **Support**                  |
-| :----------------: | :----------------: | :------------------------------------------: |
-|       4.8.61       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.61       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.61       |       4.9.14       |              :white_check_mark:              |
-|       4.8.61       |       4.9.5        |              :white_check_mark:              |
-|       4.8.56       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.56       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.56       |       4.9.14       |              :white_check_mark:              |
-|       4.8.56       |       4.9.5        |              :white_check_mark:              |
-|       4.8.52       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.52       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.52       |       4.9.14       |              :white_check_mark:              |
-|       4.8.52       |       4.9.5        |              :white_check_mark:              |
-|       4.8.33       |       4.9.5        |              :white_check_mark:              |
-|       4.8.25       |       4.9.5        |              :white_check_mark:              |
-|       4.8.22       |       4.9.5        |              :white_check_mark:              |
-|       4.8.16       |       4.9.5        |              :white_check_mark:              |
-|       4.8.12       |       4.9.5        |              :white_check_mark:              |
-|       4.8.9        |       4.9.5        |              :white_check_mark:              |
-|       4.8.8        |       4.9.5        |              :white_check_mark:              |
-|       4.7.38       |       4.9.5        |              :white_check_mark:              |
-|       4.7.29       |       4.9.5        |              :white_check_mark:              |
-|       4.7.27       |       4.9.5        |              :white_check_mark:              |
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.14       |       4.9.51       | :white_check_mark: |
+|       4.9.14       |       4.9.46       | :white_check_mark: |
+|       4.9.14       |       4.9.44       | :white_check_mark: |
+|       4.9.14       |       4.9.38       | :white_check_mark: |
+|       4.9.14       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.51       |        :x:         |
+|       4.8.62       |       4.9.46       |        :x:         |
+|       4.8.62       |       4.9.44       |        :x:         |
+|       4.8.62       |       4.9.38       |        :x:         |
+|       4.8.62       |       4.9.24       |        :x:         |
+|       4.8.62       |       4.9.14       | :white_check_mark: |
+|       4.8.62       |       4.9.5        | :white_check_mark: |
+|       4.8.61       |       4.9.51       |        :x:         |
+|       4.8.61       |       4.9.46       |        :x:         |
+|       4.8.61       |       4.9.44       |        :x:         |
+|       4.8.61       |       4.9.38       |        :x:         |
+|       4.8.61       |       4.9.24       |        :x:         |
+|       4.8.61       |       4.9.14       | :white_check_mark: |
+|       4.8.61       |       4.9.5        | :white_check_mark: |
+|       4.8.56       |       4.9.51       |        :x:         |
+|       4.8.56       |       4.9.46       |        :x:         |
+|       4.8.56       |       4.9.44       |        :x:         |
+|       4.8.56       |       4.9.38       |        :x:         |
+|       4.8.56       |       4.9.24       |        :x:         |
+|       4.8.56       |       4.9.14       | :white_check_mark: |
+|       4.8.56       |       4.9.5        | :white_check_mark: |
+|       4.8.52       |       4.9.51       |        :x:         |
+|       4.8.52       |       4.9.46       |        :x:         |
+|       4.8.52       |       4.9.44       |        :x:         |
+|       4.8.52       |       4.9.38       |        :x:         |
+|       4.8.52       |       4.9.24       |        :x:         |
+|       4.8.52       |       4.9.14       | :white_check_mark: |
+|       4.8.52       |       4.9.5        | :white_check_mark: |
+|       4.8.33       |       4.9.5        | :white_check_mark: |
+|       4.8.25       |       4.9.5        | :white_check_mark: |
+|       4.8.22       |       4.9.5        | :white_check_mark: |
+|       4.8.16       |       4.9.5        | :white_check_mark: |
+|       4.8.12       |       4.9.5        | :white_check_mark: |
+|       4.8.9        |       4.9.5        | :white_check_mark: |
+|       4.8.8        |       4.9.5        | :white_check_mark: |
+|       4.7.38       |       4.9.5        |        :x:         |
+|       4.7.29       |       4.9.5        |        :x:         |
+|       4.7.27       |       4.9.5        |        :x:         |
 
 <!-- upgrade-paths:vmware-4.9:end -->
 
@@ -545,14 +569,35 @@ few hours.
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.9.14       |       4.9.51       | :white_check_mark: |
+|       4.9.14       |       4.9.46       | :white_check_mark: |
+|       4.9.14       |       4.9.44       | :white_check_mark: |
+|       4.9.14       |       4.9.38       | :white_check_mark: |
+|       4.9.14       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.51       | :white_check_mark: |
+|       4.8.62       |       4.9.46       | :white_check_mark: |
+|       4.8.62       |       4.9.44       | :white_check_mark: |
+|       4.8.62       |       4.9.38       | :white_check_mark: |
+|       4.8.62       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.14       | :white_check_mark: |
+|       4.8.62       |       4.9.5        | :white_check_mark: |
+|       4.8.61       |       4.9.51       | :white_check_mark: |
+|       4.8.61       |       4.9.46       | :white_check_mark: |
+|       4.8.61       |       4.9.44       | :white_check_mark: |
 |       4.8.61       |       4.9.38       | :white_check_mark: |
 |       4.8.61       |       4.9.24       | :white_check_mark: |
 |       4.8.61       |       4.9.14       | :white_check_mark: |
 |       4.8.61       |       4.9.5        | :white_check_mark: |
+|       4.8.56       |       4.9.51       | :white_check_mark: |
+|       4.8.56       |       4.9.46       | :white_check_mark: |
+|       4.8.56       |       4.9.44       | :white_check_mark: |
 |       4.8.56       |       4.9.38       | :white_check_mark: |
 |       4.8.56       |       4.9.24       | :white_check_mark: |
 |       4.8.56       |       4.9.14       | :white_check_mark: |
 |       4.8.56       |       4.9.5        | :white_check_mark: |
+|       4.8.52       |       4.9.51       | :white_check_mark: |
+|       4.8.52       |       4.9.46       | :white_check_mark: |
+|       4.8.52       |       4.9.44       | :white_check_mark: |
 |       4.8.52       |       4.9.38       | :white_check_mark: |
 |       4.8.52       |       4.9.24       | :white_check_mark: |
 |       4.8.52       |       4.9.14       | :white_check_mark: |
@@ -997,22 +1042,43 @@ few hours.
 
 <!-- upgrade-paths:appliance-4.9:start -->
 
-| **Source Version** | **Target Version** |                 **Support**                  |
-| :----------------: | :----------------: | :------------------------------------------: |
-|       4.8.61       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.61       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.61       |       4.9.14       |              :white_check_mark:              |
-|       4.8.61       |       4.9.5        |              :white_check_mark:              |
-|       4.8.56       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.56       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.56       |       4.9.14       |              :white_check_mark:              |
-|       4.8.56       |       4.9.5        |              :white_check_mark:              |
-|       4.8.52       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.52       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.52       |       4.9.14       |              :white_check_mark:              |
-|       4.8.52       |       4.9.5        |              :white_check_mark:              |
-|       4.8.12       |       4.9.5        |              :white_check_mark:              |
-|       4.8.8        |       4.9.5        |              :white_check_mark:              |
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.14       |       4.9.51       | :white_check_mark: |
+|       4.9.14       |       4.9.46       | :white_check_mark: |
+|       4.9.14       |       4.9.44       | :white_check_mark: |
+|       4.9.14       |       4.9.38       | :white_check_mark: |
+|       4.9.14       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.51       | :white_check_mark: |
+|       4.8.62       |       4.9.46       | :white_check_mark: |
+|       4.8.62       |       4.9.44       | :white_check_mark: |
+|       4.8.62       |       4.9.38       | :white_check_mark: |
+|       4.8.62       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.14       | :white_check_mark: |
+|       4.8.62       |       4.9.5        | :white_check_mark: |
+|       4.8.61       |       4.9.51       | :white_check_mark: |
+|       4.8.61       |       4.9.46       | :white_check_mark: |
+|       4.8.61       |       4.9.44       | :white_check_mark: |
+|       4.8.61       |       4.9.38       | :white_check_mark: |
+|       4.8.61       |       4.9.24       | :white_check_mark: |
+|       4.8.61       |       4.9.14       | :white_check_mark: |
+|       4.8.61       |       4.9.5        | :white_check_mark: |
+|       4.8.56       |       4.9.51       | :white_check_mark: |
+|       4.8.56       |       4.9.46       | :white_check_mark: |
+|       4.8.56       |       4.9.44       | :white_check_mark: |
+|       4.8.56       |       4.9.38       | :white_check_mark: |
+|       4.8.56       |       4.9.24       | :white_check_mark: |
+|       4.8.56       |       4.9.14       | :white_check_mark: |
+|       4.8.56       |       4.9.5        | :white_check_mark: |
+|       4.8.52       |       4.9.51       | :white_check_mark: |
+|       4.8.52       |       4.9.46       | :white_check_mark: |
+|       4.8.52       |       4.9.44       | :white_check_mark: |
+|       4.8.52       |       4.9.38       | :white_check_mark: |
+|       4.8.52       |       4.9.24       | :white_check_mark: |
+|       4.8.52       |       4.9.14       | :white_check_mark: |
+|       4.8.52       |       4.9.5        | :white_check_mark: |
+|       4.8.12       |       4.9.5        | :white_check_mark: |
+|       4.8.8        |       4.9.5        | :white_check_mark: |
 
 <!-- upgrade-paths:appliance-4.9:end -->
 

--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -32,6 +32,11 @@ Refer to the following tables for the supported self-hosted Palette upgrade path
 [Kubernetes](../install-palette/install-on-kubernetes/install-on-kubernetes.md), and
 [Palette Management Appliance](../install-palette/palette-management-appliance.md) installations.
 
+In the following tables, :white_check_mark: indicates a validated direct upgrade path and :x: indicates an unsupported
+path. A [:question:](#kubernetes-version-constraint) indicates a path that self-hosted Palette supports only as a
+staggered upgrade through an intermediate release. Refer to
+[Kubernetes Version Constraint](#kubernetes-version-constraint) for the intermediate release to use.
+
 :::danger
 
 Before upgrading Palette to a new major version, you must first update it to the latest patch version of the latest
@@ -53,32 +58,34 @@ health status of MongoDB ReplicaSet members, refer to our
 
 ### Kubernetes Version Constraint
 
-Enterprise Cluster (EC) binary and Palette Management Appliance installations bundle a specific Kubernetes version with
-each Palette release. Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette
-upgrade cannot cross more than one Kubernetes minor version. An upgrade that would skip a Kubernetes minor version may
-fail mid-run and leave the management cluster in an unrecoverable state.
+This constraint applies to Enterprise Cluster (EC) binary and Palette Management Appliance installations, which bundle a
+specific Kubernetes version with each Palette release. It does not apply to Palette installed with Helm on a
+customer-managed Kubernetes cluster, where you manage the Kubernetes version independently of Palette. The paths in the
+**Kubernetes** tab are not subject to this constraint.
+
+Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette upgrade cannot cross more
+than one Kubernetes minor version. An upgrade that would skip a Kubernetes minor version may fail mid-run and leave the
+management cluster in an unrecoverable state.
 
 The following table lists the Kubernetes version bundled with each recent Palette release.
 
-| Palette Release                | Kubernetes Version |
-| :----------------------------- | :----------------: |
-| 4.7.40, 4.7.43                 |       1.31.8       |
-| 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
-| 4.9.5, 4.9.8, 4.9.14           |      1.33.10       |
-| 4.9.23 and later               |       1.34.6       |
+| Palette Release                        | Kubernetes Version |
+| :------------------------------------- | :----------------: |
+| 4.7.40, 4.7.43                         |       1.31.8       |
+| 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
+| 4.9.5, 4.9.8, 4.9.14                   |      1.33.10       |
+| 4.9.23 and later                       |       1.34.6       |
 
 Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
-`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from
-`4.8.x`, upgrade in two steps.
+`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. The upgrade path tables mark these
+paths with :question: rather than :white_check_mark:. To reach `4.9.23` or later from `4.8.x`, upgrade in two steps.
 
 1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
 
 Before you start any Palette upgrade, compare the Kubernetes version of your current release with that of the target
 release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the missing
-minor. This constraint applies to EC binary and Palette Management Appliance installations. It does not apply to Palette
-installed via Helm on a customer-managed Kubernetes cluster, where your Kubernetes version is managed independently of
-Palette.
+minor.
 
 <Tabs>
 <TabItem label="VMware" value="VMware">
@@ -87,30 +94,30 @@ Palette.
 
 <!-- upgrade-paths:vmware-4.9:start -->
 
-| **Source Version** | **Target Version** |    **Support**     |
-| :----------------: | :----------------: | :----------------: |
-|       4.8.61       |       4.9.38       | :white_check_mark: |
-|       4.8.61       |       4.9.24       | :white_check_mark: |
-|       4.8.61       |       4.9.14       | :white_check_mark: |
-|       4.8.61       |       4.9.5        | :white_check_mark: |
-|       4.8.56       |       4.9.38       | :white_check_mark: |
-|       4.8.56       |       4.9.24       | :white_check_mark: |
-|       4.8.56       |       4.9.14       | :white_check_mark: |
-|       4.8.56       |       4.9.5        | :white_check_mark: |
-|       4.8.52       |       4.9.38       | :white_check_mark: |
-|       4.8.52       |       4.9.24       | :white_check_mark: |
-|       4.8.52       |       4.9.14       | :white_check_mark: |
-|       4.8.52       |       4.9.5        | :white_check_mark: |
-|       4.8.33       |       4.9.5        | :white_check_mark: |
-|       4.8.25       |       4.9.5        | :white_check_mark: |
-|       4.8.22       |       4.9.5        | :white_check_mark: |
-|       4.8.16       |       4.9.5        | :white_check_mark: |
-|       4.8.12       |       4.9.5        | :white_check_mark: |
-|       4.8.9        |       4.9.5        | :white_check_mark: |
-|       4.8.8        |       4.9.5        | :white_check_mark: |
-|       4.7.38       |       4.9.5        | :white_check_mark: |
-|       4.7.29       |       4.9.5        | :white_check_mark: |
-|       4.7.27       |       4.9.5        | :white_check_mark: |
+| **Source Version** | **Target Version** |                 **Support**                  |
+| :----------------: | :----------------: | :------------------------------------------: |
+|       4.8.61       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.61       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.61       |       4.9.14       |              :white_check_mark:              |
+|       4.8.61       |       4.9.5        |              :white_check_mark:              |
+|       4.8.56       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.56       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.56       |       4.9.14       |              :white_check_mark:              |
+|       4.8.56       |       4.9.5        |              :white_check_mark:              |
+|       4.8.52       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.52       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.52       |       4.9.14       |              :white_check_mark:              |
+|       4.8.52       |       4.9.5        |              :white_check_mark:              |
+|       4.8.33       |       4.9.5        |              :white_check_mark:              |
+|       4.8.25       |       4.9.5        |              :white_check_mark:              |
+|       4.8.22       |       4.9.5        |              :white_check_mark:              |
+|       4.8.16       |       4.9.5        |              :white_check_mark:              |
+|       4.8.12       |       4.9.5        |              :white_check_mark:              |
+|       4.8.9        |       4.9.5        |              :white_check_mark:              |
+|       4.8.8        |       4.9.5        |              :white_check_mark:              |
+|       4.7.38       |       4.9.5        |              :white_check_mark:              |
+|       4.7.29       |       4.9.5        |              :white_check_mark:              |
+|       4.7.27       |       4.9.5        |              :white_check_mark:              |
 
 <!-- upgrade-paths:vmware-4.9:end -->
 
@@ -990,22 +997,22 @@ few hours.
 
 <!-- upgrade-paths:appliance-4.9:start -->
 
-| **Source Version** | **Target Version** |    **Support**     |
-| :----------------: | :----------------: | :----------------: |
-|       4.8.61       |       4.9.38       | :white_check_mark: |
-|       4.8.61       |       4.9.24       | :white_check_mark: |
-|       4.8.61       |       4.9.14       | :white_check_mark: |
-|       4.8.61       |       4.9.5        | :white_check_mark: |
-|       4.8.56       |       4.9.38       | :white_check_mark: |
-|       4.8.56       |       4.9.24       | :white_check_mark: |
-|       4.8.56       |       4.9.14       | :white_check_mark: |
-|       4.8.56       |       4.9.5        | :white_check_mark: |
-|       4.8.52       |       4.9.38       | :white_check_mark: |
-|       4.8.52       |       4.9.24       | :white_check_mark: |
-|       4.8.52       |       4.9.14       | :white_check_mark: |
-|       4.8.52       |       4.9.5        | :white_check_mark: |
-|       4.8.12       |       4.9.5        | :white_check_mark: |
-|       4.8.8        |       4.9.5        | :white_check_mark: |
+| **Source Version** | **Target Version** |                 **Support**                  |
+| :----------------: | :----------------: | :------------------------------------------: |
+|       4.8.61       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.61       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.61       |       4.9.14       |              :white_check_mark:              |
+|       4.8.61       |       4.9.5        |              :white_check_mark:              |
+|       4.8.56       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.56       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.56       |       4.9.14       |              :white_check_mark:              |
+|       4.8.56       |       4.9.5        |              :white_check_mark:              |
+|       4.8.52       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.52       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.52       |       4.9.14       |              :white_check_mark:              |
+|       4.8.52       |       4.9.5        |              :white_check_mark:              |
+|       4.8.12       |       4.9.5        |              :white_check_mark:              |
+|       4.8.8        |       4.9.5        |              :white_check_mark:              |
 
 <!-- upgrade-paths:appliance-4.9:end -->
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -626,18 +626,18 @@ The following component updates are applicable to this release:
 
 <!-- https://spectrocloud.atlassian.net/browse/DOC-2999 -->
 
-- Direct Enterprise Cluster (EC) binary and Palette Management Appliance upgrades from any `4.8.x` release to `4.9.23`
-  or later are not supported. The `4.8.x` series ships Kubernetes `1.32.9`, and `4.9.23` and later ship Kubernetes
-  `1.34.6`; a single Palette upgrade cannot cross more than one Kubernetes minor version. To reach `4.9.23` or later
-  from `4.8.x`, upgrade in two steps.
+- Direct Enterprise Cluster (EC) binary upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The
+  `4.8.x` series ships Kubernetes `1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`; a single Palette upgrade
+  cannot cross more than one Kubernetes minor version. To reach `4.9.23` or later from `4.8.x`, upgrade in two steps.
 
-  1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
+  1. Upgrade to `4.9.14`, which ships Kubernetes `1.33.10`.
   2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
 
   Before starting any Palette upgrade, compare the Kubernetes version of your current release with that of the target
   release. If the delta is two or more minor versions, plan an intermediate upgrade. This constraint does not apply to
-  Palette installed via Helm on a customer-managed Kubernetes cluster. For the version-to-Kubernetes mapping and full
-  guidance, refer to
+  Palette Management Appliance installations, which bundle a different Kubernetes version for the same Palette release,
+  or to Palette installed with Helm on a customer-managed Kubernetes cluster. For the version-to-Kubernetes mapping per
+  installation type and full guidance, refer to
   [Kubernetes Version Constraint](../enterprise-version/upgrade/upgrade.md#kubernetes-version-constraint).
 
 #### Features
@@ -1075,9 +1075,9 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 <!-- https://spectrocloud.atlassian.net/browse/DOC-2999 -->
 
-- The Kubernetes minor-version constraint on Enterprise Cluster (EC) binary and VerteX Management Appliance upgrades
-  from `4.8.x` to `4.9.23` or later applies to Palette VerteX as well. Refer to the Palette Enterprise Upgrade Notes for
-  the two-hop upgrade path, and to
+- The Kubernetes minor-version constraint on Enterprise Cluster (EC) binary upgrades from `4.8.x` to `4.9.23` or later
+  applies to Palette VerteX as well. VerteX Management Appliance installations are not affected. Refer to the Palette
+  Enterprise Upgrade Notes for the two-hop upgrade path, and to
   [Kubernetes Version Constraint](../vertex/upgrade/upgrade.md#kubernetes-version-constraint) for the full guidance.
 
 ### Automation

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -32,6 +32,11 @@ Refer to the following tables for the supported Palette VerteX upgrade paths for
 [Kubernetes](../install-palette-vertex/install-on-kubernetes/install-on-kubernetes.md), and
 [VerteX Management Appliance](../install-palette-vertex/vertex-management-appliance.md) installations.
 
+In the following tables, :white_check_mark: indicates a validated direct upgrade path and :x: indicates an unsupported
+path. A [:question:](#kubernetes-version-constraint) indicates a path that Palette VerteX supports only as a staggered
+upgrade through an intermediate release. Refer to [Kubernetes Version Constraint](#kubernetes-version-constraint) for
+the intermediate release to use.
+
 :::danger
 
 Before upgrading Palette VerteX to a new major version, you must first update it to the latest patch version of the
@@ -53,32 +58,34 @@ health status of MongoDB ReplicaSet members, refer to our
 
 ### Kubernetes Version Constraint
 
-Enterprise Cluster (EC) binary and VerteX Management Appliance installations bundle a specific Kubernetes version with
-each Palette VerteX release. Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette
-VerteX upgrade cannot cross more than one Kubernetes minor version in a single hop. An upgrade that would skip a
-Kubernetes minor version may fail mid-run and leave the management cluster in an unrecoverable state.
+This constraint applies to Enterprise Cluster (EC) binary and VerteX Management Appliance installations, which bundle a
+specific Kubernetes version with each Palette VerteX release. It does not apply to Palette VerteX installed with Helm on
+a customer-managed Kubernetes cluster, where you manage the Kubernetes version independently of Palette VerteX. The
+paths in the **Kubernetes** tab are not subject to this constraint.
+
+Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette VerteX upgrade cannot cross
+more than one Kubernetes minor version in a single hop. An upgrade that would skip a Kubernetes minor version may fail
+mid-run and leave the management cluster in an unrecoverable state.
 
 The following table lists the Kubernetes version bundled with each recent Palette VerteX release.
 
-| Palette VerteX Release         | Kubernetes Version |
-| :----------------------------- | :----------------: |
-| 4.7.40, 4.7.43                 |       1.31.8       |
-| 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
-| 4.9.5, 4.9.8, 4.9.14           |      1.33.10       |
-| 4.9.23 and later               |       1.34.6       |
+| Palette VerteX Release                 | Kubernetes Version |
+| :------------------------------------- | :----------------: |
+| 4.7.40, 4.7.43                         |       1.31.8       |
+| 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
+| 4.9.5, 4.9.8, 4.9.14                   |      1.33.10       |
+| 4.9.23 and later                       |       1.34.6       |
 
 Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
-`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. To reach `4.9.23` or later from
-`4.8.x`, upgrade in two steps.
+`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. The upgrade path tables mark these
+paths with :question: rather than :white_check_mark:. To reach `4.9.23` or later from `4.8.x`, upgrade in two steps.
 
 1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
 
 Before you start any Palette VerteX upgrade, compare the Kubernetes version of your current release with that of the
 target release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the
-missing minor. This constraint applies to EC binary and VerteX Management Appliance installations. It does not apply to
-Palette VerteX installed via Helm on a customer-managed Kubernetes cluster, where your Kubernetes version is managed
-independently of Palette VerteX.
+missing minor.
 
 <Tabs>
 <TabItem label="VMware" value="VMware">
@@ -87,30 +94,30 @@ independently of Palette VerteX.
 
 <!-- upgrade-paths:vmware-4.9:start -->
 
-| **Source Version** | **Target Version** |    **Support**     |
-| :----------------: | :----------------: | :----------------: |
-|       4.8.61       |       4.9.38       | :white_check_mark: |
-|       4.8.61       |       4.9.24       | :white_check_mark: |
-|       4.8.61       |       4.9.14       | :white_check_mark: |
-|       4.8.61       |       4.9.5        | :white_check_mark: |
-|       4.8.56       |       4.9.38       | :white_check_mark: |
-|       4.8.56       |       4.9.24       | :white_check_mark: |
-|       4.8.56       |       4.9.14       | :white_check_mark: |
-|       4.8.56       |       4.9.5        | :white_check_mark: |
-|       4.8.52       |       4.9.38       | :white_check_mark: |
-|       4.8.52       |       4.9.24       | :white_check_mark: |
-|       4.8.52       |       4.9.14       | :white_check_mark: |
-|       4.8.52       |       4.9.5        | :white_check_mark: |
-|       4.8.33       |       4.9.5        | :white_check_mark: |
-|       4.8.25       |       4.9.5        | :white_check_mark: |
-|       4.8.22       |       4.9.5        | :white_check_mark: |
-|       4.8.16       |       4.9.5        | :white_check_mark: |
-|       4.8.12       |       4.9.5        | :white_check_mark: |
-|       4.8.9        |       4.9.5        | :white_check_mark: |
-|       4.8.8        |       4.9.5        | :white_check_mark: |
-|       4.7.38       |       4.9.5        | :white_check_mark: |
-|       4.7.29       |       4.9.5        | :white_check_mark: |
-|       4.7.27       |       4.9.5        | :white_check_mark: |
+| **Source Version** | **Target Version** |                 **Support**                  |
+| :----------------: | :----------------: | :------------------------------------------: |
+|       4.8.61       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.61       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.61       |       4.9.14       |              :white_check_mark:              |
+|       4.8.61       |       4.9.5        |              :white_check_mark:              |
+|       4.8.56       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.56       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.56       |       4.9.14       |              :white_check_mark:              |
+|       4.8.56       |       4.9.5        |              :white_check_mark:              |
+|       4.8.52       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.52       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.52       |       4.9.14       |              :white_check_mark:              |
+|       4.8.52       |       4.9.5        |              :white_check_mark:              |
+|       4.8.33       |       4.9.5        |              :white_check_mark:              |
+|       4.8.25       |       4.9.5        |              :white_check_mark:              |
+|       4.8.22       |       4.9.5        |              :white_check_mark:              |
+|       4.8.16       |       4.9.5        |              :white_check_mark:              |
+|       4.8.12       |       4.9.5        |              :white_check_mark:              |
+|       4.8.9        |       4.9.5        |              :white_check_mark:              |
+|       4.8.8        |       4.9.5        |              :white_check_mark:              |
+|       4.7.38       |       4.9.5        |              :white_check_mark:              |
+|       4.7.29       |       4.9.5        |              :white_check_mark:              |
+|       4.7.27       |       4.9.5        |              :white_check_mark:              |
 
 <!-- upgrade-paths:vmware-4.9:end -->
 
@@ -990,22 +997,22 @@ after a few hours.
 
 <!-- upgrade-paths:appliance-4.9:start -->
 
-| **Source Version** | **Target Version** |    **Support**     |
-| :----------------: | :----------------: | :----------------: |
-|       4.8.61       |       4.9.38       | :white_check_mark: |
-|       4.8.61       |       4.9.24       | :white_check_mark: |
-|       4.8.61       |       4.9.14       | :white_check_mark: |
-|       4.8.61       |       4.9.5        | :white_check_mark: |
-|       4.8.56       |       4.9.38       | :white_check_mark: |
-|       4.8.56       |       4.9.24       | :white_check_mark: |
-|       4.8.56       |       4.9.14       | :white_check_mark: |
-|       4.8.56       |       4.9.5        | :white_check_mark: |
-|       4.8.52       |       4.9.38       | :white_check_mark: |
-|       4.8.52       |       4.9.24       | :white_check_mark: |
-|       4.8.52       |       4.9.14       | :white_check_mark: |
-|       4.8.52       |       4.9.5        | :white_check_mark: |
-|       4.8.12       |       4.9.5        | :white_check_mark: |
-|       4.8.8        |       4.9.5        | :white_check_mark: |
+| **Source Version** | **Target Version** |                 **Support**                  |
+| :----------------: | :----------------: | :------------------------------------------: |
+|       4.8.61       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.61       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.61       |       4.9.14       |              :white_check_mark:              |
+|       4.8.61       |       4.9.5        |              :white_check_mark:              |
+|       4.8.56       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.56       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.56       |       4.9.14       |              :white_check_mark:              |
+|       4.8.56       |       4.9.5        |              :white_check_mark:              |
+|       4.8.52       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
+|       4.8.52       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
+|       4.8.52       |       4.9.14       |              :white_check_mark:              |
+|       4.8.52       |       4.9.5        |              :white_check_mark:              |
+|       4.8.12       |       4.9.5        |              :white_check_mark:              |
+|       4.8.8        |       4.9.5        |              :white_check_mark:              |
 
 <!-- upgrade-paths:appliance-4.9:end -->
 

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -32,10 +32,9 @@ Refer to the following tables for the supported Palette VerteX upgrade paths for
 [Kubernetes](../install-palette-vertex/install-on-kubernetes/install-on-kubernetes.md), and
 [VerteX Management Appliance](../install-palette-vertex/vertex-management-appliance.md) installations.
 
-In the following tables, :white_check_mark: indicates a validated direct upgrade path and :x: indicates an unsupported
-path. A [:question:](#kubernetes-version-constraint) indicates a path that Palette VerteX supports only as a staggered
-upgrade through an intermediate release. Refer to [Kubernetes Version Constraint](#kubernetes-version-constraint) for
-the intermediate release to use.
+In the following tables, :white_check_mark: indicates a validated upgrade path and :x: indicates a path that is not
+supported. Refer to [Kubernetes Version Constraint](#kubernetes-version-constraint) for why some upgrades from a `4.8.x`
+release are not supported, and for the two-step route to use instead.
 
 :::danger
 
@@ -58,30 +57,34 @@ health status of MongoDB ReplicaSet members, refer to our
 
 ### Kubernetes Version Constraint
 
-This constraint applies to Enterprise Cluster (EC) binary and VerteX Management Appliance installations, which bundle a
-specific Kubernetes version with each Palette VerteX release. It does not apply to Palette VerteX installed with Helm on
-a customer-managed Kubernetes cluster, where you manage the Kubernetes version independently of Palette VerteX. The
-paths in the **Kubernetes** tab are not subject to this constraint.
-
 Kubernetes does not support skipping a minor version during a cluster upgrade, so a Palette VerteX upgrade cannot cross
 more than one Kubernetes minor version in a single hop. An upgrade that would skip a Kubernetes minor version may fail
 mid-run and leave the management cluster in an unrecoverable state.
 
+This constraint applies to Enterprise Cluster (EC) binary and VerteX Management Appliance installations, which bundle a
+specific Kubernetes version with each Palette VerteX release. The two installation types do not bundle the same
+Kubernetes version for a given release, so compare the versions for the installation type you use. The constraint does
+not apply to Palette VerteX installed with Helm on a customer-managed Kubernetes cluster, where you manage the
+Kubernetes version independently of Palette VerteX. The paths in the **Kubernetes** tab are not subject to it.
+
 The following table lists the Kubernetes version bundled with each recent Palette VerteX release.
 
-| Palette VerteX Release                 | Kubernetes Version |
-| :------------------------------------- | :----------------: |
-| 4.7.40, 4.7.43                         |       1.31.8       |
-| 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
-| 4.9.5, 4.9.8, 4.9.14                   |      1.33.10       |
-| 4.9.23 and later                       |       1.34.6       |
+| Palette VerteX Release                         | EC Binary | VerteX Management Appliance |
+| :--------------------------------------------- | :-------: | :-------------------------: |
+| 4.7.40, 4.7.43                                 |  1.31.8   |       Not documented        |
+| 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61, 4.8.62 |  1.32.9   |           1.33.9            |
+| 4.9.5, 4.9.8, 4.9.14                           |  1.33.10  |           1.34.6            |
+| 4.9.23 and later                               |  1.34.6   |           1.34.9            |
 
-Direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x` series ships Kubernetes
-`1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. The upgrade path tables mark these
-paths with :question: rather than :white_check_mark:. To reach `4.9.23` or later from `4.8.x`, upgrade in two steps.
+On EC binary installations, direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x`
+series ships Kubernetes `1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. The upgrade
+path tables mark these paths with :x:. To reach `4.9.23` or later from `4.8.x`, upgrade in two steps.
 
-1. Upgrade to a `4.9.x` release on Kubernetes `1.33.10`. We recommend `4.9.14`.
+1. Upgrade to `4.9.14`, which ships Kubernetes `1.33.10`.
 2. After the cluster returns to a healthy state, upgrade to the target `4.9.23` or later release.
+
+VerteX Management Appliance installations are not affected, because they ship Kubernetes `1.33.9` on `4.8.x` and
+`1.34.9` on `4.9.24` and later, which crosses a single minor version.
 
 Before you start any Palette VerteX upgrade, compare the Kubernetes version of your current release with that of the
 target release. If the delta is two or more minor versions, plan an intermediate upgrade through a release on the
@@ -94,30 +97,51 @@ missing minor.
 
 <!-- upgrade-paths:vmware-4.9:start -->
 
-| **Source Version** | **Target Version** |                 **Support**                  |
-| :----------------: | :----------------: | :------------------------------------------: |
-|       4.8.61       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.61       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.61       |       4.9.14       |              :white_check_mark:              |
-|       4.8.61       |       4.9.5        |              :white_check_mark:              |
-|       4.8.56       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.56       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.56       |       4.9.14       |              :white_check_mark:              |
-|       4.8.56       |       4.9.5        |              :white_check_mark:              |
-|       4.8.52       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.52       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.52       |       4.9.14       |              :white_check_mark:              |
-|       4.8.52       |       4.9.5        |              :white_check_mark:              |
-|       4.8.33       |       4.9.5        |              :white_check_mark:              |
-|       4.8.25       |       4.9.5        |              :white_check_mark:              |
-|       4.8.22       |       4.9.5        |              :white_check_mark:              |
-|       4.8.16       |       4.9.5        |              :white_check_mark:              |
-|       4.8.12       |       4.9.5        |              :white_check_mark:              |
-|       4.8.9        |       4.9.5        |              :white_check_mark:              |
-|       4.8.8        |       4.9.5        |              :white_check_mark:              |
-|       4.7.38       |       4.9.5        |              :white_check_mark:              |
-|       4.7.29       |       4.9.5        |              :white_check_mark:              |
-|       4.7.27       |       4.9.5        |              :white_check_mark:              |
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.14       |       4.9.51       | :white_check_mark: |
+|       4.9.14       |       4.9.46       | :white_check_mark: |
+|       4.9.14       |       4.9.44       | :white_check_mark: |
+|       4.9.14       |       4.9.38       | :white_check_mark: |
+|       4.9.14       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.51       |        :x:         |
+|       4.8.62       |       4.9.46       |        :x:         |
+|       4.8.62       |       4.9.44       |        :x:         |
+|       4.8.62       |       4.9.38       |        :x:         |
+|       4.8.62       |       4.9.24       |        :x:         |
+|       4.8.62       |       4.9.14       | :white_check_mark: |
+|       4.8.62       |       4.9.5        | :white_check_mark: |
+|       4.8.61       |       4.9.51       |        :x:         |
+|       4.8.61       |       4.9.46       |        :x:         |
+|       4.8.61       |       4.9.44       |        :x:         |
+|       4.8.61       |       4.9.38       |        :x:         |
+|       4.8.61       |       4.9.24       |        :x:         |
+|       4.8.61       |       4.9.14       | :white_check_mark: |
+|       4.8.61       |       4.9.5        | :white_check_mark: |
+|       4.8.56       |       4.9.51       |        :x:         |
+|       4.8.56       |       4.9.46       |        :x:         |
+|       4.8.56       |       4.9.44       |        :x:         |
+|       4.8.56       |       4.9.38       |        :x:         |
+|       4.8.56       |       4.9.24       |        :x:         |
+|       4.8.56       |       4.9.14       | :white_check_mark: |
+|       4.8.56       |       4.9.5        | :white_check_mark: |
+|       4.8.52       |       4.9.51       |        :x:         |
+|       4.8.52       |       4.9.46       |        :x:         |
+|       4.8.52       |       4.9.44       |        :x:         |
+|       4.8.52       |       4.9.38       |        :x:         |
+|       4.8.52       |       4.9.24       |        :x:         |
+|       4.8.52       |       4.9.14       | :white_check_mark: |
+|       4.8.52       |       4.9.5        | :white_check_mark: |
+|       4.8.33       |       4.9.5        | :white_check_mark: |
+|       4.8.25       |       4.9.5        | :white_check_mark: |
+|       4.8.22       |       4.9.5        | :white_check_mark: |
+|       4.8.16       |       4.9.5        | :white_check_mark: |
+|       4.8.12       |       4.9.5        | :white_check_mark: |
+|       4.8.9        |       4.9.5        | :white_check_mark: |
+|       4.8.8        |       4.9.5        | :white_check_mark: |
+|       4.7.38       |       4.9.5        |        :x:         |
+|       4.7.29       |       4.9.5        |        :x:         |
+|       4.7.27       |       4.9.5        |        :x:         |
 
 <!-- upgrade-paths:vmware-4.9:end -->
 
@@ -545,14 +569,35 @@ after a few hours.
 
 | **Source Version** | **Target Version** |    **Support**     |
 | :----------------: | :----------------: | :----------------: |
+|       4.9.14       |       4.9.51       | :white_check_mark: |
+|       4.9.14       |       4.9.46       | :white_check_mark: |
+|       4.9.14       |       4.9.44       | :white_check_mark: |
+|       4.9.14       |       4.9.38       | :white_check_mark: |
+|       4.9.14       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.51       | :white_check_mark: |
+|       4.8.62       |       4.9.46       | :white_check_mark: |
+|       4.8.62       |       4.9.44       | :white_check_mark: |
+|       4.8.62       |       4.9.38       | :white_check_mark: |
+|       4.8.62       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.14       | :white_check_mark: |
+|       4.8.62       |       4.9.5        | :white_check_mark: |
+|       4.8.61       |       4.9.51       | :white_check_mark: |
+|       4.8.61       |       4.9.46       | :white_check_mark: |
+|       4.8.61       |       4.9.44       | :white_check_mark: |
 |       4.8.61       |       4.9.38       | :white_check_mark: |
 |       4.8.61       |       4.9.24       | :white_check_mark: |
 |       4.8.61       |       4.9.14       | :white_check_mark: |
 |       4.8.61       |       4.9.5        | :white_check_mark: |
+|       4.8.56       |       4.9.51       | :white_check_mark: |
+|       4.8.56       |       4.9.46       | :white_check_mark: |
+|       4.8.56       |       4.9.44       | :white_check_mark: |
 |       4.8.56       |       4.9.38       | :white_check_mark: |
 |       4.8.56       |       4.9.24       | :white_check_mark: |
 |       4.8.56       |       4.9.14       | :white_check_mark: |
 |       4.8.56       |       4.9.5        | :white_check_mark: |
+|       4.8.52       |       4.9.51       | :white_check_mark: |
+|       4.8.52       |       4.9.46       | :white_check_mark: |
+|       4.8.52       |       4.9.44       | :white_check_mark: |
 |       4.8.52       |       4.9.38       | :white_check_mark: |
 |       4.8.52       |       4.9.24       | :white_check_mark: |
 |       4.8.52       |       4.9.14       | :white_check_mark: |
@@ -997,22 +1042,43 @@ after a few hours.
 
 <!-- upgrade-paths:appliance-4.9:start -->
 
-| **Source Version** | **Target Version** |                 **Support**                  |
-| :----------------: | :----------------: | :------------------------------------------: |
-|       4.8.61       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.61       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.61       |       4.9.14       |              :white_check_mark:              |
-|       4.8.61       |       4.9.5        |              :white_check_mark:              |
-|       4.8.56       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.56       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.56       |       4.9.14       |              :white_check_mark:              |
-|       4.8.56       |       4.9.5        |              :white_check_mark:              |
-|       4.8.52       |       4.9.38       | [:question:](#kubernetes-version-constraint) |
-|       4.8.52       |       4.9.24       | [:question:](#kubernetes-version-constraint) |
-|       4.8.52       |       4.9.14       |              :white_check_mark:              |
-|       4.8.52       |       4.9.5        |              :white_check_mark:              |
-|       4.8.12       |       4.9.5        |              :white_check_mark:              |
-|       4.8.8        |       4.9.5        |              :white_check_mark:              |
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.14       |       4.9.51       | :white_check_mark: |
+|       4.9.14       |       4.9.46       | :white_check_mark: |
+|       4.9.14       |       4.9.44       | :white_check_mark: |
+|       4.9.14       |       4.9.38       | :white_check_mark: |
+|       4.9.14       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.51       | :white_check_mark: |
+|       4.8.62       |       4.9.46       | :white_check_mark: |
+|       4.8.62       |       4.9.44       | :white_check_mark: |
+|       4.8.62       |       4.9.38       | :white_check_mark: |
+|       4.8.62       |       4.9.24       | :white_check_mark: |
+|       4.8.62       |       4.9.14       | :white_check_mark: |
+|       4.8.62       |       4.9.5        | :white_check_mark: |
+|       4.8.61       |       4.9.51       | :white_check_mark: |
+|       4.8.61       |       4.9.46       | :white_check_mark: |
+|       4.8.61       |       4.9.44       | :white_check_mark: |
+|       4.8.61       |       4.9.38       | :white_check_mark: |
+|       4.8.61       |       4.9.24       | :white_check_mark: |
+|       4.8.61       |       4.9.14       | :white_check_mark: |
+|       4.8.61       |       4.9.5        | :white_check_mark: |
+|       4.8.56       |       4.9.51       | :white_check_mark: |
+|       4.8.56       |       4.9.46       | :white_check_mark: |
+|       4.8.56       |       4.9.44       | :white_check_mark: |
+|       4.8.56       |       4.9.38       | :white_check_mark: |
+|       4.8.56       |       4.9.24       | :white_check_mark: |
+|       4.8.56       |       4.9.14       | :white_check_mark: |
+|       4.8.56       |       4.9.5        | :white_check_mark: |
+|       4.8.52       |       4.9.51       | :white_check_mark: |
+|       4.8.52       |       4.9.46       | :white_check_mark: |
+|       4.8.52       |       4.9.44       | :white_check_mark: |
+|       4.8.52       |       4.9.38       | :white_check_mark: |
+|       4.8.52       |       4.9.24       | :white_check_mark: |
+|       4.8.52       |       4.9.14       | :white_check_mark: |
+|       4.8.52       |       4.9.5        | :white_check_mark: |
+|       4.8.12       |       4.9.5        | :white_check_mark: |
+|       4.8.8        |       4.9.5        | :white_check_mark: |
 
 <!-- upgrade-paths:appliance-4.9:end -->
 

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -71,7 +71,7 @@ The following table lists the Kubernetes version bundled with each recent Palett
 
 | Palette VerteX Release                         | EC Binary | VerteX Management Appliance |
 | :--------------------------------------------- | :-------: | :-------------------------: |
-| 4.7.40, 4.7.43                                 |  1.31.8   |       Not documented        |
+| 4.7.40, 4.7.43                                 |  1.31.8   |       Not applicable        |
 | 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61, 4.8.62 |  1.32.9   |           1.33.9            |
 | 4.9.5, 4.9.8, 4.9.14                           |  1.33.10  |           1.34.6            |
 | 4.9.23 and later                               |  1.34.6   |           1.34.9            |

--- a/scripts/release/generate-upgrade-paths.README.md
+++ b/scripts/release/generate-upgrade-paths.README.md
@@ -45,25 +45,29 @@ published page cannot detect.
 
 ## Kubernetes version constraint
 
-Kubernetes minor versions cannot be skipped during an upgrade, so a path that crosses two or more
-minors is supportable only as a staggered upgrade. Rather than relying on Confluence to carry that
-judgment, the script derives it (DOC-3097):
+Kubernetes minor versions cannot be skipped during an upgrade, so a validated path that
+crosses two or more minors is a contradiction. That contradiction is what DOC-3097 was raised
+for: the tables marked every `4.8.x` → `4.9.23`+ path as supported while the prose on the same
+page said those upgrades were unsupported.
 
-1. It reads the bundled Kubernetes version per release from the **Kubernetes Version Constraint**
-   table **on the page it is writing**, so the rule and the published table cannot disagree. Both
-   cell shapes are understood — an explicit list (`4.8.54, 4.8.56, 4.8.58, 4.8.61`) and a floor
-   (`4.9.23 and later`, confined to its own `major.minor` so it never describes a `4.10.x`
-   release).
-2. For `vmware` (EC binary) and `appliance` installs, a ✅ whose source and target are two or more
-   Kubernetes minors apart becomes ❓. `kubernetes` (Helm) installs are exempt, because on a
-   customer-managed cluster the Kubernetes version is managed independently of Palette.
-3. An explicit ❌ from Confluence is never overridden.
+The published marks now **mirror Confluence exactly**. Engineering marks the unsupported direct
+paths in the matrix itself, so the script does not need to derive them. What the script does add
+is a **cross-check**:
 
-The rule **fails open**: a release the constraint table does not describe keeps the mark Confluence
-gave it, so a newly shipped release is never mislabeled by guesswork. Such a release is reported
-only when the other end of the path *is* described, since that is the case where a missing table
-entry hides a real answer. Adding the release to the **Kubernetes Version Constraint** table brings
-it under the rule.
+1. It reads the bundled Kubernetes version from the matrix's own header and row labels, for
+   example `4.9.x · K8s 1.33.10`. These are per install type, which matters: **the EC binary and
+   the Appliance Installer ship different Kubernetes versions for the same Palette release**
+   (`4.8.x` is `1.32.9` on EC but `1.33.9` on the appliance), so the constraint bites on one and
+   not the other.
+2. Any path marked supported whose own labels say it crosses more than one Kubernetes minor
+   version is **reported**, not rewritten. A disagreement means either the mark or the label is
+   wrong, and both live in Confluence — fix it at source rather than papering over it here.
+3. Labels carrying no version are skipped. That is normal for Helm installs (the cluster's
+   Kubernetes version is managed independently of Palette) and for `K8s TBD` on an unreleased
+   version.
+
+The Kubernetes version tables on the upgrade pages are for readers only; nothing parses them.
+Keep them consistent with the matrix labels by hand, per installation type.
 
 ## Failure modes
 
@@ -73,16 +77,21 @@ quietly halves a table cannot look like a clean run.
 These abort the run **before anything is written**, because each one would otherwise leave whole
 marker blocks silently stranded at their old content:
 
-- A table with no install-type heading above it. Usually an `h3` was renamed, so `INSTALL_MAP` no
-  longer matches and the table is discarded. The error names the heading it found.
+- A table with no install-type heading above it, inside the auto-managed version range. Usually
+  an `h3` was renamed, so `INSTALL_MAP` no longer matches and the table is discarded. The error
+  names the heading it found.
 - An install that parsed zero rows.
 
-These are warnings, and the run continues:
+These are warnings or notes, and the run continues:
 
+- Bare tables in the legacy version groups below 4.6 (`4.3 → 4.4`, `4.1 through 4.3`). These have
+  always been hand-maintained and out of scope, so they are only noted.
 - An `h3` heading that maps to no install and has no table under it.
 - A status cell that cannot be classified.
-- A release with no documented bundled Kubernetes version (refer to the fail-open behavior above).
-- A Confluence block the Markdown has no marker for. Add the marker pair and rerun.
+- A path marked supported that skips a Kubernetes minor version (refer to the cross-check above).
+- A Confluence block the Markdown has no marker for. Add the marker pair and rerun. This is
+  expected for a version whose docs live on another branch — for example `4.10` blocks are
+  reported here and added on `docs-rel-4-10-0`.
 
 ## Setup
 

--- a/scripts/release/generate-upgrade-paths.README.md
+++ b/scripts/release/generate-upgrade-paths.README.md
@@ -23,14 +23,66 @@ Only matrix blocks for **version 4.6 and newer** are auto-managed
 
 ## Status mapping
 
-Mirrors what the published docs show:
+Mirrors what the published docs show. Matching is by **keyword, not exact equality**, so a cell
+that has been editorialized (`Supported (staggered)`, `Supported*`) still classifies instead of
+dropping its row from the published table. The narrower cases are tested first, because
+`not supported` contains `supported` and a staggered cell usually says `supported` too.
 
-- `supported` / `verified` / `✅` → ✅
-- `fails` / `not supported` / `❌` / `:cross_mark:` → ❌
-- `staggered` / `conditional` / `intermediate` / `see note` / `❓` → ❓ linking to the **Kubernetes Version Constraint**
-  section (use for a path that is supported only through an intermediate hop, such as a Kubernetes minor-version
-  constraint)
-- `n/a` / `NA` / `In Progress` / blank → _dropped_ (not published)
+| Confluence cell contains                                                                                  | Published mark |
+| --------------------------------------------------------------------------------------------------------- | -------------- |
+| `staggered` / `conditional` / `intermediate` / `see note` / `two-step` / `not supported directly` / `❓`   | ❓             |
+| `not … supported` / `unsupported` / `fails` / `failed` / `❌`                                              | ❌             |
+| `supported` / `verified` / `passed` / `✅`                                                                 | ✅             |
+| `n/a` / `none` / `not applicable` / `not tested` / `in progress` / `pending` / `tbd` / blank               | _dropped_      |
+
+The ❓ mark renders as a link to the **Kubernetes Version Constraint** section, which exists on
+both the VerteX and self-hosted Palette upgrade pages. Use it for a path that is supported only
+through an intermediate hop.
+
+Any other non-blank cell is **reported** (with its install, source, target, and text) and its row
+is not published. That report exists because a dropped row is the one failure a reader of the
+published page cannot detect.
+
+## Kubernetes version constraint
+
+Kubernetes minor versions cannot be skipped during an upgrade, so a path that crosses two or more
+minors is supportable only as a staggered upgrade. Rather than relying on Confluence to carry that
+judgment, the script derives it (DOC-3097):
+
+1. It reads the bundled Kubernetes version per release from the **Kubernetes Version Constraint**
+   table **on the page it is writing**, so the rule and the published table cannot disagree. Both
+   cell shapes are understood — an explicit list (`4.8.54, 4.8.56, 4.8.58, 4.8.61`) and a floor
+   (`4.9.23 and later`, confined to its own `major.minor` so it never describes a `4.10.x`
+   release).
+2. For `vmware` (EC binary) and `appliance` installs, a ✅ whose source and target are two or more
+   Kubernetes minors apart becomes ❓. `kubernetes` (Helm) installs are exempt, because on a
+   customer-managed cluster the Kubernetes version is managed independently of Palette.
+3. An explicit ❌ from Confluence is never overridden.
+
+The rule **fails open**: a release the constraint table does not describe keeps the mark Confluence
+gave it, so a newly shipped release is never mislabeled by guesswork. Such a release is reported
+only when the other end of the path *is* described, since that is the case where a missing table
+entry hides a real answer. Adding the release to the **Kubernetes Version Constraint** table brings
+it under the rule.
+
+## Failure modes
+
+Every run prints the rows it adds, removes, and re-marks per block, so a Confluence change that
+quietly halves a table cannot look like a clean run.
+
+These abort the run **before anything is written**, because each one would otherwise leave whole
+marker blocks silently stranded at their old content:
+
+- A table with no install-type heading above it. Usually an `h3` was renamed, so `INSTALL_MAP` no
+  longer matches and the table is discarded. The error names the heading it found.
+- An install that parsed zero rows.
+
+These are warnings, and the run continues:
+
+- An `h3` heading that maps to no install and has no table under it.
+- A status cell that cannot be classified.
+- A release with no documented bundled Kubernetes version (refer to the fail-open behavior above).
+- A Confluence block the Markdown has no marker for. Add the marker pair and rerun.
 
 ## Setup
 
@@ -65,6 +117,17 @@ git diff
 
 Run `node scripts/release/generate-upgrade-paths.js --help` for all flags.
 
+## Tests
+
+```bash
+npx jest scripts/release/generate-upgrade-paths.test.js
+```
+
+The suite runs against fixtures (a trimmed Confluence storage-format page and the Kubernetes
+version table), so it needs no credentials and no network. It covers the status keyword
+precedence, the constraint rule and its exemptions, the fail-open behavior, the structural-drift
+reports, and the row diff.
+
 ## Notes
 
 - No extra dependencies — uses the repo's `cheerio` and Node's built-in `fetch`
@@ -74,5 +137,8 @@ Run `node scripts/release/generate-upgrade-paths.js --help` for all flags.
 - If the Confluence page gains a block the docs don't have a marker for (e.g. a
   new `appliance-4.6`), the script prints a `Note:` line instead of failing —
   add the marker pair to the Markdown and rerun.
+- Never hand-edit rows between the markers. A block is rebuilt in full on every
+  run, so a manual fix is reverted the next time the script runs — encode it in
+  Confluence or in the constraint rule instead.
 - When a Confluence service account is available, the same script runs unchanged
   in CI; the `CONFLUENCE_*` env vars become repository secrets.

--- a/scripts/release/generate-upgrade-paths.README.md
+++ b/scripts/release/generate-upgrade-paths.README.md
@@ -89,6 +89,13 @@ These are warnings or notes, and the run continues:
 - An `h3` heading that maps to no install and has no table under it.
 - A status cell that cannot be classified.
 - A path marked supported that skips a Kubernetes minor version (refer to the cross-check above).
+- A supported path the cross-check **could not evaluate**, because the matrix label announces a
+  Kubernetes version without giving one (`4.10.x · K8s TBD` on an unreleased version). This one
+  matters at regen time: while the label says `TBD`, a `4.9.x → 4.10.x` path that skips a minor
+  keeps whatever mark Confluence gave it and nothing verifies it. **Before regenerating for a new
+  release, fill the real Kubernetes version into the matrix labels in Confluence, then read the
+  warnings rather than trusting a green run.** A label with no Kubernetes version at all is
+  silent by design, since that is the normal case for Helm installs.
 - A Confluence block the Markdown has no marker for. Add the marker pair and rerun. This is
   expected for a version whose docs live on another branch — for example `4.10` blocks are
   reported here and added on `docs-rel-4-10-0`.

--- a/scripts/release/generate-upgrade-paths.README.md
+++ b/scripts/release/generate-upgrade-paths.README.md
@@ -27,6 +27,9 @@ Mirrors what the published docs show:
 
 - `supported` / `verified` / `✅` → ✅
 - `fails` / `not supported` / `❌` / `:cross_mark:` → ❌
+- `staggered` / `conditional` / `intermediate` / `see note` / `❓` → ❓ linking to the **Kubernetes Version Constraint**
+  section (use for a path that is supported only through an intermediate hop, such as a Kubernetes minor-version
+  constraint)
 - `n/a` / `NA` / `In Progress` / blank → _dropped_ (not published)
 
 ## Setup

--- a/scripts/release/generate-upgrade-paths.js
+++ b/scripts/release/generate-upgrade-paths.js
@@ -20,11 +20,12 @@
  * before writing anything if the Confluence headings changed in a way that would
  * leave marker blocks stale. Refer to the README for the failure modes.
  *
- * Beyond mirroring Confluence, the script downgrades a validated direct path to a
- * staggered one when the upgrade crosses more than one Kubernetes minor version.
- * The bundled Kubernetes version per release is read from the "Kubernetes Version
- * Constraint" table on the page being written, so a hand edit to the tables is
- * never needed and can never disagree with that section (DOC-3097).
+ * The published marks mirror Confluence exactly. As a cross-check, the script reads
+ * the bundled Kubernetes version from the matrix's own header and row labels (which
+ * differ between the EC binary and the Appliance Installer) and reports any path
+ * marked supported that skips a Kubernetes minor version. It reports rather than
+ * rewrites: that disagreement means the matrix or its labels need fixing at source
+ * (DOC-3097).
  *
  * Usage:
  *   # Reads CONFLUENCE_* env vars from .env (run `make init-release` once,
@@ -76,16 +77,13 @@ const DROP_STATUSES = [
   "tbd",
 ];
 
-// Kubernetes minor versions cannot be skipped during an upgrade, so a path that
-// crosses two or more minors is supportable only as a staggered upgrade. The
-// bundled Kubernetes version per release is read from the "Kubernetes Version
-// Constraint" table in the Markdown itself, so this rule cannot drift from what
-// the page publishes. See DOC-3097.
+// Kubernetes minor versions cannot be skipped during an upgrade, so a validated
+// path that crosses two or more minors is a contradiction worth reporting. The
+// Confluence matrix carries the bundled Kubernetes version per install type in its
+// header and row labels ("4.9.x . K8s 1.33.10"), which is the authority: the EC
+// binary and the Appliance Installer ship different Kubernetes versions for the
+// same Palette release. See DOC-3097.
 const MAX_K8S_MINOR_DELTA = 1;
-
-// Installs the constraint applies to. Helm installs on a customer-managed cluster
-// are exempt because the Kubernetes version is managed independently of Palette.
-const CONSTRAINED_INSTALLS = ["vmware", "appliance"];
 
 // Confluence install-type heading -> marker install slug.
 const INSTALL_MAP = {
@@ -135,6 +133,15 @@ function majorMinor(version) {
 
 function meetsFloor(mm) {
   return cmpKey(versionKey(mm), MIN_VERSION) >= 0;
+}
+
+// Does a Confluence version-group heading ("4.8 -> 4.9", "4.1 through 4.3") name any
+// release inside the auto-managed range? A heading with no parseable version counts as
+// in scope, so that genuine drift is never hidden behind an unreadable heading.
+function headingMeetsFloor(heading) {
+  const versions = clean(heading).match(/\d+\.\d+/g);
+  if (!versions) return true;
+  return versions.some((v) => meetsFloor(v));
 }
 
 // Expand cells such as "4.6.25 to .28" or "4.6.25 to 4.6.28" into versions.
@@ -211,75 +218,34 @@ function isKnownDropStatus(status) {
 // Kubernetes version constraint
 // ---------------------------------------------------------------------------
 
-// Read the bundled Kubernetes version per release out of the "Kubernetes Version
-// Constraint" table on the upgrade page. Both cell shapes in use are handled:
-//   "4.8.54, 4.8.56, 4.8.58, 4.8.61" -> those exact releases
-//   "4.9.23 and later"               -> any later patch of the same minor (4.9.x)
-// A floor is deliberately confined to its own major.minor, so "4.9.23 and later"
-// never claims to describe a 4.10.x release.
-function parseBundledK8sVersions(markdown) {
-  const exact = new Map();
-  const floors = [];
-  const parts = (markdown || "").split(/^### Kubernetes Version Constraint\s*$/m);
-  if (parts.length < 2) return { exact, floors };
-  const body = parts[1].split(/^#{1,3} /m)[0];
-  for (const line of body.split("\n")) {
-    const cells = splitTableRow(line);
-    if (cells.length !== 2) continue;
-    const k8s = cells[1].match(/^(\d+)\.(\d+)\.\d+$/);
-    if (!k8s) continue;
-    const version = { major: Number(k8s[1]), minor: Number(k8s[2]) };
-    const later = cells[0].match(/^(\d+\.\d+\.\d+)\s+and\s+later$/i);
-    if (later) {
-      floors.push({ release: later[1], k8s: version });
-      continue;
-    }
-    for (const release of cells[0].split(",")) {
-      const v = release.trim();
-      if (/^\d+\.\d+\.\d+$/.test(v)) exact.set(v, version);
-    }
-  }
-  return { exact, floors };
+// Pull the bundled Kubernetes version out of a Confluence label cell, for example
+// "4.9.x . K8s 1.33.10" or "4.8.x - K8s 1.32.9". Returns null when the label carries
+// no version, which is the normal case for Helm installs (the cluster's Kubernetes
+// version is managed independently of Palette) and for "K8s TBD" on an unreleased
+// version.
+function parseK8sLabel(label) {
+  const m = clean(label).match(/K8s\s*v?(\d+)\.(\d+)(?:\.\d+)?/i);
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]) };
 }
 
-// Resolve one release to its bundled Kubernetes version, or null when the table
-// does not describe it.
-function bundledK8s(map, release) {
-  if (map.exact.has(release)) return map.exact.get(release);
-  let best = null;
-  for (const floor of map.floors) {
-    if (majorMinor(floor.release) !== majorMinor(release)) continue;
-    if (cmpKey(versionKey(release), versionKey(floor.release)) < 0) continue;
-    if (!best || cmpKey(versionKey(floor.release), versionKey(best.release)) > 0) best = floor;
-  }
-  return best ? best.k8s : null;
-}
-
-// Downgrade a validated direct path to a staggered one when it crosses more than
-// MAX_K8S_MINOR_DELTA Kubernetes minor versions.
-//
-// Fails open on purpose: a release the constraint table does not describe keeps the
-// mark Confluence gave it, so a newly shipped release is never mislabeled by
-// guesswork. Such a release is reported only when the other end of the path IS
-// described, because that is the case where a missing table entry hides a real
-// answer. A path with both ends unmapped predates the table and stays quiet.
-function applyK8sConstraint(pathsByInstall, k8sMap, report) {
-  for (const install of CONSTRAINED_INSTALLS) {
-    for (const p of pathsByInstall[install] || []) {
+// Report any path Confluence marks as validated whose own labels say it crosses more
+// than MAX_K8S_MINOR_DELTA Kubernetes minor versions. This never rewrites a mark --
+// Confluence is the source of truth -- but a disagreement means either the matrix or
+// its Kubernetes labels are wrong, which is exactly the defect DOC-3097 was raised
+// for. Paths whose labels carry no Kubernetes version are skipped.
+function checkK8sConstraint(pathsByInstall, report) {
+  for (const [install, paths] of Object.entries(pathsByInstall)) {
+    for (const p of paths) {
       if (p.support !== CHECK) continue;
-      const from = bundledK8s(k8sMap, p.source);
-      const to = bundledK8s(k8sMap, p.target);
-      if (!from || !to) {
-        if (from && !to) report.unmapped.add(p.target);
-        else if (!from && to) report.unmapped.add(p.source);
-        continue;
-      }
-      const crossesMajor = from.major !== to.major;
-      if (!crossesMajor && to.minor - from.minor <= MAX_K8S_MINOR_DELTA) continue;
-      p.support = QUESTION;
-      report.staggered.push(
-        `${install}: ${p.source} -> ${p.target} ` +
-          `(Kubernetes ${from.major}.${from.minor} -> ${to.major}.${to.minor})`
+      const from = p.sourceK8s;
+      const to = p.targetK8s;
+      if (!from || !to) continue;
+      const delta = from.major === to.major ? to.minor - from.minor : Infinity;
+      if (delta <= MAX_K8S_MINOR_DELTA) continue;
+      report.constraintConflicts.push(
+        `${install}: ${p.source} -> ${p.target} is marked supported but crosses ` +
+          `Kubernetes ${from.major}.${from.minor} -> ${to.major}.${to.minor}`
       );
     }
   }
@@ -292,8 +258,8 @@ function newReport() {
     orphanTables: [],
     unrecognizedCells: [],
     emptyInstalls: [],
-    unmapped: new Set(),
-    staggered: [],
+    skippedLegacyTables: [],
+    constraintConflicts: [],
   };
 }
 
@@ -346,11 +312,15 @@ function matrixToPaths(rows, install, report) {
   }
 
   // Matrix table: row 0 = target labels, row 1 = target versions ("to ➡️").
+  // The labels carry the bundled Kubernetes version per install type, which differs
+  // between the EC binary and the Appliance Installer for the same Palette release.
+  const targetLabels = rows[0].slice(2);
   const targetVersions = rows[1].slice(2);
   for (const row of rows.slice(2)) {
     if (row.length < 3) continue;
     const source = row[1];
     if (!/^\d+\.\d+/.test(source)) continue;
+    const sourceK8s = parseK8sLabel(row[0]);
     const statuses = row.slice(2);
     for (let i = 0; i < targetVersions.length; i++) {
       const mark = statusToMark(statuses[i]);
@@ -358,9 +328,10 @@ function matrixToPaths(rows, install, report) {
         if (!isKnownDropStatus(statuses[i])) flag(statuses[i], source, targetVersions[i]);
         continue;
       }
+      const targetK8s = parseK8sLabel(targetLabels[i]);
       for (const target of expandTarget(targetVersions[i])) {
         if (/^\d+\.\d+/.test(target)) {
-          paths.push({ source, target, support: mark });
+          paths.push({ source, target, support: mark, sourceK8s, targetK8s });
         }
       }
     }
@@ -404,10 +375,14 @@ function parseUpgradePaths(html, report) {
     else tableEl = $(el).find("table").get(0) || null;
     if (!tableEl) continue;
     if (!currentInstall) {
-      // A table with no install context is discarded, which would leave every marker
-      // block for that install untouched and stale. Record it so the run can fail
-      // instead of reporting success on a page whose headings were restructured.
-      report.orphanTables.push(lastHeading || "(no preceding heading)");
+      // A table with no install context is discarded. Inside the auto-managed range
+      // that would leave marker blocks stale, so the run must fail rather than report
+      // success on a page whose headings were restructured. The legacy groups below
+      // the floor have always been bare tables and are hand-maintained, so they are
+      // only noted.
+      const where = lastHeading || "(no preceding heading)";
+      if (headingMeetsFloor(where)) report.orphanTables.push(where);
+      else report.skippedLegacyTables.push(where);
       continue;
     }
     byInstall[currentInstall].push(...matrixToPaths(getRows($, tableEl), currentInstall, report));
@@ -685,15 +660,6 @@ function assertNoStructuralDrift(report) {
   }
 }
 
-// Deep-enough copy that per-product constraint marks cannot leak between products.
-function clonePaths(pathsByInstall) {
-  const out = {};
-  for (const [install, paths] of Object.entries(pathsByInstall)) {
-    out[install] = paths.map((p) => ({ ...p }));
-  }
-  return out;
-}
-
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -708,12 +674,19 @@ async function main() {
   const html = await loadHtml(args);
   const report = newReport();
   const pathsByInstall = parseUpgradePaths(html, report);
+  checkK8sConstraint(pathsByInstall, report);
 
   console.log("Parsed upgrade paths:");
   for (const [install, paths] of Object.entries(pathsByInstall)) {
     console.log(`  ${install}: ${paths.length} rows`);
   }
 
+  if (report.skippedLegacyTables.length) {
+    console.log(
+      `Note: skipped ${report.skippedLegacyTables.length} hand-maintained table(s) ` +
+        `below ${MIN_VERSION.join(".")} (under: ${[...new Set(report.skippedLegacyTables)].join(", ")})`
+    );
+  }
   if (report.unknownHeadings.size) {
     console.log(
       `Warning: unrecognized install-type heading(s), not mapped to any install: ` +
@@ -727,41 +700,22 @@ async function main() {
     );
     for (const cell of report.unrecognizedCells) console.log(`  ${cell}`);
   }
+  if (report.constraintConflicts.length) {
+    console.log(
+      `Warning: ${report.constraintConflicts.length} path(s) are marked supported but ` +
+        `skip a Kubernetes minor version according to the matrix's own labels. Either ` +
+        `the mark or the label is wrong -- confirm with Engineering before publishing:`
+    );
+    for (const line of report.constraintConflicts) console.log(`  ${line}`);
+  }
 
   assertNoStructuralDrift(report);
 
   for (const [product, mdPath] of Object.entries(markdownPaths)) {
     const markdown = fs.readFileSync(mdPath, "utf8");
-
-    // The constraint is derived per product, from that page's own Kubernetes version
-    // table, so the rule and the published table cannot disagree.
-    const productReport = { unmapped: new Set(), staggered: [] };
-    const k8sMap = parseBundledK8sVersions(markdown);
-    const paths = clonePaths(pathsByInstall);
-    if (!k8sMap.exact.size && !k8sMap.floors.length) {
-      console.log(
-        `Warning: no "Kubernetes Version Constraint" version table found in ${mdPath}; ` +
-          `the staggered-upgrade rule was not applied.`
-      );
-    } else {
-      applyK8sConstraint(paths, k8sMap, productReport);
-    }
-
-    const [updated, missing, changes] = replaceUpgradePathMarkers(markdown, paths);
+    const [updated, missing, changes] = replaceUpgradePathMarkers(markdown, pathsByInstall);
 
     console.log(`\n${product} (${mdPath})`);
-    if (productReport.staggered.length) {
-      console.log(`  Staggered by the Kubernetes version constraint:`);
-      for (const line of productReport.staggered) console.log(`    ${line}`);
-    }
-    if (productReport.unmapped.size) {
-      console.log(
-        `  Warning: no bundled Kubernetes version documented for ` +
-          `${[...productReport.unmapped].sort((a, b) => cmpKey(versionKey(a), versionKey(b))).join(", ")}. ` +
-          `Those paths keep the mark Confluence gave them. Add the release(s) to the ` +
-          `"Kubernetes Version Constraint" table to have the rule cover them.`
-      );
-    }
     if (missing.length) {
       console.log(`  Note: no marker for: ${missing.join(", ")}`);
     }
@@ -800,14 +754,13 @@ if (require.main === module) {
 }
 
 module.exports = {
-  applyK8sConstraint,
-  bundledK8s,
-  clonePaths,
+  checkK8sConstraint,
   diffRows,
+  headingMeetsFloor,
   isKnownDropStatus,
   matrixToPaths,
   newReport,
-  parseBundledK8sVersions,
+  parseK8sLabel,
   parseRenderedRows,
   parseUpgradePaths,
   renderTable,

--- a/scripts/release/generate-upgrade-paths.js
+++ b/scripts/release/generate-upgrade-paths.js
@@ -229,6 +229,15 @@ function parseK8sLabel(label) {
   return { major: Number(m[1]), minor: Number(m[2]) };
 }
 
+// A label that announces a Kubernetes version but does not give one, such as
+// "4.10.x · K8s TBD" on an unreleased version. Distinct from a label with no
+// Kubernetes version at all, which is the normal and silent case for Helm installs:
+// here someone intended to state a version and has not yet, so the cross-check
+// cannot run and must say so rather than pass quietly.
+function isPlaceholderK8sLabel(label) {
+  return /K8s/i.test(clean(label)) && !parseK8sLabel(label);
+}
+
 // Report any path Confluence marks as validated whose own labels say it crosses more
 // than MAX_K8S_MINOR_DELTA Kubernetes minor versions. This never rewrites a mark --
 // Confluence is the source of truth -- but a disagreement means either the matrix or
@@ -240,7 +249,17 @@ function checkK8sConstraint(pathsByInstall, report) {
       if (p.support !== CHECK) continue;
       const from = p.sourceK8s;
       const to = p.targetK8s;
-      if (!from || !to) continue;
+      if (!from || !to) {
+        // Silence here would hide a path the cross-check never evaluated.
+        const unresolved = [p.sourceLabel, p.targetLabel].filter(isPlaceholderK8sLabel);
+        if (unresolved.length) {
+          report.unresolvedK8s.push(
+            `${install}: ${p.source} -> ${p.target} could not be checked ` +
+              `(${unresolved.map((l) => `"${clean(l)}"`).join(", ")})`
+          );
+        }
+        continue;
+      }
       const delta = from.major === to.major ? to.minor - from.minor : Infinity;
       if (delta <= MAX_K8S_MINOR_DELTA) continue;
       report.constraintConflicts.push(
@@ -260,6 +279,7 @@ function newReport() {
     emptyInstalls: [],
     skippedLegacyTables: [],
     constraintConflicts: [],
+    unresolvedK8s: [],
   };
 }
 
@@ -320,7 +340,8 @@ function matrixToPaths(rows, install, report) {
     if (row.length < 3) continue;
     const source = row[1];
     if (!/^\d+\.\d+/.test(source)) continue;
-    const sourceK8s = parseK8sLabel(row[0]);
+    const sourceLabel = row[0];
+    const sourceK8s = parseK8sLabel(sourceLabel);
     const statuses = row.slice(2);
     for (let i = 0; i < targetVersions.length; i++) {
       const mark = statusToMark(statuses[i]);
@@ -328,10 +349,11 @@ function matrixToPaths(rows, install, report) {
         if (!isKnownDropStatus(statuses[i])) flag(statuses[i], source, targetVersions[i]);
         continue;
       }
-      const targetK8s = parseK8sLabel(targetLabels[i]);
+      const targetLabel = targetLabels[i];
+      const targetK8s = parseK8sLabel(targetLabel);
       for (const target of expandTarget(targetVersions[i])) {
         if (/^\d+\.\d+/.test(target)) {
-          paths.push({ source, target, support: mark, sourceK8s, targetK8s });
+          paths.push({ source, target, support: mark, sourceK8s, targetK8s, sourceLabel, targetLabel });
         }
       }
     }
@@ -700,6 +722,14 @@ async function main() {
     );
     for (const cell of report.unrecognizedCells) console.log(`  ${cell}`);
   }
+  if (report.unresolvedK8s.length) {
+    console.log(
+      `Warning: ${report.unresolvedK8s.length} supported path(s) could not be checked ` +
+        `against the Kubernetes constraint because the matrix label names no version. ` +
+        `Fill in the version in Confluence, then re-run:`
+    );
+    for (const line of report.unresolvedK8s) console.log(`  ${line}`);
+  }
   if (report.constraintConflicts.length) {
     console.log(
       `Warning: ${report.constraintConflicts.length} path(s) are marked supported but ` +
@@ -755,6 +785,7 @@ if (require.main === module) {
 
 module.exports = {
   checkK8sConstraint,
+  isPlaceholderK8sLabel,
   diffRows,
   headingMeetsFloor,
   isKnownDropStatus,

--- a/scripts/release/generate-upgrade-paths.js
+++ b/scripts/release/generate-upgrade-paths.js
@@ -40,6 +40,11 @@ const cheerio = require("cheerio");
 
 const CHECK = ":white_check_mark:";
 const CROSS = ":x:";
+// Staggered/conditional path: supported only through an intermediate hop (for example,
+// a Kubernetes minor-version constraint that forbids a direct upgrade). Rendered as a
+// linked question mark that points at the hand-written "Kubernetes Version Constraint"
+// section, which exists on both the VerteX and Self-Hosted upgrade pages. See DOC-3097.
+const QUESTION = "[:question:](#kubernetes-version-constraint)";
 
 // Confluence install-type heading -> marker install slug.
 const INSTALL_MAP = {
@@ -115,9 +120,10 @@ function range(start, end) {
 
 // Map a Confluence status cell to a published Support mark, or null to drop.
 // Decision: mirror the live docs.
-//   supported / verified / ✅            -> ✅
-//   fails / not supported / ❌ / cross    -> ❌
-//   n/a / NA / in progress / blank        -> dropped
+//   supported / verified / ✅                        -> ✅
+//   fails / not supported / ❌ / cross                -> ❌
+//   staggered / conditional / intermediate / ❓        -> ❓ (links to the version constraint note)
+//   n/a / NA / in progress / blank                    -> dropped
 function statusToMark(status) {
   const s = clean(status).toLowerCase();
   if (["supported", "verified", "✅", ":white_check_mark:"].includes(s)) {
@@ -136,6 +142,23 @@ function statusToMark(status) {
     ].includes(s)
   ) {
     return CROSS;
+  }
+  // Supported only via an intermediate/staggered hop. A bare note in the cell would
+  // otherwise fall through to null and silently drop the row, so map these explicitly.
+  if (
+    [
+      "staggered",
+      "conditional",
+      "intermediate",
+      "see note",
+      "see notes",
+      "❓",
+      "❔",
+      ":question:",
+      ":grey_question:",
+    ].includes(s)
+  ) {
+    return QUESTION;
   }
   // n/a, na, "in progress", blank, notes, etc. are not published.
   return null;

--- a/scripts/release/generate-upgrade-paths.js
+++ b/scripts/release/generate-upgrade-paths.js
@@ -16,6 +16,16 @@
  * (vmware/kubernetes 4.6+, appliance 4.7+). The *-prior and legacy 4.5/4.4
  * blocks are left untouched for hand maintenance.
  *
+ * Every run prints the rows it adds, removes, and re-marks per block, and fails
+ * before writing anything if the Confluence headings changed in a way that would
+ * leave marker blocks stale. Refer to the README for the failure modes.
+ *
+ * Beyond mirroring Confluence, the script downgrades a validated direct path to a
+ * staggered one when the upgrade crosses more than one Kubernetes minor version.
+ * The bundled Kubernetes version per release is read from the "Kubernetes Version
+ * Constraint" table on the page being written, so a hand edit to the tables is
+ * never needed and can never disagree with that section (DOC-3097).
+ *
  * Usage:
  *   # Reads CONFLUENCE_* env vars from .env (run `make init-release` once,
  *   # fill in the values, then `source .env`).
@@ -45,6 +55,37 @@ const CROSS = ":x:";
 // linked question mark that points at the hand-written "Kubernetes Version Constraint"
 // section, which exists on both the VerteX and Self-Hosted upgrade pages. See DOC-3097.
 const QUESTION = "[:question:](#kubernetes-version-constraint)";
+
+// Status cells that intentionally publish nothing. Any other cell that fails to
+// classify is reported, so a Confluence wording change cannot silently drop rows.
+const DROP_STATUSES = [
+  "",
+  "-",
+  "--",
+  "\u2014",
+  "n/a",
+  "n.a.",
+  "na",
+  "none",
+  "not applicable",
+  "not tested",
+  "untested",
+  "in progress",
+  "in-progress",
+  "pending",
+  "tbd",
+];
+
+// Kubernetes minor versions cannot be skipped during an upgrade, so a path that
+// crosses two or more minors is supportable only as a staggered upgrade. The
+// bundled Kubernetes version per release is read from the "Kubernetes Version
+// Constraint" table in the Markdown itself, so this rule cannot drift from what
+// the page publishes. See DOC-3097.
+const MAX_K8S_MINOR_DELTA = 1;
+
+// Installs the constraint applies to. Helm installs on a customer-managed cluster
+// are exempt because the Kubernetes version is managed independently of Palette.
+const CONSTRAINED_INSTALLS = ["vmware", "appliance"];
 
 // Confluence install-type heading -> marker install slug.
 const INSTALL_MAP = {
@@ -118,50 +159,142 @@ function range(start, end) {
   return out;
 }
 
-// Map a Confluence status cell to a published Support mark, or null to drop.
-// Decision: mirror the live docs.
-//   supported / verified / ✅                        -> ✅
-//   fails / not supported / ❌ / cross                -> ❌
-//   staggered / conditional / intermediate / ❓        -> ❓ (links to the version constraint note)
-//   n/a / NA / in progress / blank                    -> dropped
+// Split one Markdown table row into trimmed cells. Tolerates the padding Prettier
+// adds when it aligns a table, and rows written without outer pipes.
+function splitTableRow(line) {
+  const trimmed = line.trim();
+  if (!trimmed.includes("|")) return [];
+  return trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+// Map a Confluence status cell to a published Support mark, or null to drop the row.
+// Matching is by keyword rather than exact equality so that an editorialized cell such
+// as "Supported (staggered)" still classifies instead of vanishing from the table.
+// Order matters: "not supported" contains "supported", and a staggered cell usually
+// says "supported" too, so the narrower cases are tested first.
+//   staggered / conditional / intermediate / two-step / ❓ -> ❓ (links to the constraint)
+//   not supported / unsupported / fails / ❌              -> ❌
+//   supported / verified / passed / ✅                    -> ✅
+//   n/a / in progress / blank (refer to DROP_STATUSES)   -> dropped
+// Anything else returns null and is reported by the caller.
 function statusToMark(status) {
   const s = clean(status).toLowerCase();
-  if (["supported", "verified", "✅", ":white_check_mark:"].includes(s)) {
-    return CHECK;
-  }
+  if (isKnownDropStatus(s)) return null;
   if (
-    [
-      "fails",
-      "fail",
-      "failed",
-      "not supported",
-      "unsupported",
-      "❌",
-      ":cross_mark:",
-      ":x:",
-    ].includes(s)
-  ) {
-    return CROSS;
-  }
-  // Supported only via an intermediate/staggered hop. A bare note in the cell would
-  // otherwise fall through to null and silently drop the row, so map these explicitly.
-  if (
-    [
-      "staggered",
-      "conditional",
-      "intermediate",
-      "see note",
-      "see notes",
-      "❓",
-      "❔",
-      ":question:",
-      ":grey_question:",
-    ].includes(s)
+    /staggered|conditional|intermediate|see notes?|two[- ]step|not supported directly|\u2753|\u2754|:question:|:grey_question:/.test(
+      s
+    )
   ) {
     return QUESTION;
   }
-  // n/a, na, "in progress", blank, notes, etc. are not published.
+  // Negation-aware: "not yet supported" and "not currently supported" must not fall
+  // through to the positive branch just because they contain "supported".
+  if (/\bnot\b[^.]*\bsupported\b|unsupported|\bfails?\b|\bfailed\b|\u274c|:cross_mark:|:x:/.test(s)) {
+    return CROSS;
+  }
+  if (/supported|verified|passed|\u2705|:white_check_mark:/.test(s)) {
+    return CHECK;
+  }
   return null;
+}
+
+// True when a cell is an expected "publish nothing" value rather than an unknown one.
+function isKnownDropStatus(status) {
+  return DROP_STATUSES.includes(clean(status).toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// Kubernetes version constraint
+// ---------------------------------------------------------------------------
+
+// Read the bundled Kubernetes version per release out of the "Kubernetes Version
+// Constraint" table on the upgrade page. Both cell shapes in use are handled:
+//   "4.8.54, 4.8.56, 4.8.58, 4.8.61" -> those exact releases
+//   "4.9.23 and later"               -> any later patch of the same minor (4.9.x)
+// A floor is deliberately confined to its own major.minor, so "4.9.23 and later"
+// never claims to describe a 4.10.x release.
+function parseBundledK8sVersions(markdown) {
+  const exact = new Map();
+  const floors = [];
+  const parts = (markdown || "").split(/^### Kubernetes Version Constraint\s*$/m);
+  if (parts.length < 2) return { exact, floors };
+  const body = parts[1].split(/^#{1,3} /m)[0];
+  for (const line of body.split("\n")) {
+    const cells = splitTableRow(line);
+    if (cells.length !== 2) continue;
+    const k8s = cells[1].match(/^(\d+)\.(\d+)\.\d+$/);
+    if (!k8s) continue;
+    const version = { major: Number(k8s[1]), minor: Number(k8s[2]) };
+    const later = cells[0].match(/^(\d+\.\d+\.\d+)\s+and\s+later$/i);
+    if (later) {
+      floors.push({ release: later[1], k8s: version });
+      continue;
+    }
+    for (const release of cells[0].split(",")) {
+      const v = release.trim();
+      if (/^\d+\.\d+\.\d+$/.test(v)) exact.set(v, version);
+    }
+  }
+  return { exact, floors };
+}
+
+// Resolve one release to its bundled Kubernetes version, or null when the table
+// does not describe it.
+function bundledK8s(map, release) {
+  if (map.exact.has(release)) return map.exact.get(release);
+  let best = null;
+  for (const floor of map.floors) {
+    if (majorMinor(floor.release) !== majorMinor(release)) continue;
+    if (cmpKey(versionKey(release), versionKey(floor.release)) < 0) continue;
+    if (!best || cmpKey(versionKey(floor.release), versionKey(best.release)) > 0) best = floor;
+  }
+  return best ? best.k8s : null;
+}
+
+// Downgrade a validated direct path to a staggered one when it crosses more than
+// MAX_K8S_MINOR_DELTA Kubernetes minor versions.
+//
+// Fails open on purpose: a release the constraint table does not describe keeps the
+// mark Confluence gave it, so a newly shipped release is never mislabeled by
+// guesswork. Such a release is reported only when the other end of the path IS
+// described, because that is the case where a missing table entry hides a real
+// answer. A path with both ends unmapped predates the table and stays quiet.
+function applyK8sConstraint(pathsByInstall, k8sMap, report) {
+  for (const install of CONSTRAINED_INSTALLS) {
+    for (const p of pathsByInstall[install] || []) {
+      if (p.support !== CHECK) continue;
+      const from = bundledK8s(k8sMap, p.source);
+      const to = bundledK8s(k8sMap, p.target);
+      if (!from || !to) {
+        if (from && !to) report.unmapped.add(p.target);
+        else if (!from && to) report.unmapped.add(p.source);
+        continue;
+      }
+      const crossesMajor = from.major !== to.major;
+      if (!crossesMajor && to.minor - from.minor <= MAX_K8S_MINOR_DELTA) continue;
+      p.support = QUESTION;
+      report.staggered.push(
+        `${install}: ${p.source} -> ${p.target} ` +
+          `(Kubernetes ${from.major}.${from.minor} -> ${to.major}.${to.minor})`
+      );
+    }
+  }
+}
+
+// A fresh collector for everything a run needs to report or fail on.
+function newReport() {
+  return {
+    unknownHeadings: new Set(),
+    orphanTables: [],
+    unrecognizedCells: [],
+    emptyInstalls: [],
+    unmapped: new Set(),
+    staggered: [],
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -182,9 +315,18 @@ function getRows($, tableEl) {
   return rows;
 }
 
-function matrixToPaths(rows) {
+function matrixToPaths(rows, install, report) {
   if (rows.length < 3) return [];
   const paths = [];
+
+  // An unclassifiable cell drops its row from the published table, which is the one
+  // failure a reader cannot detect, so record enough to trace it back to Confluence.
+  const flag = (raw, source, target) => {
+    if (!report) return;
+    report.unrecognizedCells.push(
+      `${install}: ${source || "?"} -> ${target || "?"} = "${clean(raw)}"`
+    );
+  };
 
   // Simple legacy table: From | To | Verified?
   if (
@@ -194,8 +336,10 @@ function matrixToPaths(rows) {
   ) {
     for (const row of rows.slice(1)) {
       if (row.length >= 2 && row[0] && row[1]) {
-        const mark = statusToMark(row.length > 2 ? row[2] : "verified");
+        const raw = row.length > 2 ? row[2] : "verified";
+        const mark = statusToMark(raw);
         if (mark) paths.push({ source: row[0], target: row[1], support: mark });
+        else if (!isKnownDropStatus(raw)) flag(raw, row[0], row[1]);
       }
     }
     return paths;
@@ -210,7 +354,10 @@ function matrixToPaths(rows) {
     const statuses = row.slice(2);
     for (let i = 0; i < targetVersions.length; i++) {
       const mark = statusToMark(statuses[i]);
-      if (!mark) continue;
+      if (!mark) {
+        if (!isKnownDropStatus(statuses[i])) flag(statuses[i], source, targetVersions[i]);
+        continue;
+      }
       for (const target of expandTarget(targetVersions[i])) {
         if (/^\d+\.\d+/.test(target)) {
           paths.push({ source, target, support: mark });
@@ -221,7 +368,7 @@ function matrixToPaths(rows) {
   return paths;
 }
 
-function parseUpgradePaths(html) {
+function parseUpgradePaths(html, report) {
   const $ = cheerio.load(html);
 
   let start = null;
@@ -234,6 +381,7 @@ function parseUpgradePaths(html) {
 
   const byInstall = { vmware: [], kubernetes: [], appliance: [] };
   let currentInstall = null;
+  let lastHeading = null;
 
   for (const el of $(start).nextAll().toArray()) {
     if (el.type !== "tag") continue;
@@ -242,18 +390,27 @@ function parseUpgradePaths(html) {
     if (tag === "h2") {
       // New version-pair group; reset install so bare tables aren't mis-filed.
       currentInstall = null;
+      lastHeading = clean($(el).text());
       continue;
     }
     if (tag === "h3") {
-      currentInstall = INSTALL_MAP[clean($(el).text())] || null;
+      lastHeading = clean($(el).text());
+      currentInstall = INSTALL_MAP[lastHeading] || null;
+      if (!currentInstall && lastHeading) report.unknownHeadings.add(lastHeading);
       continue;
     }
     let tableEl = null;
     if (tag === "table") tableEl = el;
     else tableEl = $(el).find("table").get(0) || null;
-    if (tableEl && currentInstall) {
-      byInstall[currentInstall].push(...matrixToPaths(getRows($, tableEl)));
+    if (!tableEl) continue;
+    if (!currentInstall) {
+      // A table with no install context is discarded, which would leave every marker
+      // block for that install untouched and stale. Record it so the run can fail
+      // instead of reporting success on a page whose headings were restructured.
+      report.orphanTables.push(lastHeading || "(no preceding heading)");
+      continue;
     }
+    byInstall[currentInstall].push(...matrixToPaths(getRows($, tableEl), currentInstall, report));
   }
 
   // De-dupe (drop self-upgrades) and sort newest-first.
@@ -277,6 +434,7 @@ function parseUpgradePaths(html) {
         )
     );
     deduped[install] = unique;
+    if (!unique.length) report.emptyInstalls.push(install);
   }
   return deduped;
 }
@@ -309,23 +467,59 @@ function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// Read the rows already published inside a marker block, so a run can report what it
+// changes rather than only that something changed.
+function parseRenderedRows(block) {
+  const rows = [];
+  for (const line of (block || "").split("\n")) {
+    const cells = splitTableRow(line);
+    if (cells.length === 3 && /^\d+\.\d+/.test(cells[0])) {
+      rows.push({ source: cells[0], target: cells[1], support: cells[2] });
+    }
+  }
+  return rows;
+}
+
+// Compare published rows with generated ones. A row count alone cannot distinguish a
+// clean run from a Confluence change that quietly halved a table, so every run prints
+// added, removed, and re-marked rows per block.
+function diffRows(oldRows, newRows) {
+  const label = (r) => `${r.source} -> ${r.target}`;
+  const before = new Map(oldRows.map((r) => [label(r), r.support]));
+  const after = new Map(newRows.map((r) => [label(r), r.support]));
+  const added = [];
+  const removed = [];
+  const changed = [];
+  for (const [key, mark] of after) {
+    if (!before.has(key)) added.push(key);
+    else if (before.get(key) !== mark) changed.push(`${key}: ${before.get(key)} -> ${mark}`);
+  }
+  for (const key of before.keys()) {
+    if (!after.has(key)) removed.push(key);
+  }
+  return { added, removed, changed };
+}
+
 function replaceMarkerBlock(markdown, key, table) {
   const re = new RegExp(
-    `(<!-- upgrade-paths:${escapeRe(key)}:start -->)[\\s\\S]*?(<!-- upgrade-paths:${escapeRe(
+    `(<!-- upgrade-paths:${escapeRe(key)}:start -->)([\\s\\S]*?)(<!-- upgrade-paths:${escapeRe(
       key
     )}:end -->)`
   );
   let found = false;
-  const updated = markdown.replace(re, (_m, open, close) => {
+  let previous = "";
+  const updated = markdown.replace(re, (_m, open, body, close) => {
     found = true;
+    previous = body;
     return `${open}\n\n${table}\n\n${close}`;
   });
-  return [updated, found];
+  return [updated, found, previous];
 }
 
 function replaceUpgradePathMarkers(markdown, pathsByInstall) {
   let updated = markdown;
   const missing = [];
+  const changes = [];
   for (const install of ["vmware", "kubernetes", "appliance"]) {
     const paths = pathsByInstall[install];
     if (!paths || !paths.length) continue;
@@ -334,12 +528,20 @@ function replaceUpgradePathMarkers(markdown, pathsByInstall) {
     for (const mm of mms) {
       if (!meetsFloor(mm)) continue; // scope: 4.6+
       const key = `${install}-${mm}`;
-      const [next, found] = replaceMarkerBlock(updated, key, renderTable(byMm[mm]));
+      const rows = byMm[mm];
+      const [next, found, previous] = replaceMarkerBlock(updated, key, renderTable(rows));
       updated = next;
-      if (!found) missing.push(key);
+      if (!found) {
+        missing.push(key);
+        continue;
+      }
+      const diff = diffRows(parseRenderedRows(previous), rows);
+      if (diff.added.length || diff.removed.length || diff.changed.length) {
+        changes.push({ key, diff });
+      }
     }
   }
-  return [updated, missing];
+  return [updated, missing, changes];
 }
 
 // ---------------------------------------------------------------------------
@@ -457,6 +659,41 @@ Options:
   --write                   Write changes (then run \`npm run format\`)
 `;
 
+// Structural drift in the Confluence page silently strands whole marker blocks at
+// their old content, so treat it as fatal and stop before anything is written.
+function assertNoStructuralDrift(report) {
+  const problems = [];
+  if (report.orphanTables.length) {
+    problems.push(
+      `${report.orphanTables.length} table(s) had no install-type heading above them ` +
+        `(under: ${[...new Set(report.orphanTables)].join(", ")}). ` +
+        `Every marker block for the affected install would keep its old content.`
+    );
+  }
+  if (report.emptyInstalls.length) {
+    problems.push(
+      `No rows parsed for: ${report.emptyInstalls.join(", ")}. ` +
+        `Those marker blocks would keep their old content.`
+    );
+  }
+  if (problems.length) {
+    throw new Error(
+      `The Confluence page structure changed and the tables cannot be trusted:\n  - ` +
+        problems.join("\n  - ") +
+        `\nCheck the h3 install-type headings against INSTALL_MAP, then re-run.`
+    );
+  }
+}
+
+// Deep-enough copy that per-product constraint marks cannot leak between products.
+function clonePaths(pathsByInstall) {
+  const out = {};
+  for (const [install, paths] of Object.entries(pathsByInstall)) {
+    out[install] = paths.map((p) => ({ ...p }));
+  }
+  return out;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -469,33 +706,112 @@ async function main() {
 
   const markdownPaths = resolveMarkdownPaths(args);
   const html = await loadHtml(args);
-  const pathsByInstall = parseUpgradePaths(html);
+  const report = newReport();
+  const pathsByInstall = parseUpgradePaths(html, report);
 
   console.log("Parsed upgrade paths:");
   for (const [install, paths] of Object.entries(pathsByInstall)) {
     console.log(`  ${install}: ${paths.length} rows`);
   }
 
+  if (report.unknownHeadings.size) {
+    console.log(
+      `Warning: unrecognized install-type heading(s), not mapped to any install: ` +
+        `${[...report.unknownHeadings].join(", ")}`
+    );
+  }
+  if (report.unrecognizedCells.length) {
+    console.log(
+      `Warning: ${report.unrecognizedCells.length} status cell(s) could not be ` +
+        `classified, so their rows are not published:`
+    );
+    for (const cell of report.unrecognizedCells) console.log(`  ${cell}`);
+  }
+
+  assertNoStructuralDrift(report);
+
   for (const [product, mdPath] of Object.entries(markdownPaths)) {
     const markdown = fs.readFileSync(mdPath, "utf8");
-    const [updated, missing] = replaceUpgradePathMarkers(markdown, pathsByInstall);
-    if (missing.length) {
-      console.log(`Note: ${product} had no marker for: ${missing.join(", ")}`);
+
+    // The constraint is derived per product, from that page's own Kubernetes version
+    // table, so the rule and the published table cannot disagree.
+    const productReport = { unmapped: new Set(), staggered: [] };
+    const k8sMap = parseBundledK8sVersions(markdown);
+    const paths = clonePaths(pathsByInstall);
+    if (!k8sMap.exact.size && !k8sMap.floors.length) {
+      console.log(
+        `Warning: no "Kubernetes Version Constraint" version table found in ${mdPath}; ` +
+          `the staggered-upgrade rule was not applied.`
+      );
+    } else {
+      applyK8sConstraint(paths, k8sMap, productReport);
     }
+
+    const [updated, missing, changes] = replaceUpgradePathMarkers(markdown, paths);
+
+    console.log(`\n${product} (${mdPath})`);
+    if (productReport.staggered.length) {
+      console.log(`  Staggered by the Kubernetes version constraint:`);
+      for (const line of productReport.staggered) console.log(`    ${line}`);
+    }
+    if (productReport.unmapped.size) {
+      console.log(
+        `  Warning: no bundled Kubernetes version documented for ` +
+          `${[...productReport.unmapped].sort((a, b) => cmpKey(versionKey(a), versionKey(b))).join(", ")}. ` +
+          `Those paths keep the mark Confluence gave them. Add the release(s) to the ` +
+          `"Kubernetes Version Constraint" table to have the rule cover them.`
+      );
+    }
+    if (missing.length) {
+      console.log(`  Note: no marker for: ${missing.join(", ")}`);
+    }
+    if (!changes.length) {
+      console.log(`  No row changes.`);
+    }
+    for (const { key, diff } of changes) {
+      const counts = [
+        `+${diff.added.length}`,
+        `-${diff.removed.length}`,
+        `~${diff.changed.length}`,
+      ].join(" ");
+      console.log(`  ${key} (${counts})`);
+      for (const row of diff.added) console.log(`    + ${row}`);
+      for (const row of diff.removed) console.log(`    - ${row}`);
+      for (const row of diff.changed) console.log(`    ~ ${row}`);
+    }
+
     if (args.write) {
       fs.writeFileSync(mdPath, updated, "utf8");
-      console.log(`Updated ${mdPath}`);
+      console.log(`  Updated ${mdPath}`);
     } else {
-      const changed = updated !== markdown;
-      console.log(`Would ${changed ? "update" : "leave unchanged"} ${mdPath}`);
+      console.log(`  Would ${updated !== markdown ? "update" : "leave unchanged"} ${mdPath}`);
     }
   }
   return 0;
 }
 
-main()
-  .then((code) => process.exit(code))
-  .catch((err) => {
-    console.error(`Error: ${err.message}`);
-    process.exit(1);
-  });
+if (require.main === module) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  applyK8sConstraint,
+  bundledK8s,
+  clonePaths,
+  diffRows,
+  isKnownDropStatus,
+  matrixToPaths,
+  newReport,
+  parseBundledK8sVersions,
+  parseRenderedRows,
+  parseUpgradePaths,
+  renderTable,
+  replaceUpgradePathMarkers,
+  splitTableRow,
+  statusToMark,
+};

--- a/scripts/release/generate-upgrade-paths.test.js
+++ b/scripts/release/generate-upgrade-paths.test.js
@@ -1,0 +1,370 @@
+const {
+  applyK8sConstraint,
+  bundledK8s,
+  diffRows,
+  isKnownDropStatus,
+  newReport,
+  parseBundledK8sVersions,
+  parseRenderedRows,
+  parseUpgradePaths,
+  renderTable,
+  replaceUpgradePathMarkers,
+  splitTableRow,
+  statusToMark,
+} = require("./generate-upgrade-paths");
+
+const CHECK = ":white_check_mark:";
+const CROSS = ":x:";
+const QUESTION = "[:question:](#kubernetes-version-constraint)";
+
+// A trimmed stand-in for the Confluence "Release Artifacts" storage format: one
+// version-pair group with a matrix table per install type.
+const CONFLUENCE_HTML = `
+<h1>Upgrade Paths</h1>
+<h2>4.8.x / 4.7.x to 4.9.x</h2>
+<h3>EC Install</h3>
+<table>
+  <tr><td></td><td></td><td>target</td><td>target</td></tr>
+  <tr><td>from &#11015;</td><td>to &#10145;</td><td>4.9.14</td><td>4.9.24</td></tr>
+  <tr><td></td><td>4.8.61</td><td>Supported</td><td>Supported</td></tr>
+  <tr><td></td><td>4.7.38</td><td>Supported</td><td>N/A</td></tr>
+</table>
+<h3>Helm Install</h3>
+<table>
+  <tr><td></td><td></td><td>target</td><td>target</td></tr>
+  <tr><td>from &#11015;</td><td>to &#10145;</td><td>4.9.14</td><td>4.9.24</td></tr>
+  <tr><td></td><td>4.8.61</td><td>Supported</td><td>Supported</td></tr>
+</table>
+<h3>Appliance Installer</h3>
+<table>
+  <tr><td></td><td></td><td>target</td><td>target</td></tr>
+  <tr><td>from &#11015;</td><td>to &#10145;</td><td>4.9.14</td><td>4.9.24</td></tr>
+  <tr><td></td><td>4.8.61</td><td>Supported</td><td>Supported</td></tr>
+</table>
+`;
+
+// The Kubernetes version table as it appears on the upgrade pages, including both
+// cell shapes: an explicit release list and an "and later" floor.
+const MARKDOWN_K8S_SECTION = `
+### Kubernetes Version Constraint
+
+Some prose about the constraint.
+
+| Palette Release                | Kubernetes Version |
+| :----------------------------- | :----------------: |
+| 4.7.40, 4.7.43                 |       1.31.8       |
+| 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
+| 4.9.5, 4.9.8, 4.9.14           |      1.33.10       |
+| 4.9.23 and later               |       1.34.6       |
+
+More prose.
+
+## Upgrade Guides
+`;
+
+describe("splitTableRow", () => {
+  it("trims cells and tolerates Prettier's alignment padding", () => {
+    expect(splitTableRow("|       4.8.61       |       4.9.24       | :x: |")).toEqual([
+      "4.8.61",
+      "4.9.24",
+      ":x:",
+    ]);
+  });
+
+  it("tolerates rows written without outer pipes", () => {
+    expect(splitTableRow("4.8.61 | 4.9.24")).toEqual(["4.8.61", "4.9.24"]);
+  });
+
+  it("returns nothing for a line that is not a table row", () => {
+    expect(splitTableRow("Some prose.")).toEqual([]);
+  });
+});
+
+describe("statusToMark", () => {
+  it("classifies the plain statuses", () => {
+    expect(statusToMark("Supported")).toBe(CHECK);
+    expect(statusToMark("Verified")).toBe(CHECK);
+    expect(statusToMark("Not Supported")).toBe(CROSS);
+    expect(statusToMark("Fails")).toBe(CROSS);
+    expect(statusToMark("Staggered")).toBe(QUESTION);
+  });
+
+  it("matches by keyword so an editorialized cell still classifies", () => {
+    // These dropped to null under exact-equality matching, which deleted the row.
+    expect(statusToMark("Supported (staggered)")).toBe(QUESTION);
+    expect(statusToMark("Staggered - see note")).toBe(QUESTION);
+    expect(statusToMark("Supported*")).toBe(CHECK);
+    expect(statusToMark("  NOT SUPPORTED  ")).toBe(CROSS);
+  });
+
+  it("tests the narrower cases first", () => {
+    // "not supported" contains "supported"; a staggered cell usually says both.
+    expect(statusToMark("Not supported directly, upgrade in two steps")).toBe(QUESTION);
+    expect(statusToMark("Not yet supported")).toBe(CROSS);
+  });
+
+  it("drops the expected publish-nothing values", () => {
+    for (const value of ["", "N/A", "n/a", "In Progress", "TBD", "  "]) {
+      expect(statusToMark(value)).toBeNull();
+      expect(isKnownDropStatus(value)).toBe(true);
+    }
+  });
+
+  it("reports an unknown value rather than treating it as a known drop", () => {
+    expect(statusToMark("ask QA")).toBeNull();
+    expect(isKnownDropStatus("ask QA")).toBe(false);
+  });
+});
+
+describe("parseBundledK8sVersions", () => {
+  const map = parseBundledK8sVersions(MARKDOWN_K8S_SECTION);
+
+  it("reads an explicit release list", () => {
+    expect(bundledK8s(map, "4.8.61")).toEqual({ major: 1, minor: 32 });
+    expect(bundledK8s(map, "4.7.40")).toEqual({ major: 1, minor: 31 });
+    expect(bundledK8s(map, "4.9.14")).toEqual({ major: 1, minor: 33 });
+  });
+
+  it("applies an 'and later' floor to later patches of the same minor", () => {
+    expect(bundledK8s(map, "4.9.23")).toEqual({ major: 1, minor: 34 });
+    expect(bundledK8s(map, "4.9.38")).toEqual({ major: 1, minor: 34 });
+  });
+
+  it("confines a floor to its own major.minor", () => {
+    // "4.9.23 and later" must not claim to describe the next minor release.
+    expect(bundledK8s(map, "4.10.0")).toBeNull();
+  });
+
+  it("returns null for a release the table does not describe", () => {
+    expect(bundledK8s(map, "4.7.38")).toBeNull();
+    expect(bundledK8s(map, "4.6.70")).toBeNull();
+  });
+
+  it("returns an empty map when the section is absent", () => {
+    const empty = parseBundledK8sVersions("# Upgrade\n\nNo constraint section here.\n");
+    expect(empty.exact.size).toBe(0);
+    expect(empty.floors).toEqual([]);
+  });
+});
+
+describe("applyK8sConstraint", () => {
+  const k8sMap = parseBundledK8sVersions(MARKDOWN_K8S_SECTION);
+
+  function run(pathsByInstall) {
+    const report = { unmapped: new Set(), staggered: [] };
+    applyK8sConstraint(pathsByInstall, k8sMap, report);
+    return report;
+  }
+
+  it("staggers a path that crosses two Kubernetes minor versions", () => {
+    const paths = { vmware: [{ source: "4.8.61", target: "4.9.24", support: CHECK }] };
+    const report = run(paths);
+    expect(paths.vmware[0].support).toBe(QUESTION);
+    expect(report.staggered).toEqual([
+      "vmware: 4.8.61 -> 4.9.24 (Kubernetes 1.32 -> 1.34)",
+    ]);
+  });
+
+  it("leaves a single-minor hop alone", () => {
+    const paths = { vmware: [{ source: "4.8.61", target: "4.9.14", support: CHECK }] };
+    run(paths);
+    expect(paths.vmware[0].support).toBe(CHECK);
+  });
+
+  it("exempts Helm installs on a customer-managed cluster", () => {
+    const paths = { kubernetes: [{ source: "4.8.61", target: "4.9.24", support: CHECK }] };
+    const report = run(paths);
+    expect(paths.kubernetes[0].support).toBe(CHECK);
+    expect(report.staggered).toEqual([]);
+  });
+
+  it("applies to appliance installs", () => {
+    const paths = { appliance: [{ source: "4.8.61", target: "4.9.24", support: CHECK }] };
+    run(paths);
+    expect(paths.appliance[0].support).toBe(QUESTION);
+  });
+
+  it("never overrides an explicit unsupported mark", () => {
+    const paths = { vmware: [{ source: "4.8.61", target: "4.9.24", support: CROSS }] };
+    run(paths);
+    expect(paths.vmware[0].support).toBe(CROSS);
+  });
+
+  it("fails open and reports a release the version table does not describe", () => {
+    const paths = { vmware: [{ source: "4.7.38", target: "4.9.14", support: CHECK }] };
+    const report = run(paths);
+    expect(paths.vmware[0].support).toBe(CHECK);
+    expect([...report.unmapped]).toEqual(["4.7.38"]);
+  });
+
+  it("stays quiet when both ends predate the version table", () => {
+    const paths = { vmware: [{ source: "4.6.70", target: "4.7.14", support: CHECK }] };
+    const report = run(paths);
+    expect([...report.unmapped]).toEqual([]);
+    expect(report.staggered).toEqual([]);
+  });
+});
+
+describe("parseUpgradePaths", () => {
+  it("files each matrix table under its install type", () => {
+    const report = newReport();
+    const paths = parseUpgradePaths(CONFLUENCE_HTML, report);
+    expect(paths.vmware).toEqual([
+      { source: "4.8.61", target: "4.9.24", support: CHECK },
+      { source: "4.8.61", target: "4.9.14", support: CHECK },
+      { source: "4.7.38", target: "4.9.14", support: CHECK },
+    ]);
+    expect(paths.kubernetes).toHaveLength(2);
+    expect(paths.appliance).toHaveLength(2);
+    expect(report.orphanTables).toEqual([]);
+    expect(report.unrecognizedCells).toEqual([]);
+    expect(report.emptyInstalls).toEqual([]);
+  });
+
+  it("reads the legacy From / To / Verified table shape", () => {
+    const report = newReport();
+    const paths = parseUpgradePaths(
+      `<h1>Upgrade Paths</h1><h3>EC Install</h3>
+       <table>
+         <tr><td>From</td><td>To</td><td>Verified?</td></tr>
+         <tr><td>4.8.61</td><td>4.9.14</td><td>Supported</td></tr>
+         <tr><td>4.8.56</td><td>4.9.14</td><td>Fails</td></tr>
+       </table>`,
+      report
+    );
+    expect(paths.vmware).toEqual([
+      { source: "4.8.61", target: "4.9.14", support: CHECK },
+      { source: "4.8.56", target: "4.9.14", support: CROSS },
+    ]);
+  });
+
+  it("records a table that has no install-type heading above it", () => {
+    const report = newReport();
+    // A renamed heading is the dangerous case: the table is discarded and every
+    // marker block for that install would silently keep its old content.
+    parseUpgradePaths(
+      `<h1>Upgrade Paths</h1><h3>Enterprise Cluster Install</h3>
+       <table>
+         <tr><td></td><td></td><td>target</td></tr>
+         <tr><td>from</td><td>to</td><td>4.9.14</td></tr>
+         <tr><td></td><td>4.8.61</td><td>Supported</td></tr>
+       </table>`,
+      report
+    );
+    expect([...report.unknownHeadings]).toEqual(["Enterprise Cluster Install"]);
+    expect(report.orphanTables).toEqual(["Enterprise Cluster Install"]);
+    expect(report.emptyInstalls.sort()).toEqual(["appliance", "kubernetes", "vmware"]);
+  });
+
+  it("reports a status cell it cannot classify, with enough detail to trace it", () => {
+    const report = newReport();
+    const paths = parseUpgradePaths(
+      `<h1>Upgrade Paths</h1><h3>EC Install</h3>
+       <table>
+         <tr><td></td><td></td><td>target</td></tr>
+         <tr><td>from</td><td>to</td><td>4.9.14</td></tr>
+         <tr><td></td><td>4.8.61</td><td>ask QA</td></tr>
+       </table>`,
+      report
+    );
+    expect(paths.vmware).toEqual([]);
+    expect(report.unrecognizedCells).toEqual(['vmware: 4.8.61 -> 4.9.14 = "ask QA"']);
+  });
+
+  it("throws when the Upgrade Paths heading is missing", () => {
+    expect(() => parseUpgradePaths("<h1>Something Else</h1>", newReport())).toThrow(
+      /Upgrade Paths/
+    );
+  });
+});
+
+describe("diffRows", () => {
+  it("separates added, removed, and re-marked rows", () => {
+    const before = [
+      { source: "4.8.61", target: "4.9.24", support: CHECK },
+      { source: "4.8.56", target: "4.9.14", support: CHECK },
+    ];
+    const after = [
+      { source: "4.8.61", target: "4.9.24", support: QUESTION },
+      { source: "4.8.52", target: "4.9.14", support: CHECK },
+    ];
+    expect(diffRows(before, after)).toEqual({
+      added: ["4.8.52 -> 4.9.14"],
+      removed: ["4.8.56 -> 4.9.14"],
+      changed: [`4.8.61 -> 4.9.24: ${CHECK} -> ${QUESTION}`],
+    });
+  });
+
+  it("reports no change when the rows match", () => {
+    const rows = [{ source: "4.8.61", target: "4.9.24", support: CHECK }];
+    expect(diffRows(rows, rows)).toEqual({ added: [], removed: [], changed: [] });
+  });
+});
+
+describe("parseRenderedRows", () => {
+  it("reads the rows already published in a marker block", () => {
+    const block = renderTable([
+      { source: "4.8.61", target: "4.9.24", support: QUESTION },
+      { source: "4.8.61", target: "4.9.14", support: CHECK },
+    ]);
+    expect(parseRenderedRows(block)).toEqual([
+      { source: "4.8.61", target: "4.9.24", support: QUESTION },
+      { source: "4.8.61", target: "4.9.14", support: CHECK },
+    ]);
+  });
+});
+
+describe("replaceUpgradePathMarkers", () => {
+  const markdown = [
+    "**4.9**",
+    "",
+    "<!-- upgrade-paths:vmware-4.9:start -->",
+    "",
+    "| **Source Version** | **Target Version** | **Support** |",
+    "| :----------------: | :----------------: | :---------: |",
+    "| 4.8.61 | 4.9.24 | :white_check_mark: |",
+    "",
+    "<!-- upgrade-paths:vmware-4.9:end -->",
+    "",
+  ].join("\n");
+
+  it("rewrites the block and reports the marks it changed", () => {
+    const [updated, missing, changes] = replaceUpgradePathMarkers(markdown, {
+      vmware: [{ source: "4.8.61", target: "4.9.24", support: QUESTION }],
+    });
+    expect(updated).toContain(`| 4.8.61 | 4.9.24 | ${QUESTION} |`);
+    expect(missing).toEqual([]);
+    expect(changes).toEqual([
+      {
+        key: "vmware-4.9",
+        diff: {
+          added: [],
+          removed: [],
+          changed: [`4.8.61 -> 4.9.24: ${CHECK} -> ${QUESTION}`],
+        },
+      },
+    ]);
+  });
+
+  it("reports nothing when the generated rows match what is published", () => {
+    const [, , changes] = replaceUpgradePathMarkers(markdown, {
+      vmware: [{ source: "4.8.61", target: "4.9.24", support: CHECK }],
+    });
+    expect(changes).toEqual([]);
+  });
+
+  it("reports a block the Markdown has no marker for", () => {
+    const [, missing] = replaceUpgradePathMarkers(markdown, {
+      appliance: [{ source: "4.8.61", target: "4.9.24", support: CHECK }],
+    });
+    expect(missing).toEqual(["appliance-4.9"]);
+  });
+
+  it("leaves blocks older than the 4.6 floor untouched", () => {
+    const legacy = "<!-- upgrade-paths:vmware-4.5:start -->\n\nold\n\n<!-- upgrade-paths:vmware-4.5:end -->";
+    const [updated] = replaceUpgradePathMarkers(legacy, {
+      vmware: [{ source: "4.4.1", target: "4.5.1", support: CHECK }],
+    });
+    expect(updated).toBe(legacy);
+  });
+});

--- a/scripts/release/generate-upgrade-paths.test.js
+++ b/scripts/release/generate-upgrade-paths.test.js
@@ -1,10 +1,10 @@
 const {
-  applyK8sConstraint,
-  bundledK8s,
+  checkK8sConstraint,
   diffRows,
+  headingMeetsFloor,
   isKnownDropStatus,
   newReport,
-  parseBundledK8sVersions,
+  parseK8sLabel,
   parseRenderedRows,
   parseUpgradePaths,
   renderTable,
@@ -19,189 +19,146 @@ const QUESTION = "[:question:](#kubernetes-version-constraint)";
 
 // A trimmed stand-in for the Confluence "Release Artifacts" storage format: one
 // version-pair group with a matrix table per install type.
+// The EC binary and the Appliance Installer ship different Kubernetes versions for
+// the same Palette release, which is why the labels are per table.
 const CONFLUENCE_HTML = `
 <h1>Upgrade Paths</h1>
-<h2>4.8.x / 4.7.x to 4.9.x</h2>
+<h2>4.8 &#8594; 4.9</h2>
 <h3>EC Install</h3>
 <table>
-  <tr><td></td><td></td><td>target</td><td>target</td></tr>
-  <tr><td>from &#11015;</td><td>to &#10145;</td><td>4.9.14</td><td>4.9.24</td></tr>
-  <tr><td></td><td>4.8.61</td><td>Supported</td><td>Supported</td></tr>
-  <tr><td></td><td>4.7.38</td><td>Supported</td><td>N/A</td></tr>
+  <tr><td>from</td><td></td><td>4.9.x &#183; K8s 1.33.10</td><td>4.9.x &#183; K8s 1.34.6</td></tr>
+  <tr><td></td><td>to</td><td>4.9.14</td><td>4.9.24</td></tr>
+  <tr><td>4.8.x &#183; K8s 1.32.9</td><td>4.8.61</td><td>Supported</td><td>Not Supported</td></tr>
+  <tr><td>4.9.x &#183; K8s 1.33.10</td><td>4.9.14</td><td></td><td>Supported</td></tr>
 </table>
 <h3>Helm Install</h3>
 <table>
-  <tr><td></td><td></td><td>target</td><td>target</td></tr>
-  <tr><td>from &#11015;</td><td>to &#10145;</td><td>4.9.14</td><td>4.9.24</td></tr>
-  <tr><td></td><td>4.8.61</td><td>Supported</td><td>Supported</td></tr>
+  <tr><td>from</td><td></td><td>4.9.x</td><td>4.9.x</td></tr>
+  <tr><td></td><td>to</td><td>4.9.14</td><td>4.9.24</td></tr>
+  <tr><td>4.8.x</td><td>4.8.61</td><td>Supported</td><td>Supported</td></tr>
 </table>
 <h3>Appliance Installer</h3>
 <table>
-  <tr><td></td><td></td><td>target</td><td>target</td></tr>
-  <tr><td>from &#11015;</td><td>to &#10145;</td><td>4.9.14</td><td>4.9.24</td></tr>
-  <tr><td></td><td>4.8.61</td><td>Supported</td><td>Supported</td></tr>
+  <tr><td>from</td><td></td><td>4.9.x &#183; K8s 1.34.6</td><td>4.9.x &#183; K8s 1.34.9</td></tr>
+  <tr><td></td><td>to</td><td>4.9.14</td><td>4.9.24</td></tr>
+  <tr><td>4.8.x &#183; K8s 1.33.9</td><td>4.8.61</td><td>Supported</td><td>Supported</td></tr>
 </table>
 `;
 
 // The Kubernetes version table as it appears on the upgrade pages, including both
 // cell shapes: an explicit release list and an "and later" floor.
-const MARKDOWN_K8S_SECTION = `
-### Kubernetes Version Constraint
-
-Some prose about the constraint.
-
-| Palette Release                | Kubernetes Version |
-| :----------------------------- | :----------------: |
-| 4.7.40, 4.7.43                 |       1.31.8       |
-| 4.8.54, 4.8.56, 4.8.58, 4.8.61 |       1.32.9       |
-| 4.9.5, 4.9.8, 4.9.14           |      1.33.10       |
-| 4.9.23 and later               |       1.34.6       |
-
-More prose.
-
-## Upgrade Guides
-`;
-
-describe("splitTableRow", () => {
-  it("trims cells and tolerates Prettier's alignment padding", () => {
-    expect(splitTableRow("|       4.8.61       |       4.9.24       | :x: |")).toEqual([
-      "4.8.61",
-      "4.9.24",
-      ":x:",
-    ]);
+describe("parseK8sLabel", () => {
+  it("reads the version out of a Confluence label cell", () => {
+    expect(parseK8sLabel("4.9.x \u00b7 K8s 1.33.10")).toEqual({ major: 1, minor: 33 });
+    expect(parseK8sLabel("4.8.x - K8s v1.32.9")).toEqual({ major: 1, minor: 32 });
   });
 
-  it("tolerates rows written without outer pipes", () => {
-    expect(splitTableRow("4.8.61 | 4.9.24")).toEqual(["4.8.61", "4.9.24"]);
-  });
-
-  it("returns nothing for a line that is not a table row", () => {
-    expect(splitTableRow("Some prose.")).toEqual([]);
+  it("returns null when the label carries no version", () => {
+    // Normal for Helm installs, and for "K8s TBD" on an unreleased version.
+    expect(parseK8sLabel("4.9.x")).toBeNull();
+    expect(parseK8sLabel("4.10.x \u00b7 K8s TBD")).toBeNull();
+    expect(parseK8sLabel("")).toBeNull();
   });
 });
 
-describe("statusToMark", () => {
-  it("classifies the plain statuses", () => {
-    expect(statusToMark("Supported")).toBe(CHECK);
-    expect(statusToMark("Verified")).toBe(CHECK);
-    expect(statusToMark("Not Supported")).toBe(CROSS);
-    expect(statusToMark("Fails")).toBe(CROSS);
-    expect(statusToMark("Staggered")).toBe(QUESTION);
+describe("headingMeetsFloor", () => {
+  it("recognizes an in-scope version group", () => {
+    expect(headingMeetsFloor("4.8 \u2192 4.9")).toBe(true);
+    expect(headingMeetsFloor("4.6 \u2192 4.7")).toBe(true);
   });
 
-  it("matches by keyword so an editorialized cell still classifies", () => {
-    // These dropped to null under exact-equality matching, which deleted the row.
-    expect(statusToMark("Supported (staggered)")).toBe(QUESTION);
-    expect(statusToMark("Staggered - see note")).toBe(QUESTION);
-    expect(statusToMark("Supported*")).toBe(CHECK);
-    expect(statusToMark("  NOT SUPPORTED  ")).toBe(CROSS);
+  it("recognizes the hand-maintained legacy groups", () => {
+    expect(headingMeetsFloor("4.3 \u2192 4.4")).toBe(false);
+    expect(headingMeetsFloor("4.1 through 4.3")).toBe(false);
   });
 
-  it("tests the narrower cases first", () => {
-    // "not supported" contains "supported"; a staggered cell usually says both.
-    expect(statusToMark("Not supported directly, upgrade in two steps")).toBe(QUESTION);
-    expect(statusToMark("Not yet supported")).toBe(CROSS);
-  });
-
-  it("drops the expected publish-nothing values", () => {
-    for (const value of ["", "N/A", "n/a", "In Progress", "TBD", "  "]) {
-      expect(statusToMark(value)).toBeNull();
-      expect(isKnownDropStatus(value)).toBe(true);
-    }
-  });
-
-  it("reports an unknown value rather than treating it as a known drop", () => {
-    expect(statusToMark("ask QA")).toBeNull();
-    expect(isKnownDropStatus("ask QA")).toBe(false);
+  it("treats an unreadable heading as in scope so drift is not hidden", () => {
+    expect(headingMeetsFloor("Upgrade notes")).toBe(true);
   });
 });
 
-describe("parseBundledK8sVersions", () => {
-  const map = parseBundledK8sVersions(MARKDOWN_K8S_SECTION);
-
-  it("reads an explicit release list", () => {
-    expect(bundledK8s(map, "4.8.61")).toEqual({ major: 1, minor: 32 });
-    expect(bundledK8s(map, "4.7.40")).toEqual({ major: 1, minor: 31 });
-    expect(bundledK8s(map, "4.9.14")).toEqual({ major: 1, minor: 33 });
-  });
-
-  it("applies an 'and later' floor to later patches of the same minor", () => {
-    expect(bundledK8s(map, "4.9.23")).toEqual({ major: 1, minor: 34 });
-    expect(bundledK8s(map, "4.9.38")).toEqual({ major: 1, minor: 34 });
-  });
-
-  it("confines a floor to its own major.minor", () => {
-    // "4.9.23 and later" must not claim to describe the next minor release.
-    expect(bundledK8s(map, "4.10.0")).toBeNull();
-  });
-
-  it("returns null for a release the table does not describe", () => {
-    expect(bundledK8s(map, "4.7.38")).toBeNull();
-    expect(bundledK8s(map, "4.6.70")).toBeNull();
-  });
-
-  it("returns an empty map when the section is absent", () => {
-    const empty = parseBundledK8sVersions("# Upgrade\n\nNo constraint section here.\n");
-    expect(empty.exact.size).toBe(0);
-    expect(empty.floors).toEqual([]);
-  });
-});
-
-describe("applyK8sConstraint", () => {
-  const k8sMap = parseBundledK8sVersions(MARKDOWN_K8S_SECTION);
-
+describe("checkK8sConstraint", () => {
   function run(pathsByInstall) {
-    const report = { unmapped: new Set(), staggered: [] };
-    applyK8sConstraint(pathsByInstall, k8sMap, report);
-    return report;
+    const report = newReport();
+    checkK8sConstraint(pathsByInstall, report);
+    return report.constraintConflicts;
   }
 
-  it("staggers a path that crosses two Kubernetes minor versions", () => {
-    const paths = { vmware: [{ source: "4.8.61", target: "4.9.24", support: CHECK }] };
-    const report = run(paths);
-    expect(paths.vmware[0].support).toBe(QUESTION);
-    expect(report.staggered).toEqual([
-      "vmware: 4.8.61 -> 4.9.24 (Kubernetes 1.32 -> 1.34)",
+  it("reports a supported path that skips a Kubernetes minor version", () => {
+    expect(
+      run({
+        vmware: [
+          {
+            source: "4.8.61",
+            target: "4.9.24",
+            support: CHECK,
+            sourceK8s: { major: 1, minor: 32 },
+            targetK8s: { major: 1, minor: 34 },
+          },
+        ],
+      })
+    ).toEqual([
+      "vmware: 4.8.61 -> 4.9.24 is marked supported but crosses Kubernetes 1.32 -> 1.34",
     ]);
   });
 
-  it("leaves a single-minor hop alone", () => {
-    const paths = { vmware: [{ source: "4.8.61", target: "4.9.14", support: CHECK }] };
-    run(paths);
+  it("stays quiet on a single-minor hop", () => {
+    // Appliance ships 1.33.9 on 4.8.x and 1.34.9 on 4.9.24+, so this is one minor.
+    expect(
+      run({
+        appliance: [
+          {
+            source: "4.8.61",
+            target: "4.9.24",
+            support: CHECK,
+            sourceK8s: { major: 1, minor: 33 },
+            targetK8s: { major: 1, minor: 34 },
+          },
+        ],
+      })
+    ).toEqual([]);
+  });
+
+  it("skips paths with no Kubernetes labels, such as Helm installs", () => {
+    expect(
+      run({
+        kubernetes: [
+          { source: "4.8.61", target: "4.9.24", support: CHECK, sourceK8s: null, targetK8s: null },
+        ],
+      })
+    ).toEqual([]);
+  });
+
+  it("does not report a path that is already marked unsupported", () => {
+    expect(
+      run({
+        vmware: [
+          {
+            source: "4.8.61",
+            target: "4.9.24",
+            support: CROSS,
+            sourceK8s: { major: 1, minor: 32 },
+            targetK8s: { major: 1, minor: 34 },
+          },
+        ],
+      })
+    ).toEqual([]);
+  });
+
+  it("never rewrites a mark", () => {
+    const paths = {
+      vmware: [
+        {
+          source: "4.8.61",
+          target: "4.9.24",
+          support: CHECK,
+          sourceK8s: { major: 1, minor: 32 },
+          targetK8s: { major: 1, minor: 34 },
+        },
+      ],
+    };
+    checkK8sConstraint(paths, newReport());
     expect(paths.vmware[0].support).toBe(CHECK);
-  });
-
-  it("exempts Helm installs on a customer-managed cluster", () => {
-    const paths = { kubernetes: [{ source: "4.8.61", target: "4.9.24", support: CHECK }] };
-    const report = run(paths);
-    expect(paths.kubernetes[0].support).toBe(CHECK);
-    expect(report.staggered).toEqual([]);
-  });
-
-  it("applies to appliance installs", () => {
-    const paths = { appliance: [{ source: "4.8.61", target: "4.9.24", support: CHECK }] };
-    run(paths);
-    expect(paths.appliance[0].support).toBe(QUESTION);
-  });
-
-  it("never overrides an explicit unsupported mark", () => {
-    const paths = { vmware: [{ source: "4.8.61", target: "4.9.24", support: CROSS }] };
-    run(paths);
-    expect(paths.vmware[0].support).toBe(CROSS);
-  });
-
-  it("fails open and reports a release the version table does not describe", () => {
-    const paths = { vmware: [{ source: "4.7.38", target: "4.9.14", support: CHECK }] };
-    const report = run(paths);
-    expect(paths.vmware[0].support).toBe(CHECK);
-    expect([...report.unmapped]).toEqual(["4.7.38"]);
-  });
-
-  it("stays quiet when both ends predate the version table", () => {
-    const paths = { vmware: [{ source: "4.6.70", target: "4.7.14", support: CHECK }] };
-    const report = run(paths);
-    expect([...report.unmapped]).toEqual([]);
-    expect(report.staggered).toEqual([]);
   });
 });
 
@@ -209,16 +166,45 @@ describe("parseUpgradePaths", () => {
   it("files each matrix table under its install type", () => {
     const report = newReport();
     const paths = parseUpgradePaths(CONFLUENCE_HTML, report);
-    expect(paths.vmware).toEqual([
-      { source: "4.8.61", target: "4.9.24", support: CHECK },
-      { source: "4.8.61", target: "4.9.14", support: CHECK },
-      { source: "4.7.38", target: "4.9.14", support: CHECK },
+    const summarize = (rows) => rows.map((p) => `${p.source} -> ${p.target} ${p.support}`);
+
+    expect(summarize(paths.vmware)).toEqual([
+      `4.9.14 -> 4.9.24 ${CHECK}`,
+      `4.8.61 -> 4.9.24 ${CROSS}`,
+      `4.8.61 -> 4.9.14 ${CHECK}`,
     ]);
-    expect(paths.kubernetes).toHaveLength(2);
-    expect(paths.appliance).toHaveLength(2);
+    expect(summarize(paths.kubernetes)).toEqual([
+      `4.8.61 -> 4.9.24 ${CHECK}`,
+      `4.8.61 -> 4.9.14 ${CHECK}`,
+    ]);
+    expect(summarize(paths.appliance)).toEqual([
+      `4.8.61 -> 4.9.24 ${CHECK}`,
+      `4.8.61 -> 4.9.14 ${CHECK}`,
+    ]);
     expect(report.orphanTables).toEqual([]);
     expect(report.unrecognizedCells).toEqual([]);
     expect(report.emptyInstalls).toEqual([]);
+  });
+
+  it("captures the bundled Kubernetes version per install type", () => {
+    // The same Palette releases carry different Kubernetes versions on the EC binary
+    // and the Appliance Installer, which is why the labels cannot be read from a
+    // single table in the docs.
+    const paths = parseUpgradePaths(CONFLUENCE_HTML, newReport());
+    const ec = paths.vmware.find((p) => p.source === "4.8.61" && p.target === "4.9.24");
+    const appliance = paths.appliance.find((p) => p.source === "4.8.61" && p.target === "4.9.24");
+    expect(ec.sourceK8s).toEqual({ major: 1, minor: 32 });
+    expect(ec.targetK8s).toEqual({ major: 1, minor: 34 });
+    expect(appliance.sourceK8s).toEqual({ major: 1, minor: 33 });
+    expect(appliance.targetK8s).toEqual({ major: 1, minor: 34 });
+    expect(paths.kubernetes[0].sourceK8s).toBeNull();
+  });
+
+  it("finds no constraint conflict in a matrix whose marks match its labels", () => {
+    const report = newReport();
+    const paths = parseUpgradePaths(CONFLUENCE_HTML, report);
+    checkK8sConstraint(paths, report);
+    expect(report.constraintConflicts).toEqual([]);
   });
 
   it("reads the legacy From / To / Verified table shape", () => {

--- a/scripts/release/generate-upgrade-paths.test.js
+++ b/scripts/release/generate-upgrade-paths.test.js
@@ -1,5 +1,6 @@
 const {
   checkK8sConstraint,
+  isPlaceholderK8sLabel,
   diffRows,
   headingMeetsFloor,
   isKnownDropStatus,
@@ -61,6 +62,24 @@ describe("parseK8sLabel", () => {
   });
 });
 
+describe("isPlaceholderK8sLabel", () => {
+  it("flags a label that announces a version but gives none", () => {
+    // The 4.9 -> 4.10 EC Install column is labelled "K8s TBD" while unreleased.
+    expect(isPlaceholderK8sLabel("4.10.x \u00b7 K8s TBD")).toBe(true);
+    expect(isPlaceholderK8sLabel("4.10.x \u00b7 K8s ?")).toBe(true);
+  });
+
+  it("does not flag a label with no Kubernetes version at all", () => {
+    // Normal and expected for Helm installs.
+    expect(isPlaceholderK8sLabel("4.9.x")).toBe(false);
+    expect(isPlaceholderK8sLabel("")).toBe(false);
+  });
+
+  it("does not flag a resolved label", () => {
+    expect(isPlaceholderK8sLabel("4.9.x \u00b7 K8s 1.33.10")).toBe(false);
+  });
+});
+
 describe("headingMeetsFloor", () => {
   it("recognizes an in-scope version group", () => {
     expect(headingMeetsFloor("4.8 \u2192 4.9")).toBe(true);
@@ -119,11 +138,43 @@ describe("checkK8sConstraint", () => {
     ).toEqual([]);
   });
 
-  it("skips paths with no Kubernetes labels, such as Helm installs", () => {
+  it("reports a supported path it could not check because the label says TBD", () => {
+    const report = newReport();
+    checkK8sConstraint(
+      {
+        vmware: [
+          {
+            source: "4.9.51",
+            target: "4.10.11",
+            support: CHECK,
+            sourceK8s: { major: 1, minor: 34 },
+            targetK8s: null,
+            sourceLabel: "4.9.x \u00b7 K8s 1.34.6",
+            targetLabel: "4.10.x \u00b7 K8s TBD",
+          },
+        ],
+      },
+      report
+    );
+    expect(report.constraintConflicts).toEqual([]);
+    expect(report.unresolvedK8s).toEqual([
+      'vmware: 4.9.51 -> 4.10.11 could not be checked ("4.10.x \u00b7 K8s TBD")',
+    ]);
+  });
+
+  it("stays silent for paths with no Kubernetes labels, such as Helm installs", () => {
     expect(
       run({
         kubernetes: [
-          { source: "4.8.61", target: "4.9.24", support: CHECK, sourceK8s: null, targetK8s: null },
+          {
+            source: "4.8.61",
+            target: "4.9.24",
+            support: CHECK,
+            sourceK8s: null,
+            targetK8s: null,
+            sourceLabel: "4.8.x",
+            targetLabel: "4.9.x",
+          },
         ],
       })
     ).toEqual([]);


### PR DESCRIPTION
# ✅ Pull Request Checklist

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** for all affected pages are provided in the [Changed Pages](#-changed-pages) section.
- [x] Conduct a **self-review** for your pages using your preview links.
- [x] **Check formatting** for your pages. _Prettier clean. Tables regenerated by the script and then formatted, so column alignment matches repo style._
- [x] Ensure all **Vale comments** are resolved. _0 errors, 0 warnings on both pages at CI's alert level._
- [x] All **CI jobs** have completed successfully. _The Netlify deploy preview is failing and is being looked at separately; `npm run build` exits 0 in the Build job on the same commit._
- [x] Add **Backport labels** if the change should be reflected in previous versions. _`auto-backport` + `backport-version-4-9` applied and required, since this changes published pages._
- [x] **Outside review:** Engineering (Gaurav) supplied the matrix data this PR mirrors. No further outside review needed.
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

---

## 📝 Describe the Change

The **Kubernetes Version Constraint** section of both self-hosted upgrade pages says a Palette upgrade cannot cross more than one Kubernetes minor version, and that a direct upgrade from any `4.8.x` release to `4.9.23` or later is therefore unsupported. The upgrade path tables on the same page marked every one of those paths as a validated direct upgrade. A customer reported the contradiction, which is what DOC-3097 tracks.

Engineering has since reworked the **Upgrade Paths** matrix on the Confluence Release Artifacts page: it now carries the bundled Kubernetes version per install type in its labels, marks the offending direct paths as **Not Supported**, and adds the `4.9.14 → 4.9.x` rows that make the two-step upgrade real. This PR mirrors that, and adds a guard so the same class of defect is caught next time.

### The thing that made the original fix wrong

**The EC binary and the Appliance Installer do not bundle the same Kubernetes version for a given Palette release.**

| Release | EC binary | Appliance |
| :-- | :-- | :-- |
| `4.8.x` | 1.32.9 | **1.33.9** |
| `4.9.5`, `4.9.14` | 1.33.10 | **1.34.6** |
| `4.9.24` and later | 1.34.6 | **1.34.9** |

So `4.8.x → 4.9.24` skips a minor on the EC binary but crosses only one on the appliance. An earlier revision of this PR derived the mark from the single Kubernetes version table in the docs and applied it to both, which produced the wrong answer for appliance installs. That table was itself only ever describing the EC binary.

### Published pages

- **EC (VMware tab):** `4.8.52 / 4.8.56 / 4.8.61 / 4.8.62 → 4.9.24, 4.9.38, 4.9.44, 4.9.46, 4.9.51` now show ❌, matching the constraint section instead of contradicting it. `4.7.27 / 4.7.29 / 4.7.38 → 4.9.5` also become ❌, which is the same two-minor jump and was the second half of the defect.
- **Appliance tab:** back to ✅, which the per-install Kubernetes versions confirm is correct.
- **Kubernetes (Helm) tab:** unchanged ✅. On a customer-managed cluster the Kubernetes version is managed independently of Palette.
- **`4.9.14 → 4.9.24 / 4.9.38 / 4.9.44 / 4.9.46 / 4.9.51` rows added.** The two-step note tells customers to hop through `4.9.14`; until now no `4.9.x → 4.9.x` row existed anywhere, so the second hop was not shown as supported. It is now.
- **63 new rows per page** in total, from `4.8.62`, `4.9.44`, `4.9.46`, and `4.9.51`.
- **The Kubernetes version table gains a column per installation type**, so it stops being wrong for appliance installs, and the two-step guidance is scoped to EC binary with an explicit note that appliance installs are unaffected.
- **A mark legend** now sits above the tables. There was no explanation on the page of what ✅ or ❌ meant.

The `4.9 → 4.10` blocks are reported by the script as having no marker and are deliberately left alone; they belong on `docs-rel-4-10-0`.

### The same wrong claim elsewhere

Engineering has confirmed the Management Appliance was **never** affected by this constraint, for the reason above. Three other places told appliance customers otherwise, and all three are corrected here:

| Where | Was | Now |
| :-- | :-- | :-- |
| `_partials/self-hosted/management-appliance/_upgrade-palette-upgrade-notes.mdx` | Opened with the `4.8.x → 4.9.23+` constraint as its first bullet, rendered on **both** appliance upgrade pages | Bullet removed; it never applied there |
| `release-notes.md` 4.9.23 Palette Enterprise upgrade note | "EC binary **and Palette Management Appliance** upgrades … are not supported" | Scoped to the EC binary, and states that appliance installations are unaffected and why |
| `release-notes.md` matching VerteX note | Named the VerteX Management Appliance | Same fix |

The partial was the most consequential: it sits on the two Management Appliance upgrade pages, so appliance customers were being told to perform a two-step upgrade they do not need.

Worth noting that the cross-check below cannot catch this class of error, because the disagreement was between a docs page and Confluence rather than inside Confluence.

### Generator

Marks now **mirror Confluence** rather than being derived. The constraint survives as a **cross-check**: the script reads the bundled Kubernetes version from the matrix's own labels (per install type) and reports any path marked supported that skips a minor version. It reports rather than rewrites, because that disagreement means the mark or the label is wrong and both live in Confluence. Run against the current page it reports **no conflicts**, so the matrix is now self-consistent.

That check is the guard the original defect needed: pointed at the old page it would have flagged all 24 rows.

Three silent failure modes let the tables drift this far, and each is now loud:

| Was | Now |
| --- | --- |
| `statusToMark()` matched the whole cell exactly, so `Supported (staggered)` or `Supported*` fell through to `null` and the row vanished from the published table with no warning. | Keyword matching with precedence, and negation-aware so `Not yet supported` does not land on ✅ just because it contains "supported". Any cell that still cannot be classified is reported with its install, source, target, and text. Against the current page: **0 unclassified cells**. |
| A renamed Confluence `h3` meant every table under it was discarded, leaving whole marker blocks stale while the run reported success. | Fatal, before anything is written, naming the heading it found. An install that parses zero rows is fatal too. Bare tables in the legacy groups below the 4.6 floor are hand-maintained and expected, so they are noted rather than fatal. |
| Output was a row count per install, so a Confluence change that quietly halved a table looked like a clean run. | Every run prints added, removed, and re-marked rows per block. |

A 28-test fixture suite covers the keyword precedence, the per-install label parsing, the cross-check and its exemptions, the floor handling, the structural-drift reports, and the row diff. No credentials or network needed.

```bash
npx jest scripts/release/generate-upgrade-paths.test.js
```

### Verification

- `--dry-run` after the write reports **no row changes**, so the published tables and Confluence agree and the result is reproducible rather than hand-edited.
- 28/28 tests pass; Prettier and ESLint clean; Vale 0 errors and 0 warnings on both upgrade pages.
- Vale on `release-notes.md` reports 5 errors, all pre-existing and none on changed lines (90, 1425, 1703, 1893, 2760). Left alone; flagged here rather than fixed in this PR.

### Answered along the way

All three questions this PR previously carried as open are now settled by the reworked matrix: `4.8.52` ships Kubernetes `1.32.9` on EC, `4.7.x → 4.9.5` direct is Not Supported, and the `4.9.14` second hop is validated and now published.

---

## 💻 Changed Pages

- [Self-hosted Palette — Upgrade](https://deploy-preview-11869--docs-spectrocloud.netlify.app/enterprise-version/upgrade/#supported-upgrade-paths)
- [Palette VerteX — Upgrade](https://deploy-preview-11869--docs-spectrocloud.netlify.app/vertex/upgrade/#supported-upgrade-paths)
- [Palette Management Appliance — Upgrade](https://deploy-preview-11869--docs-spectrocloud.netlify.app/enterprise-version/upgrade/palette-management-appliance/) — the constraint bullet is gone from the upgrade notes
- [VerteX Management Appliance — Upgrade](https://deploy-preview-11869--docs-spectrocloud.netlify.app/vertex/upgrade/vertex-management-appliance/) — same
- [Release Notes 4.9.23](https://deploy-preview-11869--docs-spectrocloud.netlify.app/release-notes/#june-29-2026---release-4923) — upgrade notes scoped to the EC binary

Worth checking in the preview: the **VMware** tab under **4.9** shows ❌ for `4.8.x` → `4.9.24`+ and ✅ for `4.9.14` → those same targets, the appliance tab is all ✅, and the two-column Kubernetes version table reads correctly against the two-step note.

---

## 🎫 Jira Tickets

[DOC-3097](https://spectrocloud.atlassian.net/browse/DOC-3097)


[DOC-3097]: https://spectrocloud.atlassian.net/browse/DOC-3097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ