### PR TITLE
docs: correct the 4.10 release heading and fix version branch ordering

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,11 +11,11 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
-## September 6, 2026 - Release 4.10.0 {#release-notes-4.10.0}
+## September 6, 2026 - Release 4.10.13 {#release-notes-4.10.0}
 
 <!-- COMPONENT UPDATES TICKET: DOC-3171 -->
 <!-- RELEASE DATE: September 6, 2026 -->
-<!-- RELEASE MANAGEMENT APPLIANCE: 4.10.11 -->
+<!-- RELEASE MANAGEMENT APPLIANCE: NA -->
 <!-- RELEASE ARTIFACT STUDIO: NA -->
 <!-- RELEASE TERRAFORM VERSION: 0.30.0 -->
 

--- a/scripts/index-breaking-changes.sh
+++ b/scripts/index-breaking-changes.sh
@@ -53,11 +53,12 @@ echo "Saved master archiveVersions.json to $TEMP_ARCHIVE_FILE"
 git fetch --prune --no-tags --depth=1 origin \
   '+refs/heads/version-*:refs/remotes/origin/version-*'
 
-# Get remote version branches (no locals, no HEAD), exclude version-3-4
+# Get remote version branches (no locals, no HEAD), exclude version-3-4. Sort by version so
+# two-digit minors order naturally (version-4-9 before version-4-10, not after version-4-1).
  branches="$(git for-each-ref --format='%(refname:strip=3)' 'refs/remotes/origin/version-*' \
    | grep -v '^HEAD$' \
    | grep -v '^version-3-4$' \
-   | sort -u)"
+   | sort -V -u)"
 
 # Leave this commented. To be used when doing local testing. 
 # branches="version-4-7 version-4-8"


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Two changes, both prompted by `version-4-10` being cut.

**1. Release note correction** (`release-notes.md`)

| Field | Before | After |
| --- | --- | --- |
| Heading | `Release 4.10.0` | `Release 4.10.13` |
| Release Management Appliance | `4.10.11` | `NA` |

The heading anchor is deliberately left as `{#release-notes-4.10.0}` so external inbound links keep resolving; nothing in this repo references it. Note this also renames the generated breaking-changes partial to `br_4_10_13.mdx`, with `versions.json` recording `4.10.13`.

**2. Branch ordering in the breaking-changes indexer** (`index-breaking-changes.sh`)

The branch list used a lexical `sort -u`, so `version-4-10` was processed between `version-4-1` and `version-4-2` instead of after `version-4-9` — confusing to read in a build log. Switched to `sort -V -u`.

Presentational only, verified three ways: the branch set is identical (reorder only, nothing added or dropped); no two version branches share a release number, so processing order cannot change which partial wins (`version-4-10` contains only `Release 4.10.0`); and [ReleaseNotesBreakingChanges.tsx](https://github.com/spectrocloud/librarium/blob/master/src/components/ReleaseNotesBreakingChanges/ReleaseNotesBreakingChanges.tsx#L109) re-sorts `versions.json` on load with a numeric comparator, so file order never reaches the UI. `sort -V` is supported by both GNU sort (CI) and BSD sort (local macOS).

Backport labels target `version-4-10` only — that branch carries the identical uncorrected release-note lines and the same unsorted script. No earlier branch has a 4.10 release note.

Note: `vale --minAlertLevel=error` reports one pre-existing error on the release notes page (`Did you really mean 'JWTs'?`, line 388). It is untouched by this change and left alone per the scoping rule.

---

## 💻 Changed Pages

- [Release Notes — Release 4.10.13](https://deploy-preview-11887--docs-spectrocloud.netlify.app/release-notes/#release-notes-4.10.0)

---

## 🎫 Jira Tickets

No corresponding Jira ticket — this is a small factual correction to a shipped page.
