### PR TITLE
PE-9465: k8s systemd ext edge (4.10.0)

### DIFF
--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -281,7 +281,7 @@ mode Edge clusters in both connected and airgapped environments.
   versions continue to follow the existing flow, where Kubernetes and Palette Agent binaries are embedded in the
   provider image.
 - **CanvOS 4.10.0** or later to build provider images that opt in or out of the extensions path.
-- Palette can deliver all supported Kubernetes flavors through systemd extensions.
+- Palette can deliver all supported Kubernetes variants through systemd extensions.
 
 Unified Kernel Image (UKI) deployments do not support systemd extensions. Refer to
 [Unified Kernel Image (UKI) Considerations](#unified-kernel-image-uki-considerations) for the behavior on those hosts.

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -317,17 +317,15 @@ following steps.
 The first upgrade after adopting CanvOS 4.10.0 requires a provider image that ships the aligned Palette Agent version.
 Subsequent Kubernetes upgrades run without a provider image.
 
-1. Build a provider image with a supported CanvOS release and set `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true` in the
-   `.arg` file. Set `system.uri: <provider-image>` in the BYOOS pack for the initial upgrade. This upgrade replaces the
-   `kairos-agent` on the system with the aligned Palette Agent version. Refer to
+1. Build a provider image with a supported CanvOS release. Set `system.uri: <provider-image>` in the BYOOS pack for the
+   upgrade. This upgrade replaces the `kairos-agent` on the system with the aligned Palette Agent version. Refer to
    [Support Requirements](#support-requirements) for the minimum CanvOS release.
-2. For subsequent Kubernetes upgrades, set `system.uri: NA` in the BYOOS pack and update the Kubernetes pack in the
-   cluster profile to the target version. Palette delivers the new Kubernetes binaries through systemd extensions and
-   does not require a provider image. A provider image can still be supplied for each repave, in which case
-   `BUNDLE_K8S_AND_AGENT_PROVIDER` is not required.
+2. For subsequent Kubernetes upgrades, if you intend to use systemd extensions, set `system.uri: NA` in the BYOOS pack
+   and update the Kubernetes pack in the cluster profile to the target version. Palette delivers the new Kubernetes
+   binaries through systemd extensions and does not require a provider image. A provider image can still be supplied if
+   you intend to perform operating system or Kubernetes upgrades, which follow the current behavior.
 3. If the Palette Edge agent remains pinned to an earlier release, systemd extensions are not available on this cluster.
-   Build provider images from a supported CanvOS release with `BUNDLE_K8S_AND_AGENT_PROVIDER` set to `true` for every
-   upgrade.
+   Build provider images from a supported CanvOS release and use one for every upgrade.
 
 ### Upgrade Operating System Packages
 

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -266,18 +266,19 @@ guide when you do not require [specialized configurations](#specialized-build-gu
 
 ## Deliver Kubernetes and Agent Binaries via systemd Extensions {#bundle-k8s-and-agent-provider-flag}
 
-Starting with **CanvOS 4.10**, connected Edge clusters can use systemd extensions to deliver Kubernetes and Palette
-Agent binaries at runtime instead of embedding them in the provider image. This reduces provider image size and lets a
-single provider image serve multiple Kubernetes versions on the same host. This capability applies to connected clusters
-only.
+Starting with **CanvOS 4.10**, Edge clusters in appliance mode can use systemd extensions to deliver Kubernetes and
+Palette Agent binaries at runtime instead of embedding them in the provider image. This reduces provider image size and
+lets a single provider image serve multiple Kubernetes versions on the same host. This capability applies to appliance
+mode Edge clusters in both connected and airgapped environments.
 
 ### Support Requirements
 
 - **Palette Edge agent 4.10.0** (Stylus) or later on the cluster. When Stylus is pinned to an earlier release, systemd
   extensions are not available on the cluster regardless of the operating system or Kubernetes pack settings, and the
   cluster falls back to the pre-systemd-extensions behavior.
-- An operating system with **systemd version 255 or later**, such as Ubuntu 24 or RHEL 10. Operating systems on earlier
-  systemd versions continue to follow the existing flow, where Kubernetes and Palette Agent binaries are embedded in the
+- An operating system with **systemd version 255 or later**. Ubuntu 24 and RHEL 10 are the tested and verified operating
+  systems, and any operating system with systemd 255 or later is supported. Operating systems on earlier systemd
+  versions continue to follow the existing flow, where Kubernetes and Palette Agent binaries are embedded in the
   provider image.
 - **CanvOS 4.10.0** or later to build provider images that opt in or out of the extensions path.
 - Palette can deliver all supported Kubernetes flavors through systemd extensions.
@@ -300,8 +301,8 @@ existing behavior.
 
 ### New Clusters
 
-When you provision a new connected Edge cluster on an operating system with systemd 255 or later, take the following
-steps.
+When you provision a new appliance mode Edge cluster on an operating system with systemd 255 or later, take the
+following steps.
 
 1. Set `system.uri: NA` in the BYOOS pack. Palette does not need a provider image to deliver Kubernetes and Palette
    Agent binaries when systemd extensions are available.

--- a/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
+++ b/docs/docs-content/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md
@@ -273,11 +273,17 @@ only.
 
 ### Support Requirements
 
-- **Palette Edge agent 4.10.0** or later on the cluster. Earlier releases fall back to the pre-systemd-extensions
-  behavior.
-- An operating system with **systemd version 255 or later**. Operating systems on earlier systemd versions continue to
-  follow the existing flow, where Kubernetes and Palette Agent binaries are embedded in the provider image.
+- **Palette Edge agent 4.10.0** (Stylus) or later on the cluster. When Stylus is pinned to an earlier release, systemd
+  extensions are not available on the cluster regardless of the operating system or Kubernetes pack settings, and the
+  cluster falls back to the pre-systemd-extensions behavior.
+- An operating system with **systemd version 255 or later**, such as Ubuntu 24 or RHEL 10. Operating systems on earlier
+  systemd versions continue to follow the existing flow, where Kubernetes and Palette Agent binaries are embedded in the
+  provider image.
 - **CanvOS 4.10.0** or later to build provider images that opt in or out of the extensions path.
+- Palette can deliver all supported Kubernetes flavors through systemd extensions.
+
+Unified Kernel Image (UKI) deployments do not support systemd extensions. Refer to
+[Unified Kernel Image (UKI) Considerations](#unified-kernel-image-uki-considerations) for the behavior on those hosts.
 
 ### `BUNDLE_K8S_AND_AGENT_PROVIDER` Flag Behavior
 
@@ -314,9 +320,10 @@ Subsequent Kubernetes upgrades run without a provider image.
    `.arg` file. Set `system.uri: <provider-image>` in the BYOOS pack for the initial upgrade. This upgrade replaces the
    `kairos-agent` on the system with the aligned Palette Agent version. Refer to
    [Support Requirements](#support-requirements) for the minimum CanvOS release.
-2. For subsequent Kubernetes upgrades, set `system.uri: NA` in the BYOOS pack. Palette delivers Kubernetes binaries
-   through systemd extensions and does not require a provider image. A provider image can still be supplied for each
-   repave, in which case `BUNDLE_K8S_AND_AGENT_PROVIDER` is not required.
+2. For subsequent Kubernetes upgrades, set `system.uri: NA` in the BYOOS pack and update the Kubernetes pack in the
+   cluster profile to the target version. Palette delivers the new Kubernetes binaries through systemd extensions and
+   does not require a provider image. A provider image can still be supplied for each repave, in which case
+   `BUNDLE_K8S_AND_AGENT_PROVIDER` is not required.
 3. If the Palette Edge agent remains pinned to an earlier release, systemd extensions are not available on this cluster.
    Build provider images from a supported CanvOS release with `BUNDLE_K8S_AND_AGENT_PROVIDER` set to `true` for every
    upgrade.
@@ -329,13 +336,10 @@ version.
 
 ### Unified Kernel Image (UKI) Considerations
 
-For Edge hosts using [Unified Kernel Images](../../../trusted-boot/trusted-boot.md), signing keys must line up in both
-directions.
-
-- New provider images must be signed with the same keys used to sign the installer. A mismatch causes the host to reject
-  the image at boot.
-- systemd extensions delivered outside of the provider image must be signed with the same keys used to sign the
-  installer.
+Edge hosts that use [Unified Kernel Images](../../../trusted-boot/trusted-boot.md) do not support systemd extensions.
+These hosts continue to receive Kubernetes and Palette Agent binaries embedded in the provider image, which you build
+from a supported CanvOS release for every upgrade. Sign the provider image with the same keys that you used to sign the
+installer. A mismatch causes the host to reject the image at boot.
 
 ## Next Steps
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -250,8 +250,9 @@ troubleshooting scenario.
   provider image built with **CanvOS 4.10.x** that sets `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Reference the image
   through `system.uri` in the BYOOS pack for the first upgrade after you adopt **CanvOS 4.10.x**. This upgrade aligns
   the Palette Edge node agent on the host with the Palette release. Subsequent Kubernetes upgrades do not need a
-  provider image, so set `system.uri: NA` in the BYOOS pack. For Unified Kernel Image (UKI) deployments, sign the new
-  provider image and the systemd extensions with the same keys that you used to sign the installer. Refer to
+  provider image, so set `system.uri: NA` in the BYOOS pack. Unified Kernel Image (UKI) deployments do not support
+  systemd extensions and continue to receive Kubernetes and Palette Agent binaries embedded in the provider image, which
+  you sign with the same keys that you used to sign the installer. Refer to
   [Upgrade an Existing Cluster](../clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md#upgrade-an-existing-cluster)
   for more information.
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -241,21 +241,6 @@ troubleshooting scenario.
 
 :::
 
-#### Breaking Changes {#edge-breaking-changes-4.10.0}
-
-<!-- https://spectrocloud.atlassian.net/browse/PE-8314 -->
-<!-- https://spectrocloud.atlassian.net/browse/PE-8648 -->
-
-- Upgrading an existing connected Edge cluster on an operating system with systemd version 255 or later requires a
-  provider image built with **CanvOS 4.10.x** that sets `BUNDLE_K8S_AND_AGENT_PROVIDER` to `true`. Reference the image
-  through `system.uri` in the BYOOS pack for the first upgrade after you adopt **CanvOS 4.10.x**. This upgrade aligns
-  the Palette Edge node agent on the host with the Palette release. Subsequent Kubernetes upgrades do not need a
-  provider image, so set `system.uri: NA` in the BYOOS pack. Unified Kernel Image (UKI) deployments do not support
-  systemd extensions and continue to receive Kubernetes and Palette Agent binaries embedded in the provider image, which
-  you sign with the same keys that you used to sign the installer. Refer to
-  [Upgrade an Existing Cluster](../clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md#upgrade-an-existing-cluster)
-  for more information.
-
 #### Features
 
 <!-- https://spectrocloud.atlassian.net/browse/PE-8679 -->
@@ -285,12 +270,14 @@ troubleshooting scenario.
 <!-- https://spectrocloud.atlassian.net/browse/PE-8314 -->
 <!-- https://spectrocloud.atlassian.net/browse/PE-8648 -->
 
-- Connected Edge clusters can now use systemd extensions to deliver Kubernetes and Palette Agent binaries at runtime,
-  instead of embedding those binaries in the provider image. On operating systems running systemd version 255 or later,
-  provider images built with CanvOS 4.10.x exclude the binaries by default, and Stylus (Palette Edge node agent) 4.10.x
-  delivers them through systemd extensions. Set `system.uri: NA` in the BYOOS pack for standard upgrades. The new
-  `BUNDLE_K8S_AND_AGENT_PROVIDER` flag in the CanvOS `.arg` file overrides the default when a specific flow requires the
-  binaries embedded. Refer to
+- Edge clusters in appliance mode can now use systemd extensions to deliver Kubernetes and Palette Agent binaries at
+  runtime, instead of embedding those binaries in the provider image. This applies in both connected and airgapped
+  environments. On operating systems running systemd version 255 or later, provider images built with CanvOS 4.10.x
+  exclude the binaries by default, and Stylus (Palette Edge node agent) 4.10.x delivers them through systemd extensions.
+  Set `system.uri: NA` in the BYOOS pack for standard upgrades. The new `BUNDLE_K8S_AND_AGENT_PROVIDER` flag in the
+  CanvOS `.arg` file overrides the default when a specific flow requires the binaries embedded. Unified Kernel Image
+  (UKI) deployments do not support systemd extensions and continue to receive these binaries embedded in the provider
+  image. Refer to
   [Deliver Kubernetes and Agent Binaries via systemd Extensions](../clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/build-provider-images.md#bundle-k8s-and-agent-provider-flag)
   for build and upgrade guidance.
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** for all affected pages are provided in the [Changed Pages](#-changed-pages) section.
- [x] Conduct a **self-review** for your pages using your preview links.
- [x] **Check formatting** for your pages. _Prettier clean._
- [x] Ensure all **Vale comments** are resolved. _No new findings; pre-existing `heading-all-caps` false positive on `BUNDLE_K8S_AND_AGENT_PROVIDER` is unchanged._
- [ ] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _Targets `docs-rel-4-10-0`; the feature is new in 4.10.0, so no earlier-version backport applies._
- [x] **Outside review:** Edge engineering confirmation pending on the points noted below.
- [x] Add the `notify-slack` label once this checklist has been completed.

---

## 📝 Describe the Change

Documents Kubernetes systemd extensions (sysexts) support for Edge clusters in 4.10.0 per PE-9465, and corrects the earlier PE-8648 wording where it now differs. With sysexts, Palette ships the Kubernetes distribution as an extension layered onto the immutable OS at boot, so a Kubernetes version bump no longer requires a full OS provider-image rebuild.

Key changes:

- **Release notes (Edge breaking change):** Unified Kernel Image (UKI) deployments do **not** support systemd extensions. Those hosts continue to receive Kubernetes and Palette Agent binaries embedded in the signed provider image. This reverses the earlier entry, which described UKI as supported with signing.
- **Build guide (Deliver Kubernetes and Agent Binaries via systemd Extensions):** names the supported operating systems (Ubuntu 24, RHEL 10) alongside the systemd 255+ requirement; calls out the Stylus version dependency; notes that all supported Kubernetes flavors can be delivered through sysexts; adds the Kubernetes-pack update to the existing-cluster upgrade steps; and reworks the UKI section to state sysexts are not supported on UKI hosts.

A few specifics are being confirmed with Edge engineering before merge: whether UKI is truly unsupported, whether the capability is limited to a particular cluster mode, and whether it applies to disconnected/airgapped Edge as well as connected. Please hold merge until those are resolved.

---

## 💻 Changed Pages

- [Release Notes → 4.10.0 → Edge Breaking Changes:](https://deploy-preview-11876--docs-spectrocloud.netlify.app/release-notes/#edge-breaking-changes-4.10.0)
- [Build Provider Images → Deliver Kubernetes and Agent Binaries via systemd Extensions:](https://deploy-preview-11876--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images/#bundle-k8s-and-agent-provider-flag)

*Reviewer-generated links*
- [Build Provider Images](https://deploy-preview-11876--docs-spectrocloud.netlify.app/clusters/edge/edgeforge-workflow/palette-canvos/build-provider-images)
- [Release Notes](https://deploy-preview-11876--docs-spectrocloud.netlify.app/release-notes)
---

## 🎫 Jira Tickets

[PE-9465](https://spectrocloud.atlassian.net/browse/PE-9465)


[PE-9465]: https://spectrocloud.atlassian.net/browse/PE-9465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ