### PR TITLE
DOC-3189 - Patch release notes for 4.7.48

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,24 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## August 6, 2026 - Release 4.7.48
+
+<!-- PATCH RELEASE TICKET: DOC-3189 -->
+<!-- PATCH RELEASE VERSION: 4.7.48 -->
+
+### Improvements
+
+<!-- https://spectrocloud.atlassian.net/browse/PEM-11193 -->
+
+- Updated the base Nginx image to version 1.30.2 to improve security and currency.
+
+### Bug Fixes
+
+<!-- https://spectrocloud.atlassian.net/browse/PE-9011 -->
+
+- Fixed an issue where forced recovery upgrades triggered unexpected version changes by pinning recovery to the
+  currently running Stylus version.
+
 ## July 6, 2026 - Release 4.7.47
 
 <!-- PATCH RELEASE TICKET: DOC-2959 -->


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title.
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages).
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [ ] Add **Backport labels** if the change should be reflected in previous versions. _Not applicable: see the note on labels below._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Adds the **4.7.48** patch release notes entry to the release notes page: one Improvement (base Nginx image bumped to 1.30.2) and one Bug Fix (forced recovery upgrades pinned to the currently running Stylus version).

Three judgment calls a reviewer would otherwise have to reconstruct:

| Decision | Why |
| --- | --- |
| Base is `version-4-7`, not `master` | 4.7.x release notes exist only on this branch. The page on `master` starts at 4.10.13 and carries no 4.7.4x entries at all. This matches the two most recent 4.7.x patch PRs, #11050 (4.7.47) and #10996 (4.7.46), both raised directly against `version-4-7`. |
| No labels applied | Every prior 4.7.x patch notes PR merged with no labels. `auto-backport` / `backport-version-*` do not apply, because this is 4.7-specific content already on its target branch rather than a change flowing down from `master`. |
| Release date is August 6, 2026 | The Jira ticket describes this as the N-2 security patch shipping alongside 4.9.c in early August. The heading initially read July 7, 2026 (one day after 4.7.47), which was carried over from the preceding entry and has been corrected. |

One prose fix beyond the drafted content: `NGINX` was normalised to `Nginx` in the new Improvement line, to satisfy the `Vale.Terms` rule and match the eight existing `Nginx` references already on the page. The remaining 10 Vale errors on this file are all on pre-existing lines (all-caps headings, `Nvidia`, `Addon`, and two `(FIPS)` definitions) and were left untouched.

---

## 💻 Changed Pages

- [Release Notes / August 6, 2026 - Release 4.7.48](https://deploy-preview-11895--docs-spectrocloud.netlify.app/release-notes/#august-6-2026---release-4748)

---

## 🎫 Jira Tickets

[DOC-3189](https://spectrocloud.atlassian.net/browse/DOC-3189)


[DOC-3189]: https://spectrocloud.atlassian.net/browse/DOC-3189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ