### PR TITLE
DOC-3187 - Fix awsgov STS to POST

### DIFF
--- a/_partials/self-hosted/_aws-sts-config.mdx
+++ b/_partials/self-hosted/_aws-sts-config.mdx
@@ -73,7 +73,7 @@ to deploy clusters in AWS using STS. Without this configuration, the STS option 
    <TabItem value="AWS GOV">
 
    ```bash
-   curl --insecure --request PUT \
+   curl --insecure --request POST \
     --url https://<palette-api-url>/v1/system/config/awsgov/sts/account \
     --header "Authorization: $TOKEN" \
     --header "Content-Type: application/json" \

--- a/_partials/self-hosted/_aws-sts-config.mdx
+++ b/_partials/self-hosted/_aws-sts-config.mdx
@@ -79,7 +79,13 @@ to deploy clusters in AWS using STS. Without this configuration, the STS option 
     --header "Content-Type: application/json" \
     --data "$CONFIG_JSON"
    ```
+   
+   :::info
 
+   To modify an existing AWS account, change `POST` to `PUT` in the curl statement.
+
+   :::
+   
    </TabItem>
 
    </Tabs>


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and
      provides any additional context.
- [x] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has
      no corresponding Jira ticket, then please indicate so in this section._
- [x] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR
      makes no user-facing changes, please indicate so in this section._
- [x] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [x] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the
        [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt).
        _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the
      `auto-backport` label, as well as the `backport-version-**` labels._
- [x] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for
      example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

Change the AWS GovCloud STS account curl example in `_partials/self-hosted/_aws-sts-config.mdx` from `PUT` to `POST`. Per engineering, `/v1/system/config/awsgov/sts/account` requires `POST` for creation; the commercial `/v1/system/config/aws/sts/account` correctly stays on `PUT` as already documented. Applies to versions 4.8 and 4.9, which carry the same incorrect `PUT` example; 4.6 and 4.7 already use `POST` for awsgov.

---

## 💻 Changed Pages

- [Enable Adding AWS Accounts Using STS](https://deploy-preview-11941--docs-spectrocloud.netlify.app/vertex/system-management/configure-aws-sts-account) - consumes updated partial `sts-config` - awsgov STS create curl switched from PUT to POST
- [Enable Adding AWS Accounts Using STS](https://deploy-preview-11941--docs-spectrocloud.netlify.app/enterprise-version/system-management/configure-aws-sts-account) - consumes updated partial `sts-config` - awsgov STS create curl switched from PUT to POST

---

## 🎫 Jira Tickets

https://spectrocloud.atlassian.net/browse/DOC-3187
