### PR TITLE
DOC-3188 - Patch release notes for 4.8.62

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,24 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## August 6, 2026 - Release 4.8.62
+
+<!-- PATCH RELEASE TICKET: DOC-3188 -->
+<!-- PATCH RELEASE VERSION: 4.8.62 -->
+
+### Improvements
+
+<!-- https://spectrocloud.atlassian.net/browse/PEM-11193 -->
+
+- Updated the base Nginx image to version 1.30.2.
+
+### Bug Fixes
+
+<!-- https://spectrocloud.atlassian.net/browse/PE-9011 -->
+
+- Fixed an issue where forced recovery upgrades triggered an unexpected version upgrade instead of remaining on the
+  running Stylus version.
+
 ## July 6, 2026 - Release 4.8.61
 
 <!-- PATCH RELEASE TICKET: DOC-2958 -->


### PR DESCRIPTION
## Describe the Change

Adds the **4.8.62** patch release notes entry to the release notes page: one Improvement (base Nginx image bumped to 1.30.2) and one Bug Fix (forced recovery upgrades now remain on the running Stylus version).

Two judgment calls a reviewer would otherwise have to reconstruct:

| Decision | Why |
| --- | --- |
| Base is `version-4-8`, not `master` | 4.8.x release notes exist only on this branch. The page on `master` carries no `Release 4.8.x` entries at all, so this content has nowhere else to live. Matches #10995 (4.8.61), raised directly against `version-4-8`. |
| No labels applied | Every prior 4.8.x patch notes PR merged with no labels. This is 4.8-specific content already sitting on its target branch rather than a change flowing down from `master`. |

The `August 6, 2026` date matches the Jira ticket, which describes 4.8.62 as the N-1 security patch shipping alongside 4.9.c in early August.

One prose fix beyond the drafted content: `NGINX` was normalised to `Nginx` in the new Improvement line, to satisfy the `Vale.Terms` rule and match the existing `Nginx` references already on the page. The 4 remaining Vale errors on this file are all on pre-existing lines well away from this change (`Terminal User Interface (TUI)`, `(PXE)`, `Nvidia`, and `KAI`) and were left untouched.

## Changed Pages

💻 [Release Notes / August 6, 2026 - Release 4.8.62](https://deploy-preview-11898--docs-spectrocloud.netlify.app/release-notes/#august-6-2026---release-4862)

## Jira Tickets

🎫 [DOC-3188](https://spectrocloud.atlassian.net/browse/DOC-3188)

## Backports

Can this PR be backported?

- [ ] Yes. _Remember to add the relevant backport labels to your PR._
- [x] No. _Please leave a short comment below about why this PR cannot be backported._

**No** is the answer here, left unticked for the author to confirm. These are 4.8-specific patch release notes raised directly against `version-4-8`, so there is no branch to backport them to: the 4.8.x release notes page does not exist on `master` or on any other version branch. Adding `auto-backport` or `backport-version-*` would push a 4.8 patch entry onto pages for versions that never shipped it.


[DOC-3188]: https://spectrocloud.atlassian.net/browse/DOC-3188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ