### PR TITLE
chore: read nickfury through the GitHub CLI instead of a token in .env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,6 @@ init-release:
 	grep -q "^export JIRA_EMAIL=" .env || echo "export JIRA_EMAIL=" >> .env
 	grep -q "^export JIRA_API_TOKEN=" .env || echo "export JIRA_API_TOKEN=" >> .env
 	grep -q "^export SUPER_API_TOKEN=" .env || echo "export SUPER_API_TOKEN=" >> .env
-	grep -q "^export GITHUB_TOKEN=" .env || echo "# Optional. Read access to the private nickfury repo, used only as a fallback for Edge matrix component versions your .env leaves empty.\nexport GITHUB_TOKEN=" >> .env
 	grep -q "^# RELEASE IDENTITY" .env || echo "\n# RELEASE IDENTITY" >> .env
 	grep -q "^export RELEASE_NAME=" .env || echo "export RELEASE_NAME=" >> .env
 	grep -q "^export RELEASE_VERSION=" .env || echo "export RELEASE_VERSION=" >> .env

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -293,16 +293,17 @@ page.
 
 #### Issue Tracker and Super API
 
-| **Environment Variable** | **Description**                                                                               | **Example Value**       |
-| ------------------------ | --------------------------------------------------------------------------------------------- | ----------------------- |
-| `JIRA_EMAIL`             | Issue tracker email.                                                                          | `name@spectrocloud.com` |
-| `JIRA_API_TOKEN`         | Issue tracker API token.                                                                      | `XXX`                   |
-| `SUPER_API_TOKEN`        | Super API token.                                                                              | `XXX`                   |
-| `GITHUB_TOKEN`           | _(Optional)_ GitHub token with read access to the private `spectrocloud/nickfury` repository. | `XXX`                   |
+| **Environment Variable** | **Description**          | **Example Value**       |
+| ------------------------ | ------------------------ | ----------------------- |
+| `JIRA_EMAIL`             | Issue tracker email.     | `name@spectrocloud.com` |
+| `JIRA_API_TOKEN`         | Issue tracker API token. | `XXX`                   |
+| `SUPER_API_TOKEN`        | Super API token.         | `XXX`                   |
 
-`GITHUB_TOKEN` is only needed to look up component versions. Set it in your `.env` file, the same as the other tokens.
-When it is not set, the scripts fall back to the token the GitHub CLI already holds, so a machine that has run
-`gh auth login` against the organisation needs no `.env` entry at all. The scripts say which of the two they used.
+Looking component versions up from the private `spectrocloud/nickfury` repository is optional, and needs no token in
+your `.env` file. The scripts read it through the [GitHub CLI](https://cli.github.com), so a machine that has run
+`gh auth login` against the organisation can look versions up, and one that has not is told so and falls back to the
+values you set yourself. Spectro Cloud issues short-lived GitHub credentials through Bulwark rather than long-lived
+personal access tokens, so authenticate the CLI with one of those rather than storing a token.
 
 Super API keys are personal, and Super only accepts a key while its owner has a current SSO session. When the owner has
 not signed in to [Super](https://app.super.work) recently, Super rejects the key with an HTTP 401 error. Because Super

--- a/scripts/release/generate-edge-compatibility-matrix.sh
+++ b/scripts/release/generate-edge-compatibility-matrix.sh
@@ -67,7 +67,7 @@ palette_cli_source=""
 if [[ -n "${RELEASE_SKIP_NICKFURY:-}" ]]; then
     canvos_source="the calling script"
     palette_cli_source="the calling script"
-elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+elif github_cli_ready; then
     nickfury_versions="$(fetch_github_file "$NICKFURY_REPO" "$nickfury_ref" "$NICKFURY_VERSIONS_PATH")" || nickfury_versions=""
     if [[ -n "$nickfury_versions" ]]; then
         nf_nickfury="$(printf '%s\n' "$nickfury_versions" | get_keyed_value "nickfury")"
@@ -81,7 +81,7 @@ elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
         echo "⚠️  Could not fetch $NICKFURY_VERSIONS_PATH from nickfury@$nickfury_ref, so only the .env values are available."
     fi
 else
-    echo "ℹ️  GITHUB_TOKEN is not set, so nickfury cannot be read and only the .env values are available."
+    echo "ℹ️  The GitHub CLI is not set up, so nickfury cannot be read and only the .env values are available. Install gh and run 'gh auth login' to look component versions up automatically."
 fi
 
 if [[ -z "$canvos_source" ]]; then

--- a/scripts/release/generate-patch-release-notes.sh
+++ b/scripts/release/generate-patch-release-notes.sh
@@ -139,17 +139,9 @@ fi
 echo "ℹ️  Extracted release date: $RELEASE_DATE."
 echo "ℹ️  Extracted release patch: $RELEASE_PATCH."
 
-# Reading nickfury needs a token that can see a private repository. Resolve it quietly here and
-# report on it only if the component versions are actually wanted, so a run that has none to record
-# never mentions nickfury at all.
-#
-# GITHUB_TOKEN comes from .env for a local run and from the workflow environment in CI. When it is
-# absent, fall back to the token the GitHub CLI already holds, which is usually signed in to the
-# organisation on a writer's machine.
-if [[ -z "${GITHUB_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
-  GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
-  [[ -n "$GITHUB_TOKEN" ]] && export GITHUB_TOKEN
-fi
+# Reading nickfury needs credentials that can see a private repository, which come from the GitHub
+# CLI rather than from a token in .env. Whether the CLI is set up is reported below, and only if the
+# component versions are actually wanted, so a run that has none to record never mentions nickfury.
 
 # The prompts below form a short interview, so only the values that apply to this patch are asked
 # for. Each is skipped when its environment variable is already set, and an unattended run answers
@@ -242,11 +234,11 @@ if [[ "$COMPONENT_UPDATES" == false ]]; then
   if [[ -n "${NICKFURY_REF:-}" ]] || any_patch_cli_sha_supplied; then
     echo "⚠️  A branch or tag, or a checksum, was supplied but no new component versions were requested, so it is ignored. Answer yes to the component version question, or set PATCH_COMPONENT_UPDATES=true, to use it." >&2
   fi
-elif [[ -z "${GITHUB_TOKEN:-}" ]]; then
-  echo "⚠️  No GitHub token is available, so $NICKFURY_REPO cannot be read and the component versions are recorded as pending. Add 'export GITHUB_TOKEN=<token>' to your .env file, or run 'gh auth login', to look them up. 'make init-release' adds the .env placeholder." >&2
+elif ! github_cli_ready; then
+  echo "⚠️  The GitHub CLI is not set up, so $NICKFURY_REPO cannot be read and the component versions are recorded as pending. Install gh and run 'gh auth login' to look them up, or supply the versions when prompted." >&2
 fi
 
-if [[ "$COMPONENT_UPDATES" == true && -n "${GITHUB_TOKEN:-}" ]]; then
+if [[ "$COMPONENT_UPDATES" == true ]] && github_cli_ready; then
   # The release engineers hand over a branch or a tag, and neither is named after the patch
   # release version alone: a branch is "release-<version>" and a tag is "v<version>", where a
   # tag can also carry an "-rc.N" release candidate suffix. Ask for that name directly rather

--- a/scripts/release/utilities.sh
+++ b/scripts/release/utilities.sh
@@ -385,28 +385,39 @@ normalize_super_body() {
     rm -f "$stripped_file" "$formatted_file"
 }
 
-# Utility function to fetch a single file's raw contents from a (private) GitHub
-# repository at a given ref, using a token-based REST call. Writes the raw file
-# body to stdout. Requires the GITHUB_TOKEN environment variable.
+# Utility function to report whether the GitHub CLI can read a private Spectro Cloud repository.
+# Reading component versions from nickfury is always optional: it saves looking a version up by
+# hand, and every caller falls back to the values already in .env when it is not available. So this
+# is a capability check rather than a requirement, and a writer without the CLI is told what to set
+# up rather than being stopped.
+#
+# The CLI is used in place of a personal access token in .env, because Spectro Cloud issues
+# short-lived GitHub credentials through Bulwark rather than long-lived tokens. `gh` holds that
+# credential itself, and in CI it reads the token the workflow exports, so neither case needs a
+# token recorded in a file.
+github_cli_ready() {
+    command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1
+}
+
+# Utility function to fetch a single file's raw contents from a (private) GitHub repository at a
+# given ref, through the GitHub CLI. Writes the raw file body to stdout.
 # Params:
 # $1 - repository, example: spectrocloud/nickfury
 # $2 - ref (branch, tag, or SHA), example: v4.9.21
 # $3 - file path within the repo, example: release/spectro_versions.txt
+# Returns 1 if the CLI is unavailable or the file cannot be read.
 fetch_github_file() {
     local repo="$1"
     local ref="$2"
     local path="$3"
 
-    if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-        echo "🟠 GITHUB_TOKEN is empty or not set; cannot fetch $repo/$path." >&2
+    if ! github_cli_ready; then
+        echo "🟠 The GitHub CLI is not set up, so $repo/$path cannot be read. Install gh and run 'gh auth login' to look component versions up automatically." >&2
         return 1
     fi
 
-    curl -sfL \
-        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github.raw" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        "https://api.github.com/repos/${repo}/contents/${path}?ref=${ref}"
+    gh api "repos/${repo}/contents/${path}?ref=${ref}" \
+        --header "Accept: application/vnd.github.raw" 2>/dev/null
 }
 
 # Utility function to read a "key=value" line from text on stdin and return the


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [x] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

The release scripts read component versions from the private `spectrocloud/nickfury` repository using a `GITHUB_TOKEN` taken from `.env`. Spectro Cloud issues short-lived GitHub credentials through [Bulwark](https://spectrocloud.atlassian.net/wiki/spaces/ENGINEERIN/pages/3575709698) rather than long-lived personal access tokens, so a `GITHUB_TOKEN=` line in `.env` invites exactly the kind of credential the company restricts, and asks a writer to keep it current by hand.

`fetch_github_file` now reads the file with `gh api` instead of `curl` and a bearer token. The CLI holds the credential itself, so nothing is stored in `.env`, and `make init-release` no longer seeds the variable. A new `github_cli_ready` helper reports whether the CLI is installed and authenticated.

**The lookup stays optional, which it always was.** Each caller falls back exactly as before — the Edge matrix uses the `.env` values, and the patch notes record the versions as pending — and a writer without the CLI is now told what to set up rather than told to add a token. Verified against all three paths:

| Scenario | Behaviour |
| --- | --- |
| `gh` authenticated, `.env` blank | nickfury fills both values, with no token in the environment at all |
| `gh` off `PATH`, `.env` set | Reports that the CLI is not set up, then uses the `.env` values |
| `gh` off `PATH`, `.env` blank | Same message, skips cleanly, exit 0 |

**CI needs no workflow changes.** `generate_patch_release_notes.yaml` and `update_patch_release_notes.yaml` already export the Vault-issued token as `GITHUB_TOKEN` for the script step, precisely because the default repository-scoped token cannot read nickfury. `gh` reads `GH_TOKEN` or `GITHUB_TOKEN` from the environment, so `gh api` uses that same Vault token — confirmed by checking that `gh auth status` succeeds when the token arrives only as an environment variable. Both workflows run on `ubuntu-latest` and already invoke `gh` directly, so the binary is present.

One behaviour inverts. `generate-patch-release-notes.sh` previously resolved `GITHUB_TOKEN` from `gh auth token` when `.env` had none, which made the CLI a *source for the token*. Now the CLI is the mechanism and no token is resolved at all.

`scripts/screenshot_artifacts.sh` is deliberately untouched. It serves `visual-comparison.yaml` rather than a release, and uses the token GitHub Actions provides to that job rather than anything from `.env`.

The matching internal references are updated in the same change: `docs/contributing/release-process.md` drops the `GITHUB_TOKEN` row and explains the CLI requirement instead. The [Confluence Release Checklist](https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1830420481/Release+Checklist) has been updated separately and no longer mentions the token.

---

## 💻 Changed Pages

No user-facing changes. This touches the release scripts, the `init-release` Makefile target, and `docs/contributing/release-process.md` — an internal repo document that is not part of the published site (it returns 404 on docs.spectrocloud.com, is absent from `docusaurus.config.js`, and opens with `<!-- vale off -->`).

---

## 🎫 Jira Tickets

No corresponding Jira ticket. This came out of reviewing the release scripts against the company policy on GitHub credentials.
