### PR TITLE
docs: PAIIL patch release 1.1.4

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -100,8 +100,18 @@ appliance sets the default; there is no operator control to change which model i
 An external inference endpoint is a box-wide OpenAI-compatible host that an operator registers so the gateway can route
 tier traffic to it as egress. Each endpoint carries a short **Endpoint id** that becomes the routing prefix. The id
 cannot be changed after registration, and it cannot collide with a built-in frontier provider (`anthropic`, `openai`,
-`gemini`); registration refuses a colliding id. The credential is stored once for the appliance and is never held per
-client, which is why the client drawer shows `box-managed` in place of a per-client key for that row.
+`gemini`); registration refuses a colliding id. The **Endpoint URL** can be an origin or an origin followed by a path
+prefix; the appliance appends the OpenAI-compatible request paths itself, so the URL does not include `/v1`.
+
+The credential for an endpoint is stored once for the appliance and is never held per client, which is why the client
+drawer shows `box-managed` in place of a per-client key for that row. The credential can be an API key, one or more
+custom headers, or both. The appliance sends any custom headers on both the model-catalog probe and every routed
+request.
+
+The appliance can additionally trust a self-signed or private-CA certificate presented by the endpoint on the outbound
+connection to it. That trust is scoped to the endpoint, and it does not change the certificate the appliance itself
+presents on its own inbound console. Header values are stored as secrets, but a CA certificate is not; the appliance
+shows a stored CA certificate in full whenever an operator edits the endpoint.
 
 Disabling or removing an endpoint takes effect immediately, and it is fail-safe: any routing rule that still points at
 that endpoint falls back to the appliance's local serving in flight rather than returning an error. To register a host,

--- a/docs/products/paletteai-inference-launchpad/explanation/explanation.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/explanation.md
@@ -22,3 +22,4 @@ They cover design decisions, component relationships, and trade-offs rather than
 | [Model Certification](./model-certification.md)             | What certified means, how models are certified, and how to choose models for your use case.                      |
 | [Inference Engines](./inference-engines.md)                 | What an inference engine is, automatic engine selection, the supported kinds, and when to override it.           |
 | [Installation Architecture](./installation-architecture.md) | How the appliance installs, why the network uses a bond, and how day-two upgrades stay in Local UI.              |
+| [The Thinking Directive](./thinking-directive.md)           | How the Thinking directive on the Tier Map controls reasoning depth by effort level and how each engine reacts.  |

--- a/docs/products/paletteai-inference-launchpad/explanation/routing-behavior.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/routing-behavior.md
@@ -58,9 +58,10 @@ Each Tier map row has three columns.
 - **Model.** A model the appliance serves, or the special picker value **Choose per request**. When Model is a served
   model, the Tier map settles the request in Stage 1. When Model is **Choose per request**, the alias is handed to the
   semantic router in Stage 2.
-- **Thinking.** A directive attached to the chosen model, one of `off`, `on`, `budget` (with a token count), or `effort`
-  (with a level: low, medium, high, max). The directive follows the request onto whichever model answers, even when the
-  semantic router picks that model.
+- **Thinking.** A directive attached to the chosen model that tells a reasoning-capable model how much reasoning to do
+  before it answers. The directive follows the request onto whichever model answers, even when the semantic router picks
+  that model. For the modes, levels, and per-engine behavior, refer to
+  [The Thinking Directive](./thinking-directive.md).
 
 A client that names a model no row matches, and no other rule catches, falls back to the box's **Fallback for unmatched
 requests**. When that fallback is off, the appliance returns HTTP `404`.

--- a/docs/products/paletteai-inference-launchpad/explanation/thinking-directive.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/thinking-directive.md
@@ -1,0 +1,103 @@
+---
+sidebar_label: "The Thinking Directive"
+title: "The Thinking Directive"
+description:
+  "How the Thinking directive on the Tier Map controls reasoning depth by effort level, why the off option is disabled
+  for some providers, how each engine interprets the level, and the shared output allowance that reasoning and answer
+  tokens draw from."
+hide_table_of_contents: false
+sidebar_position: 8
+tags: ["paletteai-inference-launchpad", "routing", "tier-map", "thinking", "explanation"]
+keywords: ["launchpad", "ai", "thinking", "reasoning", "effort", "tier map"]
+---
+
+The Thinking directive is a per-tier setting on the [Tier Map](../reference/glossary.md#tier-map) that tells the tier's
+resolved model how much reasoning to do before it answers. Each Tier Map row carries its own Thinking directive, so
+different tiers on the same appliance can reason at different depths.
+
+Reasoning is a hidden generation phase that a reasoning-capable model runs before it produces the visible answer. The
+hidden phase costs tokens and adds latency. Setting the Thinking directive is how a platform administrator trades that
+cost against answer quality for each tier. To perform this task, refer to
+[Set the Thinking Directive for a Tier](../how-to-guides/set-tier-thinking.md). For the values each mode carries, refer
+to [Thinking Directive Modes](../reference/thinking-modes.md).
+
+## How Each Mode Is Interpreted
+
+The console offers three modes: **off**, **on**, and **effort**. The tier's engine and its resolved model together
+decide what the mode does at request time.
+
+- **off** turns reasoning off. On a reasoning-capable model, the model skips the hidden phase and answers directly.
+
+- **on** turns reasoning on at medium effort. It is a shorthand for `effort:medium`.
+
+- **effort** turns reasoning on at the level you pick. The five levels are `low`, `medium`, `high`, `xhigh`, and `max`.
+  Each level maps to the model's native effort control.
+
+:::info
+
+Selecting **on** without a level uses `medium`. The behavior is the same as `effort:medium`, but the picker does not
+show the cost difference between **off** and **on**.
+
+:::
+
+## Model-Aware Off
+
+Some frontier providers do not expose a switch that turns reasoning off. For these providers, a Thinking value of
+**off** has no meaning at the wire, so the console does not offer it. The Tier Map's Thinking selector disables **off**
+whenever the tier resolves to one of the following models.
+
+- OpenAI o-series models.
+
+- OpenAI GPT-5 family models.
+
+For a tier that resolves to one of these models, the selector offers only **on** and **effort**.
+
+## When the Engine Has No Thinking Surface
+
+Some engines have no reasoning surface at all. A small chat model that ships without a reasoning phase is the common
+case. When the tier's resolved model runs on such an engine, the appliance accepts the Thinking directive and the engine
+ignores it, because there is no phase for the directive to act on.
+
+To make this state visible, the Tier Map row renders the **Thinking** column in a grey chip that reads
+`ignored — no thinking surface`. The gateway passes the request through unchanged, so the request does not fail. The
+directive takes effect the moment a reasoning-capable model serves the tier.
+
+## Per-Engine Effort Behavior
+
+An `effort:<level>` directive maps to each model's native effort control. How the mapping behaves depends on the engine
+family.
+
+- **Anthropic frontier models**. Every level takes effect. Reasoning depth rises monotonically from `low` to `max`.
+
+- **OpenAI frontier models**. Each model version supports its own set of levels. A level deeper than the model supports
+  silently reduces to the deepest supported level. The request does not fail.
+
+- **Local models**. The engine honors **on** and **off**. Most local models do not read a graded level, because effort
+  grading lives in the model's own prompt template rather than in an API parameter the gateway can push. The Tier Map
+  still shows the level that was set.
+
+- **Engines with no reasoning surface**. The directive is accepted and ignored. Refer to
+  [When the Engine Has No Thinking Surface](#when-the-engine-has-no-thinking-surface).
+
+## Shared Output Allowance
+
+Reasoning tokens and the visible answer draw from a single output-token allowance per request. A deep effort level can
+consume the whole allowance during the hidden phase, so the answer starts against a zero budget and the reply is empty.
+The reasoning tokens are still charged.
+
+The appliance raises the output allowance when reasoning is on, which makes the empty-reply case rare in practice. A
+client that sets a small output-token limit on its own request still has this risk.
+
+:::warning
+
+If a client sets a small output-token limit on a request that reaches a tier configured for a deep effort level, the
+reply can be empty. Charge for the reasoning tokens still applies.
+
+:::
+
+## Legacy Tier Rules with a Token Budget
+
+Earlier PaletteAI Inference Launchpad versions exposed a **budget** mode on the Thinking picker, which took a token
+count. The current console no longer offers **budget** as a picker choice, but a tier rule saved under an earlier
+release still works. The console reads the saved token budget, maps it to the closest effort level, and displays the
+rule as that effort level. Rules do not need to be re-saved.

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/how-to-guides.md
@@ -23,6 +23,7 @@ you the steps to do it without teaching background concepts.
 | [Upload a Model](./upload-a-model.md)                                                   | Download a model on a jumpbox and upload it to the appliance.                                                  |
 | [Bring Your Own Model](./bring-your-own-model.md)                                       | Author metadata for a model that is not certified, then upload and deploy it.                                  |
 | [Configure Semantic Routing](./configure-semantic-routing.md)                           | Set the Complexity threshold, author category rules, override both per client, and turn on Decision recording. |
+| [Set the Thinking Directive for a Tier](./set-tier-thinking.md)                         | Choose off, on, or an effort level per tier on the Tier Map.                                                   |
 | [Enable Vision Preprocessing](./enable-vision-preprocessing.md)                         | Deploy a vision model and turn on image-to-text preprocessing for a text-only model.                           |
 | [Create a Client](./create-a-client.md)                                                 | Create a client and issue its first API token.                                                                 |
 | [Generate an API Token](./generate-an-api-token.md)                                     | Create an API token that clients use to authenticate to the appliance.                                         |

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/register-an-external-inference-endpoint.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/register-an-external-inference-endpoint.md
@@ -18,7 +18,10 @@ together as egress, refer to [Clients and Quotas](../explanation/clients-and-quo
 ## Prerequisites
 
 - A running PaletteAI Inference Launchpad appliance, with the admin console reachable and operator access.
-- The endpoint's URL, reachable from the appliance, and a key if the host requires one.
+- The endpoint's URL, reachable from the appliance.
+- The credentials the host requires, if any. Credentials can be an API key, one or more custom headers, or both.
+- If the endpoint's TLS certificate is self-signed or issued by a private Certificate Authority (CA), that certificate
+  in Privacy-Enhanced Mail (PEM) format.
 - An existing client to authorize. To create one, refer to [Create a Client](./create-a-client.md).
 - Egress permitted for the appliance. Sovereignty must not be armed. To check or disarm it, refer to
   [Sovereignty and Egress](../explanation/clients-and-quotas.md#sovereignty-and-egress).
@@ -27,21 +30,37 @@ together as egress, refer to [Clients and Quotas](../explanation/clients-and-quo
 
 1. From the left main menu, select **Integrations**.
 
-2. In **External inference endpoints**, under **Add an endpoint**, enter an **Endpoint id**, the **Endpoint URL**, and
-   the **Key** if the host requires one. Enter the origin only, such as `https://host.example.com`. For the id's
-   constraints and role, refer to
+2. In **External inference endpoints**, under **Add an endpoint**, enter an **Endpoint id** and the **Endpoint URL**.
+   The URL can be an origin, such as `https://host.example.com`, or an origin followed by a path prefix, such as
+   `https://gateway.example.com/openai`. Do not include `/v1` in the URL. A URL that ends in `/v1` is refused, and
+   nothing is stored. For the id's constraints and role, and for how the appliance handles the URL, refer to
    [External Inference Endpoints](../explanation/architecture.md#external-inference-endpoints).
 
-3. _(Optional)_ Enter **Input $/1M tokens** and **Output $/1M tokens** so usage is priced at the rates you set. If you
+3. Enter the **Key** if the host requires an API key. Otherwise, leave **Key** blank; the appliance sends no
+   `Authorization` header.
+
+4. _(Optional)_ Add one or more custom headers. In **Custom headers**, select **Add header**, and then enter a header
+   name and its value. You can add up to 16 headers. Header values are stored as secrets and are not shown again after
+   you save. A small set of transport-level header names is reserved and refused. When you edit an existing endpoint,
+   leaving a header's value blank keeps the stored value.
+
+5. _(Optional)_ Trust a self-signed or private CA certificate. Only supply a certificate when the endpoint's own TLS
+   certificate is not signed by a publicly trusted CA. Expand **Advanced: self-signed or private CA**, and in **CA
+   certificate (PEM)**, paste the endpoint's certificate or bundle in PEM format. When you edit an existing endpoint,
+   the appliance shows the stored certificate in full.
+
+6. _(Optional)_ Enter **Input $/1M tokens** and **Output $/1M tokens** so usage is priced at the rates you set. If you
    leave them blank, the appliance applies a generic rate.
 
-4. Select **Probe models**. The appliance contacts the host and lists the models it serves. A bad key or an unreachable
-   host reports the failure and stores nothing.
+7. Select **Probe models**. The appliance contacts the host and lists the models it serves. The appliance reports the
+   failure and stores nothing if the key or a header is rejected, a header name is disallowed, more than 16 headers are
+   set, the certificate is untrusted, or the host is unreachable.
 
-5. Review **Discovered models**, then select **Add endpoint**. Review the preview, and then select **Confirm & apply**.
+8. Review **Discovered models**, then select **Add endpoint**. Review the preview, and then select **Confirm & apply**.
 
-6. Confirm the endpoint appears in the list with an **enabled** chip, its URL, its model count, and a **key set** or
-   **no key** indicator on its row.
+9. Confirm the endpoint appears in the list with an **enabled** chip, its URL, its model count, and a **key set** or
+   **no key** indicator on its row. If you added custom headers, the row reports the header count and names. If you
+   added a CA certificate, the row shows a **custom CA** indicator.
 
 To stop routing to the endpoint without deleting it, select **Disable**. To delete it, select **Remove**. For the
 fail-safe behavior that catches a routing rule still pointing at a disabled or removed endpoint, refer to
@@ -82,14 +101,14 @@ Requests that match that alias go to the registered host and are counted as egre
 
 ## Validate the Endpoint
 
-Send a request through the appliance that matches an alias rule you just routed to the endpoint, then confirm the
-appliance metered it as egress from that endpoint.
+Send a request through the appliance that matches the alias you just routed to the endpoint, then confirm the appliance
+metered it as egress from that endpoint.
 
 1. From a client with a valid API token, call the alias you routed to the endpoint.
 
 2. From the left main menu, select **Usage**.
 
-3. Select the **By Model** tab and find the row labeled **External · egress**. For the field it uses and the per-client
+3. Select the **By Model** tab and find the row labeled **External · egress**. For the metric field and the per-client
    split, refer to [Usage Metrics Reference: By Model Tab](../reference/usage-metrics-reference.md#by-model-tab).
 
 ## Next Steps

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/set-tier-thinking.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/set-tier-thinking.md
@@ -1,0 +1,54 @@
+---
+sidebar_label: "Set the Thinking Directive for a Tier"
+title: "Set the Thinking Directive for a Tier"
+description:
+  "Step-by-step guidance for platform administrators on how to set the Thinking directive for a tier on the Tier Map of
+  a PaletteAI Inference Launchpad appliance."
+hide_table_of_contents: false
+sidebar_position: 2.4
+tags: ["paletteai-inference-launchpad", "routing", "tier-map", "thinking", "how-to"]
+keywords: ["launchpad", "ai", "thinking", "reasoning", "tier map", "effort", "routing"]
+---
+
+This guide explains how to set the Thinking directive for a tier on the [Tier Map](../reference/glossary.md#tier-map) of
+a PaletteAI Inference Launchpad appliance. For what the directive does and how each mode is interpreted, refer to
+[The Thinking Directive](../explanation/thinking-directive.md). For the values each mode carries at request time, refer
+to [Thinking Directive Modes](../reference/thinking-modes.md).
+
+## Prerequisites
+
+- A running PaletteAI Inference Launchpad appliance, with the console reachable.
+
+- Console access with permission to edit routing settings.
+
+- At least one tier with a resolved model on the Tier Map. To place a model on the appliance, refer to
+  [Deploy a Model](./deploy-a-model.md).
+
+## Set the Thinking Directive
+
+1. From the left main menu, select **Routing**.
+
+2. On the **Tier Map** card, find the row for the tier you want to change and select **edit**.
+
+3. In the **Thinking** selector, choose **off**, **on**, or **effort**.
+
+4. _(**effort** only)_ In the level selector next to the **effort** option, choose **low**, **medium**, **high**,
+   **xhigh**, or **max**.
+
+5. Select **Apply tier** and confirm the plan card.
+
+## Validate
+
+- The **Tier Map** row shows the new directive in the **Thinking** column, formatted as `on`, `off`, or
+  `effort:<level>`.
+
+- Send a request through the tier and open its trace. On a reasoning-capable model, the response reports a non-zero
+  reasoning-token count.
+
+## Next Steps
+
+- [The Thinking Directive](../explanation/thinking-directive.md)
+
+- [Thinking Directive Modes](../reference/thinking-modes.md)
+
+- [Manage a Client's Model Access](./manage-client-model-access.md)

--- a/docs/products/paletteai-inference-launchpad/reference/glossary.md
+++ b/docs/products/paletteai-inference-launchpad/reference/glossary.md
@@ -185,7 +185,9 @@ model is exposed as an [OpenAI-compatible endpoint](#openai-compatible-api) at p
 
 An OpenAI-compatible inference host registered on the appliance as an appliance-wide [egress](#egress) target. The host
 can be a hosted router, a partner API, a second appliance, or an in-house inference server. After you register it, its
-models appear in a client's routing picker, and traffic to it is metered as egress. Refer to
+models appear in a client's routing picker, and traffic to it is metered as egress. The host can authenticate the
+appliance with a key, custom headers, or both, and can present a self-signed or private-CA certificate the appliance
+trusts individually. Refer to
 [Register an External Inference Endpoint](../how-to-guides/register-an-external-inference-endpoint.md).
 
 ## F

--- a/docs/products/paletteai-inference-launchpad/reference/reference.md
+++ b/docs/products/paletteai-inference-launchpad/reference/reference.md
@@ -21,6 +21,7 @@ is configured, not how to accomplish a task.
 | [Certified Models by Hardware](./certified-models-by-hardware.md) | Which models are certified for each supported NVIDIA and AMD GPU configuration.                |
 | [Model Upload Reference](./model-upload-reference.md)             | Palette CLI model download and upload flags, and the model metadata file fields.               |
 | [Usage Metrics Reference](./usage-metrics-reference.md)           | Every filter, metric, table column, and export field on the Usage page.                        |
+| [Thinking Directive Modes](./thinking-modes.md)                   | Thinking modes and effort levels, per-engine interpretation, and console override states.      |
 | [Claude Code Configuration](./claude-code-reference.md)           | Environment variables and values for pointing Claude Code at the appliance.                    |
 | [Cursor Configuration](./cursor-reference.md)                     | Settings and values for pointing Cursor at the appliance.                                      |
 | [OpenAI Codex Configuration](./codex-reference.md)                | Configuration file fields and values for pointing Codex at the appliance.                      |

--- a/docs/products/paletteai-inference-launchpad/reference/thinking-modes.md
+++ b/docs/products/paletteai-inference-launchpad/reference/thinking-modes.md
@@ -1,0 +1,55 @@
+---
+sidebar_label: "Thinking Directive Modes"
+title: "Thinking Directive Modes"
+description:
+  "Reference of the Thinking directive modes on the Tier Map, the effort levels, per-engine interpretation, and the
+  console states that override the setting."
+hide_table_of_contents: false
+sidebar_position: 4.8
+tags: ["paletteai-inference-launchpad", "routing", "tier-map", "thinking", "reference"]
+keywords: ["launchpad", "ai", "thinking", "reasoning", "effort", "tier map"]
+---
+
+This reference lists the Thinking directive modes on the [Tier Map](./glossary.md#tier-map) of a PaletteAI Inference
+Launchpad appliance, the effort levels, how each engine family interprets the level, and the console states that
+override the setting. For the concept behind the directive, refer to
+[The Thinking Directive](../explanation/thinking-directive.md). For the steps to set the directive, refer to
+[Set the Thinking Directive for a Tier](../how-to-guides/set-tier-thinking.md).
+
+## Modes
+
+| **Mode**   | **Authored value** | **What the model does**                                                                                    |
+| ---------- | ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **off**    | `off`              | The model does not reason. It answers each request directly.                                               |
+| **on**     | `on`               | The model reasons at medium effort. Equivalent to `effort:medium`.                                         |
+| **effort** | `effort:<level>`   | The model reasons at the chosen level. Each level maps to the model's native effort control on the engine. |
+
+## Effort Levels
+
+<!-- vale off -->
+
+| **Level** | **Authored value** | **Relative depth**                        |
+| --------- | ------------------ | ----------------------------------------- |
+| low       | `effort:low`       | Shortest hidden phase the model supports. |
+| medium    | `effort:medium`    | Default depth. Selected by a bare **on**. |
+| high      | `effort:high`      | Deeper reasoning than `medium`.           |
+| xhigh     | `effort:xhigh`     | Deeper reasoning than `high`.             |
+| max       | `effort:max`       | Deepest hidden phase the model supports.  |
+
+<!-- vale on -->
+
+## Per-Engine Interpretation of Effort
+
+| **Engine family**                 | **How the level is treated**                                                                                                      |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Anthropic frontier                | Every level takes effect. Reasoning depth rises monotonically from `low` to `max`.                                                |
+| OpenAI frontier                   | Each model version supports its own set of levels. A level deeper than the model supports reduces to the deepest supported level. |
+| Local models                      | Only **on** and **off** are honored. Most local models do not read a graded level.                                                |
+| Engines with no reasoning surface | The directive is accepted and ignored. The row shows the ignored chip.                                                            |
+
+## Console States That Override the Setting
+
+| **State**                                         | **When it appears**                                                        | **Effect**                                                        |
+| ------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `off` is disabled                                 | The tier resolves to an OpenAI o-series or GPT-5 family model.             | The selector does not offer **off** for that tier.                |
+| Grey chip reading `ignored — no thinking surface` | The tier's resolved model runs on an engine that has no reasoning surface. | The engine ignores the directive; the request is served normally. |


### PR DESCRIPTION
Document the Thinking directive on the Tier Map as a strict-Diataxis
set under the latest 1.1.x collection: a how-to for setting it, an
explanation of the three modes and the five effort levels including
the new xhigh level, and a reference table of mode values and
per-engine interpretation.

Drop the stale Thinking-mode enumeration from the routing-behavior
explanation, which listed the retired budget mode with only four
effort levels, and point it at the new explanation page as the
source of truth.

Add one Contents row for each new page to the how-to-guides,
explanation, and reference landing pages.

Extend the external inference endpoint how-to with a path-prefix
Endpoint URL, a blank Key that omits the outbound Authorization
header, a custom-headers step covering the 16-header cap and the
reserved transport-level names, and an Advanced disclosure for a
self-signed or private-CA certificate in PEM.

Extend the External Inference Endpoints explanation and the glossary
entry so credentials may be a key, custom headers, or both, and note
the per-endpoint CA trust.

Refs: AIL-639, AIL-692, https://spectrocloud.atlassian.net/browse/DOC-3194