### PR TITLE
chore: prompt for release variables with examples rather than defaults

### DIFF
--- a/scripts/release/release-variables.sh
+++ b/scripts/release/release-variables.sh
@@ -1,52 +1,129 @@
 #!/usr/bin/env bash
 
-prompt() {
-  local var_name=$1
-  local default_value=$2
+# Collects the values `make generate-release` needs and writes them to release.env, so a whole
+# release's variables can be gathered in one pass and sourced into the current shell.
+#
+# Every prompt shows an example rather than a default, and an empty reply leaves the value empty.
+# That is deliberate. The script exists to confirm that the values for *this* release are in hand,
+# and a prompt that offers a value an empty reply accepts is not confirming anything: the earlier
+# version of this script carried hardcoded 4.8.c versions forward, and reading them from .env would
+# only move the same problem one release closer, because .env still holds the previous release when
+# a cycle starts. So nothing is ever carried forward silently, and the run ends by naming whatever
+# was left blank.
+#
+# Each entry below is "VARIABLE|example". The three Palette CLI checksums are optional, because
+# generate-downloads.sh records "SHA PENDING" for one it does not know and a later run fills the
+# cell in. Everything else is guarded by check_env in the script that reads it, so a blank stops
+# that page from being generated.
 
-  read -p "$var_name [$default_value]: " input
-  echo "${input:-$default_value}"
+set -uo pipefail
+
+OUTPUT_FILE="${OUTPUT_FILE:-release.env}"
+
+# Groups and order match the .env layout that `make init-release` writes, so the two files can be
+# compared line by line. Identity and component versions lead because together they are what
+# `make generate-release-notes` needs. There is no credentials group: tokens are set once and do not
+# belong in a file regenerated every release.
+IDENTITY=(
+    "RELEASE_NAME|for example, 4.10.0"
+    "RELEASE_VERSION|for example, 4.10.13"
+    "RELEASE_DATE|for example, September 6, 2026"
+)
+COMPONENTS=(
+    "RELEASE_CANVOS|for example, 4.10.3"
+    "RELEASE_PALETTE_CLI_VERSION|for example, 4.10.3"
+    "RELEASE_TERRAFORM_VERSION|for example, 0.30.0"
+    "RELEASE_PALETTE_CLI_SHA|SHA256 checksum, or empty to record as pending"
+    "RELEASE_PALETTE_CLI_ARM64_SHA|SHA256 checksum, or empty to record as pending"
+    "RELEASE_PALETTE_CLI_MACOS_SHA|SHA256 checksum, or empty to record as pending"
+    "RELEASE_SPECTRO_CLI_VERSION|for example, 4.10.0"
+    "RELEASE_REGISTRY_VERSION|for example, 4.10.0"
+)
+KUBERNETES=(
+    "RELEASE_VMWARE_KUBERNETES_VERSION|for example, 1.34.6"
+    "RELEASE_VMWARE_OVA_URL|for example, https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1346-0.ova"
+    "RELEASE_VMWARE_FIPS_OVA_URL|for example, https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1346-fips.ova"
+    "RELEASE_HIGHEST_KUBERNETES_VERSION|for example, 1.35.6"
+    "RELEASE_PCG_KUBERNETES_VERSION|for example, 1.34.6"
+)
+
+# The checksums a run may legitimately leave empty. Reported separately at the end, so a pending
+# checksum is not mixed in with a blank that will stop a page being generated.
+OPTIONAL=(RELEASE_PALETTE_CLI_SHA RELEASE_PALETTE_CLI_ARM64_SHA RELEASE_PALETTE_CLI_MACOS_SHA)
+
+is_optional() {
+    local var="$1" opt
+    for opt in "${OPTIONAL[@]}"; do
+        [[ "$var" == "$opt" ]] && return 0
+    done
+    return 1
 }
 
-# Prompt for values (defaults = last release)
-RELEASE_NAME=$(prompt "RELEASE_NAME" "4-8-c")
-RELEASE_VERSION=$(prompt "RELEASE_VERSION" "4.8.c")
-RELEASE_SPECTRO_CLI_VERSION=$(prompt "RELEASE_SPECTRO_CLI_VERSION" "4.8.4")
-RELEASE_REGISTRY_VERSION=$(prompt "RELEASE_REGISTRY_VERSION" "4.8.4")
-RELEASE_DATE=$(prompt "RELEASE_DATE" "April 5, 2026")
-RELEASE_CANVOS=$(prompt "RELEASE_CANVOS" "4.8.18")
-RELEASE_TERRAFORM_VERSION=$(prompt "RELEASE_TERRAFORM_VERSION" "0.28.3")
-RELEASE_PALETTE_CLI_VERSION=$(prompt "RELEASE_PALETTE_CLI_VERSION" "4.8.10")
-RELEASE_PALETTE_CLI_SHA=$(prompt "RELEASE_PALETTE_CLI_SHA" "06e3d139fcfec018830ab2a9e03ee0c760dfc8cd8b0283eca93a43c86ae68b24")
-RELEASE_PALETTE_CLI_ARM64_SHA=$(prompt "RELEASE_PALETTE_CLI_ARM64_SHA" "")
-RELEASE_PALETTE_CLI_MACOS_SHA=$(prompt "RELEASE_PALETTE_CLI_MACOS_SHA" "")
-RELEASE_VMWARE_KUBERNETES_VERSION=$(prompt "RELEASE_VMWARE_KUBERNETES_VERSION" "1.32.9")
-RELEASE_VMWARE_OVA_URL=$(prompt "RELEASE_VMWARE_OVA_URL" "https://vmwaregoldenimage-console.s3.amazonaws.com/u-2204-0-k-1329-0.ova")
-RELEASE_VMWARE_FIPS_OVA_URL=$(prompt "RELEASE_VMWARE_FIPS_OVA_URL" "https://vmwaregoldenimage-console.s3.amazonaws.com/u-2004-0-k-1329-fips.ova")
-RELEASE_PCG_KUBERNETES_VERSION=$(prompt "RELEASE_PCG_KUBERNETES_VERSION" "1.32.9")
-RELEASE_HIGHEST_KUBERNETES_VERSION=$(prompt "RELEASE_HIGHEST_KUBERNETES_VERSION" "1.35.5")
+# Ask for one variable, showing the example in the prompt so the format is clear without a value
+# being asserted. An empty reply leaves the variable empty.
+prompt_var() {
+    local var="$1" example="$2" reply
+    read -r -p "$var ($example): " reply
+    printf -v "$var" '%s' "$reply"
+}
+
+# Quote only a value that contains whitespace, matching how .env records the release date but leaves
+# versions and URLs bare, so a line can be copied between the two files unchanged.
+emit() {
+    local entry var value
+    for entry in "$@"; do
+        var="${entry%%|*}"
+        value="${!var}"
+        if [[ "$value" == *[[:space:]]* ]]; then
+            printf 'export %s="%s"\n' "$var" "$value"
+        else
+            printf 'export %s=%s\n' "$var" "$value"
+        fi
+    done
+}
+
+echo "Every value is for this release. The prompts show examples, not defaults, so an empty reply"
+echo "leaves the value empty and is reported at the end."
+echo ""
+
+for entry in "${IDENTITY[@]}" "${COMPONENTS[@]}" "${KUBERNETES[@]}"; do
+    prompt_var "${entry%%|*}" "${entry#*|}"
+done
+
+{
+    echo "# RELEASE IDENTITY"
+    emit "${IDENTITY[@]}"
+    echo ""
+    echo "# COMPONENT VERSIONS"
+    emit "${COMPONENTS[@]}"
+    echo ""
+    echo "# KUBERNETES REQUIREMENTS"
+    emit "${KUBERNETES[@]}"
+} > "$OUTPUT_FILE"
 
 echo ""
-echo "Exporting variables..."
+echo "Saved to $OUTPUT_FILE. Run 'source $OUTPUT_FILE' to use the values in this shell."
 
-cat > release.env <<EOF
-export RELEASE_NAME=$RELEASE_NAME
-export RELEASE_VERSION=$RELEASE_VERSION
-export RELEASE_SPECTRO_CLI_VERSION=$RELEASE_SPECTRO_CLI_VERSION
-export RELEASE_REGISTRY_VERSION=$RELEASE_REGISTRY_VERSION
-export RELEASE_DATE="$RELEASE_DATE"
-export RELEASE_CANVOS=$RELEASE_CANVOS
-export RELEASE_TERRAFORM_VERSION=$RELEASE_TERRAFORM_VERSION
-export RELEASE_PALETTE_CLI_VERSION=$RELEASE_PALETTE_CLI_VERSION
-export RELEASE_PALETTE_CLI_SHA=$RELEASE_PALETTE_CLI_SHA
-export RELEASE_PALETTE_CLI_ARM64_SHA=$RELEASE_PALETTE_CLI_ARM64_SHA
-export RELEASE_PALETTE_CLI_MACOS_SHA=$RELEASE_PALETTE_CLI_MACOS_SHA
-export RELEASE_VMWARE_KUBERNETES_VERSION=$RELEASE_VMWARE_KUBERNETES_VERSION
-export RELEASE_VMWARE_OVA_URL="$RELEASE_VMWARE_OVA_URL"
-export RELEASE_VMWARE_FIPS_OVA_URL="$RELEASE_VMWARE_FIPS_OVA_URL"
-export RELEASE_PCG_KUBERNETES_VERSION=$RELEASE_PCG_KUBERNETES_VERSION
-export RELEASE_HIGHEST_KUBERNETES_VERSION=$RELEASE_HIGHEST_KUBERNETES_VERSION
-EOF
+missing=()
+pending=()
+for entry in "${IDENTITY[@]}" "${COMPONENTS[@]}" "${KUBERNETES[@]}"; do
+    var="${entry%%|*}"
+    [[ -n "${!var}" ]] && continue
+    if is_optional "$var"; then
+        pending+=("$var")
+    else
+        missing+=("$var")
+    fi
+done
 
-echo "Saved to release.env"
-echo "Done."
+if (( ${#pending[@]} )); then
+    echo ""
+    echo "ℹ️  Recorded as pending, for a later run to fill in:"
+    printf '     %s\n' "${pending[@]}"
+fi
+
+if (( ${#missing[@]} )); then
+    echo ""
+    echo "⚠️  Left empty. Each of these stops the page that reads it from being generated:"
+    printf '     %s\n' "${missing[@]}"
+fi


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [x] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

`scripts/release/release-variables.sh` offered a hardcoded default for every prompt, and the set was last refreshed for **4.8.c**. The comment claimed the defaults were the last release, so pressing Enter through the prompts quietly produced a `release.env` two minor versions out of date — CanvOS `4.8.18`, Palette CLI `4.8.10`, Kubernetes `1.32.9`, and a `RELEASE_NAME` of `4-8-c` in the hyphenated form the release naming no longer uses.

Each prompt now shows an **example** and asserts no value:

```
RELEASE_CANVOS (for example, 4.10.3):
RELEASE_PALETTE_CLI_SHA (SHA256 checksum, or empty to record as pending):
```

The script exists to confirm that this release's values are in hand, and a prompt offering a value that an empty reply accepts is not confirming anything. Sourcing the defaults from `.env` was tried first and rejected: it moves the same problem one release closer rather than removing it, because `.env` still holds the previous release at the point in the cycle where this script is useful — and a `.env` that is already current makes the script redundant anyway, since `make` reads `.env` directly via `-include`.

Nothing is carried forward silently, and the run ends by naming what was left blank, split by consequence:

| Reported as | Variables | Why |
| --- | --- | --- |
| `ℹ️ Recorded as pending` | The three Palette CLI checksums | `generate-downloads.sh` writes `SHA PENDING` for one it does not know, and a later run fills the cell in |
| `⚠️ Left empty` | Everything else | Each is `check_env`-guarded, so a blank stops the page that reads it from being generated |

`release.env` is now grouped under the same three headers, in the same order, that `make init-release` writes to `.env`, so the two files can be compared line by line. Identity and component versions lead because together they are what `make generate-release-notes` needs. There is no credentials group — tokens are set once and do not belong in a file regenerated every release, and no header is emitted with nothing under it.

Coverage is unchanged: all 15 variables `make generate-release` reads are still collected, plus `RELEASE_DATE` for the release notes. A value is quoted only when it contains whitespace, matching how `.env` records the release date but leaves versions and URLs bare, so a line can be copied between the two files unchanged.

Verified across five runs: all values supplied; all blank (confirming nothing leaks from a `.env` that is present); the realistic mix of versions supplied and checksums pending; `source release.env` returning the spaced date intact; and the prompt text as a writer sees it.

---

## 💻 Changed Pages

No user-facing changes. This touches one shell script that writes a local `release.env`, and produces no rendered output. `scripts/release/` is Prettier-ignored, and Vale lints `.md` only, so neither content gate applies.

---

## 🎫 Jira Tickets

No corresponding Jira ticket. This came out of checking `release-variables.sh` against the current `make init-release` variable set and the values `make generate-release` actually reads.
