### PR TITLE
DOC-3208: Fill the empty Network Topology section in the architecture page

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -119,4 +119,30 @@ refer to [Register an External Inference Endpoint](../how-to-guides/register-an-
 
 ## Network Topology
 
+A client reaches a served model over a single address. The **Platform IP Address** set during cluster deployment is an
+unused address that MetalLB assigns to Traefik, and Traefik fronts both the appliance console and the OpenAI-compatible
+API. MetalLB announces that address on the node's bond through the interface selected as the Cilium and MetalLB
+interface, so platform traffic arrives on the bond and is delivered to Traefik. Traefik passes each request to the
+gateway, which authenticates the calling client, applies routing, and forwards the request to the inference engine
+serving the chosen model.
+
+The node keeps its own management address, the Host IP, and the two addresses do different jobs. The Host IP belongs to
+the node and carries SSH, Local UI, and the Kubernetes API. The Platform IP belongs to the cluster load balancer and
+carries the console and the API. Both must be distinct addresses in the same subnet, because setting the Platform IP to
+the Host IP on a single-node appliance makes MetalLB intercept traffic bound for the node's own services. Refer to
+[SSH, Local UI, or Kubernetes API unreachable after cluster deploy](../reference/known-issues.md#ssh-local-ui-or-kubernetes-api-unreachable-after-cluster-deploy).
+
+Traefik also carries a load-balancer access control list that restricts which source addresses may reach the console.
+Where that list is narrower than the network an operator works from, the console refuses the connection even though the
+cluster is healthy. Refer to
+[Appliance console unreachable from the jumpbox after cluster deploy](../reference/known-issues.md#appliance-console-unreachable-from-the-jumpbox-after-cluster-deploy).
+
+The node's operating system serves [Local UI](../reference/glossary.md#local-ui) on port `5080`, rather than the cluster
+serving it, so Local UI sits outside the MetalLB and Traefik path. That separation is why Local UI stays reachable when
+platform services are unavailable, and why it is the surface for install and for platform upgrades.
+
+Cluster traffic and [Piraeus](../reference/glossary.md#piraeus) storage replication share the same bond, which is why
+the appliance aggregates two physical NICs into one logical link instead of bridging them. For that reasoning and the
+field values the bond uses, refer to [Bond, not bridge](./installation-architecture.md#bond-not-bridge).
+
 ## Data Residency and Isolation

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -121,10 +121,10 @@ refer to [Register an External Inference Endpoint](../how-to-guides/register-an-
 
 A client reaches a served model over a single address. The **Platform IP Address** set during cluster deployment is an
 unused address that MetalLB assigns to Traefik, and Traefik fronts both the appliance console and the OpenAI-compatible
-API. MetalLB announces that address on the node's bond through the interface selected as the Cilium and MetalLB
-interface, so platform traffic arrives on the bond and is delivered to Traefik. Traefik passes each request to the
-gateway, which authenticates the calling client, applies routing, and forwards the request to the inference engine
-serving the chosen model.
+API. MetalLB announces that address on the node's [bond](../reference/glossary.md#bond) through the interface selected
+as the Cilium and MetalLB interface, so platform traffic arrives on the bond and is delivered to Traefik. Traefik passes
+each request to the gateway, which authenticates the calling client, applies routing, and forwards the request to the
+inference engine serving the chosen model.
 
 The node keeps its own management address, the Host IP, and the two addresses do different jobs. The Host IP belongs to
 the node and carries SSH, Local UI, and the Kubernetes API. The Platform IP belongs to the cluster load balancer and
@@ -132,17 +132,14 @@ carries the console and the API. Both must be distinct addresses in the same sub
 the Host IP on a single-node appliance makes MetalLB intercept traffic bound for the node's own services. Refer to
 [SSH, Local UI, or Kubernetes API unreachable after cluster deploy](../reference/known-issues.md#ssh-local-ui-or-kubernetes-api-unreachable-after-cluster-deploy).
 
-Traefik also carries a load-balancer access control list that restricts which source addresses may reach the console.
-Where that list is narrower than the network an operator works from, the console refuses the connection even though the
-cluster is healthy. Refer to
+The Traefik Service also carries a load-balancer access control list that restricts which source addresses may reach the
+Platform IP. That list is enforced at the load balancer, so a request from a source outside it is rejected before it
+reaches Traefik. Because Traefik fronts both surfaces, a list narrower than the network an operator works from locks
+that host out of the console and the API alike, even though the cluster is healthy. Refer to
 [Appliance console unreachable from the jumpbox after cluster deploy](../reference/known-issues.md#appliance-console-unreachable-from-the-jumpbox-after-cluster-deploy).
 
 The node's operating system serves [Local UI](../reference/glossary.md#local-ui) on port `5080`, rather than the cluster
 serving it, so Local UI sits outside the MetalLB and Traefik path. That separation is why Local UI stays reachable when
 platform services are unavailable, and why it is the surface for install and for platform upgrades.
-
-Cluster traffic and [Piraeus](../reference/glossary.md#piraeus) storage replication share the same bond, which is why
-the appliance aggregates two physical NICs into one logical link instead of bridging them. For that reasoning and the
-field values the bond uses, refer to [Bond, not bridge](./installation-architecture.md#bond-not-bridge).
 
 ## Data Residency and Isolation

--- a/docs/products/paletteai-inference-launchpad/explanation/explanation.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/explanation.md
@@ -14,7 +14,7 @@ They cover design decisions, component relationships, and trade-offs rather than
 
 | **Topic**                                                   | **What you understand**                                                                                          |
 | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| [Architecture Overview](./architecture.md)                  | The component stack, request routing, model provisioning lifecycle, and data residency model.                    |
+| [Architecture Overview](./architecture.md)                  | The component stack, request routing, model provisioning lifecycle, network topology, and data residency model.  |
 | [Model Placement](./model-placement.md)                     | How a model is placed on cluster nodes, when to pin it to a subset, and how the Cluster view reports placement.  |
 | [Vision Preprocessing](./vision-preprocessing.md)           | How a text-only model answers questions about images by converting them to text first.                           |
 | [Clients and Quotas](./clients-and-quotas.md)               | What a client is, how quotas meter usage, and how utilization, consumption, and historical windows are reported. |

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
@@ -81,4 +81,30 @@ appliance sets the default; there is no operator control to change which model i
 
 ## Network Topology
 
+A client reaches a served model over a single address. The **Platform IP Address** set during cluster deployment is an
+unused address that MetalLB assigns to Traefik, and Traefik fronts both the appliance console and the OpenAI-compatible
+API. MetalLB announces that address on the node's bond through the interface selected as the Cilium and MetalLB
+interface, so platform traffic arrives on the bond and is delivered to Traefik. Traefik passes each request to the
+gateway, which authenticates the calling client, applies routing, and forwards the request to the inference engine
+serving the chosen model.
+
+The node keeps its own management address, the Host IP, and the two addresses do different jobs. The Host IP belongs to
+the node and carries SSH, Local UI, and the Kubernetes API. The Platform IP belongs to the cluster load balancer and
+carries the console and the API. Both must be distinct addresses in the same subnet, because setting the Platform IP to
+the Host IP on a single-node appliance makes MetalLB intercept traffic bound for the node's own services. Refer to
+[SSH, Local UI, or Kubernetes API unreachable after cluster deploy](../reference/known-issues.md#ssh-local-ui-or-kubernetes-api-unreachable-after-cluster-deploy).
+
+Traefik also carries a load-balancer access control list that restricts which source addresses may reach the console.
+Where that list is narrower than the network an operator works from, the console refuses the connection even though the
+cluster is healthy. Refer to
+[Appliance console unreachable from the jumpbox after cluster deploy](../reference/known-issues.md#appliance-console-unreachable-from-the-jumpbox-after-cluster-deploy).
+
+The node's operating system serves [Local UI](../reference/glossary.md#local-ui) on port `5080`, rather than the
+cluster serving it, so Local UI sits outside the MetalLB and Traefik path. That separation is why Local UI stays
+reachable when platform services are unavailable, and why it is the surface for install and for platform upgrades.
+
+Cluster traffic and [Piraeus](../reference/glossary.md#piraeus) storage replication share the same bond, which is why
+the appliance aggregates two physical NICs into one logical link instead of bridging them. For that reasoning and the
+field values the bond uses, refer to [Bond, not bridge](./installation-architecture.md#bond-not-bridge).
+
 ## Data Residency and Isolation

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
@@ -83,10 +83,10 @@ appliance sets the default; there is no operator control to change which model i
 
 A client reaches a served model over a single address. The **Platform IP Address** set during cluster deployment is an
 unused address that MetalLB assigns to Traefik, and Traefik fronts both the appliance console and the OpenAI-compatible
-API. MetalLB announces that address on the node's bond through the interface selected as the Cilium and MetalLB
-interface, so platform traffic arrives on the bond and is delivered to Traefik. Traefik passes each request to the
-gateway, which authenticates the calling client, applies routing, and forwards the request to the inference engine
-serving the chosen model.
+API. MetalLB announces that address on the node's [bond](../reference/glossary.md#bond) through the interface selected
+as the Cilium and MetalLB interface, so platform traffic arrives on the bond and is delivered to Traefik. Traefik passes
+each request to the gateway, which authenticates the calling client, applies routing, and forwards the request to the
+inference engine serving the chosen model.
 
 The node keeps its own management address, the Host IP, and the two addresses do different jobs. The Host IP belongs to
 the node and carries SSH, Local UI, and the Kubernetes API. The Platform IP belongs to the cluster load balancer and
@@ -94,17 +94,14 @@ carries the console and the API. Both must be distinct addresses in the same sub
 the Host IP on a single-node appliance makes MetalLB intercept traffic bound for the node's own services. Refer to
 [SSH, Local UI, or Kubernetes API unreachable after cluster deploy](../reference/known-issues.md#ssh-local-ui-or-kubernetes-api-unreachable-after-cluster-deploy).
 
-Traefik also carries a load-balancer access control list that restricts which source addresses may reach the console.
-Where that list is narrower than the network an operator works from, the console refuses the connection even though the
-cluster is healthy. Refer to
+The Traefik Service also carries a load-balancer access control list that restricts which source addresses may reach the
+Platform IP. That list is enforced at the load balancer, so a request from a source outside it is rejected before it
+reaches Traefik. Because Traefik fronts both surfaces, a list narrower than the network an operator works from locks
+that host out of the console and the API alike, even though the cluster is healthy. Refer to
 [Appliance console unreachable from the jumpbox after cluster deploy](../reference/known-issues.md#appliance-console-unreachable-from-the-jumpbox-after-cluster-deploy).
 
-The node's operating system serves [Local UI](../reference/glossary.md#local-ui) on port `5080`, rather than the
-cluster serving it, so Local UI sits outside the MetalLB and Traefik path. That separation is why Local UI stays
-reachable when platform services are unavailable, and why it is the surface for install and for platform upgrades.
-
-Cluster traffic and [Piraeus](../reference/glossary.md#piraeus) storage replication share the same bond, which is why
-the appliance aggregates two physical NICs into one logical link instead of bridging them. For that reasoning and the
-field values the bond uses, refer to [Bond, not bridge](./installation-architecture.md#bond-not-bridge).
+The node's operating system serves [Local UI](../reference/glossary.md#local-ui) on port `5080`, rather than the cluster
+serving it, so Local UI sits outside the MetalLB and Traefik path. That separation is why Local UI stays reachable when
+platform services are unavailable, and why it is the surface for install and for platform upgrades.
 
 ## Data Residency and Isolation

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/explanation.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/explanation.md
@@ -14,7 +14,7 @@ They cover design decisions, component relationships, and trade-offs rather than
 
 | **Topic**                                                   | **What you understand**                                                                                           |
 | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| [Architecture Overview](./architecture.md)                  | The component stack, request routing, model provisioning lifecycle, and data residency model.                     |
+| [Architecture Overview](./architecture.md)                  | The component stack, request routing, model provisioning lifecycle, network topology, and data residency model.   |
 | [Clients and Quotas](./clients-and-quotas.md)               | What a client is, why the appliance serves many clients, and how API tokens and quotas govern usage.              |
 | [Model Certification](./model-certification.md)             | What certified means, how models are certified, and how to choose models for your use case.                       |
 | [Inference Engines](./inference-engines.md)                 | What an inference engine is, automatic engine selection, the supported kinds, and when to override it.            |


### PR DESCRIPTION
**Jira:** [DOC-3208](https://spectrocloud.atlassian.net/browse/DOC-3208)

## Intent

Fix a documentation defect in the PaletteAI Inference Launchpad docs: the architecture page shipped an empty 'Network Topology' heading in both the master tree and the v1.0.x snapshot. Write that section by assembling facts that already exist elsewhere in the docs: the inbound path from the Platform IP through MetalLB and Traefik to the gateway and serving engine, why the Host IP and Platform IP must differ, the load balancer access list that can lock out an administrative host, and why Local UI sits outside that path. Strict Diataxis: this is an explanation page, so keep it conceptual with no procedures. Must comply with the repo style-guide.md. Tracked as DOC-3208.

## What Changed

- Wrote the previously empty `## Network Topology` section on the PaletteAI Inference Launchpad architecture explanation page, covering the inbound path from the Platform IP through MetalLB and Traefik to the gateway and inference engine, why the Host IP and Platform IP must be distinct addresses in the same subnet, how the Traefik load-balancer access control list can lock an operator's host out of both the console and the API, and why the OS-served Local UI on port `5080` sits outside the MetalLB and Traefik path.
- Cross-linked the new section to the existing `bond` and `Local UI` glossary entries and to the two related known-issues entries instead of restating them, keeping the page conceptual with no procedures.
- Updated the "Architecture Overview" row in the explanation index table to list network topology among the topics the page covers.
- Applied all of the above to both the master tree (`docs/products/paletteai-inference-launchpad/`) and the `version-1.0.x` snapshot (`inference-launchpad_versioned_docs/`) so the two stay in sync.

## Risk Assessment

✅ Low: A well-bounded, prose-only documentation addition that satisfies all four required intent facts with valid links and source-backed claims, and whose prior fix round correctly landed both prescribed changes; the residual issues are one version-scoping clause in a de-indexed frozen snapshot and three precision nits, none of which affect product behavior.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"dae7c009096aae95efa548270a9469d7620dd718","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"skipped"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 4 issues (1 warning, 3 infos)</summary>

- ⚠️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:135` - The load-balancer ACL paragraph says the list &#34;restricts which source addresses may reach the console&#34; and that &#34;the console refuses the connection&#34;, but the ACL is `spec.loadBalancerSourceRanges` on the Traefik Service, and this same section&#39;s first paragraph states Traefik fronts &#34;both the appliance console and the OpenAI-compatible API&#34;. Source confirms both share it: `reference/hardware-requirements.md:105` (&#34;443/TCP | Appliance console and API, served by Traefik on the platform IP address&#34;) and `reference/known-issues.md:214` (`https://&lt;platform-ip&gt;/v1/models`). Concrete path: an operator runs an inference client on a jumpbox outside the `/32` range Local UI sets; its POST to `https://&lt;platform-ip&gt;/v1/chat/completions` is rejected at the load balancer before reaching Traefik, exactly as the console is, yet this page attributes the restriction to the console alone, so the reader does not connect their API failure to the access list. The paragraph is scoped narrower than the behavior it explains. Remedy is to say the list gates every source reaching the platform IP, so it can lock out both the console and the API. Flagged ask-user rather than auto-fix because the intent frames this fact as &#34;the load balancer access list that can lock out an administrative host&#34;, so the console-only emphasis may be deliberate. Identical text at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:97.
- ⚠️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:144` - Simplification: the change introduces a fifth paragraph (&#34;Cluster traffic and Piraeus storage replication share the same bond, which is why the appliance aggregates two physical NICs into one logical link instead of bridging them.&#34;) that no intent requirement needs. The intent enumerates exactly four facts to assemble: the inbound Platform IP -&gt; MetalLB -&gt; Traefik -&gt; gateway -&gt; serving engine path, why Host IP and Platform IP must differ, the load balancer access list, and why Local UI sits outside that path. The bond rationale is none of these, and it is a second copy of a rule the docs already define once in `explanation/installation-architecture.md:52-64`, which this very sentence then links to. Recommended remedy is removing the paragraph; if paragraph 1&#39;s mention of &#34;the node&#39;s bond&#34; needs support, the strictly narrower form is the bare pointer to Bond, not bridge without restating its reasoning or the two-NIC aggregation claim. Same paragraph at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:106.
- ℹ️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:126` - Informational, master tree only: the inbound-path sentence ends at &#34;forwards the request to the inference engine serving the chosen model&#34;, while the same page at lines 82-83 documents that routing policy can instead send a request off the appliance to a built-in frontier provider or a registered external inference endpoint as egress. A reader could take the topology description as exhaustive. No action recommended: the intent scopes this section to &#34;the inbound path from the Platform IP through MetalLB and Traefik to the gateway and serving engine&#34;, so omitting egress is intent-conformant, and the v1.0.x snapshot has no egress path to describe.

🔧 Fix applied.
4 issues (1 warning, 3 infos) still open:

- ⚠️ `inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:105` - In the frozen v1.0.x snapshot, the clause &#34;and why it is the surface for install and for platform upgrades&#34; is the only claim in the new section that no fact in that tree supports, contradicting the intent&#39;s &#34;assembling facts that already exist elsewhere in the docs.&#34; Evidence: `grep -rn -i &#34;platform upgrade&#34; inference-launchpad_versioned_docs/version-1.0.x/` returns this new line and nothing else. The v1.0.x glossary entry for Local UI (reference/glossary.md:278-280) lists only &#34;create the bond, link nodes, upload the content bundle, and deploy the cluster&#34; — the master copy at glossary.md:331-334 adds &#34;scale nodes, and apply a platform upgrade&#34;. The v1.0.x tree also has no upgrade-the-platform.md, no manage-cluster-infrastructure.md, and its release-notes.md 1.0.0 Features list omits the &#34;Upgrades the platform from Local UI&#34; bullet that master&#39;s release-notes.md:96 carries; v1.0.x/explanation/installation-architecture.md has no &#34;Day-two cluster operations stay in Local UI&#34; paragraph (master has it at line 46). Concrete path: a reader on the v1.0.x version dropdown is told Local UI is the surface for platform upgrades, then finds no page, procedure, or glossary reference for that flow anywhere in the version they are reading. This also runs against style-guide.md &#34;Future Features&#34; (line 603): &#34;Avoid documenting features, products, or behaviors that are not available at present&#34; — from inside the snapshot nothing establishes the behavior. The defect lives inside a clause the intent does not require (the intent asks only &#34;why Local UI sits outside that path&#34;), so the smallest honest remedy is to drop &#34;and for platform upgrades&#34; from the v1.0.x copy, leaving &#34;and why it is the surface for install&#34;; master line 143 is correct as written and should keep the clause. Flagged ask-user because the remedy diverges the two copies the author deliberately kept identical, and because it is user-visible product-behavior text.
- ℹ️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:142` - &#34;That separation is why Local UI stays reachable when platform services are unavailable&#34; is stated without qualification, but how-to-guides/install-the-appliance.md:420 documents the opposite for the main platform operation: &#34;During deployment, Traefik and Local UI restart alongside the packs, so the browser may display a **\&#34;Your service is temporarily unavailable\&#34;** page more than once.&#34; Concrete path: an operator whose console is down during a deploy or platform upgrade reads this page, treats Local UI as a guaranteed lifeline, and instead hits the temporarily-unavailable page the install guide already warns about, with no pointer back to that warning. Nothing in either tree asserts the unqualified reachability property; the supportable underlying fact is the one the sentence already states — the edge OS serves Local UI, not the cluster (glossary.md:331). Suggested remedy is to scope the claim, for example to Local UI not depending on the cluster&#39;s load-balancer path, rather than to a blanket availability guarantee. Same sentence at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:104.
- ℹ️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:129` - The master copy of the section is written entirely in the singular — &#34;MetalLB announces that address on the node&#39;s bond&#34; (line 124), &#34;The node keeps its own management address&#34; (line 129), &#34;The node&#39;s operating system serves Local UI&#34; (line 141) — while the master tree documents multi-server clusters as supported: architecture.md:27 (&#34;Multi-server clusters are possible: you choose which nodes run each model&#34;), install-the-appliance.md:201 (&#34;Every host must have a static IP, a Local UI login, and its own bond&#34;), and manage-cluster-infrastructure.md:20 (&#34;Sign in to Local UI on the leader node&#34;). Concrete path: an operator running a three-node cluster reads this topology section, finds three Host IPs where the page describes one, and gets no statement of which node MetalLB announces the Platform IP from or which node&#39;s Local UI to use. Note the section already qualifies the one place it matters for the failure mode (&#34;on a single-node appliance&#34;, line 132), which makes the unqualified singular elsewhere read as an oversight rather than a deliberate scope. The v1.0.x copy needs no change: that release is single-node only (v1.0.x architecture.md:27). Flagged ask-user because narrowing or generalizing the framing is a scope decision about the page.
- ℹ️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:124` - &#34;MetalLB announces that address on the node&#39;s [bond] through the interface selected as the Cilium and MetalLB interface&#34; presents the bond and the selected interface as two different things joined by &#34;through&#34;, but reference/profile-variables.md:32 defines them as the same object: the **Cilium and MetalLB interface** is the &#34;Host NIC that Cilium and MetalLB use to advertise the Platform IP Address on the local network. Select the bond that carries the node&#39;s management IP.&#34; As written the sentence resolves to &#34;announces on the bond through the bond&#34;. Concrete path: a reader parses &#34;through the interface selected as...&#34; as a second, distinct NIC and goes looking in the wizard for an interface separate from the bond they created. The narrower form that satisfies the intent is a single identification, for example naming the bond as the interface the operator selects as the **Cilium and MetalLB interface**, rather than chaining the two. Same sentence at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:86.
</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:52` - Follow-up, out of scope for DOC-3208: the architecture page still ships two empty `##` headings in both trees, the same defect class this change fixed for Network Topology. `## Appliance and Cluster Formation` (master line 52, v1.0.x line 51) is followed immediately by the next heading, and `## Data Residency and Isolation` is the last line of both files with no body at all. Both render as bare headings with no content, and both are listed in reader-facing summaries: the page&#39;s own frontmatter `description` promises the component stack and data flow, and `explanation/explanation.md:17` advertises &#34;data residency model&#34; as something the page explains. The intent for this change scopes it to Network Topology only, and writing the other two sections is substantive authoring rather than housekeeping, so I did not touch them. Recommend a separate ticket to fill both, mirroring the approach used here of assembling facts already owned elsewhere (installation-architecture.md and the glossary cover much of the cluster-formation material). Same headings at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:51 and :107.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

[DOC-3208]: https://spectrocloud.atlassian.net/browse/DOC-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ