### PR TITLE
DOC-3081: upgrade matrix for 4.10.0

### DIFF
--- a/docs/docs-content/enterprise-version/upgrade/upgrade.md
+++ b/docs/docs-content/enterprise-version/upgrade/upgrade.md
@@ -75,6 +75,7 @@ The following table lists the Kubernetes version bundled with each recent Palett
 | 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61, 4.8.62 |  1.32.9   |            1.33.9            |
 | 4.9.5, 4.9.8, 4.9.14                           |  1.33.10  |            1.34.6            |
 | 4.9.23 and later                               |  1.34.6   |            1.34.9            |
+| 4.10.0 and later                               |    TBD    |            1.35.6            |
 
 On EC binary installations, direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x`
 series ships Kubernetes `1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. The upgrade
@@ -92,6 +93,16 @@ minor.
 
 <Tabs>
 <TabItem label="VMware" value="VMware">
+
+**4.10**
+
+<!-- upgrade-paths:vmware-4.10:start -->
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.51       |      4.10.11       | :white_check_mark: |
+
+<!-- upgrade-paths:vmware-4.10:end -->
 
 **4.9**
 
@@ -562,6 +573,16 @@ few hours.
 </TabItem>
 
 <TabItem label="Kubernetes" value="Kubernetes">
+
+**4.10**
+
+<!-- upgrade-paths:kubernetes-4.10:start -->
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.51       |      4.10.11       | :white_check_mark: |
+
+<!-- upgrade-paths:kubernetes-4.10:end -->
 
 **4.9**
 
@@ -1037,6 +1058,16 @@ few hours.
 :::preview
 
 :::
+
+**4.10**
+
+<!-- upgrade-paths:appliance-4.10:start -->
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.51       |      4.10.11       | :white_check_mark: |
+
+<!-- upgrade-paths:appliance-4.10:end -->
 
 **4.9**
 

--- a/docs/docs-content/vertex/upgrade/upgrade.md
+++ b/docs/docs-content/vertex/upgrade/upgrade.md
@@ -75,6 +75,7 @@ The following table lists the Kubernetes version bundled with each recent Palett
 | 4.8.52, 4.8.54, 4.8.56, 4.8.58, 4.8.61, 4.8.62 |  1.32.9   |           1.33.9            |
 | 4.9.5, 4.9.8, 4.9.14                           |  1.33.10  |           1.34.6            |
 | 4.9.23 and later                               |  1.34.6   |           1.34.9            |
+| 4.10.0 and later                               |    TBD    |           1.35.6            |
 
 On EC binary installations, direct upgrades from any `4.8.x` release to `4.9.23` or later are not supported. The `4.8.x`
 series ships Kubernetes `1.32.9`, and `4.9.23` and later ship Kubernetes `1.34.6`, which skips `1.33.x`. The upgrade
@@ -92,6 +93,16 @@ missing minor.
 
 <Tabs>
 <TabItem label="VMware" value="VMware">
+
+**4.10**
+
+<!-- upgrade-paths:vmware-4.10:start -->
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.51       |      4.10.11       | :white_check_mark: |
+
+<!-- upgrade-paths:vmware-4.10:end -->
 
 **4.9**
 
@@ -562,6 +573,16 @@ after a few hours.
 </TabItem>
 
 <TabItem label="Kubernetes" value="Kubernetes">
+
+**4.10**
+
+<!-- upgrade-paths:kubernetes-4.10:start -->
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.51       |      4.10.11       | :white_check_mark: |
+
+<!-- upgrade-paths:kubernetes-4.10:end -->
 
 **4.9**
 
@@ -1037,6 +1058,16 @@ after a few hours.
 :::preview
 
 :::
+
+**4.10**
+
+<!-- upgrade-paths:appliance-4.10:start -->
+
+| **Source Version** | **Target Version** |    **Support**     |
+| :----------------: | :----------------: | :----------------: |
+|       4.9.51       |      4.10.11       | :white_check_mark: |
+
+<!-- upgrade-paths:appliance-4.10:end -->
 
 **4.9**
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** for all affected pages are provided in the [Changed Pages](#-changed-pages) section.
- [x] Conduct a **self-review** for your pages using your preview links.
- [x] **Check formatting** for your pages. _Prettier clean._
- [x] Ensure all **Vale comments** are resolved. _No new findings._
- [ ] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _Targets `docs-rel-4-10-0`; the 4.10 tables are release-specific, so no earlier-version backport applies._
- [x] **Outside review:** Upgrade paths are sourced from the QA-verified release upgrade-path matrix; the constraint-table approach was confirmed with the docs team.
- [x] Add the `notify-slack` label once this checklist has been completed.

---

## 📝 Describe the Change

Adds the 4.10.0 upgrade-path matrix tables to the Self-Hosted (Palette Enterprise) and VerteX upgrade pages for the 4.10.0 release (DOC-3081), on top of the corrected DOC-3097 base already on `docs-rel-4-10-0`.

Changes, in both upgrade pages:

- A new **4.10** block in each tab (VMware, Kubernetes, and the Management Appliance), with the single validated path `4.9.51 → 4.10.11` (✅). These use the standard `upgrade-paths:*-4.10` marker blocks, so the release generator stays idempotent.
- A new `4.10.0 and later` row in the **Kubernetes Version Constraint** table: EC Binary `TBD`, Appliance `1.35.6`. The EC Kubernetes version is not yet finalized (typically confirmed at release), so `TBD` is an intentional placeholder to update before publish.

---

## 💻 Changed Pages

- [Self-Hosted → Supported Upgrade Paths:](https://deploy-preview-11879--docs-spectrocloud.netlify.app/enterprise-version/upgrade/#supported-upgrade-paths)
- [VerteX → Supported Upgrade Paths:](https://deploy-preview-11879--docs-spectrocloud.netlify.app/vertex/upgrade/#supported-upgrade-paths)

---

## 🎫 Jira Tickets

[DOC-3081](https://spectrocloud.atlassian.net/browse/DOC-3081)


[DOC-3081]: https://spectrocloud.atlassian.net/browse/DOC-3081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ