### PR TITLE
DOC-3190 - Anchor version branch match in index-breaking-changes.sh

### DIFF
--- a/scripts/index-breaking-changes.sh
+++ b/scripts/index-breaking-changes.sh
@@ -73,7 +73,9 @@ mkdir -p "$BREAKING_CHANGES_PARTIALS_PATH"
 for branch in $branches; do
   echo "ℹ️ Checking branch: $branch"
   release_notes_path="$RELEASE_NOTES_PATH"
-  if [[ $branch == *version-4-0* || $branch == *version-4-1* ]]; then
+  # Match exact branch names. Unanchored globs would also match version-4-10
+  # and later two-digit minors, routing them to the pre-4.2 release notes path.
+  if [[ $branch == "version-4-0" || $branch == "version-4-1" ]]; then
     release_notes_path="$OLD_RELEASE_NOTES_PATH"
   fi
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

One-line fix to the release-notes path selector in `scripts/index-breaking-changes.sh`, needed before `version-4-10` is cut.

The selector used unanchored globs, so `version-4-10` matched the `*version-4-1*` pattern and was routed to the pre-4.2 layout `docs/docs-content/release-notes.md`. That path does not exist on a 4.10 branch, and a failed redirect on a `while ... done < file` compound command does **not** abort under `set -e` — bash writes one line to stderr and carries on with exit 0. The result would have been a silent gap: 4.10 absent from the Breaking Changes component, with a green production build. `version-4-11` through `version-4-19` would hit the same thing.

Verified against an isolated rig (a bare fake origin populated from GitHub, plus a synthetic `version-4-10` branch re-badged with real `Release 4.10.x` headings) rather than a live branch, since the script's `git fetch --depth=1` shallows remote-tracking refs.

| Check | Old | Fixed |
| --- | --- | --- |
| Routing for `version-3-4` … `version-4-9` | unchanged | unchanged |
| The 36 existing partials | baseline | byte-for-byte identical, 0 differ |
| `br_4_10_*.mdx` partials generated | 0 | 5 |
| `4.10.x` entries in `versions.json` | 0 | 20, valid JSON |
| Script exit code | 0 (silent skip) | 0 |

No backport labels: the base is `docs-rel-4-10-0` and the content is unreleased.

---

## 💻 Changed Pages

No user-facing changes. This PR touches a build script only and produces no page diffs — the effect is that 4.10 breaking-changes partials get generated at all, once that branch exists.

---

## 🎫 Jira Tickets

[DOC-3190](https://spectrocloud.atlassian.net/browse/DOC-3190)


[DOC-3190]: https://spectrocloud.atlassian.net/browse/DOC-3190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ