### PR TITLE
[version-4-7] fix: unlink deprecated Nginx pack references to clear broken links (#11912)

### DIFF
--- a/docs/docs-content/clusters/cluster-groups/cluster-groups.md
+++ b/docs/docs-content/clusters/cluster-groups/cluster-groups.md
@@ -42,9 +42,8 @@ clusters in a cluster group, you must consider the following limitations:
 - The cluster group can only support one Edge cluster.
 <!-- prettier-ignore -->
 - You must provide the capability to support a load balancer or ingress endpoint for the cluster group. You can use
-  solutions such as <VersionedLink text="MetalLB" url="/integrations/packs/?pack=lb-metallb-helm" /> and
-  <VersionedLink text="Nginx" url="/integrations/packs/?pack=nginx" /> in your cluster profile to support these types of
-  endpoints.
+  solutions such as <VersionedLink text="MetalLB" url="/integrations/packs/?pack=lb-metallb-helm" /> and Nginx in your
+  cluster profile to support these types of endpoints.
 
 ## Get Started
 

--- a/docs/docs-content/clusters/cluster-groups/create-cluster-group.md
+++ b/docs/docs-content/clusters/cluster-groups/create-cluster-group.md
@@ -32,7 +32,7 @@ Downstream consumers can use the cluster group when using Palette in
 <!-- prettier-ignore -->
 - If the cluster group will contain Edge clusters, provide the capability to support a load balancer or ingress endpoint for the cluster group.You can use
   solutions such as <VersionedLink text="MetalLB" url="/integrations/packs/?pack=lb-metallb-helm" /> and
-  <VersionedLink text="Nginx" url="/integrations/packs/?pack=nginx" /> in your cluster profile to support these types
+  Nginx in your cluster profile to support these types
   of endpoints.
 
 ## Enablement

--- a/docs/docs-content/security-bulletins/security-advisories/security-advisories.md
+++ b/docs/docs-content/security-bulletins/security-advisories/security-advisories.md
@@ -352,7 +352,7 @@ The following Nginx versions are affected by [CVE-2026-4342](https://github.com/
 
 - **Palette Enterprise and Palette VerteX environments** - All multi-tenant SaaS, dedicated SaaS, self-hosted, and
   appliance-based deployments earlier than version 4.7.39.
-- **Workload Clusters** - All workload clusters using the <VersionedLink text="Nginx" url="/integrations/packs/?pack=nginx" /> pack with an affected Nginx version.
+- **Workload Clusters** - All workload clusters using the Nginx pack with an affected Nginx version.
 
 <!-- prettier-ignore-end -->
 
@@ -370,7 +370,7 @@ Kubernetes Secrets.
   process. No action is required.
 - **Self-Hosted Deployments** - Palette version 4.7.39 has the fixed version of the `ingress-nginx` controller. Users should update their environments to this version..
 - **Workload Clusters** - Upgrade
-  your workload clusters to use the latest version of the <VersionedLink text="Nginx" url="/integrations/packs/?pack=nginx" /> pack. If using vendor-managed ingress add-ons, follow your cloud provider's patch guidance.
+  your workload clusters to use the latest version of the Nginx pack. If using vendor-managed ingress add-ons, follow your cloud provider's patch guidance.
 
 <!-- prettier-ignore-end -->
 
@@ -541,7 +541,7 @@ Palette version 4.7.31 uses Nginx controller version 1.13.7. Refer to the
 
 1. **Workload Clusters**
 
-   - All clusters using the <VersionedLink text="Nginx" url="/integrations/packs/?pack=nginx" /> pack.
+   - All clusters using the Nginx pack.
 
 2. **Palette Enterprise and Palette VerteX deployments**
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-7`:
 - [fix: unlink deprecated Nginx pack references to clear broken links (#11912)](https://github.com/spectrocloud/librarium/pull/11912)

The auto-backport bot could not cherry-pick cleanly because the security advisories and cluster-group pages have drifted between branches. This branch applies the same unlink by hand, scoped to the five `?pack=nginx` VersionedLinks that exist on `version-4-7`.

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
