### PR TITLE
[version-4-6] fix: unlink deprecated Nginx pack references to clear broken links (#11912)

### DIFF
--- a/docs/docs-content/clusters/cluster-groups/cluster-groups.md
+++ b/docs/docs-content/clusters/cluster-groups/cluster-groups.md
@@ -42,9 +42,8 @@ clusters in a cluster group, you must consider the following limitations:
 - The cluster group can only support one Edge cluster.
 <!-- prettier-ignore -->
 - You must provide the capability to support a load balancer or ingress endpoint for the cluster group. You can use
-  solutions such as <VersionedLink text="MetalLB" url="/integrations/packs/?pack=lb-metallb-helm" /> and
-  <VersionedLink text="Nginx" url="/integrations/packs/?pack=nginx" /> in your cluster profile to support these types of
-  endpoints.
+  solutions such as <VersionedLink text="MetalLB" url="/integrations/packs/?pack=lb-metallb-helm" /> and Nginx in your
+  cluster profile to support these types of endpoints.
 
 ## Get Started
 

--- a/docs/docs-content/clusters/cluster-groups/create-cluster-group.md
+++ b/docs/docs-content/clusters/cluster-groups/create-cluster-group.md
@@ -32,7 +32,7 @@ Downstream consumers can use the cluster group when using Palette in
 <!-- prettier-ignore -->
 - If the cluster group will contain Edge clusters, provide the capability to support a load balancer or ingress endpoint for the cluster group.You can use
   solutions such as <VersionedLink text="MetalLB" url="/integrations/packs/?pack=lb-metallb-helm" /> and
-  <VersionedLink text="Nginx" url="/integrations/packs/?pack=nginx" /> in your cluster profile to support these types
+  Nginx in your cluster profile to support these types
   of endpoints.
 
 ## Enablement

--- a/docs/docs-content/security-bulletins/security-advisories/security-advisories.md
+++ b/docs/docs-content/security-bulletins/security-advisories/security-advisories.md
@@ -59,7 +59,7 @@ Palette version 4.6.49 uses Nginx controller version 1.13.7. Refer to the
 
 1. **Workload Clusters**
 
-   - All clusters using the <VersionedLink text="Nginx" url="/integrations/packs/?pack=nginx" /> pack.
+   - All clusters using the Nginx pack.
 
 2. **Palette Enterprise and Palette VerteX deployments**
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-6`:
 - [fix: unlink deprecated Nginx pack references to clear broken links (#11912)](https://github.com/spectrocloud/librarium/pull/11912)

The auto-backport bot could not cherry-pick cleanly because the security advisories and cluster-group pages have drifted between branches. This branch applies the same unlink by hand, scoped to the three `?pack=nginx` VersionedLinks that exist on `version-4-6`.

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
