### PR TITLE
DOC-3209: Add a maintenance window to the platform upgrade prerequisites

### DIFF
--- a/docs/products/paletteai-inference-launchpad/how-to-guides/upgrade-the-platform.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/upgrade-the-platform.md
@@ -17,6 +17,7 @@ applying the **Update** action in Local UI. You do not reinstall the OS or redep
 
 Confirm each prerequisite before starting:
 
+- A maintenance window. The appliance may reboot during the upgrade, which makes Local UI briefly unreachable.
 - A running PaletteAI Inference Launchpad appliance and network access to Local UI on the leader node at
   `https://<node-ip>:5080`.
 - The [Zot registry](../reference/profile-variables.md#container-registry-zot) password you set during the initial

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/upgrade-the-platform.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/upgrade-the-platform.md
@@ -17,7 +17,7 @@ applying the **Update** action in Local UI. You do not reinstall the OS or redep
 
 Confirm each prerequisite before starting:
 
-- A maintenance window. The appliance may reboot during the upgrade.
+- A maintenance window. The appliance may reboot during the upgrade, which makes Local UI briefly unreachable.
 - A running PaletteAI Inference Launchpad appliance and network access to Local UI on the leader node at
   `https://<node-ip>:5080`.
 - The [Zot registry](../reference/profile-variables.md#container-registry-zot) password you set during the initial

--- a/docs/products/paletteai-inference-launchpad/how-to-guides/upgrade-the-platform.md
+++ b/docs/products/paletteai-inference-launchpad/how-to-guides/upgrade-the-platform.md
@@ -17,7 +17,7 @@ applying the **Update** action in Local UI. You do not reinstall the OS or redep
 
 Confirm each prerequisite before starting:
 
-- A maintenance window. The appliance may reboot during the upgrade, which makes Local UI briefly unreachable.
+- A maintenance window. The appliance may reboot during the upgrade.
 - A running PaletteAI Inference Launchpad appliance and network access to Local UI on the leader node at
   `https://<node-ip>:5080`.
 - The [Zot registry](../reference/profile-variables.md#container-registry-zot) password you set during the initial


### PR DESCRIPTION
**Jira:** [DOC-3209](https://spectrocloud.atlassian.net/browse/DOC-3209)

## Intent

Close a gap in the PaletteAI Inference Launchpad upgrade how-to: the page mentioned a possible reboot only at step 10, so a reader learned about the interruption after the upgrade had already begun, and the doc set had no maintenance window guidance at all. Add a maintenance window to the prerequisites, naming the reboot and the brief Local UI unreachability that step 10 of the same page already documents. Deliberately do not answer whether inference keeps serving through a platform upgrade, because that claim is unverified and needs an engineering owner. Strict Diataxis: this is a how-to page, so keep the addition task-oriented with no concept exposition. Must comply with the repo style-guide.md. Tracked as DOC-3209.

## What Changed

- Added a maintenance window bullet to the **Prerequisites** section of the PaletteAI Inference Launchpad *Upgrade the Platform* how-to, noting that the appliance may reboot during the upgrade.
- The new bullet is listed first, so readers see the interruption before starting, rather than only at step 10 where the reboot and brief Local UI unreachability are already documented.

## Risk Assessment

✅ Low: The net change is a single documentation prerequisite bullet that restates a reboot caveat already present at step 10, it matches the doc set's prerequisite conventions and the repo style guide, and the pipeline fix round applied the minimal one-line wording the recorded decision prescribed without adding any new claims or machinery.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7610dcb6e29281a297ead5ef1e7bd45c3e5b55a8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"skipped"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `docs/products/paletteai-inference-launchpad/how-to-guides/upgrade-the-platform.md:20` - Commit e4bcf71d reverts the fix the user accepted in review round 1, so the branch&#39;s net state re-introduces the exact wording that round decided to remove. Round 1 recorded finding &#34;reboot-impact-scoped-to-local-ui&#34; as chosen-to-fix, and recommended the narrower form &#34;A maintenance window. The appliance may reboot during the upgrade.&#34; Commit 8b3f2a35 applied exactly that. Commit e4bcf71d then restored the removed clause: &#34;- A maintenance window. The appliance may reboot during the upgrade, which makes Local UI briefly unreachable.&#34; Two authoritative signals now conflict and I cannot resolve them: the recorded decision says drop the Local UI scoping, while the current intent explicitly requires &#34;naming the reboot and the brief Local UI unreachability that step 10 of the same page already documents&#34; — and the pipeline rule is that a recorded decision supersedes conflicting intent wording. This is materially different from round 1: the question is no longer whether the phrasing is right, but whether an accepted remediation was intentionally undone. Two mitigating facts, both source-verified: the author reaffirmed the restore in e4bcf71d with a stated rationale, and the sentence is not a new assertion — step 10 at line 63 carried the identical claim (&#34;The appliance may reboot during the upgrade, which briefly makes Local UI unreachable.&#34;) at base commit d8c5afc5, so the page&#39;s substantive claims are unchanged. The unresolved risk the round-1 finding named still stands: naming Local UI as the reboot&#39;s only consequence in a planning bullet lets an operator serving production inference size a window that protects admin UI access only, without asserting anything about inference. Because this turns on how much the doc may say about upgrade impact — the question the intent reserves for an engineering owner — it needs the author&#39;s decision, not a reviewer edit. Confirm whether e4bcf71d supersedes the round-1 decision, or whether the narrower form should be restored.

🔧 Fix applied.
1 info still open:

- ℹ️ `docs/products/paletteai-inference-launchpad/how-to-guides/upgrade-the-platform.md:20` - Informational, no action needed. The shipped prerequisite reads &#34;- A maintenance window. The appliance may reboot during the upgrade.&#34; and deliberately omits the Local UI clause that the intent sentence names as required (&#34;naming the reboot and the brief Local UI unreachability that step 10 of the same page already documents&#34;). This is not a conformance defect: the earlier recorded decision (finding &#34;reboot-impact-scoped-to-local-ui&#34;, chosen to fix) prescribed exactly this narrower form, and a recorded decision supersedes conflicting intent wording. This run&#39;s fix commit 7610dcb6 restored that form, making HEAD byte-identical to 8b3f2a35, the state that decision produced. The reasoning behind the narrowing is preserved: scoping the reboot&#39;s consequence to Local UI inside a planning bullet would let an operator serving production inference size a window that protects admin UI access only, which implicitly answers the inference-continuity question the intent reserves for an engineering owner. The Local UI detail still ships at line 63 (step 10), unchanged from base commit d8c5afc5, where it is procedural context rather than planning guidance. Noted only so the intent text and the delivered wording are not later read as an unexplained mismatch; the DOC-3209 intent sentence is the artifact that is now stale, not the doc.
</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

[DOC-3209]: https://spectrocloud.atlassian.net/browse/DOC-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ