### PR TITLE
chore: group the init-release .env variables under accurate headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,28 +410,37 @@ generate-release: ## Generate all release files, refreshing the release notes he
 	make -s format > /dev/null 2>&1
 
 init-release:
-	grep -q "^# RELEASE NOTES" .env || echo "\n# RELEASE NOTES" >> .env
+	grep -q "^# CREDENTIALS AND TOKENS" .env || echo "\n# CREDENTIALS AND TOKENS" >> .env
+	grep -q "^export JIRA_EMAIL=" .env || echo "export JIRA_EMAIL=" >> .env
+	grep -q "^export JIRA_API_TOKEN=" .env || echo "export JIRA_API_TOKEN=" >> .env
+	grep -q "^export SUPER_API_TOKEN=" .env || echo "export SUPER_API_TOKEN=" >> .env
+	grep -q "^export GITHUB_TOKEN=" .env || echo "# Optional. Read access to the private nickfury repo, used only as a fallback for Edge matrix component versions your .env leaves empty.\nexport GITHUB_TOKEN=" >> .env
+	grep -q "^# RELEASE IDENTITY" .env || echo "\n# RELEASE IDENTITY" >> .env
 	grep -q "^export RELEASE_NAME=" .env || echo "export RELEASE_NAME=" >> .env
 	grep -q "^export RELEASE_VERSION=" .env || echo "export RELEASE_VERSION=" >> .env
 	grep -q "^export RELEASE_DATE=" .env || echo "export RELEASE_DATE=" >> .env
+# The first three variables under COMPONENT VERSIONS are the ones `make generate-release-notes`
+# requires, alongside the three under RELEASE IDENTITY. Keep them at the top of the group so the
+# writer can fill in everything that target needs without reading past the checksums. Do not
+# alphabetise this group.
+	grep -q "^# COMPONENT VERSIONS" .env || echo "\n# COMPONENT VERSIONS" >> .env
 	grep -q "^export RELEASE_CANVOS=" .env || echo "export RELEASE_CANVOS=" >> .env
 	grep -q "^export RELEASE_PALETTE_CLI_VERSION=" .env || echo "export RELEASE_PALETTE_CLI_VERSION=" >> .env
 	grep -q "^export RELEASE_TERRAFORM_VERSION=" .env || echo "export RELEASE_TERRAFORM_VERSION=" >> .env
-	grep -q "^# COMPONENT UPDATES" .env || echo "\n# COMPONENT UPDATES" >> .env
 	grep -q "^export RELEASE_PALETTE_CLI_SHA=" .env || echo "export RELEASE_PALETTE_CLI_SHA=" >> .env
 	grep -q "^export RELEASE_PALETTE_CLI_ARM64_SHA=" .env || echo "export RELEASE_PALETTE_CLI_ARM64_SHA=" >> .env
 	grep -q "^export RELEASE_PALETTE_CLI_MACOS_SHA=" .env || echo "export RELEASE_PALETTE_CLI_MACOS_SHA=" >> .env
-	grep -q "^export RELEASE_REGISTRY_VERSION=" .env || echo "export RELEASE_REGISTRY_VERSION=" >> .env
 	grep -q "^export RELEASE_SPECTRO_CLI_VERSION=" .env || echo "export RELEASE_SPECTRO_CLI_VERSION=" >> .env
+	grep -q "^export RELEASE_REGISTRY_VERSION=" .env || echo "export RELEASE_REGISTRY_VERSION=" >> .env
+	grep -q "^# KUBERNETES REQUIREMENTS" .env || echo "\n# KUBERNETES REQUIREMENTS" >> .env
 	grep -q "^export RELEASE_VMWARE_KUBERNETES_VERSION=" .env || echo "export RELEASE_VMWARE_KUBERNETES_VERSION=" >> .env
 	grep -q "^export RELEASE_VMWARE_OVA_URL=" .env || echo "export RELEASE_VMWARE_OVA_URL=" >> .env
 	grep -q "^export RELEASE_VMWARE_FIPS_OVA_URL=" .env || echo "export RELEASE_VMWARE_FIPS_OVA_URL=" >> .env
 	grep -q "^export RELEASE_HIGHEST_KUBERNETES_VERSION=" .env || echo "export RELEASE_HIGHEST_KUBERNETES_VERSION=" >> .env
 	grep -q "^export RELEASE_PCG_KUBERNETES_VERSION=" .env || echo "export RELEASE_PCG_KUBERNETES_VERSION=" >> .env
-	grep -q "^export JIRA_EMAIL=" .env || echo "export JIRA_EMAIL=" >> .env
-	grep -q "^export JIRA_API_TOKEN=" .env || echo "export JIRA_API_TOKEN=" >> .env
-	grep -q "^export SUPER_API_TOKEN=" .env || echo "export SUPER_API_TOKEN=" >> .env
-	grep -q "^export GITHUB_TOKEN=" .env || echo "export GITHUB_TOKEN=" >> .env
+	grep -q "^# COMPONENT UPDATES" .env || echo "\n# COMPONENT UPDATES" >> .env
+	grep -q "^export RELEASE_MANAGEMENT_APPLIANCE=" .env || echo "export RELEASE_MANAGEMENT_APPLIANCE=" >> .env
+	grep -q "^export RELEASE_ARTIFACT_STUDIO=" .env || echo "export RELEASE_ARTIFACT_STUDIO=" >> .env
 	grep -q "^# UPGRADE PATHS" .env || echo "\n# UPGRADE PATHS" >> .env
 	grep -q "^export CONFLUENCE_BASE_URL=" .env || echo "export CONFLUENCE_BASE_URL=https://spectrocloud.atlassian.net" >> .env
 	grep -q "^export CONFLUENCE_PAGE_ID=" .env || echo "export CONFLUENCE_PAGE_ID=2087419998" >> .env


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [x] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

`make init-release` seeded 24 variables under three headers, and the grouping had drifted. `# COMPONENT UPDATES` covered twelve of them, only two of which relate to component updates: it had absorbed the `make generate-release` inputs for the VMware, Kubernetes and PCG tables, and all four credentials landed under it with no header of their own.

Regrouped under six headers that each hold one kind of value:

| Header | Holds |
| --- | --- |
| `# CREDENTIALS AND TOKENS` | `JIRA_EMAIL`, `JIRA_API_TOKEN`, `SUPER_API_TOKEN`, `GITHUB_TOKEN` — previously orphaned with no header |
| `# RELEASE IDENTITY` | `RELEASE_NAME`, `RELEASE_VERSION`, `RELEASE_DATE` |
| `# COMPONENT VERSIONS` | CanvOS, Palette CLI, Terraform, the three checksums, Spectro CLI, registry |
| `# KUBERNETES REQUIREMENTS` | The VMware, highest-Kubernetes and PCG values |
| `# COMPONENT UPDATES` | `RELEASE_MANAGEMENT_APPLIANCE`, `RELEASE_ARTIFACT_STUDIO` — now accurate |
| `# UPGRADE PATHS` | `CONFLUENCE_*`, unchanged |

Grouping by what a value *is*, rather than by the target that reads it, is deliberate: `RELEASE_CANVOS`, `RELEASE_PALETTE_CLI_VERSION` and `RELEASE_TERRAFORM_VERSION` are each read by more than one target and would otherwise need duplicate entries. Within `# COMPONENT VERSIONS` those same three lead the group, because together with the three under `# RELEASE IDENTITY` they are exactly the six that `generate-release-notes.sh` guards — so preparing release notes means filling in a contiguous run and stopping, rather than reading past checksums that only `make generate-release` needs. A comment records this so the group is not later alphabetised.

**Two variables are seeded that the target has never written:** `RELEASE_MANAGEMENT_APPLIANCE` and `RELEASE_ARTIFACT_STUDIO`. Both are `check_env`-gated in `generate-component-updates-ai.sh`, which exits with a message asking for them to be set in `.env`, so they have had to be added by hand.

`GITHUB_TOKEN` gains an inline comment recording that it is optional — a blank token otherwise reads as something the writer must go and obtain, when it only serves as a fallback for Edge matrix component versions that `.env` leaves empty.

`RELEASE_COMPONENT_YEAR`, `WEEK`, `START_VERSION` and `END_VERSION` are deliberately still **not** seeded. The script derives all four itself, from the Jira ticket title and the release-notes headings, and never reads them from the environment, so any value set in `.env` is overwritten.

Verification, in a disposable worktree so no real `.env` was touched: a fresh empty `.env` produces all six headers and 26 variables in order; re-running twice is byte-identical, so the target is still idempotent; an existing `.env` keeps its values and gains only what it is missing; and no variable the old target seeded was dropped (24 → 26). The rationale comment sits at column 0 inside a Make recipe, which can terminate a rule, so that was checked explicitly — the target still runs to completion.

The target stays append-only, so an existing `.env` keeps its current order and gains only the new headers and the two new variables at the end. Getting the new layout in a file that already exists means a one-off manual tidy; making the target reorganise an existing file was considered and rejected as too destructive for what it buys.

---

## 💻 Changed Pages

No user-facing changes. This touches only the `init-release` target in the `Makefile`, which seeds a local `.env` file and produces no rendered output.

---

## 🎫 Jira Tickets

No corresponding Jira ticket. This came out of reviewing the release scripts and the Release Checklist against what `init-release` actually seeds.
