### PR TITLE
docs: make the release scripts safe to re-run after a component bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,10 @@ unused_images.json
 
 # Cursor
 .cursor/
+# Intermediate files the release scripts render templates into. They are removed on a successful
+# run, but a run that aborts part-way (a missing table marker, for example) leaves them behind,
+# and they are otherwise untracked files sitting in a tracked directory.
+scripts/release/temp_file.md
+scripts/release/*-output.md
+scripts/release/*-composed.md
+scripts/release/templates/*-output.md

--- a/Makefile
+++ b/Makefile
@@ -405,6 +405,7 @@ generate-release: ## Generate all release files except release notes
 	./scripts/release/generate-install-palette-cli.sh
 	./scripts/release/generate-kubernetes-palette-versions.sh
 	./scripts/release/generate-pcg-kubernetes-versions.sh
+	./scripts/release/generate-release-notes-callouts.sh
 	make -s format > /dev/null 2>&1
 
 init-release:

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -237,7 +237,15 @@ tags: ["release-notes"]
 
 ### Edge
 
+<!-- release-notes-edge-callout-4.10.0-start -->
+
+:::info
+
 The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the 4.10.0 Palette release is 4.10.3.
+
+:::
+
+<!-- release-notes-edge-callout-4.10.0-end -->
 
 :::warning
 
@@ -479,12 +487,16 @@ troubleshooting scenario.
 
 ### Automation
 
+<!-- release-notes-automation-callout-4.10.0-start -->
+
 :::info
 
 The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the 4.10.0 Palette release is
-4.10.0. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+4.10.3. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
 
 :::
+
+<!-- release-notes-automation-callout-4.10.0-end -->
 
 #### Features
 

--- a/scripts/release/generate-downloads.sh
+++ b/scripts/release/generate-downloads.sh
@@ -8,11 +8,19 @@ DOWNLOADS_FILE="${DOWNLOADS_FILE:-docs/docs-content/downloads/cli-tools.md}"
 CLI_TEMPLATE_FILE="scripts/release/templates/palette-cli.md"
 CLI_PARAMETERISED_FILE="scripts/release/cli-output.md"
 TABLE_OFFSET=2
+# 1-based columns of the CLI Tools table, counting the Palette Release cell as column 1. Used to
+# read back what a release's row already records, so a re-run can reuse a checksum it derived
+# earlier instead of downloading the binary again.
+DOWNLOADS_CLI_VERSION_COLUMN=2
+DOWNLOADS_SHA_COLUMN=4
 
+# The checksums are deliberately not required. Each architecture's row records a marker naming its
+# missing checksum instead, so the entry exists from the first run and a later run only has to fill
+# the cell in. Requiring the AMD64 checksum here used to skip the whole file, which left the ARM64
+# and macOS rows unwritten even when their own checksums were known.
 if ! check_env "RELEASE_NAME" ||
    ! check_env "RELEASE_VERSION" ||
-   ! check_env "RELEASE_PALETTE_CLI_VERSION" ||
-   ! check_env "RELEASE_PALETTE_CLI_SHA" ; then
+   ! check_env "RELEASE_PALETTE_CLI_VERSION" ; then
     echo "‼️  Skipping generate $DOWNLOADS_FILE due to missing environment variables. ‼️"
     exit 0
 fi
@@ -43,16 +51,52 @@ for spec in "${ARCHES[@]}"; do
         continue
     fi
 
-    # Only the AMD64 checksum is required, because it is the one the check above guarantees and the
-    # one every release publishes. An architecture whose checksum this run does not know still gets
-    # its row, with a marker naming what is missing, so the entry exists from the first run and a
-    # later run only has to fill the cell in. A caller that resolved a value itself, such as
-    # generate-patch-release-notes.sh, passes it in and it is used as given.
+    # Resolve this architecture's checksum, in order of preference:
+    #
+    #   1. The value already in the environment, normally from .env. This wins outright, including
+    #      when it is a pending marker, because a caller that resolved a value itself is telling us
+    #      what to record. generate-patch-release-notes.sh always passes something, so it never
+    #      reaches the steps below and its own prompt stays the only place it asks.
+    #   2. The checksum this release's row already records, but only when that row also records the
+    #      Palette CLI version this run is writing. Matching on the version is what makes reuse safe:
+    #      after a release-day bump the recorded checksum belongs to the previous binary, so it has
+    #      to be re-derived rather than carried over onto a new download URL.
+    #   3. The published binary, hashed as it downloads. This is a fallback rather than the norm
+    #      because the transfer runs to several hundred megabytes per architecture.
+    #   4. A marker naming what is missing, so the row exists from the first run and a later run
+    #      only has to fill the cell in.
     RELEASE_PALETTE_CLI_SHA="${!sha_var:-}"
+    sha_source=""
 
-    if [[ -z "$RELEASE_PALETTE_CLI_SHA" ]]; then
-        RELEASE_PALETTE_CLI_SHA="$PENDING_SHA"
-        echo "🟠 '$sha_var' is empty or not set, so the $arch_name row records '$PENDING_SHA'." >&2
+    if [[ -n "$RELEASE_PALETTE_CLI_SHA" ]]; then
+        sha_source="$sha_var"
+    else
+        recorded_cli_version=$(get_table_cell_for_release \
+            "$DOWNLOADS_FILE" "$DOWNLOADS_CLI_VERSION_COLUMN" "$RELEASE_VERSION" "$marker")
+        recorded_sha=$(get_table_cell_for_release \
+            "$DOWNLOADS_FILE" "$DOWNLOADS_SHA_COLUMN" "$RELEASE_VERSION" "$marker")
+
+        if [[ "$recorded_cli_version" == "$RELEASE_PALETTE_CLI_VERSION" && "$recorded_sha" =~ ^[0-9a-f]{64}$ ]]; then
+            RELEASE_PALETTE_CLI_SHA="$recorded_sha"
+            sha_source="the checksum already recorded for Palette CLI $RELEASE_PALETTE_CLI_VERSION"
+        else
+            # A version that is not published yet returns HTTP 403, which the helper checks for
+            # before trusting a digest, so an unavailable binary costs one request and reports
+            # itself. That is an expected outcome on release day rather than a failure, so the run
+            # continues and the cell is left pending.
+            echo "ℹ️  '$sha_var' is empty or not set, so the $arch_name checksum is derived from the published binary." >&2
+
+            if RELEASE_PALETTE_CLI_SHA=$(fetch_palette_cli_sha "$RELEASE_PALETTE_CLI_VERSION" "$url_suffix"); then
+                sha_source="the published binary"
+            else
+                RELEASE_PALETTE_CLI_SHA="$PENDING_SHA"
+                echo "🟠 The $arch_name Palette CLI $RELEASE_PALETTE_CLI_VERSION binary could not be hashed, so the row records '$PENDING_SHA'. Set '$sha_var' in your .env file, or re-run this script once the binary is published." >&2
+            fi
+        fi
+    fi
+
+    if [[ -n "$sha_source" ]]; then
+        echo "ℹ️  $arch_name checksum sourced from $sha_source."
     fi
 
     # The download URL is normally derived from the Palette CLI version, but a caller that does not

--- a/scripts/release/generate-edge-compatibility-matrix.sh
+++ b/scripts/release/generate-edge-compatibility-matrix.sh
@@ -39,20 +39,34 @@ if ! check_env "RELEASE_NAME" ||
     exit 0
 fi
 
-# Source component versions from nickfury's spectro_versions.txt at the release
-# tag. The matrix columns map to nickfury keys as:
+# Resolve the component versions the matrix records. The environment, normally .env, is the
+# authoritative source: `make generate-release` exists so that a version bumped on the day of
+# release can be corrected by editing .env and re-running, and every other page in that run takes
+# its value from there. nickfury's spectro_versions.txt is consulted as a second opinion, and its
+# values fill anything .env does not set, so the script still records a row when a version has not
+# been added to .env yet. The matrix columns map to nickfury keys as:
 #   CanvOS / Stylus / Edge Host -> stylus
 #   Palette CLI Version         -> palette-cli
-# Falls back to any values already present in the environment if GITHUB_TOKEN is
-# unset or the fetch fails, so the script still works without network access.
+#
+# Where both sources have a value and they disagree, .env is used and the difference is reported,
+# because that is usually either a .env that has not caught up with the release or a release tag
+# that does not match the versions being documented, and both are worth seeing.
 #
 # NICKFURY_REF lets a caller that has already resolved a ref pass it in, because a
 # patch release can be documented from a release branch rather than a release tag.
 # RELEASE_SKIP_NICKFURY lets a calling script that has already resolved these versions, or has
 # deliberately recorded them as pending, keep the values it passed in.
 nickfury_ref="${NICKFURY_REF:-v${RELEASE_VERSION}}"
+env_canvos="${RELEASE_CANVOS:-}"
+env_palette_cli="${RELEASE_PALETTE_CLI_VERSION:-}"
+nf_stylus=""
+nf_palette_cli=""
+canvos_source=""
+palette_cli_source=""
+
 if [[ -n "${RELEASE_SKIP_NICKFURY:-}" ]]; then
-    echo "ℹ️  Using the caller-provided Edge matrix versions (RELEASE_CANVOS=$RELEASE_CANVOS, RELEASE_PALETTE_CLI_VERSION=$RELEASE_PALETTE_CLI_VERSION)."
+    canvos_source="the calling script"
+    palette_cli_source="the calling script"
 elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
     nickfury_versions="$(fetch_github_file "$NICKFURY_REPO" "$nickfury_ref" "$NICKFURY_VERSIONS_PATH")" || nickfury_versions=""
     if [[ -n "$nickfury_versions" ]]; then
@@ -63,23 +77,49 @@ elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
         if [[ -n "$nf_nickfury" && "$nf_nickfury" != "$RELEASE_VERSION" ]]; then
             echo "⚠️  nickfury@$nickfury_ref reports version '$nf_nickfury' but RELEASE_VERSION is '$RELEASE_VERSION'."
         fi
-
-        [[ -n "$nf_stylus" ]] && RELEASE_CANVOS="$nf_stylus"
-        [[ -n "$nf_palette_cli" ]] && RELEASE_PALETTE_CLI_VERSION="$nf_palette_cli"
-        echo "ℹ️  Sourced Edge matrix versions from nickfury@$nickfury_ref (stylus=$nf_stylus, palette-cli=$nf_palette_cli)"
     else
-        echo "⚠️  Could not fetch $NICKFURY_VERSIONS_PATH from nickfury@$nickfury_ref; using environment-provided values."
+        echo "⚠️  Could not fetch $NICKFURY_VERSIONS_PATH from nickfury@$nickfury_ref, so only the .env values are available."
     fi
 else
-    echo "ℹ️  GITHUB_TOKEN not set; using environment-provided Edge matrix versions."
+    echo "ℹ️  GITHUB_TOKEN is not set, so nickfury cannot be read and only the .env values are available."
 fi
 
-# Component versions must now be present, whether from nickfury or the environment.
+if [[ -z "$canvos_source" ]]; then
+    if [[ -n "$env_canvos" ]]; then
+        RELEASE_CANVOS="$env_canvos"
+        canvos_source=".env"
+
+        if [[ -n "$nf_stylus" && "$nf_stylus" != "$env_canvos" ]]; then
+            echo "⚠️  .env sets RELEASE_CANVOS to '$env_canvos' but nickfury@$nickfury_ref reports stylus '$nf_stylus'. The .env value is used."
+        fi
+    elif [[ -n "$nf_stylus" ]]; then
+        RELEASE_CANVOS="$nf_stylus"
+        canvos_source="nickfury@$nickfury_ref"
+    fi
+fi
+
+if [[ -z "$palette_cli_source" ]]; then
+    if [[ -n "$env_palette_cli" ]]; then
+        RELEASE_PALETTE_CLI_VERSION="$env_palette_cli"
+        palette_cli_source=".env"
+
+        if [[ -n "$nf_palette_cli" && "$nf_palette_cli" != "$env_palette_cli" ]]; then
+            echo "⚠️  .env sets RELEASE_PALETTE_CLI_VERSION to '$env_palette_cli' but nickfury@$nickfury_ref reports palette-cli '$nf_palette_cli'. The .env value is used."
+        fi
+    elif [[ -n "$nf_palette_cli" ]]; then
+        RELEASE_PALETTE_CLI_VERSION="$nf_palette_cli"
+        palette_cli_source="nickfury@$nickfury_ref"
+    fi
+fi
+
+# Component versions must now be present, from whichever source supplied them.
 if ! check_env "RELEASE_CANVOS" ||
    ! check_env "RELEASE_PALETTE_CLI_VERSION"; then
     echo "‼️  Skipping generate $EDGE_COMPATIBILITY_MATRIX_FILE due to missing component versions. ‼️"
     exit 0
 fi
+
+echo "ℹ️  Edge matrix versions: CanvOS $RELEASE_CANVOS (from $canvos_source), Palette CLI $RELEASE_PALETTE_CLI_VERSION (from $palette_cli_source)."
 
 # The "Palette Edge CLI Status" column is fixed. The Palette Edge CLI is deprecated
 # from Palette 4.9.14 onwards and there will be no further Palette Edge CLI releases,

--- a/scripts/release/generate-kubernetes-palette-versions.sh
+++ b/scripts/release/generate-kubernetes-palette-versions.sh
@@ -29,7 +29,11 @@ generate_parameterised_file $VMWARE_TEMPLATE_FILE $VMWARE_PARAMETERISED_FILE
 generate_parameterised_file $VERTEX_VMWARE_TEMPLATE_FILE $VERTEX_VMWARE_PARAMETERISED_FILE
 generate_parameterised_file $KUBERNETES_TEMPLATE_FILE $KUBERNETES_PARAMETERISED_FILE
 
-existing_vmware=$(search_line "vmware-k8s-$RELEASE_NAME" $VERSIONS_FILE)
+# The anchor is matched with its closing " -->" so a release name cannot substring-match a
+# longer one, matching the row for another release and overwriting it. RELEASE_NAME is a
+# named release such as 4.10.0 or 4.10.a today, but generate-patch-release-notes.sh passes a
+# patch version through the same scripts, where 4.9.5 and 4.9.51 can both hold a row.
+existing_vmware=$(search_line "vmware-k8s-$RELEASE_NAME -->" $VERSIONS_FILE)
 if [[ -n "$existing_vmware" && "$existing_vmware" -ne 0 ]]; then
     echo "ℹ️ VMware Kubernetes version for $RELEASE_NAME has already been generated in $VERSIONS_FILE"
     replace_line $existing_vmware $VMWARE_PARAMETERISED_FILE $VERSIONS_FILE
@@ -39,7 +43,7 @@ else
     echo "✅ Parameterised VMware Kubernetes version inserted into $VERSIONS_FILE"
 fi
 
-existing_vertex_vmware=$(search_line "vmware-k8s-$RELEASE_NAME" $VERTEX_VERSIONS_FILE)
+existing_vertex_vmware=$(search_line "vmware-k8s-$RELEASE_NAME -->" $VERTEX_VERSIONS_FILE)
 if [[ -n "$existing_vertex_vmware" && "$existing_vertex_vmware" -ne 0 ]]; then
     echo "ℹ️ VMware Kubernetes version for $RELEASE_NAME has already been generated in $VERTEX_VERSIONS_FILE"
     replace_line $existing_vertex_vmware $VERTEX_VMWARE_PARAMETERISED_FILE $VERTEX_VERSIONS_FILE
@@ -49,7 +53,7 @@ else
     echo "✅ Parameterised VMware Kubernetes version inserted into $VERTEX_VERSIONS_FILE"
 fi
 
-existing_kubernetes=$(search_line "k8s-max-$RELEASE_NAME" $K8S_VERSIONS_FILE)
+existing_kubernetes=$(search_line "k8s-max-$RELEASE_NAME -->" $K8S_VERSIONS_FILE)
 if [[ -n "$existing_kubernetes" && "$existing_kubernetes" -ne 0 ]]; then
     echo "ℹ️ Kubernetes highest version entry for $RELEASE_NAME has already been generated in $K8S_VERSIONS_FILE"
     replace_line $existing_kubernetes $KUBERNETES_PARAMETERISED_FILE $K8S_VERSIONS_FILE

--- a/scripts/release/generate-pcg-kubernetes-versions.sh
+++ b/scripts/release/generate-pcg-kubernetes-versions.sh
@@ -18,7 +18,11 @@ fi
 
 generate_parameterised_file $PCG_TEMPLATE_FILE $PCG_PARAMETERISED_FILE
 
-existing_pcg=$(search_line "pcg-k8s-$RELEASE_NAME" $PCG_FILE)
+# The anchor is matched with its closing " -->" so a release name cannot substring-match a
+# longer one, matching the row for another release and overwriting it. RELEASE_NAME is a
+# named release such as 4.10.0 or 4.10.a today, but generate-patch-release-notes.sh passes a
+# patch version through the same scripts, where 4.9.5 and 4.9.51 can both hold a row.
+existing_pcg=$(search_line "pcg-k8s-$RELEASE_NAME -->" $PCG_FILE)
 if [[ -n "$existing_pcg" && "$existing_pcg" -ne 0 ]]; then
     echo "ℹ️ PCG Kubernetes version for $RELEASE_NAME has already been generated in $PCG_FILE"
     replace_line $existing_pcg $PCG_PARAMETERISED_FILE $PCG_FILE

--- a/scripts/release/generate-release-notes-callouts.sh
+++ b/scripts/release/generate-release-notes-callouts.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Refreshes the component version callouts in the current release's published release notes, so a
+# component bumped after the notes were drafted is corrected everywhere rather than only in the
+# tables. Runs as part of `make generate-release`.
+#
+# We aim to settle the CanvOS and Palette CLI versions before a release ships, but either can be
+# bumped again on the day, and the rest of `make generate-release` already picks a new version up
+# from .env on a re-run. The release notes did not: generate-release-notes.sh writes the block once
+# and afterwards only refreshes its heading, because everything else in the block is hand-written.
+# That left the two callouts naming a version no later run could correct.
+#
+# Each callout is therefore delimited by a start and an end marker keyed on RELEASE_NAME, which is
+# stable across a release cycle even while RELEASE_VERSION is still a placeholder. The region
+# between them is owned by this script and rewritten in full, so nothing outside it is touched and
+# the markers are re-rendered ready for the next run.
+#
+# A release whose notes predate the markers is reported and skipped. Add the markers around the
+# existing callout to bring that release under the script, or leave it alone if it has shipped.
+
+# Import utility functions
+source scripts/release/utilities.sh
+
+# Define release note related files
+RELEASE_NOTES_FILE="${RELEASE_NOTES_FILE:-docs/docs-content/release-notes/release-notes.md}"
+EDGE_CALLOUT_TEMPLATE_FILE="scripts/release/templates/release-notes-edge-callout.md"
+AUTOMATION_CALLOUT_TEMPLATE_FILE="scripts/release/templates/release-notes-automation-callout.md"
+EDGE_CALLOUT_PARAMETERISED_FILE="scripts/release/release-notes-edge-callout-output.md"
+AUTOMATION_CALLOUT_PARAMETERISED_FILE="scripts/release/release-notes-automation-callout-output.md"
+
+if ! check_env "RELEASE_NAME" ||
+   ! check_env "RELEASE_VERSION" ||
+   ! check_env "RELEASE_CANVOS" ||
+   ! check_env "RELEASE_PALETTE_CLI_VERSION" ; then
+    echo "‼️  Skipping refresh of the $RELEASE_NOTES_FILE callouts due to missing environment variables. ‼️"
+    exit 0
+fi
+
+if [[ ! -f "$RELEASE_NOTES_FILE" ]]; then
+    echo "❌ Release notes file $RELEASE_NOTES_FILE not found. Nothing was refreshed."
+    exit 1
+fi
+
+# Each spec carries the display name used in log output, the marker base the region is keyed on,
+# the template rendering that region, the file the rendered region is written to, and the names of
+# the variables the template needs beyond RELEASE_NAME and RELEASE_VERSION.
+CALLOUTS=(
+    "Edge|release-notes-edge-callout|$EDGE_CALLOUT_TEMPLATE_FILE|$EDGE_CALLOUT_PARAMETERISED_FILE|RELEASE_CANVOS"
+    "Automation|release-notes-automation-callout|$AUTOMATION_CALLOUT_TEMPLATE_FILE|$AUTOMATION_CALLOUT_PARAMETERISED_FILE|RELEASE_PALETTE_CLI_VERSION"
+)
+
+for spec in "${CALLOUTS[@]}"; do
+    IFS='|' read -r callout_name marker_base template_file output_file version_var <<< "$spec"
+
+    start_marker="<!-- ${marker_base}-${RELEASE_NAME}-start -->"
+    end_marker="<!-- ${marker_base}-${RELEASE_NAME}-end -->"
+
+    if ! grep -qF "$start_marker" "$RELEASE_NOTES_FILE"; then
+        echo "ℹ️ $RELEASE_NOTES_FILE has no $callout_name callout marker for $RELEASE_NAME, so it is skipped."
+        continue
+    fi
+
+    # Only the variables the template uses are substituted, and through awk rather than sed,
+    # because `sed -i ''` is BSD-only.
+    generate_parameterised_file_local_vars \
+        "$template_file" "$output_file" \
+        RELEASE_NAME RELEASE_VERSION "$version_var"
+
+    if replace_region "$start_marker" "$end_marker" "$output_file" "$RELEASE_NOTES_FILE"; then
+        echo "✅ Refreshed the $callout_name callout for $RELEASE_NAME in $RELEASE_NOTES_FILE (${version_var}=${!version_var})"
+    else
+        echo "🟠 $RELEASE_NOTES_FILE has a $callout_name start marker for $RELEASE_NAME but no matching end marker, so the callout was left unchanged." >&2
+    fi
+
+    cleanup "$output_file"
+done

--- a/scripts/release/generate-release-notes.sh
+++ b/scripts/release/generate-release-notes.sh
@@ -6,12 +6,19 @@ source scripts/release/utilities.sh
 RELEASE_NOTES_FILE="docs/docs-content/release-notes/release-notes.md"
 RELEASE_NOTES_TEMPLATE_FILE="scripts/release/templates/release-notes.md"
 RELEASE_NOTES_HEADING_TEMPLATE_FILE="scripts/release/templates/release-notes-heading.md"
+EDGE_CALLOUT_TEMPLATE_FILE="scripts/release/templates/release-notes-edge-callout.md"
+AUTOMATION_CALLOUT_TEMPLATE_FILE="scripts/release/templates/release-notes-automation-callout.md"
+RELEASE_NOTES_COMPOSED_FILE="scripts/release/release-notes-composed.md"
 RELEASE_NOTES_PARAMETERISED_FILE="scripts/release/release-notes-output.md"
 RELEASE_NOTES_HEADING_PARAMETERISED_FILE="scripts/release/release-notes-heading-output.md"
 
 # RELEASE_CANVOS and RELEASE_PALETTE_CLI_VERSION fill the Edge and Automation callouts. Both are
 # required, because generate_parameterised_file substitutes an unset variable with an empty string
 # and would leave a sentence that names no version rather than a visible placeholder.
+#
+# RELEASE_TERRAFORM_VERSION deliberately fills both the Terraform provider and the Crossplane
+# provider entries under Automation. The two providers have so far always released on the same
+# version, so they share one variable; split it if that ever stops being true.
 if ! check_env "RELEASE_DATE" ||
    ! check_env "RELEASE_NAME" ||
    ! check_env "RELEASE_CANVOS" ||
@@ -22,18 +29,38 @@ if ! check_env "RELEASE_DATE" ||
     exit 0
 fi
 
-generate_parameterised_file $RELEASE_NOTES_TEMPLATE_FILE $RELEASE_NOTES_PARAMETERISED_FILE
+# The Edge and Automation callouts are held in their own templates, because the component versions
+# they name can be bumped again on the day of release and generate-release-notes-callouts.sh has to
+# be able to rewrite them in the published notes afterwards. They are composed into the release
+# notes template here rather than duplicated inline, so each sentence has one definition and the
+# published callout cannot drift from the one a later refresh would write.
+#
+# The composed file still carries the {{RELEASE_*}} placeholders the callout templates use, so the
+# substitution pass below fills them along with the rest of the template.
+EDGE_CALLOUT="$(cat "$EDGE_CALLOUT_TEMPLATE_FILE")"
+AUTOMATION_CALLOUT="$(cat "$AUTOMATION_CALLOUT_TEMPLATE_FILE")"
+
+generate_parameterised_file_local_vars \
+    "$RELEASE_NOTES_TEMPLATE_FILE" "$RELEASE_NOTES_COMPOSED_FILE" \
+    EDGE_CALLOUT AUTOMATION_CALLOUT
+
+generate_parameterised_file $RELEASE_NOTES_COMPOSED_FILE $RELEASE_NOTES_PARAMETERISED_FILE
 generate_parameterised_file $RELEASE_NOTES_HEADING_TEMPLATE_FILE $RELEASE_NOTES_HEADING_PARAMETERISED_FILE
 
-existing_notes=$(search_line "#release-notes-$RELEASE_NAME" $RELEASE_NOTES_FILE)
+# The anchor is matched with its closing brace so a release name cannot substring-match a longer
+# one, for example "#release-notes-4.10.1" matching an existing "#release-notes-4.10.10" heading
+# and relabelling that release's block instead of inserting a new one.
+existing_notes=$(search_line "#release-notes-$RELEASE_NAME}" $RELEASE_NOTES_FILE)
 if [[ -n "$existing_notes" && "$existing_notes" -ne 0 ]]; then
     echo "ℹ️ Release notes for $RELEASE_NAME have already been generated in $RELEASE_NOTES_FILE"
     replace_line $existing_notes $RELEASE_NOTES_HEADING_PARAMETERISED_FILE $RELEASE_NOTES_FILE
     echo "✅ Replaced release notes heading in $RELEASE_NOTES_FILE"
+    echo "ℹ️ Only the heading is refreshed here, because the rest of the block is hand-written. Run 'make generate-release' to refresh the Edge and Automation component version callouts."
 else
     insert_file_after "<ReleaseNotesVersions />" $RELEASE_NOTES_PARAMETERISED_FILE $RELEASE_NOTES_FILE
     echo "✅ Parameterised release notes inserted into $RELEASE_NOTES_FILE"
 fi
 
+cleanup $RELEASE_NOTES_COMPOSED_FILE
 cleanup $RELEASE_NOTES_PARAMETERISED_FILE
 cleanup $RELEASE_NOTES_HEADING_PARAMETERISED_FILE

--- a/scripts/release/templates/release-notes-automation-callout.md
+++ b/scripts/release/templates/release-notes-automation-callout.md
@@ -1,0 +1,9 @@
+<!-- release-notes-automation-callout-{{RELEASE_NAME}}-start -->
+
+:::info
+
+The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the {{RELEASE_VERSION}} Palette release is {{RELEASE_PALETTE_CLI_VERSION}}. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
+
+:::
+
+<!-- release-notes-automation-callout-{{RELEASE_NAME}}-end -->

--- a/scripts/release/templates/release-notes-edge-callout.md
+++ b/scripts/release/templates/release-notes-edge-callout.md
@@ -1,0 +1,9 @@
+<!-- release-notes-edge-callout-{{RELEASE_NAME}}-start -->
+
+:::info
+
+The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the {{RELEASE_VERSION}} Palette release is {{RELEASE_CANVOS}}.
+
+:::
+
+<!-- release-notes-edge-callout-{{RELEASE_NAME}}-end -->

--- a/scripts/release/templates/release-notes.md
+++ b/scripts/release/templates/release-notes.md
@@ -16,11 +16,7 @@
 
 ### Edge
 
-:::info
-
-The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to the {{RELEASE_VERSION}} Palette release is {{RELEASE_CANVOS}}.
-
-:::
+{{EDGE_CALLOUT}}
 
 #### Features
 
@@ -54,11 +50,7 @@ The [CanvOS](https://github.com/spectrocloud/CanvOS) version corresponding to th
 
 ### Automation
 
-:::info
-
-The [Palette CLI](../automation/palette-cli/palette-cli.md) version corresponding to the {{RELEASE_VERSION}} Palette release is {{RELEASE_PALETTE_CLI_VERSION}}. Refer to [CLI Tools](/downloads/cli-tools/) for the download URL and checksum.
-
-:::
+{{AUTOMATION_CALLOUT}}
 
 #### Features
 

--- a/scripts/release/utilities.sh
+++ b/scripts/release/utilities.sh
@@ -219,6 +219,60 @@ replace_line() {
   mv "$tmp_file" "$target_file"
 }
 
+# Utility function to replace an inclusive region of a target file, delimited by a start and an end
+# marker, with the contents of a source file. Used to refresh a managed block of prose that a
+# re-run has to rewrite in full, such as a release note callout naming a component version that was
+# bumped on the day of release.
+#
+# A region rather than a single line, because Prettier reflows prose to 120 columns: the Automation
+# callout in the release notes runs past that and is published across two lines, so a replacement
+# keyed on one line would rewrite half a sentence.
+#
+# Both markers are matched literally, and nothing is changed unless both are present and the end
+# marker follows the start marker, so a half-marked block is left alone rather than mangled. The
+# markers themselves sit inside the region and are re-rendered from the template with it, which is
+# what lets the same region be replaced again on the next run.
+# Params:
+# $1 - literal start marker, example: <!-- release-notes-edge-callout-4.10.0-start -->
+# $2 - literal end marker, example: <!-- release-notes-edge-callout-4.10.0-end -->
+# $3 - source file whose contents replace the region, its own markers included
+# $4 - target file
+# Returns 0 if the region was replaced, 1 if it was not found.
+replace_region() {
+    local start_marker="$1"
+    local end_marker="$2"
+    local source_file="$3"
+    local target_file="$4"
+    local start_line end_line tmp_file
+
+    [[ -f "$target_file" ]] || return 1
+
+    start_line=$(search_line "$start_marker" "$target_file")
+    end_line=$(search_line "$end_marker" "$target_file")
+
+    if [[ -z "$start_line" || -z "$end_line" || "$end_line" -le "$start_line" ]]; then
+        return 1
+    fi
+
+    tmp_file="$(mktemp)"
+
+    awk -v start_line="$start_line" -v end_line="$end_line" -v source_file="$source_file" '
+      NR == start_line {
+        while ((getline line < source_file) > 0) {
+          print line
+        }
+        close(source_file)
+        next
+      }
+
+      NR > start_line && NR <= end_line { next }
+
+      { print }
+    ' "$target_file" > "$tmp_file"
+
+    mv "$tmp_file" "$target_file"
+}
+
 # Utility function to remove a file
 # Params:
 # $1 - file name


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

`make generate-release` exists so that a component version bumped on release day can be corrected by editing `.env` and re-running. An end-to-end audit of both release targets found three places where that did not hold. `make generate-release` was already idempotent for an unchanged `.env` — that is verified, not changed.

| Problem | Fix |
| --- | --- |
| The release notes were write-once, so the Edge and Automation callouts named a version no later run could correct. The published 4.10.0 Automation callout said Palette CLI `4.10.0` while the CLI Tools table said `4.10.3`. | The two callouts moved into their own templates, wrapped in start/end markers keyed on `RELEASE_NAME` (stable across a cycle while `RELEASE_VERSION` is a placeholder). A new `generate-release-notes-callouts.sh` rewrites each marked region in full, as part of `make generate-release`. A region rather than a line, because Prettier reflows the Automation callout onto two lines. |
| CLI Tools checksums were trusted from `.env` alone, so bumping the Palette CLI version without bumping the checksums paired new download URLs with the previous binary's digests. | Each checksum now resolves in order: `.env`, then the checksum the release's row already records **but only when that row also records the version being written**, then the published binary hashed as it downloads, then a pending marker. |
| The Edge matrix preferred nickfury over `.env` while every other page took `.env`, so one page out of three ignored an edited value. | `.env` is authoritative; nickfury fills only what `.env` leaves blank, and a disagreement is reported rather than silently resolved. Both scripts now name the source of each value in their output. |

Smaller fixes: an empty AMD64 checksum no longer skips all three CLI tabs (it previously left the ARM64 and macOS rows unwritten even when their own checksums were known, and made the existing `SHA PENDING` fallback dead code for AMD64); the pcg, Kubernetes and release-notes anchor lookups now match their closing terminator, so a release name cannot substring-match a longer one; and the script intermediates are gitignored so an aborted run cannot leak them into a commit.

Judgment calls a reviewer would otherwise have to reconstruct:

- **Base is `docs-rel-4-10-0`, not `master`**, because the 4.10.0 release notes block this touches exists only on that branch. The script changes reach `master` when the release ships. No backport labels, per the release-branch convention.
- **Checksum reuse is version-matched on purpose.** Reusing unconditionally would reintroduce the stale-digest bug; not reusing at all would re-download ~1.1 GB on every re-run. Verified: a re-run with all three SHA vars unset completes in 0.36s and changes nothing.
- **A derived checksum was validated against a published one.** Deriving Palette CLI 4.9.21 Linux AMD64 from scratch produced `ad6e3e6b86db…d13154`, matching the value already in the table byte for byte.
- **Fallback failure is expected, not an error.** An unpublished binary returns HTTP 403 from the availability check, so the fallback costs one request, reports itself, and leaves the cell pending — the run continues and still writes all three rows.
- **Terraform and Crossplane keep sharing `RELEASE_TERRAFORM_VERSION`.** The two providers have so far always released on the same version; the reasoning is now recorded in the script so it reads as a decision rather than an oversight. Split it if that changes.
- **The 4.10.0 Edge callout regained its `:::info` wrapper**, which had been lost at some point and left it rendering as plain prose while the Automation one was an admonition. Both marked regions are now byte-identical to what the refresher renders for CanvOS 4.10.3 / Palette CLI 4.10.3, so the next `make generate-release` is a no-op on them rather than a surprise diff.

Verification: `make generate-release` ×3 interleaved with `make generate-release-notes` ×3 produces a byte-identical diff. Also covered in disposable worktrees — fresh-release insert, release-day bump, all-checksums-empty, derive-then-reuse handoff, a release predating the markers (skipped cleanly), and the two anchor collisions the terminator fix closes. Vale reports 7 errors across the changed `.md` files, all pre-existing and identical on the base (uppercase `#### OS` / `#### CNI` / `#### CSI` headings, and `JWTs`); the two new templates are clean.

---

## 💻 Changed Pages

One user-facing page changes. The edit is confined to the 4.10.0 block: two HTML comment markers per callout, the restored `:::info` wrapper on the Edge callout, and the Palette CLI version corrected from `4.10.0` to `4.10.3`.

- [Release Notes — 4.10.0](https://deploy-preview-11880--docs-spectrocloud.netlify.app/release-notes/#release-notes-4.10.0)

Everything else is tooling with no rendered output: `scripts/release/`, `Makefile`, and `.gitignore`.

---

## 🎫 Jira Tickets

No corresponding Jira ticket. This came out of a review of the release scripts after the recent changes to `make generate-release` and `make generate-release-notes`, matching the recent ticketless `docs:` PRs for the same scripts.
