### PR TITLE
chore: sort version branch Netlify triggers by version number

### DIFF
--- a/.github/workflows/netlify-version-release.yaml
+++ b/.github/workflows/netlify-version-release.yaml
@@ -57,10 +57,13 @@ jobs:
             branches="$INPUT_BRANCH"
           else
             # List remote release branches matching version-X-Y. This intentionally excludes
-            # backport/version-* and other version-suffixed branches.
+            # backport/version-* and other version-suffixed branches. sort -V orders the
+            # branches by version number rather than lexicographically, so version-4-10 is
+            # triggered after version-4-9 instead of between version-4-1 and version-4-2.
             branches=$(git ls-remote --heads origin 'version-*' \
               | sed 's#.*refs/heads/##' \
-              | grep -E '^version-[0-9]+-[0-9]+$' || true)
+              | grep -E '^version-[0-9]+-[0-9]+$' \
+              | sort -V || true)
           fi
 
           if [ -z "$branches" ]; then


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

The `Netlify Version Branch Release` workflow builds its branch list with `git ls-remote`, which emits refs in lexicographic order. Now that `version-4-10` exists, that put it between `version-4-1` and `version-4-2` in the trigger loop. This pipes the list through `sort -V` so the branches are triggered in version order, ending `version-4-8`, `version-4-9`, `version-4-10`.

Verified against the live remote:

| Before | After |
| --- | --- |
| `version-4-1`, `version-4-10`, `version-4-2`, … `version-4-9` | `version-4-1`, `version-4-2`, … `version-4-9`, `version-4-10` |

Two notes for the reviewer:

- **The effect is on the trigger sequence and the job log, not on build completion order.** Each iteration is an independent `POST` to the Netlify build hook, and Netlify queues the resulting builds itself. `sort -V` makes the loop and its output read correctly; it does not guarantee `version-4-10` finishes building after `version-4-9`.
- **Backported to `version-4-6` through `version-4-10`.** The scheduled run only fires on the default branch, so this changes nothing for the twice-daily builds. It is backported because the workflow also has `workflow_dispatch` and can be dispatched against a version branch ref, which uses that branch's copy of the file — and because the file is currently byte-identical across all five branches, so leaving master alone to diverge would cost a conflict on the next change near these lines. A dry-run cherry-pick onto each of the five branch tips applies cleanly.

`sort -V` is GNU coreutils, which the `ubuntu-latest` runner provides. `.prettierignore` excludes `**/*.yaml`, so Prettier was not run on this file, and Vale does not lint YAML.

---

## 💻 Changed Pages

No user-facing changes — this PR only touches a GitHub Actions workflow, so there are no docs pages to preview.

---

## 🎫 Jira Tickets

No corresponding Jira ticket. This came out of an observation about the trigger order in the scheduled workflow run.
