### PR TITLE
[version-4-9] DOC-3190 - anchor version branch match in index-breaking-changes.sh (#11886)

### DIFF
--- a/scripts/index-breaking-changes.sh
+++ b/scripts/index-breaking-changes.sh
@@ -73,7 +73,9 @@ mkdir -p "$BREAKING_CHANGES_PARTIALS_PATH"
 for branch in $branches; do
   echo "ℹ️ Checking branch: $branch"
   release_notes_path="$RELEASE_NOTES_PATH"
-  if [[ $branch == *version-4-0* || $branch == *version-4-1* ]]; then
+  # Match exact branch names. Unanchored globs would also match version-4-10
+  # and later two-digit minors, routing them to the pre-4.2 release notes path.
+  if [[ $branch == "version-4-0" || $branch == "version-4-1" ]]; then
     release_notes_path="$OLD_RELEASE_NOTES_PATH"
   fi
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-9`:
 - [DOC-3190 - anchor version branch match in index-breaking-changes.sh (#11886)](https://github.com/spectrocloud/librarium/pull/11886)

<!--- Backport version: manual -->

Raised by hand rather than by the bot: the original PR was based on `docs-rel-4-10-0` and so carried no backport labels.

This is unblocking a live failure. `scripts/index-breaking-changes.sh` iterates every `version-*` branch regardless of which branch it runs on, and the unanchored globs matched the newly cut `version-4-10` against `*version-4-1*`, routing it to the pre-4.2 path `docs/docs-content/release-notes.md`. That path does not exist on a 4.10 branch, so the read loop's redirect fails and aborts the script under `set -e`, failing the whole Netlify build. Both scheduled builds for this branch have been failing since `version-4-10` was created.

`version-4-6` and `version-4-7` need no equivalent fix — they predate the indexer and do not ship `scripts/index-breaking-changes.sh` at all.

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
