### PR TITLE
DOC-3207: Write the Data Residency section in the architecture page

### DIFF
--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -2,12 +2,12 @@
 sidebar_label: "Architecture Overview"
 title: "PaletteAI Inference Launchpad Architecture Overview"
 description:
-  "An explanation of the PaletteAI Inference Launchpad architecture, including its component stack, data flow, and
-  network topology."
+  "An explanation of the PaletteAI Inference Launchpad architecture, including its component stack, data flow, network
+  topology, and data residency model."
 hide_table_of_contents: false
 sidebar_position: 1
 tags: ["paletteai-inference-launchpad", "architecture", "explanation"]
-keywords: ["launchpad", "ai", "architecture", "kubernetes", "kairos", "helm", "data flow"]
+keywords: ["launchpad", "ai", "architecture", "kubernetes", "kairos", "helm", "data flow", "data residency"]
 ---
 
 This page explains how PaletteAI Inference Launchpad works, how its components interact, and what key decisions shaped

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -152,10 +152,10 @@ for the whole appliance rather than one client at a time. Refer to
 [Sovereignty and Egress](./clients-and-quotas.md#sovereignty-and-egress).
 
 The **Usage** page labels traffic that left the appliance **Egress** and meters it in tokens and cost rather than in
-request counts, so an operator can see what share of the total went off the box. Refer to
+request counts, so an operator can review what share of the total went off the box. Refer to
 [Usage Metrics Reference](../reference/usage-metrics-reference.md).
 
-The appliance needs no outbound internet access to install or to run day to day, so an appliance whose clients all have
-egress disabled answers every request without reaching a network beyond your own. The residency guarantee is therefore
-an operator-controlled one rather than a physical one. The appliance is capable of reaching an external host, and it
-does so only where an operator has allowed it.
+The appliance needs no outbound internet access to install or to run day to day, so an appliance on which no client has
+egress enabled answers every request without reaching a network beyond your own. The residency guarantee is therefore an
+operator-controlled one rather than a physical one. The appliance is capable of reaching an external host, and it does
+so only where an operator has allowed it.

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -136,23 +136,19 @@ Once an operator enables egress, a client can reach two kinds of destination:
 - A registered [external inference endpoint](#external-inference-endpoints), which is any OpenAI-compatible host an
   operator has added to the appliance.
 
-Egress is not only a destination a client asks for. When the appliance is at capacity, a request that asked for local
-serving can go to an external provider instead, which the **Usage** page reports as capacity spill. Naming a local model
-is therefore not on its own what keeps a prompt on the box.
-
-<!-- vale off -->
-
-{/* NEEDS REVIEW: the Usage page documents a capacity-spill tile, but no source states whether capacity spill honors a client's egress setting. A subject-matter expert should confirm that interaction before this page publishes. */}
-
-<!-- vale on -->
+Egress is not only a destination a client asks for. An operator can arm frontier-model bursting for a client, which
+sends a request that asked for local serving to an external provider once the client exhausts its local quota rather
+than refusing it. Naming a local model is therefore not on its own what keeps a prompt on the box. Bursting is still
+egress and runs through the same permission, so a client that cannot reach an external destination cannot burst to one
+either.
 
 Sovereignty sits above the per-client controls as an appliance-wide switch that overrides every client's egress. While
 it is armed, no request leaves the box regardless of what any client is permitted to do, so an operator holds residency
 for the whole appliance rather than one client at a time. Refer to
 [Sovereignty and Egress](./clients-and-quotas.md#sovereignty-and-egress).
 
-The **Usage** page reports locally served and off-box traffic as separate figures rather than summing them, so an
-operator can review what share of the total went off the box. Refer to
+The **Usage** page reports what share of traffic stayed on the appliance and what share went off the box, and it pairs
+the two per client rather than summing them into one figure. Refer to
 [Usage Metrics Reference](../reference/usage-metrics-reference.md).
 
 The appliance needs no outbound internet access to install or to run day to day, so an appliance on which no client has

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -120,3 +120,26 @@ refer to [Register an External Inference Endpoint](../how-to-guides/register-an-
 ## Network Topology
 
 ## Data Residency and Isolation
+
+Inference runs on the appliance, so a request and the model that answers it stay inside your environment by default.
+Nothing about a prompt leaves the appliance unless an operator gives a client permission to send it elsewhere.
+
+That permission is [egress](../reference/glossary.md#egress), and it denies by default. A new client cannot reach any
+destination outside the appliance until an operator enables it. Refer to
+[Manage a Client's Model Access](../how-to-guides/manage-client-model-access.md).
+
+Once an operator enables egress, a client can reach two kinds of destination:
+
+- A built-in [frontier model](../reference/glossary.md#frontier-model) served by `anthropic`, `openai`, or `gemini`.
+
+- A registered [external inference endpoint](#external-inference-endpoints), which is any OpenAI-compatible host an
+  operator has added to the appliance.
+
+The **Usage** view labels both kinds of traffic **Egress**, so an operator can confirm from the console whether any
+request left the appliance and what share of the total it represented. Refer to
+[Usage Metrics Reference](../reference/usage-metrics-reference.md).
+
+The appliance needs no outbound internet access to install or to run day to day, so an appliance whose clients all have
+egress disabled answers every request without reaching a network beyond your own. The residency guarantee is therefore
+an operator-controlled one rather than a physical one. The appliance is capable of reaching an external host, and it
+does so only where an operator has allowed it.

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -151,8 +151,8 @@ it is armed, no request leaves the box regardless of what any client is permitte
 for the whole appliance rather than one client at a time. Refer to
 [Sovereignty and Egress](./clients-and-quotas.md#sovereignty-and-egress).
 
-The **Usage** page labels traffic that left the appliance **Egress** and meters it in tokens and cost rather than in
-request counts, so an operator can review what share of the total went off the box. Refer to
+The **Usage** page reports locally served and off-box traffic as separate figures rather than summing them, so an
+operator can review what share of the total went off the box. Refer to
 [Usage Metrics Reference](../reference/usage-metrics-reference.md).
 
 The appliance needs no outbound internet access to install or to run day to day, so an appliance on which no client has

--- a/docs/products/paletteai-inference-launchpad/explanation/architecture.md
+++ b/docs/products/paletteai-inference-launchpad/explanation/architecture.md
@@ -130,13 +130,29 @@ destination outside the appliance until an operator enables it. Refer to
 
 Once an operator enables egress, a client can reach two kinds of destination:
 
-- A built-in [frontier model](../reference/glossary.md#frontier-model) served by `anthropic`, `openai`, or `gemini`.
+- A built-in [frontier model](../reference/glossary.md#frontier-model), which is a model hosted by an external provider
+  rather than served from the appliance.
 
 - A registered [external inference endpoint](#external-inference-endpoints), which is any OpenAI-compatible host an
   operator has added to the appliance.
 
-The **Usage** view labels both kinds of traffic **Egress**, so an operator can confirm from the console whether any
-request left the appliance and what share of the total it represented. Refer to
+Egress is not only a destination a client asks for. When the appliance is at capacity, a request that asked for local
+serving can go to an external provider instead, which the **Usage** page reports as capacity spill. Naming a local model
+is therefore not on its own what keeps a prompt on the box.
+
+<!-- vale off -->
+
+{/* NEEDS REVIEW: the Usage page documents a capacity-spill tile, but no source states whether capacity spill honors a client's egress setting. A subject-matter expert should confirm that interaction before this page publishes. */}
+
+<!-- vale on -->
+
+Sovereignty sits above the per-client controls as an appliance-wide switch that overrides every client's egress. While
+it is armed, no request leaves the box regardless of what any client is permitted to do, so an operator holds residency
+for the whole appliance rather than one client at a time. Refer to
+[Sovereignty and Egress](./clients-and-quotas.md#sovereignty-and-egress).
+
+The **Usage** page labels traffic that left the appliance **Egress** and meters it in tokens and cost rather than in
+request counts, so an operator can see what share of the total went off the box. Refer to
 [Usage Metrics Reference](../reference/usage-metrics-reference.md).
 
 The appliance needs no outbound internet access to install or to run day to day, so an appliance whose clients all have

--- a/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
+++ b/docs/products/paletteai-inference-launchpad/paletteai-inference-launchpad.md
@@ -18,9 +18,10 @@ PaletteAI Inference Launchpad turns your own hardware into a private AI platform
 are serving large language models (LLMs) in your own environment, with no cloud dependency, no AI consulting engagement,
 and no weeks spent wiring together an inference stack.
 
-Because inference runs on the appliance, your data never leaves your environment, and unpredictable per-token API bills
-become a fixed, predictable infrastructure cost. The appliance deploys as a single bootable image with no Palette or
-PaletteAI dependency.
+Because inference runs on the appliance, your data stays in your environment by default, and unpredictable per-token API
+bills become a fixed, predictable infrastructure cost. The appliance deploys as a single bootable image with no Palette
+or PaletteAI dependency. For the conditions under which a request can leave the appliance, refer to
+[Data Residency and Isolation](./explanation/architecture.md#data-residency-and-isolation).
 
 ## The Problem It Solves
 

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
@@ -104,8 +104,8 @@ is therefore not on its own what keeps a prompt on the box.
 
 <!-- vale on -->
 
-The **Usage** page labels traffic that left the appliance **Egress** and meters it in tokens and cost rather than in
-request counts, so an operator can review what share of the total went off the box. Refer to
+The **Usage** page reports locally served and off-box traffic as separate figures rather than summing them, so an
+operator can review what share of the total went off the box. Refer to
 [Usage Metrics Reference](../reference/usage-metrics-reference.md).
 
 The appliance needs no outbound internet access to install or to run day to day, so an appliance on which no client has

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
@@ -105,10 +105,10 @@ is therefore not on its own what keeps a prompt on the box.
 <!-- vale on -->
 
 The **Usage** page labels traffic that left the appliance **Egress** and meters it in tokens and cost rather than in
-request counts, so an operator can see what share of the total went off the box. Refer to
+request counts, so an operator can review what share of the total went off the box. Refer to
 [Usage Metrics Reference](../reference/usage-metrics-reference.md).
 
-The appliance needs no outbound internet access to install or to run day to day, so an appliance whose clients all
-have egress disabled answers every request without reaching a network beyond your own. The residency guarantee is
-therefore an operator-controlled one rather than a physical one. The appliance is capable of reaching an external host,
-and it does so only where an operator has allowed it.
+The appliance needs no outbound internet access to install or to run day to day, so an appliance on which no client has
+egress enabled answers every request without reaching a network beyond your own. The residency guarantee is therefore an
+operator-controlled one rather than a physical one. The appliance is capable of reaching an external host, and it does
+so only where an operator has allowed it.

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
@@ -2,12 +2,12 @@
 sidebar_label: "Architecture Overview"
 title: "PaletteAI Inference Launchpad Architecture Overview"
 description:
-  "An explanation of the PaletteAI Inference Launchpad architecture, including its component stack, data flow, and
-  network topology."
+  "An explanation of the PaletteAI Inference Launchpad architecture, including its component stack, data flow, network
+  topology, and data residency model."
 hide_table_of_contents: false
 sidebar_position: 1
 tags: ["paletteai-inference-launchpad", "architecture", "explanation"]
-keywords: ["launchpad", "ai", "architecture", "kubernetes", "kairos", "helm", "data flow"]
+keywords: ["launchpad", "ai", "architecture", "kubernetes", "kairos", "helm", "data flow", "data residency"]
 ---
 
 This page explains how PaletteAI Inference Launchpad works, how its components interact, and what key decisions shaped

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
@@ -94,8 +94,18 @@ Once an operator enables egress, a client can reach a built-in
 [frontier model](../reference/glossary.md#frontier-model), which is a model hosted by an external provider rather than
 served from the appliance.
 
-The **Usage** view labels that traffic **Egress**, so an operator can confirm from the console whether any request left
-the appliance and what share of the total it represented. Refer to
+Egress is not only a destination a client asks for. When the appliance is at capacity, a request that asked for local
+serving can go to an external provider instead, which the **Usage** page reports as capacity spill. Naming a local model
+is therefore not on its own what keeps a prompt on the box.
+
+<!-- vale off -->
+
+{/* NEEDS REVIEW: the Usage page documents a capacity-spill tile, but no source states whether capacity spill honors a client's egress setting. A subject-matter expert should confirm that interaction before this page publishes. */}
+
+<!-- vale on -->
+
+The **Usage** page labels traffic that left the appliance **Egress** and meters it in tokens and cost rather than in
+request counts, so an operator can see what share of the total went off the box. Refer to
 [Usage Metrics Reference](../reference/usage-metrics-reference.md).
 
 The appliance needs no outbound internet access to install or to run day to day, so an appliance whose clients all

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
@@ -82,3 +82,23 @@ appliance sets the default; there is no operator control to change which model i
 ## Network Topology
 
 ## Data Residency and Isolation
+
+Inference runs on the appliance, so a request and the model that answers it stay inside your environment by default.
+Nothing about a prompt leaves the appliance unless an operator gives a client permission to send it elsewhere.
+
+That permission is [egress](../reference/glossary.md#egress), and it denies by default. A new client cannot reach any
+destination outside the appliance until an operator enables it. Refer to
+[Manage a Client's Model Access](../how-to-guides/manage-client-model-access.md).
+
+Once an operator enables egress, a client can reach a built-in
+[frontier model](../reference/glossary.md#frontier-model), which is a model hosted by an external provider rather than
+served from the appliance.
+
+The **Usage** view labels that traffic **Egress**, so an operator can confirm from the console whether any request left
+the appliance and what share of the total it represented. Refer to
+[Usage Metrics Reference](../reference/usage-metrics-reference.md).
+
+The appliance needs no outbound internet access to install or to run day to day, so an appliance whose clients all
+have egress disabled answers every request without reaching a network beyond your own. The residency guarantee is
+therefore an operator-controlled one rather than a physical one. The appliance is capable of reaching an external host,
+and it does so only where an operator has allowed it.

--- a/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md
@@ -94,18 +94,14 @@ Once an operator enables egress, a client can reach a built-in
 [frontier model](../reference/glossary.md#frontier-model), which is a model hosted by an external provider rather than
 served from the appliance.
 
-Egress is not only a destination a client asks for. When the appliance is at capacity, a request that asked for local
-serving can go to an external provider instead, which the **Usage** page reports as capacity spill. Naming a local model
-is therefore not on its own what keeps a prompt on the box.
+Egress is not only a destination a client asks for. An operator can arm frontier-model bursting for a client, which
+sends a request that asked for local serving to an external provider once the client exhausts its local quota rather
+than refusing it. Naming a local model is therefore not on its own what keeps a prompt on the box. Bursting is still
+egress and runs through the same permission, so a client that cannot reach an external destination cannot burst to one
+either.
 
-<!-- vale off -->
-
-{/* NEEDS REVIEW: the Usage page documents a capacity-spill tile, but no source states whether capacity spill honors a client's egress setting. A subject-matter expert should confirm that interaction before this page publishes. */}
-
-<!-- vale on -->
-
-The **Usage** page reports locally served and off-box traffic as separate figures rather than summing them, so an
-operator can review what share of the total went off the box. Refer to
+The **Usage** page reports what share of traffic stayed on the appliance and what share went off the box, and it pairs
+the two per client rather than summing them into one figure. Refer to
 [Usage Metrics Reference](../reference/usage-metrics-reference.md).
 
 The appliance needs no outbound internet access to install or to run day to day, so an appliance on which no client has

--- a/inference-launchpad_versioned_docs/version-1.0.x/paletteai-inference-launchpad.md
+++ b/inference-launchpad_versioned_docs/version-1.0.x/paletteai-inference-launchpad.md
@@ -18,9 +18,10 @@ PaletteAI Inference Launchpad turns your own hardware into a private AI platform
 are serving large language models (LLMs) in your own environment, with no cloud dependency, no AI consulting engagement,
 and no weeks spent wiring together an inference stack.
 
-Because inference runs on the appliance, your data never leaves your environment, and unpredictable per-token API bills
-become a fixed, predictable infrastructure cost. The appliance deploys as a single bootable image with no Palette or
-PaletteAI dependency.
+Because inference runs on the appliance, your data stays in your environment by default, and unpredictable per-token API
+bills become a fixed, predictable infrastructure cost. The appliance deploys as a single bootable image with no Palette
+or PaletteAI dependency. For the conditions under which a request can leave the appliance, refer to
+[Data Residency and Isolation](./explanation/architecture.md#data-residency-and-isolation).
 
 ## The Problem It Solves
 


### PR DESCRIPTION
**Jira:** [DOC-3207](https://spectrocloud.atlassian.net/browse/DOC-3207)

## Intent

Fix a documentation defect in the PaletteAI Inference Launchpad docs: the architecture page shipped an empty 'Data Residency and Isolation' heading in both the master tree and the v1.0.x snapshot, while the explanation index already advertised the page as covering a data residency model. Write that section, stating the residency guarantee together with its egress qualifier, because a client with egress enabled genuinely does send prompts off the appliance. Strict Diataxis: this is an explanation page, so keep it conceptual with no procedures. Must comply with the repo style-guide.md. Tracked as DOC-3207.

## What Changed

- Filled the previously empty `## Data Residency and Isolation` heading on the Inference Launchpad architecture explanation page with conceptual prose: inference and prompts stay on the appliance by default, per-client egress denies by default and is the only way a prompt leaves, capacity spill can send a locally-targeted request to an external provider, appliance-wide sovereignty overrides every client's egress, and the **Usage** page meters egress traffic in tokens and cost — closing with the guarantee being operator-controlled rather than physical. Cross-links the egress and frontier-model glossary entries, the client model-access how-to, the sovereignty section, and the usage metrics reference; no procedures were added.
- Added the same section to the `version-1.0.x` snapshot, scoped down to what that release documents: frontier models as the only egress destination, with the external-inference-endpoint destination and the sovereignty override omitted.
- Left a Vale-suppressed `NEEDS REVIEW` MDX comment in both copies noting that no source states whether capacity spill honors a client's egress setting, for subject-matter-expert confirmation before publish.

## Corrections After Review

Verified against the product source at `launchpad-ai`, which changed three things:

- **Spill trigger.** Bursting fires when a client exhausts its **local quota**, not when the appliance is at hardware capacity. `gateway/pkg/core/destination.go:37` defines `ReasonBurst` as frontier reached "because the local budget was spent and the overflow policy authorised going out", and `gateway/pkg/frontier/types.go:67` defines `FrontierOverflow` as a per-consumer "burst to frontier when local quota is exhausted" policy. The UI tile is *labelled* "spilled at capacity", which is where the original framing came from.
- **The open question is answered, so the `NEEDS REVIEW` flag is gone.** Bursting is opt-in (`Enabled=false` is the zero value, leaving plain 429-on-quota) and lives inside the client's egress policy, so a client without egress cannot burst. That also resolves the contradiction the risk assessment flagged between the section's opening and closing guarantees.
- **Usage metering.** Dropped the claim that off-box traffic is metered in tokens and cost rather than request counts; the product counts egress requests. The text now states only that local and off-box figures are paired rather than summed, and avoids naming an on-screen label that reads `Egress` on **By Model** but `Frontier` on the client columns.

The landing page edit is deliberate and in scope: it carried an unqualified "your data never leaves your environment", which this section would otherwise contradict. Verified to merge cleanly with #11949 and #11948.

## Risk Assessment

⚠️ Medium: Documentation-only change that satisfies every stated intent constraint with all links, anchors, version scoping, and factual claims verified against sources, but the section's opening and closing absolute residency guarantees were never reconciled with the capacity-spill caveat the fix round inserted between them, and the docset's own frontier-bursting statements suggest the closing guarantee is wrong rather than merely unverified on a compliance-sensitive page.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e1865473eaf100809b81312fa7935bcbee0d4bbc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"skipped"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 3 issues (2 warnings, 1 info)</summary>

- ⚠️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:142` - The residency model is attributed entirely to per-client egress (&#34;Nothing about a prompt leaves the appliance unless an operator gives a client permission to send it elsewhere&#34;, line 125; &#34;an appliance whose clients all have egress disabled answers every request without reaching a network beyond your own&#34;, line 142), but explanation/clients-and-quotas.md:161-165 documents an appliance-wide Sovereignty switch that &#34;overrides every client&#39;s egress&#34; so that &#34;no request leaves the box regardless of any client&#39;s permission&#34;, and how-to-guides/register-an-external-inference-endpoint.md:26 treats &#34;Sovereignty must not be armed&#34; as a hard prerequisite for egress. Concrete case: sovereignty armed, a client with egress enabled and a frontier rule authored -- the section&#39;s stated condition is satisfied yet no prompt leaves, and conversely a compliance reader is never told the box-wide control exists, so they believe residency can only be held by auditing every client individually. The section is the page the explanation index advertises as covering the data residency model, so this is the canonical home for that control. Remedy is a content-scope decision (state the sovereignty override, or cross-reference clients-and-quotas.md#sovereignty-and-egress) rather than a mechanical correction, so it needs the author&#39;s call. Master tree only: the v1.0.x snapshot does not document sovereignty anywhere, so its section is correct as written.
- ⚠️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:138` - &#34;an operator can confirm from the console whether any request left the appliance&#34; points the reader at a figure that is documented never to report egress. reference/usage-metrics-reference.md:73, identical in both trees, states &#34;The egress meter records tokens and cost but not a request count, so the external request count always reads 0.&#34; Concrete case: prompts route to a frontier provider all week; an operator follows this sentence to the By Client tab and reads Local / Egress Requests as &#34;1.2K / 0&#34; (usage-metrics-reference.md:134) and concludes nothing left the appliance, while the egress token and cost tiles show otherwise. The share claim is supported only in tokens (&#34;routed externally&#34;, line 69), not requests. The smallest honest remedy is to drop the verification sentence, since the stated intent requires the guarantee plus its egress qualifier and not a console-verification pointer; if the pointer is kept, it must be phrased in tokens and cost rather than requests. Same defect at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:97.
- ⚠️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:131` - The section frames off-box traffic only as destinations &#34;a client can reach&#34; once an operator enables egress, but reference/usage-metrics-reference.md:71 (identical in both trees) documents a &#34;spilled at capacity&#34; tile: &#34;The share of requests that asked for local serving and went to an external provider because the appliance was at capacity.&#34; Concrete case: a client has egress enabled so it can use a frontier model for complex prompts; the appliance saturates; a request that explicitly named a local model is sent to an external provider. A reader of this section concludes that naming a local model keeps the prompt on the box, which the spill tile contradicts. This is exactly the egress qualifier the intent asks to state, and the stated qualifier is narrower than the shipped behavior. Whether spill is itself gated on the client&#39;s egress flag is not documented anywhere in the docset, so the remedy needs the author or an SME: state the spill qualifier, or add the repo&#39;s {/* NEEDS REVIEW ... */} note as done at explanation/routing-behavior.md:188. Same gap at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:93.
- ⚠️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:133` - Simplification: the component introduced here is the provider-id enumeration &#34;served by `anthropic`, `openai`, or `gemini`&#34;. No intent requirement needs it -- the intent requires the residency guarantee and its egress qualifier -- and it is a second copy of the provider set already defined on this same page at line 102-103, where the ids exist for a specific reason (an endpoint id &#34;cannot collide with a built-in frontier provider&#34;). The docset otherwise names these providers in prose form, not as identifiers (explanation/thinking-directive.md:70-72, &#34;Anthropic frontier models&#34;, &#34;OpenAI frontier models&#34;), so this list reads as an identifier set that must now be kept in sync in two places on one page. The narrower form that satisfies the intent is the bullet without the id list: &#34;A built-in frontier model.&#34; Recommend removing the enumeration rather than documenting or maintaining it.
- ℹ️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:138` - &#34;The **Usage** view&#34; names a console surface the rest of this docset consistently calls the **Usage** page, including the reference page this sentence links to (reference/usage-metrics-reference.md:13, &#34;every filter, metric, and column on the **Usage** page of the appliance console&#34;) and the sibling explanation page (explanation/routing-behavior.md:175 and :180). The only other &#34;Usage view&#34; in the product docs is release-notes.md:63. Mechanical consistency fix, &#34;view&#34; to &#34;page&#34;, in both files: same wording at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:97.
- ℹ️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:120` - Informational, no action for this change. The same page still ships two empty H2 headings of the defect class DOC-3207 fixes: &#34;Appliance and Cluster Formation&#34; (line 52) and &#34;Network Topology&#34; (line 120), the latter immediately above the new section; both are also empty in the v1.0.x snapshot (lines 51 and 82). Pre-existing and outside the stated intent, which scopes this change to the data residency section only. Noted so the remaining placeholders are not mistaken for something this change introduced or was expected to fill.

🔧 Fix applied.
3 issues (2 warnings, 1 info) still open:

- ⚠️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:158` - The fix round added a capacity-spill caveat in the middle of the section but left the section&#39;s opening and closing absolute guarantees conditioned solely on per-client egress, so the published prose now asserts both things at once. Opening (line 125): &#34;Nothing about a prompt leaves the appliance unless an operator gives a client permission to send it elsewhere.&#34; Closing (lines 158-161): &#34;an appliance whose clients all have egress disabled answers every request without reaching a network beyond your own... The appliance is capable of reaching an external host, and it does so only where an operator has allowed it.&#34; Middle (lines 139-141): a request that asked for local serving &#34;can go to an external provider instead.&#34; Worse, independent sources indicate the closing guarantee is likely false rather than merely unverified: how-to-guides/manage-client-model-access.md:84 states &#34;Frontier-model bursting is configured separately and is out of scope for this guide&#34; -- said inside the section that documents enabling per-client egress, i.e. bursting is configured outside the per-client egress toggle -- and release-notes.md:131 frames it as an appliance capability (&#34;Grants every client access to all local models, and can burst to external frontier models&#34;), as does release-notes.md:14 (&#34;bursts to external endpoints&#34;). Concrete case: an operator on a compliance-constrained appliance disables egress for every client, reads the closing paragraph, and concludes no prompt can reach an external network. If spill/bursting is not gated on the client&#39;s egress flag, that conclusion is wrong and the reader gets no signal, because MDX comments are stripped from the rendered page so the NEEDS REVIEW note at line 145 is invisible to them. This is the section&#39;s concluding summary and the sentence a compliance reader will quote. It also regresses to the per-client framing three paragraphs after the section itself establishes sovereignty as the control that &#34;holds residency for the whole appliance rather than one client at a time.&#34; Remedy is a content decision, not a mechanical correction: qualify the opening and closing guarantees with the spill caveat, or anchor the closing guarantee to sovereignty (master only), or widen the NEEDS REVIEW note to state that the closing guarantee itself is pending SME confirmation. Same defect at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:111, with the opening at line 87; the v1.0.x tree has the same bursting statement at how-to-guides/manage-client-model-access.md:74 and release-notes.md:59, and has no sovereignty to fall back on.
- ⚠️ `docs/products/paletteai-inference-launchpad/explanation/architecture.md:145` - The NEEDS REVIEW note the fix round added asserts &#34;no source states whether capacity spill honors a client&#39;s egress setting.&#34; That premise is contradicted by the docset. how-to-guides/manage-client-model-access.md:84 states &#34;Frontier-model bursting is configured separately and is out of scope for this guide,&#34; and line 85 carries a pending {/* TODO: link to the frontier-model bursting guide once published. */}; release-notes.md:131 and :14 both describe bursting to external frontier models/endpoints as an appliance-level capability rather than a per-client grant. Concrete consequence: the SME who picks this note up is told the gap is total and starts from scratch, when the docset already has a separately-configured frontier-bursting mechanism and an unwritten guide for it sitting directly on the per-client egress page. The note also never asks the question that actually decides the section&#39;s guarantees -- whether &#34;capacity spill&#34; (reference/usage-metrics-reference.md:71, the only source for spill anywhere in the docset) and &#34;frontier-model bursting&#34; are the same mechanism. If they are, spill is not egress-gated and the guarantees flagged in the preceding finding are wrong as written. Remedy is a content/SME-routing decision: rewrite the note to cite manage-client-model-access.md:84-85 as the lead and to ask whether spill and bursting are one mechanism. Same note at inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:103, where the corresponding sources are how-to-guides/manage-client-model-access.md:74-75 and release-notes.md:59.
- ℹ️ `inference-launchpad_versioned_docs/version-1.0.x/explanation/architecture.md:101` - Informational, no action needed. The &lt;!-- vale off --&gt; / &lt;!-- vale on --&gt; pair the fix round wrapped around the NEEDS REVIEW note is inert in this file: .vale.ini sets `BasedOnStyles =` (empty) for the [*_versioned_docs/**] scope, with the comment &#34;Frozen product-doc archives are shipped output... so no styles run there,&#34; so no Vale style can fire inside the versioned tree regardless. In the master copy (docs/products/paletteai-inference-launchpad/explanation/architecture.md:143-147) the wrapper is live and matches the precedent at explanation/routing-behavior.md:188, which round 1 cited. Worth noting only so the two copies&#39; wrappers are understood as parity rather than as two working suppressions; the other ~43 NEEDS REVIEW notes in this docset carry no wrapper at all.
</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `docs/products/paletteai-inference-launchpad/how-to-guides/install-the-appliance.md:413` - Informational, no action taken. The Vale sweep surfaced two pre-existing error-level alerts in an untouched file: Vale.Spelling on &#39;QA&#39;s&#39; (line 413) and on &#39;repos&#39; (line 538). Both predate this change and live outside the changed files, so fixing them is out of scope for this pass. They are currently invisible to CI because `make check-writing` runs Vale only on files changed against master, so they will surface the next time that guide is edited. Resolving them means either rewording or adding the terms to the spectrocloud-vocab accept list. Noted so they are not mistaken for something this change introduced.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

[DOC-3207]: https://spectrocloud.atlassian.net/browse/DOC-3207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ