### PR TITLE
chore: suppress Vale spelling on bolded UI text

### DIFF
--- a/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
+++ b/docs/docs-content/user-management/saml-sso/palette-sso-with-keycloak.md
@@ -234,9 +234,13 @@ Use the following steps to validate the SSO configuration.
 
    ![Image of keycloak client scopes highlighted](/keycloak/user-management_oidc-sso-keycloak-20-keycloak-mapper.webp "Palette Project")
 
+   <!-- vale Vale.Spelling = NO -->
+
 5. Enable all four token-inclusion toggles: **Add to ID token**, **Add to access token**, **Add to userinfo**, and **Add
    to token introspection**. Palette Console SSO reads the groups claim from the ID token. Virtual Machine Orchestrator
    (VMO) 2.0 and later requires all four to be enabled for group-based RBAC to resolve correctly against the realm.
+
+   <!-- vale Vale.Spelling = YES -->
 
 6. Deselect the radio button for **Full group path**.
 

--- a/docs/docs-content/vm-management/vm-launchpad/system/audit.md
+++ b/docs/docs-content/vm-management/vm-launchpad/system/audit.md
@@ -43,6 +43,8 @@ are incorrect and when the OIDC provider is unavailable.
 
 The events table contains the following columns.
 
+<!-- vale Vale.Spelling = NO -->
+
 | **Column**    | **Description**                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------- |
 | **Time**      | Date and time the event occurred.                                                                     |
@@ -52,6 +54,8 @@ The events table contains the following columns.
 | **Name**      | Name of the affected resource.                                                                        |
 | **Namespace** | Namespace of the affected resource. Cluster-level actions display a dash.                             |
 | **Detail**    | Additional context, such as `VM tmp-nad-test patched`.                                                |
+
+<!-- vale Vale.Spelling = YES -->
 
 Select a column heading to sort the table by that column. Select **Refresh** to load the events that VMO has recorded
 since you opened the page.


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [x] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Silences two `Vale.Spelling` errors that flagged bolded text reproducing UI strings verbatim (`**Vm**` and `**Add to userinfo**`). House convention is to write UI labels exactly as the product renders them, so the words are correct as written and the alerts are false positives. Both guards are scoped to `Vale.Spelling` rather than a blanket `<!-- vale off -->`, so every other rule keeps running over the same content. No prose changed — the guards are HTML comments and render as nothing.

| File | Alert | Guard placement |
| --- | --- | --- |
| `vm-management/vm-launchpad/system/audit.md` | `Vm` | Wraps the whole events table — a guard comment cannot sit inside a table row. |
| `user-management/saml-sso/palette-sso-with-keycloak.md` | `userinfo` | Opening guard is an indented block under step 4, closing guard an indented block at the end of step 5. |

Two judgment calls worth flagging:

- **Why the table is wrapped rather than the row.** Vale scopes its comments by line, and a comment placed inside a Markdown table row is not a comment — it is cell content. Wrapping the table is the pattern already used in `vm-management/vm-launchpad/metrics-and-logs.md`.
- **Why the keycloak guards straddle two list items.** The alert is on an ordered list item, and a guard placed above the `5.` marker splits the list and restarts the numbering. Keeping both guards as indented continuation blocks leaves the numbering intact while still bracketing step 5's text positionally. **This is the thing worth eyeballing on the preview** — please confirm steps 5, 6, and 7 still number as 5, 6, 7.

An accept-list entry in `spectro-vale-pkg` was considered instead and rejected: `Vm` and `userinfo` are correct only in these UI-string contexts, and accepting them globally would stop Vale catching them where they genuinely are typos.

---

## 💻 Changed Pages

Neither change alters rendered output, so the previews are for confirming nothing broke rather than for reviewing new copy.

- [VMO Audit Trail — View the Audit Trail](https://deploy-preview-11914--docs-spectrocloud.netlify.app/vm-management/vm-launchpad/system/audit/#view-the-audit-trail)
- [Palette SSO with Keycloak — Sync Keycloak Groups and Palette Teams](https://deploy-preview-11914--docs-spectrocloud.netlify.app/user-management/saml-sso/palette-sso-with-keycloak/#sync-keycloak-groups-and-palette-teams)

---

## 🎫 Jira Tickets

No corresponding Jira ticket — this came out of a Vale spellcheck sweep of the working tree.
