### PR TITLE
docs: backfill customer-found bug fixes missed from the 4.10.13 notes

### DIFF
--- a/docs/docs-content/release-notes/release-notes.md
+++ b/docs/docs-content/release-notes/release-notes.md
@@ -238,24 +238,35 @@ tags: ["release-notes"]
 
 <!-- https://spectrocloud.atlassian.net/browse/PCP-4655 -->
 
-- Fixed an issue that caused multi-line error messages to appear truncated in a cluster's **Events** tab. Only the first
-  line of the message was recorded, so an event displayed `"Reconciler error" err=<` while the description of the
-  failure that followed it, such as `NoCredentialProviders: no valid providers in chain`, was dropped. The complete
-  message is now recorded as a single event. Only error-level events were affected.
+- Fixed an issue that caused multi-line error messages to appear truncated in a cluster's **Events** tab, so an event
+  showed only `"Reconciler error" err=<` without the failure description that followed it. The complete message is now
+  recorded as a single event. Only error-level events were affected.
 
 <!-- https://spectrocloud.atlassian.net/browse/PCP-7401 -->
 
 - Fixed an issue that caused changing a cluster-level tag on a healthy
-  [Amazon EKS cluster](../clusters/public-cloud/aws/eks.md) to emit a misleading `ClusterUpgradeTriggered` event and
-  replace every node in the cluster's worker node pools. Pipelines that update tag values on each run, such as
-  compliance tagging, could therefore repave nodes repeatedly on a cluster that was never upgraded. Changing tags
-  directly on a worker node pool still replaces that pool's nodes.
+  [Amazon EKS cluster](../clusters/public-cloud/aws/eks.md) to emit a `ClusterUpgradeTriggered` event and replace every
+  node in the cluster's worker node pools. Pipelines that update tag values on each run, such as compliance tagging,
+  could therefore repave nodes repeatedly. Changing tags directly on a worker node pool still replaces that pool's
+  nodes.
 
 <!-- https://spectrocloud.atlassian.net/browse/PCP-7524 -->
 
 - Fixed an issue that caused sustained high CPU usage by the Palette management plane. The management plane repeatedly
   reconciled packs whose configuration had not changed, consuming approximately 1.3 vCPU per affected cluster
   continuously. Cluster provisioning and pack functionality were not affected.
+
+<!-- https://spectrocloud.atlassian.net/browse/PCP-7236 -->
+
+- Fixed an issue where [OS patching](../clusters/cluster-management/os-patching.md) on Ubuntu cluster nodes could leave
+  a node in `Ready,SchedulingDisabled` and unable to accept workloads, and could prevent scheduled patches from running.
+  Palette now requires OS patch schedules to run no more frequently than hourly.
+
+<!-- https://spectrocloud.atlassian.net/browse/PCP-7245 -->
+
+- Fixed an issue that caused the [cert-manager](../clusters/cluster-management/cert-manager-addon.md) add-on pack to
+  fail with `ChartInstallFailed` when the pack enabled Gateway API support before the Gateway API custom resource
+  definitions existed on the cluster. Palette now applies the setting once those definitions are available.
 
 ### Edge
 
@@ -353,14 +364,12 @@ troubleshooting scenario.
 - Fixed an issue that prevented digest-pinned application images from being redirected to the
   [local registry](../clusters/edge/site-deployment/deploy-custom-registries/local-registry.md) on airgapped Edge
   clusters. Pods that referenced an image by digest rather than by tag attempted to pull from the upstream registry and
-  remained in `ImagePullBackOff`, while the same image referenced by tag deployed successfully.
+  remained in `ImagePullBackOff`.
 
 <!-- https://spectrocloud.atlassian.net/browse/PE-9033 -->
 
 - Fixed an issue that caused packs whose name contains a forward slash, such as Helm OCI packs sourced from a private
-  registry, to fail to download on Edge hosts with `failed to rename pack: no such file or directory` errors. The
-  affected packs were never cached, and the cluster re-downloaded them every two minutes without reaching a steady
-  state.
+  registry, to fail to download on Edge hosts with `failed to rename pack: no such file or directory` errors.
 
 <!-- https://spectrocloud.atlassian.net/browse/PE-9143 -->
 
@@ -381,9 +390,25 @@ troubleshooting scenario.
 
 - Fixed an issue that prevented the NTP servers configured on an Edge host through the
   [Palette TUI](../clusters/edge/site-deployment/site-installation/initial-setup.md) from being visible in Local UI. The
-  Edge host overview page now lists them in an **NTP Servers** field, so an operator working only in Local UI can
-  confirm the host's time synchronization settings. These servers remain specific to the host, and cluster-level NTP
-  configured in cluster settings continues to override them on every host in the cluster.
+  Edge host overview page now lists them in an **NTP Servers** field.
+
+<!-- https://spectrocloud.atlassian.net/browse/PE-9302 -->
+
+- Fixed an issue that left a [two-node Edge cluster](../clusters/edge/architecture/two-node.md) without a Kubernetes API
+  server after the loss of the leader node. The surviving node did not complete its promotion, so the cluster virtual IP
+  served no traffic. Loss of the follower node was unaffected.
+
+<!-- https://spectrocloud.atlassian.net/browse/PE-9348 -->
+
+- Fixed an issue that could place the Kubernetes datastore of a
+  [two-node Edge cluster](../clusters/edge/architecture/two-node.md) on ephemeral rather than persistent storage. Data
+  written since the last persistent snapshot was lost on reboot, and the node could not be promoted during failover.
+
+<!-- https://spectrocloud.atlassian.net/browse/PE-9388 -->
+
+- Fixed an issue that prevented leader promotion from completing on a connected-mode
+  [two-node Edge cluster](../clusters/edge/architecture/two-node.md) while Palette was unreachable, leaving the local
+  control plane unavailable until connectivity was restored. Promotion now completes without Palette connectivity.
 
 ### VerteX
 

--- a/scripts/compress-convert-images.sh
+++ b/scripts/compress-convert-images.sh
@@ -5,8 +5,12 @@ set -e
 
 echo "Checking for files not in WebP format in static/assets/docs/images/ folder..."
 
-# Find files that are not in WebP format and are not .DS_STORE files
-non_webp_files=$(find static/assets/docs/images/ -type f ! -name "*.webp" ! -name "*.gif" -not -name ".DS_STORE")
+# Find files that are not in WebP format, excluding dotfiles.
+# find -name is case-sensitive, so the previous ".DS_STORE" exclusion never
+# matched the real ".DS_Store" filename macOS creates. Excluding all dotfiles
+# covers that and its siblings (AppleDouble "._*" files, .gitkeep) rather than
+# chasing one spelling at a time.
+non_webp_files=$(find static/assets/docs/images/ -type f ! -name "*.webp" ! -name "*.gif" ! -name ".*")
 
 # Check if there are any non-WebP files
 if [[ -n "$non_webp_files" ]]; then


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [x] Verify indentations, admonitions, and tables (if applicable).
  - [x] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [x] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Backfills five customer-found bug fixes that were missed from the 4.10.13 release notes, and tightens five existing entries against two new writing rules.

**Why they were missed.** All five carried fixVersion 4.10.0, were Verified, and named customers, but every one entered the Jira filter *after* the candidate inventory was last generated on 28 August — five of them reaching Verified on 31 August or 1 September, in the QA sweep before the 6 September release. A single inventory run nine days out could not see them. `PCP 7524` was the same class of miss and was caught separately last week.

**Added** — Palette Enterprise > Bug Fixes: `PCP 7236` (OS patching on Ubuntu nodes), `PCP 7245` (cert-manager add-on pack with Gateway API). Edge > Bug Fixes: `PE 9302` (two-node cluster left without an API server), `PE 9348` (two-node datastore placed on ephemeral storage), `PE 9388` (leader promotion blocked while Palette is unreachable).

Shipped code was confirmed by commit for each, not by `resolution: Done` — crony#666 and ally#3681, palette#6090 (to `rc-4.10`), and stylus #6373/#6406/#6414 plus `e85af2ae`.

**Deliberately excluded: `PVM 1107`.** No commit in any repository names it; its recorded resolution is a cluster configuration change (a containerd CDI drop-in added to the OS layer) rather than a code fix; and Jira marks it a duplicate of `PVM 1051`, already documented in this block. QA closed it noting images under roughly 9 GB now upload while larger ones still fail, tracked separately and still open. There may be a docs need there, but it is a page rather than a release note.

**Tightened, against two rules added to the `release-notes-bug-fixes` skill** — never mention future or planned support, and keep entries concise and neutral in tone:

| Entry | Removed |
| --- | --- |
| `PE 9316` + `PE 9351` | A justification clause and a trailing sentence of host-versus-cluster NTP scoping |
| `PCP 7401` | "misleading" and "on a cluster that was never upgraded" |
| `PCP 4655` | Mechanism narration and a second error-string example |
| `PE 8891` | "while the same image referenced by tag deployed successfully" |
| `PE 9033` | The trailing re-download mechanism |

Every searchable identifier and triggering condition was kept — the cuts are mechanism, diagnostic asides and phrasing that dwelt on what went undetected. `PCP 7401` keeps its present-tense limitation about pool-level tag changes, which is still current.

**Two judgment calls worth knowing.** `PCP 7236` is scoped to Ubuntu; RHEL and CentOS are handled under a different ticket, and the entry deliberately says nothing about them rather than promising work with no date. `PCP 7236` also adds a validation rejecting sub-hourly OS patch schedules — stated in one sentence because anyone running such a schedule is affected. The ticket carries no `breaking` label, so it was not routed to Breaking Changes; happy to move it if you disagree.

**Also in this PR: a one-line fix to `scripts/compress-convert-images.sh`.** Its guard excluded `.DS_STORE`, but `find -name` is case-sensitive and the file macOS creates is `.DS_Store`, so the exclusion never matched. Every commit reported the dotfile as a non-WebP image, tried to convert it, and — because the if-branch was always taken — also ran a blanket `git add static/assets/docs/images/`. The guard now excludes all dotfiles, which also covers AppleDouble `._*` files; `scripts/find-unused-images.sh` already lists both spellings, so this had been hit before and fixed there only. No user-facing change.

---

## 💻 Changed Pages

- [Release Notes — Release 4.10.13](https://deploy-preview-11937--docs-spectrocloud.netlify.app/release-notes/#release-notes-4.10.0)
- [Release Notes — Palette Enterprise](https://deploy-preview-11937--docs-spectrocloud.netlify.app/release-notes/#palette-enterprise-4.10.0)

---

## 🎫 Jira Tickets

No corresponding Jira ticket. This is docs-team follow-up on release notes that had already shipped, identified while auditing the customer-found bug fix filter. The individual fixes are tracked under their engineering tickets, listed above with keys spaced so merging this PR does not resolve them.
