### PR TITLE
DOC-3196: probe hints bug fix note

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -253,10 +253,9 @@ tags: ["release-notes"]
 
 <!-- https://spectrocloud.atlassian.net/browse/PCP-7524 -->
 
-- Fixed an issue that caused sustained high CPU usage by the Palette management plane on clusters whose
-  [cluster profile](../profiles/cluster-profiles/cluster-profiles.md) included one or more add-on, CNI, or CSI packs.
-  The management plane repeatedly reconciled packs whose configuration had not changed, consuming approximately 1.3 vCPU
-  per affected cluster continuously. Cluster provisioning and pack functionality were not affected.
+- Fixed an issue that caused sustained high CPU usage by the Palette management plane. The management plane repeatedly
+  reconciled packs whose configuration had not changed, consuming approximately 1.3 vCPU per affected cluster
+  continuously. Cluster provisioning and pack functionality were not affected.
 
 ### Edge
 

--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -251,6 +251,13 @@ tags: ["release-notes"]
   compliance tagging, could therefore repave nodes repeatedly on a cluster that was never upgraded. Changing tags
   directly on a worker node pool still replaces that pool's nodes.
 
+<!-- https://spectrocloud.atlassian.net/browse/PCP-7524 -->
+
+- Fixed an issue that caused sustained high CPU usage by the Palette management plane on clusters whose
+  [cluster profile](../profiles/cluster-profiles/cluster-profiles.md) included one or more add-on, CNI, or CSI packs.
+  The management plane repeatedly reconciled packs whose configuration had not changed, consuming approximately 1.3 vCPU
+  per affected cluster continuously. Cluster provisioning and pack functionality were not affected.
+
 ### Edge
 
 <!-- release-notes-edge-callout-4.10.0-start -->


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [ ] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Adds a customer-facing Bug Fixes entry to the 4.10.13 release notes, under **Palette Enterprise**, for a management-plane defect where Palette repeatedly reconciled packs whose configuration had not changed, consuming approximately 1.3 vCPU per affected cluster continuously. Engineering flagged that the fix was missing from the release notes; the customer-visible symptom is sustained control-plane CPU on clusters whose cluster profile includes add-on, CNI, or CSI packs, with no impact to cluster provisioning or pack functionality. The fix ships in 4.10.13.

The entry is written to the observable symptom rather than the root cause (no internal implementation detail), and keeps the measured ~1.3 vCPU figure deliberately, because the related customer escalation is a billing dispute over exactly that cost. The published entry references the engineering ticket in its source comment. Auto-backport is set to `version-4-10` so the entry also lands on the 4.10 release branch's copy of these notes.

---

## 💻 Changed Pages

- [Release Notes — 4.10.13 / Palette Enterprise / Bug Fixes](https://deploy-preview-11931--docs-spectrocloud.netlify.app/release-notes/#release-notes-4.10.0)

---

## 🎫 Jira Tickets

[DOC-3196](https://spectrocloud.atlassian.net/browse/DOC-3196)


[DOC-3196]: https://spectrocloud.atlassian.net/browse/DOC-3196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ