### PR TITLE
docs: expand release notes template headers and sync the Packs table

### DIFF
--- a/scripts/release/templates/release-notes.md
+++ b/scripts/release/templates/release-notes.md
@@ -8,15 +8,7 @@
 
 #### Breaking Changes {#breaking-changes-{{RELEASE_NAME}}}
 
-#### Features
-
-#### Improvements
-
-#### Deprecations and Removals
-
-### Edge
-
-{{EDGE_CALLOUT}}
+#### Upgrade Notes {#upgrade-notes-{{RELEASE_NAME}}}
 
 #### Features
 
@@ -24,33 +16,69 @@
 
 #### Bug Fixes
 
+#### Deprecations and Removals
+
+### Edge
+
+{{EDGE_CALLOUT}}
+
+#### Breaking Changes {#breaking-changes-edge-{{RELEASE_NAME}}}
+
+#### Upgrade Notes {#upgrade-notes-edge-{{RELEASE_NAME}}}
+
+#### Features
+
+#### Improvements
+
+#### Bug Fixes
+
+#### Deprecations and Removals
+
 ### VerteX
+
+#### Breaking Changes {#breaking-changes-vertex-{{RELEASE_NAME}}}
+
+#### Upgrade Notes {#upgrade-notes-vertex-{{RELEASE_NAME}}}
 
 #### Features
 
 - Includes all Palette features, improvements, breaking changes, and deprecations in this release. Refer to the [Palette section](#palette-enterprise-{{RELEASE_NAME}}) for more details.
 
+#### Improvements
+
+#### Bug Fixes
+
 ### Virtual Machine Orchestrator (VMO)
 
 #### VMO Pack
 
-##### Features
-
-##### Improvements
-
-##### Bug Fixes
-
-#### PaletteAI VM Launchpad
+##### Breaking Changes {#breaking-changes-vmo-pack-{{RELEASE_NAME}}}
 
 ##### Features
 
 ##### Improvements
 
 ##### Bug Fixes
+
+##### Deprecations and Removals
+
+#### PaletteAI VM Launchpad {#paletteai-vm-launchpad-{{RELEASE_NAME}}}
+
+##### Breaking Changes {#breaking-changes-vm-launchpad-{{RELEASE_NAME}}}
+
+##### Features
+
+##### Improvements
+
+##### Bug Fixes
+
+##### Deprecations and Removals
 
 ### Automation
 
 {{AUTOMATION_CALLOUT}}
+
+#### Breaking Changes {#breaking-changes-automation-{{RELEASE_NAME}}}
 
 #### Features
 
@@ -58,40 +86,21 @@
 
 #### Improvements
 
+#### Bug Fixes
+
+#### Deprecations and Removals
+
 ### Docs and Education
 
 ### Packs
 
+<!-- prettier-ignore-start -->
+
+| Pack Name | Layer | Non-FIPS | FIPS | New Version |
+| --------- | ----- | -------- | ---- | ----------- |
+
+<!-- prettier-ignore-end -->
+
 #### Pack Notes
-
-#### OS
-
-| Pack Name | New Version |
-| --------- | ----------- |
-
-#### Kubernetes
-
-| Pack Name | New Version |
-| --------- | ----------- |
-
-#### CNI
-
-| Pack Name | New Version |
-| --------- | ----------- |
-
-#### CSI
-
-| Pack Name | New Version |
-| --------- | ----------- |
-
-#### Add-on Packs
-
-| Pack Name | New Version |
-| --------- | ----------- |
-
-#### FIPS Packs
-
-| Pack Name | New Version |
-| --------- | ----------- |
 
 #### Deprecations and Removals


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

This PR updates the release notes scaffold in `scripts/release/templates/release-notes.md`. No published page changes.

**Headers.** Published release notes have used a wider set of section headers since 4.6 than the template offered, so writers re-added the same headings by hand every release. This adds the missing ones, taken from a sweep of every `version-4-*` branch: `Bug Fixes` and `Upgrade Notes` under Palette Enterprise; `Breaking Changes`, `Upgrade Notes` and `Deprecations and Removals` under Edge; `Breaking Changes`, `Upgrade Notes`, `Improvements` and `Bug Fixes` under VerteX; `Breaking Changes`, `Bug Fixes` and `Deprecations and Removals` under Automation; and `Breaking Changes` plus `Deprecations and Removals` at H5 under both VMO subsections. `Bug Fixes` under Palette Enterprise was the largest gap — 16 prior release blocks used it, 4.10.0 included.

Ordering follows the spine every block already uses: Breaking Changes, Upgrade Notes, Features, Improvements, Bug Fixes, Deprecations and Removals. The new `Breaking Changes` and `Upgrade Notes` headings carry section-scoped anchors (`#breaking-changes-edge-`, `#upgrade-notes-vertex-` and so on) so they cannot collide with the existing Palette Enterprise anchors. Typos and superseded variants found in the sweep were deliberately left out: `Packs Notes`, the `Add-on` / `FIPS` / `Community` short forms, `Documentation & Education Updates`, the three older VM Launchpad namings, and the flat `VMO > Features/Improvements/Bug Fixes` headings the current nested VMO layout replaces.

**Packs.** The six per-layer subsections (`OS`, `Kubernetes`, `CNI`, `CSI`, `Add-on Packs`, `FIPS Packs`) and their `Pack Name | New Version` tables are replaced by the single table the Component Updates section already uses. Reconciling a Component Updates week that coincides with a release previously meant splitting one flat table across six per-layer sections and discarding its `Layer`, `Non-FIPS` and `FIPS` columns; both sections are now `### Packs` → table → `#### Pack Notes`, so rows transplant as-is. The 4.10.0 block is already in this shape from a hand-merge, so the template now matches what shipped.

Two details worth flagging for review:

| Detail | Why |
| --- | --- |
| The table header and separator are byte-identical to what `generate-component-updates-ai.sh` emits, not to the padded placeholder in `component-updates.md` | The generator overwrites its own template's header wholesale between the `PACKS LIST BODY` markers, so the generator's unpadded form is what actually lands in the file |
| The `prettier-ignore` fences are load-bearing | Without them Prettier pads every table cell, which would fight the generator's unpadded rows on every run. Verified by checking a table with real generated rows both with and without the fences |

The ticket-keyed `<!-- BEGIN PACKS LIST BODY: ... -->` markers are **not** included here. `generate_parameterised_file` substitutes only exported environment variables and `generate-release-notes.sh` never sets a ticket, so a `{{JIRA_TICKET}}` placeholder survives literally into the published page rather than resolving or emptying.

Verified against the release automation: the substitution pass leaves no unresolved placeholders and produces no duplicate anchors; all three regions in `generate-release-notes-callouts.sh` still refresh; and `index-breaking-changes.sh` produces one partial per release with content concatenated in document order when several `Breaking Changes` headings appear in one block (checked by running its parsing loop against a populated block). Removing the `OS`, `CNI` and `CSI` headings also clears three pre-existing `heading-all-caps` Vale errors, taking the file to zero.

No backport labels applied. The template scaffolds a **new minor release** block, which is only ever authored on the newest branch — older version branches take patch releases and component updates from their own templates — so there is nothing for it to do there. Happy to add `auto-backport` plus `backport-version-4-6` through `backport-version-4-10` if you'd rather keep the `scripts/` tree identical across branches, which is what the earlier template PRs did.

---

## 💻 Changed Pages

No user-facing changes. This PR only changes the release notes template used to scaffold a new release block, so no published page is affected and there is nothing to preview. The template's output will appear on [Release Notes](https://docs.spectrocloud.com/release-notes/) the next time a release is generated from it.

---

## 🎫 Jira Tickets

No corresponding Jira ticket.
