### PR TITLE
chore: refresh the release notes heading during make generate-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ generate-patch-release-notes: ## Generate patch release notes only
 	./scripts/release/generate-patch-release-notes.sh
 	make -s format > /dev/null 2>&1
 
-generate-release: ## Generate all release files except release notes
+generate-release: ## Generate all release files, refreshing the release notes heading and component versions but not the hand-written notes
 	./scripts/release/generate-spectro-cli-reference.sh
 	./scripts/release/generate-downloads.sh
 	./scripts/release/generate-edge-compatibility-matrix.sh
@@ -406,6 +406,7 @@ generate-release: ## Generate all release files except release notes
 	./scripts/release/generate-kubernetes-palette-versions.sh
 	./scripts/release/generate-pcg-kubernetes-versions.sh
 	./scripts/release/generate-release-notes-callouts.sh
+	REFRESH_ONLY=true ./scripts/release/generate-release-notes.sh
 	make -s format > /dev/null 2>&1
 
 init-release:

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -293,12 +293,12 @@ page.
 
 #### Issue Tracker and Super API
 
-| **Environment Variable** | **Description**                                                                  | **Example Value**       |
-| ------------------------ | -------------------------------------------------------------------------------- | ----------------------- |
-| `JIRA_EMAIL`             | Issue tracker email.                                                             | `name@spectrocloud.com` |
-| `JIRA_API_TOKEN`         | Issue tracker API token.                                                         | `XXX`                   |
-| `SUPER_API_TOKEN`        | Super API token.                                                                 | `XXX`                   |
-| `GITHUB_TOKEN`           | GitHub token with read access to the private `spectrocloud/nickfury` repository. | `XXX`                   |
+| **Environment Variable** | **Description**                                                                               | **Example Value**       |
+| ------------------------ | --------------------------------------------------------------------------------------------- | ----------------------- |
+| `JIRA_EMAIL`             | Issue tracker email.                                                                          | `name@spectrocloud.com` |
+| `JIRA_API_TOKEN`         | Issue tracker API token.                                                                      | `XXX`                   |
+| `SUPER_API_TOKEN`        | Super API token.                                                                              | `XXX`                   |
+| `GITHUB_TOKEN`           | _(Optional)_ GitHub token with read access to the private `spectrocloud/nickfury` repository. | `XXX`                   |
 
 `GITHUB_TOKEN` is only needed to look up component versions. Set it in your `.env` file, the same as the other tokens.
 When it is not set, the scripts fall back to the token the GitHub CLI already holds, so a machine that has run
@@ -314,13 +314,26 @@ run the workflow again.
 
 #### Release Notes
 
-| **Environment Variable**    | **Description**                                       | **Example Value**  |
-| --------------------------- | ----------------------------------------------------- | ------------------ |
-| `RELEASE_NAME`              | The internal release name.                            | `4-7-c`            |
-| `RELEASE_VERSION`           | The external release version.                         | `4.7.6`            |
-| `RELEASE_DATE`              | The date that the release takes place.                | `"March 18, 2025"` |
-| `RELEASE_CANVOS`            | The CanvOS version.                                   | `4.7.13`           |
-| `RELEASE_TERRAFORM_VERSION` | The version of the Terraform and Crossplane provider. | `0.24.5`           |
+| **Environment Variable**      | **Description**                                       | **Example Value**  |
+| ----------------------------- | ----------------------------------------------------- | ------------------ |
+| `RELEASE_NAME`                | The internal release name.                            | `4-7-c`            |
+| `RELEASE_VERSION`             | The external release version.                         | `4.7.6`            |
+| `RELEASE_DATE`                | The date that the release takes place.                | `"March 18, 2025"` |
+| `RELEASE_CANVOS`              | The CanvOS version.                                   | `4.7.13`           |
+| `RELEASE_PALETTE_CLI_VERSION` | The Palette CLI version.                              | `4.7.9`            |
+| `RELEASE_TERRAFORM_VERSION`   | The version of the Terraform and Crossplane provider. | `0.24.5`           |
+
+All six variables are required. `make generate-release-notes` drafts a block that names every one of them, so the target
+fails and writes nothing when any of them is blank. It reports which ones to set. When a component version is not
+settled yet, use the release's own identifier as a placeholder, for example `4.10.0` for the GA or `4.10.a` for a patch
+release in that train. Do not use `4.10.x`, which is too broad to search for and replace on release day.
+
+`make generate-release` needs only `RELEASE_DATE`, `RELEASE_NAME`, and `RELEASE_VERSION`, because it refreshes an
+already-drafted block rather than creating one. That target reports and skips rather than failing, so a blank component
+version leaves the section that names it unchanged.
+
+`RELEASE_PALETTE_CLI_VERSION` also drives the pages listed under [Other Release Updates](#other-release-updates), so it
+is set once and used by both.
 
 #### Component Updates
 
@@ -452,8 +465,13 @@ published, and an unattended run always keeps it.
 
 - `make init-release` creates placeholders for all the release related environment variables in your `.env` file. Use
   the placeholders to fill in the values relevant to the Palette release.
-- `make generate-release-notes` creates only the release notes changes for the Palette release.
-- `make generate-release` creates all Palette release related updates, excluding release notes.
+- `make generate-release-notes` creates only the release notes changes for the Palette release. When the release notes
+  already contain a block for `RELEASE_NAME`, the target refreshes that block's heading and leaves the hand-written
+  content unchanged.
+- `make generate-release` creates all Palette release related updates. It refreshes the current release notes block's
+  heading along with its Edge and Automation component versions, so a `RELEASE_VERSION` or `RELEASE_DATE` value that
+  changes after you draft the notes is corrected in both places. It never creates a block and never alters hand-written
+  content.
 - `make generate-component-updates` creates component updates using the issue tracker API and Super.
 - `make generate-patch-release-notes` creates patch release notes using the issue tracker API and Super, and records any
   CanvOS or Palette CLI version the patch ships. Refer to [Patch Release Notes](#patch-release-notes) for the values it

--- a/scripts/release/generate-release-notes.sh
+++ b/scripts/release/generate-release-notes.sh
@@ -3,7 +3,7 @@
 source scripts/release/utilities.sh
 
 # Define release note related files
-RELEASE_NOTES_FILE="docs/docs-content/release-notes/release-notes.md"
+RELEASE_NOTES_FILE="${RELEASE_NOTES_FILE:-docs/docs-content/release-notes/release-notes.md}"
 RELEASE_NOTES_TEMPLATE_FILE="scripts/release/templates/release-notes.md"
 RELEASE_NOTES_HEADING_TEMPLATE_FILE="scripts/release/templates/release-notes-heading.md"
 EDGE_CALLOUT_TEMPLATE_FILE="scripts/release/templates/release-notes-edge-callout.md"
@@ -13,6 +13,20 @@ RELEASE_NOTES_COMPOSED_FILE="scripts/release/release-notes-composed.md"
 RELEASE_NOTES_PARAMETERISED_FILE="scripts/release/release-notes-output.md"
 RELEASE_NOTES_HEADING_PARAMETERISED_FILE="scripts/release/release-notes-heading-output.md"
 
+# REFRESH_ONLY limits the run to rewriting the heading of a release block that has already been
+# drafted, and never inserts a new one. `make generate-release` uses it so the heading is corrected
+# alongside the component versions that generate-release-notes-callouts.sh refreshes.
+#
+# The two have to move together. RELEASE_VERSION appears both in the heading and inside the Edge and
+# Automation callouts, so refreshing only the callouts left the block naming the drafting-time
+# version in its heading and the shipping version in its prose. A block that names two versions is
+# worse than one that is uniformly stale.
+#
+# Inserting is deliberately excluded rather than merely unlikely: `make generate-release` runs on
+# every component bump, including before the block for a new RELEASE_NAME has been drafted, and the
+# insert branch would silently add an empty release skeleton to the published page each time.
+REFRESH_ONLY="${REFRESH_ONLY:-false}"
+
 # RELEASE_CANVOS and RELEASE_PALETTE_CLI_VERSION fill the Edge and Automation callouts. Both are
 # required, because generate_parameterised_file substitutes an unset variable with an empty string
 # and would leave a sentence that names no version rather than a visible placeholder.
@@ -20,52 +34,148 @@ RELEASE_NOTES_HEADING_PARAMETERISED_FILE="scripts/release/release-notes-heading-
 # RELEASE_TERRAFORM_VERSION deliberately fills both the Terraform provider and the Crossplane
 # provider entries under Automation. The two providers have so far always released on the same
 # version, so they share one variable; split it if that ever stops being true.
-if ! check_env "RELEASE_DATE" ||
-   ! check_env "RELEASE_NAME" ||
-   ! check_env "RELEASE_CANVOS" ||
-   ! check_env "RELEASE_PALETTE_CLI_VERSION" ||
-   ! check_env "RELEASE_TERRAFORM_VERSION" ||
-   ! check_env "RELEASE_VERSION" ; then
-    echo "‼️  Skipping generate $RELEASE_NOTES_FILE due to missing environment variables. ‼️"
-    exit 0
+#
+# Refresh-only mode asks for none of those three, because it never renders the templates that name
+# them. Requiring them anyway would make a heading correction depend on values it does not use, and
+# `make generate-release` would skip the correction whenever one was still blank.
+if [[ "$REFRESH_ONLY" == "true" ]]; then
+    REQUIRED_VARS=(RELEASE_DATE RELEASE_NAME RELEASE_VERSION)
+else
+    REQUIRED_VARS=(
+        RELEASE_DATE
+        RELEASE_NAME
+        RELEASE_CANVOS
+        RELEASE_PALETTE_CLI_VERSION
+        RELEASE_TERRAFORM_VERSION
+        RELEASE_VERSION
+    )
 fi
 
-# The component version sections are held in their own templates, because the versions they name can
-# be bumped again on the day of release and generate-release-notes-callouts.sh has to be able to
-# rewrite them in the published notes afterwards. They are composed into the release notes template
-# here rather than duplicated inline, so each sentence has one definition and the published text
-# cannot drift from what a later refresh would write.
+# Every variable is checked rather than stopping at the first missing one, so a run that is short
+# of several reports all of them in one pass instead of one per re-run.
+missing_vars=()
+for var in "${REQUIRED_VARS[@]}"; do
+    check_env "$var" || missing_vars+=("$var")
+done
+
+if [[ ${#missing_vars[@]} -gt 0 ]]; then
+    # Refresh-only keeps the convention the other release generators follow of reporting and
+    # skipping rather than failing, because it runs inside `make generate-release` alongside eight
+    # other generators and a formatting pass. Exiting non-zero there would abort the target part
+    # way through, and generate-release-notes-callouts.sh already skips a region the same way when
+    # a version it needs is blank.
+    if [[ "$REFRESH_ONLY" == "true" ]]; then
+        echo "‼️  Skipping the release notes heading refresh in $RELEASE_NOTES_FILE due to missing environment variables. ‼️"
+        exit 0
+    fi
+
+    # Drafting a block either writes every one of these values or writes nothing, and it used to
+    # write nothing while still exiting 0. That reads as a target that ran and had no work to do,
+    # so a first run against a half-filled .env looked like the release notes needed no changes.
+    # Fail instead, and name both what to set and what to set it to, because there is no prompt:
+    # release-variables.sh has the machinery for one but no target calls it.
+    echo "❌ Cannot draft the release notes block in $RELEASE_NOTES_FILE."
+    echo "   Set the following in your .env file, then run 'make generate-release-notes' again:"
+    for var in "${missing_vars[@]}"; do
+        echo "     - $var"
+    done
+    echo "   All ${#REQUIRED_VARS[@]} of ${REQUIRED_VARS[*]} are required, because the block names every one of them."
+    echo "   For a version that is not settled yet, use the release's own identifier as a placeholder, for example"
+    echo "   '4.10.0' for the GA or '4.10.a' for a patch release in that train. Do not use '4.10.x', which is too"
+    echo "   broad to search for and replace on release day."
+    exit 1
+fi
+
+if [[ ! -f "$RELEASE_NOTES_FILE" ]]; then
+    echo "❌ Release notes file $RELEASE_NOTES_FILE not found. Nothing was generated."
+    exit 1
+fi
+
+# The heading and the component version sections are held in their own templates, because a later
+# run has to be able to rewrite them in the published notes: the heading when RELEASE_VERSION or
+# RELEASE_DATE is settled after the notes were drafted, and the callouts when a component is bumped
+# again on the day of release. They are composed into the release notes template here rather than
+# duplicated inline, so each has one definition and the published text cannot drift from what a
+# later refresh would write.
+#
+# The heading in particular used to be written out identically in both this template and
+# release-notes-heading.md, so a change to its shape had to be made twice or the refresh would
+# rewrite a newly inserted block's heading into a different form.
 #
 # The Automation features region covers only the two provider bullets. Anything a writer adds to
 # that section goes outside the end marker and is left alone by a refresh.
 #
 # The composed file still carries the {{RELEASE_*}} placeholders these templates use, so the
 # substitution pass below fills them along with the rest of the template.
-EDGE_CALLOUT="$(cat "$EDGE_CALLOUT_TEMPLATE_FILE")"
-AUTOMATION_CALLOUT="$(cat "$AUTOMATION_CALLOUT_TEMPLATE_FILE")"
-AUTOMATION_FEATURES="$(cat "$AUTOMATION_FEATURES_TEMPLATE_FILE")"
+#
+# Skipped in refresh-only mode, which replaces a single heading line and so never reads the full
+# block. Composing it there would also require the component version variables that mode does not
+# ask for, and would substitute each one to an empty string.
+if [[ "$REFRESH_ONLY" != "true" ]]; then
+    RELEASE_HEADING="$(cat "$RELEASE_NOTES_HEADING_TEMPLATE_FILE")"
+    EDGE_CALLOUT="$(cat "$EDGE_CALLOUT_TEMPLATE_FILE")"
+    AUTOMATION_CALLOUT="$(cat "$AUTOMATION_CALLOUT_TEMPLATE_FILE")"
+    AUTOMATION_FEATURES="$(cat "$AUTOMATION_FEATURES_TEMPLATE_FILE")"
 
-generate_parameterised_file_local_vars \
-    "$RELEASE_NOTES_TEMPLATE_FILE" "$RELEASE_NOTES_COMPOSED_FILE" \
-    EDGE_CALLOUT AUTOMATION_CALLOUT AUTOMATION_FEATURES
+    generate_parameterised_file_local_vars \
+        "$RELEASE_NOTES_TEMPLATE_FILE" "$RELEASE_NOTES_COMPOSED_FILE" \
+        RELEASE_HEADING EDGE_CALLOUT AUTOMATION_CALLOUT AUTOMATION_FEATURES
 
-generate_parameterised_file $RELEASE_NOTES_COMPOSED_FILE $RELEASE_NOTES_PARAMETERISED_FILE
+    generate_parameterised_file $RELEASE_NOTES_COMPOSED_FILE $RELEASE_NOTES_PARAMETERISED_FILE
+fi
+
 generate_parameterised_file $RELEASE_NOTES_HEADING_TEMPLATE_FILE $RELEASE_NOTES_HEADING_PARAMETERISED_FILE
 
 # The anchor is matched with its closing brace so a release name cannot substring-match a longer
 # one, for example "#release-notes-4.10.1" matching an existing "#release-notes-4.10.10" heading
 # and relabelling that release's block instead of inserting a new one.
+#
+# It is keyed on RELEASE_NAME rather than RELEASE_VERSION, because the anchor is the page's permanent
+# deep link and stays frozen for the cycle even once the shipping version is known. A release drafted
+# as 4.10.0 that ships as 4.10.13 keeps "#release-notes-4.10.0" and gains a "Release 4.10.13"
+# heading, so editing RELEASE_NAME mid-cycle both breaks inbound links and stops this match finding
+# the block.
 existing_notes=$(search_line "#release-notes-$RELEASE_NAME}" $RELEASE_NOTES_FILE)
 if [[ -n "$existing_notes" && "$existing_notes" -ne 0 ]]; then
     echo "ℹ️ Release notes for $RELEASE_NAME have already been generated in $RELEASE_NOTES_FILE"
     replace_line $existing_notes $RELEASE_NOTES_HEADING_PARAMETERISED_FILE $RELEASE_NOTES_FILE
-    echo "✅ Replaced release notes heading in $RELEASE_NOTES_FILE"
-    echo "ℹ️ Only the heading is refreshed here, because the rest of the block is hand-written. Run 'make generate-release' to refresh the Edge and Automation component versions."
+    echo "✅ Replaced release notes heading in $RELEASE_NOTES_FILE (RELEASE_VERSION=$RELEASE_VERSION, RELEASE_DATE=$RELEASE_DATE)"
+
+    if [[ "$REFRESH_ONLY" != "true" ]]; then
+        echo "ℹ️ Only the heading is refreshed here, because the rest of the block is hand-written. Run 'make generate-release' to refresh the Edge and Automation component versions."
+    fi
+elif [[ "$REFRESH_ONLY" == "true" ]]; then
+    # Two different situations reach here, and they want opposite advice, so they are told apart by
+    # the component version markers that generate-release-notes-callouts.sh keys on RELEASE_NAME. A
+    # block that has never been drafted carries no markers and genuinely wants
+    # `make generate-release-notes`. A block whose heading anchor has been edited away still carries
+    # them, and running that target against it takes the insert branch and adds a second copy of the
+    # release rather than repairing the heading.
+    #
+    # The second case is also the one arrangement in which refreshing the callouts and refreshing the
+    # heading come apart, because the callouts are found by their markers while the heading is found
+    # by its anchor. That is the inconsistency this mode exists to prevent, so it is reported rather
+    # than left for a reader to notice on the published page.
+    block_markers_found=false
+    for marker_base in release-notes-edge-callout release-notes-automation-callout release-notes-automation-features; do
+        if grep -qF "<!-- ${marker_base}-${RELEASE_NAME}-start -->" "$RELEASE_NOTES_FILE"; then
+            block_markers_found=true
+            break
+        fi
+    done
+
+    if [[ "$block_markers_found" == "true" ]]; then
+        echo "🟠 $RELEASE_NOTES_FILE carries component version markers for $RELEASE_NAME but no '{#release-notes-$RELEASE_NAME}' heading anchor, so the heading still names the version it was drafted with while the callouts name $RELEASE_VERSION. Restore the anchor on that release's heading and re-run. Do not run 'make generate-release-notes', which would insert a second copy of the release." >&2
+    else
+        echo "ℹ️ $RELEASE_NOTES_FILE has no release notes block for $RELEASE_NAME, so the heading refresh is skipped. Run 'make generate-release-notes' to draft the block."
+    fi
 else
     insert_file_after "<ReleaseNotesVersions />" $RELEASE_NOTES_PARAMETERISED_FILE $RELEASE_NOTES_FILE
     echo "✅ Parameterised release notes inserted into $RELEASE_NOTES_FILE"
 fi
 
-cleanup $RELEASE_NOTES_COMPOSED_FILE
-cleanup $RELEASE_NOTES_PARAMETERISED_FILE
+# Guarded individually, because cleanup removes a named file and the composed and parameterised
+# release notes are only written outside refresh-only mode.
+[[ -f "$RELEASE_NOTES_COMPOSED_FILE" ]] && cleanup $RELEASE_NOTES_COMPOSED_FILE
+[[ -f "$RELEASE_NOTES_PARAMETERISED_FILE" ]] && cleanup $RELEASE_NOTES_PARAMETERISED_FILE
 cleanup $RELEASE_NOTES_HEADING_PARAMETERISED_FILE

--- a/scripts/release/templates/release-notes.md
+++ b/scripts/release/templates/release-notes.md
@@ -1,4 +1,4 @@
-## {{RELEASE_DATE}} - Release {{RELEASE_VERSION}} {#release-notes-{{RELEASE_NAME}}}
+{{RELEASE_HEADING}}
 
 ### Security Notices
 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _No corresponding Jira ticket — see that section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _No user-facing changes — see that section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

`make generate-release` refreshes the Edge and Automation component versions inside the current release block, but never the block's heading — the target deliberately excluded `generate-release-notes.sh`. Because `RELEASE_VERSION` appears in both the heading and those callouts, a version settled after the notes were drafted left the block naming the drafting-time version in its heading and the shipping version in its prose. That is the state #11887 corrected by hand when 4.10 drafted as `4.10.0` and shipped as `4.10.13`.

This adds a `REFRESH_ONLY` mode that rewrites the heading of an already-drafted block, and calls it from `make generate-release` after the callouts refresh so the two can no longer disagree.

Judgment calls a reviewer would otherwise have to reconstruct:

- **Refresh-only never inserts.** `generate-release-notes.sh` inserts a full skeleton when it finds no block for `RELEASE_NAME`. `make generate-release` runs on every component bump, including before a new release has a block, so reaching that branch would add an empty skeleton to the published page on each run. The mode reports and skips instead.
- **The heading is located by its `{#release-notes-<NAME>}` anchor, not by comment markers.** Markers were considered, and work, but the anchor is already unique, needs no migration into the live 4.10 block on `master` and `version-4-10`, and is load-bearing for deep links — deleting it visibly breaks something, whereas a deleted HTML comment fails silently. The rationale is recorded in a comment above the lookup.
- **The heading is now composed from `release-notes-heading.md`** instead of being repeated in `release-notes.md`. The two were byte-identical, so changing the heading's shape had to be done twice or a refresh would rewrite a newly inserted block's heading into a different form.
- **Drafting a block now fails when any of the six required variables is blank.** It previously reported them and exited 0, which reads as a target that ran and had no work to do, so a first run against a half-filled `.env` looked like the release notes needed no changes. There is no prompt either: `release-variables.sh` has the machinery but no target calls it. The failure names the missing variables and the placeholder convention (`4.10.0`, `4.10.a`).
- **Refresh-only still reports and skips rather than failing**, unlike drafting. It runs inside `make generate-release` after eight other generators, and every script in that family skips on a missing variable — including the callouts script it pairs with.
- **The docs fix is in scope, not drive-by.** `release-process.md` described the heading as outside `make generate-release`, which this change falsifies, and its Release Notes table listed five of the six required variables (`RELEASE_PALETTE_CLI_VERSION` was only under Other Release Updates).
- **No backport labels.** This is a behavioural change to release tooling, which has historically stayed on `master`; only dependency bumps and security sweeps travel to the release branches. The heading refresh also has nothing to do on those branches, since their release notes are frozen.
- **The formatting checklist items are left unticked as not applicable** — no docs pages, images, or tables change.

One unrelated hunk is included with permission: the `GITHUB_TOKEN` row in the Issue Tracker and Super API table is marked `_(Optional)_`. It was already in the working tree and sits in the same file.

Verification, against scratch copies so the live release notes were never touched:

| Case | Result |
| --- | --- |
| Refresh over the drafting-time heading | Reproduces #11887's hand-fix byte-for-byte |
| Full `make generate-release` sequence plus `make format` | Output identical to the current published file |
| Refresh with no block for `RELEASE_NAME` | Reports and skips, file unchanged, exit 0 |
| Refresh with component versions blank | Heading still refreshes |
| Writer-pruned block (22 of 44 template headings deleted) | Heading count unchanged, nothing re-added |
| Whole Edge section and its markers deleted | Callouts skip, heading refreshes, section stays deleted |
| Heading anchor edited away | Warns, and explicitly advises against the target that would duplicate the release |
| Draft mode with 1 of 6 variables blank | Exit 1, nothing written, `make` aborts before the format step |
| Draft mode with all 6 set | Inserts cleanly, no placeholders left, three marker pairs rendered |

Note that `docs/contributing/release-process.md` opens with `<!-- vale off -->`, so Vale is disabled for it file-wide; its prose was checked against the style guide by hand rather than by CI.

---

## 💻 Changed Pages

No user-facing changes. Nothing under `docs/docs-content`, `docs/api-content`, or `docs/products` is touched, so there are no preview links to provide.

The only Markdown change is `docs/contributing/release-process.md`, which is repo-only documentation — it is not served by any docs plugin instance and has no sidebar entry, so it renders on GitHub rather than on the docs site.

---

## 🎫 Jira Tickets

No corresponding Jira ticket. This came out of a question about why `make generate-release` left the release notes heading stale, and is release-tooling maintenance rather than ticketed docs work.
