### PR TITLE
DOC-3193 - Patch release notes for 4.10.14

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -11,6 +11,18 @@ tags: ["release-notes"]
 
 <ReleaseNotesVersions />
 
+## September 8, 2026 - Release 4.10.14
+
+<!-- PATCH RELEASE TICKET: DOC-3193 -->
+<!-- PATCH RELEASE VERSION: 4.10.14 -->
+
+### Bug Fixes
+
+<!-- https://spectrocloud.atlassian.net/browse/PEM-11942 -->
+
+- Fixed an issue where some OIDC sign-ins failed with an `OidcRedirectUriNotAllowed` error. This affected
+  `kubectl oidc-login` authentication from headless hosts and access to the Virtual Machine Orchestrator (VMO) console.
+
 ## September 6, 2026 - Release 4.10.13 {#release-notes-4.10.0}
 
 <!-- COMPONENT UPDATES TICKET: DOC-3171 -->


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Adds the release notes section for the 4.10.14 patch, which resolves the OIDC sign-in failures reported after 4.10.13.

`make generate-patch-release-notes` could not produce this one. The script exits at the "List of candidates" lookup, and the tracking ticket carries a prose description plus a single linked bug instead of a candidates JQL link, so the release date and `fixVersion` it normally derives were unavailable. The section was drafted by hand against the template and the linked bug (PEM 11942), with the version taken from the ticket summary and the date set to the publication date.

The patch is a single service-side revert, so CanvOS and the Palette CLI are unchanged from 4.10.13. No Edge or Automation section is added, and neither the Edge Compatibility Matrix nor the CLI Tools table gains a row.

Labelled for backport to `version-4-10` only — the entry documents a 4.10-train patch and does not apply to the older release branches.

---

## 💻 Changed Pages

- [Release Notes — September 8, 2026 - Release 4.10.14](https://deploy-preview-11909--docs-spectrocloud.netlify.app/release-notes/#september-8-2026---release-41014)

---

## 🎫 Jira Tickets

[DOC-3193](https://spectrocloud.atlassian.net/browse/DOC-3193)

_Related tickets are written without a hyphen and left unlinked on purpose. The merge automation resolves every Jira key it finds in this body, including keys inside a `browse/<KEY>` URL, so hyphenating or linking them would silently resolve tickets this PR does not own._


[DOC-3193]: https://spectrocloud.atlassian.net/browse/DOC-3193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ