### PR TITLE
DOC-3184 - Patch release notes for 4.9.54

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -21,17 +21,9 @@ tags: ["release-notes"]
 <!-- https://spectrocloud.atlassian.net/browse/OPS-11070 -->
 
 - Fixed an issue where Palette 4.9.53 deployed release candidate builds of five internal container images instead of
-  their generally available builds. As a result, an image scan of a Palette 4.9.53 installation reports the following
-  image tags:
-
-  - `http-oci-proxy:4.9.6-rc.1`
-  - `hubble-msgbroker:4.9.9-rc.1`
-  - `hubble-msgbroker-config-init:4.9.9-rc.1`
-  - `spectro-tunnel:4.9.6-rc.1`
-  - `specman:4.9.7-rc.1` (FIPS deployments only)
-
-  Palette 4.9.54 deploys the generally available build of each image. These builds contain the same code as the release
-  candidates, so Palette behavior is unchanged.
+  their generally available builds. As a result, an image scan of a Palette 4.9.53 installation reports image tags with
+  an `-rc.1` suffix. Palette 4.9.54 deploys the generally available build of each image. These builds contain the same
+  code as the release candidates, so Palette behavior is unchanged.
 
 ## September 3, 2026 - Release 4.9.53
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,28 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## September 4, 2026 - Release 4.9.54
+
+<!-- PATCH RELEASE TICKET: DOC-3184 -->
+<!-- PATCH RELEASE VERSION: 4.9.54 -->
+
+### Bug Fixes
+
+<!-- https://spectrocloud.atlassian.net/browse/OPS-11070 -->
+
+- Fixed an issue where Palette 4.9.53 deployed release candidate builds of five internal container images instead of
+  their generally available builds. As a result, an image scan of a Palette 4.9.53 installation reports the following
+  image tags:
+
+  - `http-oci-proxy:4.9.6-rc.1`
+  - `hubble-msgbroker:4.9.9-rc.1`
+  - `hubble-msgbroker-config-init:4.9.9-rc.1`
+  - `spectro-tunnel:4.9.6-rc.1`
+  - `specman:4.9.7-rc.1` (FIPS deployments only)
+
+  Palette 4.9.54 deploys the generally available build of each image. These builds contain the same code as the release
+  candidates, so Palette behavior is unchanged.
+
 ## September 3, 2026 - Release 4.9.53
 
 <!-- PATCH RELEASE TICKET: DOC-3179 -->


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Adds the 4.9.54 patch release notes. The patch replaces five internal container images that shipped in 4.9.53 as release candidate builds with their generally available builds, so an image scan of a 4.9.53 installation no longer reports `-rc.1` tags. Release engineering confirmed the promoted builds carry no code changes, so Palette behavior is unchanged.

`make generate-patch-release-notes` could not be used here. It derives both the release date and the candidate ticket set from a "List of candidates" JQL link in the DOC ticket description, and this ticket carries only a free-text pointer to the OPS bug. The section is written by hand to match the script's template output, including the two HTML markers so a later run can find and replace it.

Where the derived values came from:

| Value | Source |
| --- | --- |
| September 4, 2026 | Blink deploy notices for Prod, Merck, and EU Multi Tenant in `#prod-release` and `#support-sustaining` |
| The affected images | The OPS ticket description, with the 4.9.53 → 4.9.54 upgrade verification in its comments |
| "no code changes" | Release engineering, in the `#deployments-saas` hotfix thread |

**No component tables are touched.** nickfury at `v4.9.54` reports `stylus=4.9.39` and `palette-cli=4.9.21`, identical to what 4.9.53 already documents, so there is no Edge or Automation section and neither the Edge Compatibility Matrix nor CLI Tools gains a row.

The note gives the count and the `-rc.1` suffix rather than naming the five images, so a reader who ran a scan against 4.9.53 can still correlate what they found without internal image names appearing on a customer-facing page.

---

## 💻 Changed Pages

- [Release Notes](https://deploy-preview-11873--docs-spectrocloud.netlify.app/release-notes/#september-4-2026---release-4954) — new 4.9.54 section

---

## 🎫 Jira Tickets

[DOC-3184](https://spectrocloud.atlassian.net/browse/DOC-3184)

Related: OPS 11070

_The related key is written without its hyphen and left unlinked so that merging this PR does not transition it. A linked `browse/<KEY>` URL triggers the automation even when the visible label is spaced._


[DOC-3184]: https://spectrocloud.atlassian.net/browse/DOC-3184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ