### PR TITLE
fix: make the patch release notes due date optional

### DIFF
--- a/.github/workflows/generate_patch_release_notes.yaml
+++ b/.github/workflows/generate_patch_release_notes.yaml
@@ -14,6 +14,9 @@ on:
       patch_version:
         description: "Palette patch release version, for example 4.9.48. Use a placeholder such as 4.9.x while it is undecided. Empty takes the version from the candidates JQL."
         required: false
+      patch_release_date:
+        description: "Palette patch release date as YYYY-MM-DD, for example 2026-09-14. Empty takes the date from the candidates JQL, or records it as PENDING when that JQL has no due date."
+        required: false
       component_updates:
         description: "Tick when this patch adds a new CanvOS or Palette CLI version, or both. Leave clear to generate the release notes body only, in which case the fields below are ignored."
         required: false
@@ -91,6 +94,7 @@ jobs:
           # nickfury repository that holds the component versions, so use the Vault token here.
           GITHUB_TOKEN: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
           PATCH_RELEASE_VERSION: ${{ github.event.inputs.patch_version }}
+          PATCH_RELEASE_DATE: ${{ github.event.inputs.patch_release_date }}
           NICKFURY_REF: ${{ github.event.inputs.nickfury_ref }}
           PATCH_PALETTE_CLI_SHA: ${{ github.event.inputs.palette_cli_sha }}
           PATCH_PALETTE_CLI_ARM64_SHA: ${{ github.event.inputs.palette_cli_arm64_sha }}

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -378,6 +378,7 @@ skipped when its environment variable is already set.
 | **Question**                                                      | **Answer**                                                                         | **Environment Variable**      |
 | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------- |
 | Do you know the Palette patch release version?                    | Yes, give the version. No, give a placeholder such as `4.9.x`.                     | `PATCH_RELEASE_VERSION`       |
+| The Palette patch release date                                    | Give it as `YYYY-MM-DD`, or leave it empty to record the date as pending.          | `PATCH_RELEASE_DATE`          |
 | Does this patch add a new CanvOS or Palette CLI version, or both? | No, only the release notes body is generated and no other page is touched.         | `PATCH_COMPONENT_UPDATES`     |
 | Do you know the nickfury branch or tag name?                      | Yes, give the name. No, the pending markers are used instead.                      | `NICKFURY_REF`                |
 | The Linux AMD64 Palette CLI checksum                              | Paste it from ReTool, type `derive`, or leave it empty to record it as pending.    | `PATCH_PALETTE_CLI_SHA`       |
@@ -400,6 +401,13 @@ A patch ticket often names its `fixVersion` as a placeholder such as `4.9.x`, so
 prompt heads the new section. A placeholder is a valid answer, and pressing Enter accepts the one the candidates JQL
 reported. Re-running the target on the same ticket refreshes the section, including its heading, so you can draft the
 notes before the version is decided and re-run once it is confirmed.
+
+The section heading is dated from the end of the due date window that the candidates JQL searches. A ticket whose JQL
+searches on something else, or whose due date is not set yet, leaves the date unknown, so the target asks you for it.
+Leaving that answer empty heads the section with a `DATE PENDING` marker rather than stopping, and because a later run
+refreshes the heading, the run you make once the date is known replaces the marker. The target reads both spellings of
+the due date field, `due` and `duedate`, and both shapes of the `fixVersion` clause, a single value and a list, so a
+candidates link written either way is understood.
 
 Each generated section records the version it was built for in a `<!-- PATCH RELEASE VERSION: ... -->` comment. When a
 later run confirms a different version, the target removes the rows the earlier run wrote for the old one, so a

--- a/scripts/release/generate-patch-release-notes.sh
+++ b/scripts/release/generate-patch-release-notes.sh
@@ -110,34 +110,104 @@ fi
 JQL=$(printf '%b' "${JQL_ENCODED//%/\\x}")
 JQL=${JQL//+/ }
 
-END_DATE=$(printf '%s' "$JQL" | sed -n 's/.*duedate <= "\([^"]*\)".*/\1/p')
+# Formats a YYYY-MM-DD date the way a release notes heading writes it, for example
+# "September 14, 2026". BSD date (macOS) is tried first and GNU date (Linux) second. An empty
+# date is refused rather than passed on, because the GNU fallback reads `date -d ""` as the
+# daylight saving time flag and silently returns today's date, which would date the release
+# notes wrongly instead of failing.
+# Params:
+# $1 - date in YYYY-MM-DD form
+# Prints the formatted date and returns 0, or returns 1 when the date cannot be parsed.
+format_release_date() {
+  local raw="$1"
 
-# Bail out on a missing due date rather than guessing one. On macOS the GNU fallback below
-# reads `date -d ""` as the daylight saving time flag and silently returns today's date,
-# which would date the release notes wrongly instead of failing.
+  if [[ -z "$raw" ]]; then
+    return 1
+  fi
+
+  if date -j -f "%Y-%m-%d" "$raw" +"%B %-d, %Y" 2>/dev/null; then
+    return 0
+  fi
+
+  if date -d "$raw" +"%B %-d, %Y" 2>/dev/null; then
+    return 0
+  fi
+
+  return 1
+}
+
+# The release date comes from the end of the due date window the candidates JQL searches. Jira
+# accepts both "duedate" and its "due" alias, and a candidates link can carry either, so both are
+# read. The last matching clause wins, because the window is written as a lower bound followed by
+# an upper one.
+END_DATE=$(printf '%s' "$JQL" \
+  | grep -oiE '(^|[^[:alnum:]_])due(date)?[[:space:]]*<=[[:space:]]*"[^"]+"' \
+  | tail -1 \
+  | sed -n 's/.*"\([^"]*\)".*/\1/p' || true)
+
+# A candidates JQL that searches on something other than a due date window, or whose due date is
+# not set yet, leaves the release date unknown. That is not a reason to stop, because the date is
+# only needed for the section heading, so ask for it instead. Leaving the answer empty records the
+# pending marker, and a later run refreshes the heading, so an unknown date is corrected the same
+# way a placeholder version is.
 if [[ -z "$END_DATE" ]]; then
-  echo "❌  No 'duedate <= \"YYYY-MM-DD\"' clause found in the candidates JQL" >&2
-  exit 1
+  echo "🟠 No 'due <= \"YYYY-MM-DD\"' clause found in the candidates JQL, so the release date is unknown." >&2
+
+  END_DATE="${PATCH_RELEASE_DATE:-}"
+
+  if [[ -z "$END_DATE" && -t 0 ]]; then
+    while true; do
+      if ! read -r -p "   Specify the release date as YYYY-MM-DD, or leave it empty to record '$PENDING_DATE': " END_DATE; then
+        # The input ended. Whatever was typed before it still counts as the reply, but there is
+        # no way to ask again, so an unusable one leaves the date pending rather than stopping.
+        if [[ -n "$END_DATE" ]] && ! format_release_date "$END_DATE" >/dev/null; then
+          echo "   '$END_DATE' is not a date in YYYY-MM-DD form, so the release date is left pending." >&2
+          END_DATE=""
+        fi
+
+        break
+      fi
+
+      if [[ -z "$END_DATE" ]] || format_release_date "$END_DATE" >/dev/null; then
+        break
+      fi
+
+      echo "   '$END_DATE' is not a date in YYYY-MM-DD form, for example 2026-09-14." >&2
+    done
+  fi
 fi
 
-# Try parsing with BSD date first (macOS), fallback to GNU date (Linux)
-if date -j -f "%Y-%m-%d" "$END_DATE" +"%B %-d, %Y" >/dev/null 2>&1; then
-  RELEASE_DATE=$(date -j -f "%Y-%m-%d" "$END_DATE" +"%B %-d, %Y")
-else
-  RELEASE_DATE=$(date -d "$END_DATE" +"%B %-d, %Y")
+if [[ -z "$END_DATE" ]]; then
+  RELEASE_DATE="$PENDING_DATE"
+  echo "ℹ️  No release date given, so the release notes heading records '$PENDING_DATE'. Re-run this script once the date is known to correct the heading."
+elif ! RELEASE_DATE=$(format_release_date "$END_DATE"); then
+  echo "❌  '$END_DATE' is not a date in YYYY-MM-DD form, for example 2026-09-14." >&2
+  exit 1
 fi
 
 # The fixVersion in the candidates JQL is often still a placeholder such as "4.9.x", so it
-# only seeds the release heading. The prompt below confirms the real version.
-RELEASE_PATCH=$(printf '%s' "$JQL" | sed -n 's/.*fixVersion IN (\([^)]*\)).*/\1/p')
+# only seeds the release heading. The prompt below confirms the real version. A candidates link
+# can name one version, "fixVersion = 4.9.x", or a list, "fixVersion IN (4.9.x)", so both are
+# read, and the value is unquoted either way.
+RELEASE_PATCH=$(printf '%s' "$JQL" | sed -n 's/.*fixVersion[[:space:]]*IN[[:space:]]*(\([^)]*\)).*/\1/p')
 
 if [[ -z "$RELEASE_PATCH" ]]; then
-  echo "❌  No 'fixVersion IN (...)' clause found in the candidates JQL" >&2
-  exit 1
+  RELEASE_PATCH=$(printf '%s' "$JQL" | sed -n 's/.*fixVersion[[:space:]]*=[[:space:]]*"\{0,1\}\([^"[:space:]]*\).*/\1/p')
+fi
+
+RELEASE_PATCH=${RELEASE_PATCH//\"/}
+
+# A clause in some other shape only costs the heading its seed, because the prompt below asks for
+# the version regardless, so say so and carry on rather than stopping.
+if [[ -z "$RELEASE_PATCH" ]]; then
+  echo "🟠 No fixVersion clause found in the candidates JQL, so the patch release version has to be given below." >&2
 fi
 
 echo "ℹ️  Extracted release date: $RELEASE_DATE."
-echo "ℹ️  Extracted release patch: $RELEASE_PATCH."
+
+if [[ -n "$RELEASE_PATCH" ]]; then
+  echo "ℹ️  Extracted release patch: $RELEASE_PATCH."
+fi
 
 # Reading nickfury needs credentials that can see a private repository, which come from the GitHub
 # CLI rather than from a token in .env. Whether the CLI is set up is reported below, and only if the
@@ -152,11 +222,18 @@ echo "ℹ️  Extracted release patch: $RELEASE_PATCH."
 RELEASE_PATCH_VERSION="${PATCH_RELEASE_VERSION:-}"
 
 if [[ -z "$RELEASE_PATCH_VERSION" && -t 0 ]]; then
+  # The placeholder prompt offers the version the candidates JQL reported, when it reported one.
+  if [[ -n "$RELEASE_PATCH" ]]; then
+    placeholder_hint=" [$RELEASE_PATCH]"
+  else
+    placeholder_hint=""
+  fi
+
   if confirm "Do you know the Palette patch release version?" y; then
     read -r -p "   Specify the Palette patch release version, for example 4.9.48: " RELEASE_PATCH_VERSION
   else
     echo "   The version heads the release notes section, so a placeholder stands in until it is known."
-    read -r -p "   Specify a placeholder version, for example 4.9.x [$RELEASE_PATCH]: " RELEASE_PATCH_VERSION
+    read -r -p "   Specify a placeholder version, for example 4.9.x$placeholder_hint: " RELEASE_PATCH_VERSION
   fi
 fi
 
@@ -164,6 +241,14 @@ fi
 # candidates JQL reported. That is usually a placeholder such as 4.9.x, which is a valid answer.
 if [[ -z "$RELEASE_PATCH_VERSION" ]]; then
   RELEASE_PATCH_VERSION="$RELEASE_PATCH"
+fi
+
+# With no version from either the prompt or the candidates JQL there is nothing to head the section
+# with, and unlike the release date a placeholder cannot be invented, because the version is the key
+# a later run matches the section on.
+if [[ -z "$RELEASE_PATCH_VERSION" ]]; then
+  echo "❌  No patch release version given. Specify one at the prompt, or set PATCH_RELEASE_VERSION." >&2
+  exit 1
 fi
 
 # A version is either a real patch release, such as 4.9.48, or a placeholder standing in for one,

--- a/scripts/release/utilities.sh
+++ b/scripts/release/utilities.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-# Markers written into a documentation table in place of a value that is not known yet. Each names
-# what is missing, so a reviewer can see which cells still need filling and can grep the docs for
-# "PENDING". They live here because the script that decides a value is pending and the scripts that
-# write the rows are not the same script, and a marker that differs between them would publish a
-# cell that no later run recognises as still pending.
+# Markers written into a documentation table or heading in place of a value that is not known yet.
+# Each names what is missing, so a reviewer can see what still needs filling and can grep the docs
+# for "PENDING". They live here because the script that decides a value is pending and the scripts
+# that write the rows are not the same script, and a marker that differs between them would publish
+# a cell that no later run recognises as still pending.
 PENDING_VERSION="VERSION PENDING"
 PENDING_URL="URL PENDING"
 PENDING_SHA="SHA PENDING"
+PENDING_DATE="DATE PENDING"
 
 # Utility function to generate parameterised files using placeholders and environment variables
 # Params: 


### PR DESCRIPTION
# ✅ Pull Request Checklist

Before submitting your PR for review, please complete this checklist to ensure quality.

## Checklist

- [x] The **PR description** in the [Describe the Change](#-describe-the-change) section explains what changed and provides any additional context.
- [ ] A **Jira ticket** is provided in the [Jira Tickets](#-jira-tickets) section AND in the PR title. _If this PR has no corresponding Jira ticket, then please indicate so in this section._
- [ ] **Preview links** are for all affected pages are provided in the [Changed Pages](#-changed-pages). _If this PR makes no user-facing changes, please indicate so in this section._
- [ ] Conduct a **self-review** for your pages using your preview links. Verify grammar, clarity, and accuracy.
- [ ] **Check formatting** for your pages
  - [ ] Verify indentations, admonitions, and tables (if applicable).
  - [ ] Verify all images display.
- [x] Ensure all **Vale comments** are resolved.
  - [ ] If required, raise a PR to modify the [Vale accept list](https://github.com/spectrocloud/spectro-vale-pkg/blob/main/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt). _This can be done later, but leave a note if required._
- [x] All **CI jobs** have completed successfully.
- [x] Add **Backport labels** if the change should be reflected in previous versions. _If required, remember to add the `auto-backport` label, as well as the `backport-version-**` labels._
- [ ] **Outside review:** Does this PR require review outside of Docs? If yes, tag the appropriate reviewer (for example, Engineering, Product, etc.)
- [x] Add the `notify-slack` label once this checklist has been completed. The team will be notified and review your PR.

Good job! 👏👏👏

---

## 📝 Describe the Change

`make generate-patch-release-notes` stopped before generating anything on a patch ticket whose candidates JQL reads `fixVersion = 4.10.x AND due > "..." AND due <= "..."`. Jira accepts `due` as an alias for `duedate` and `=` as an alternative to `IN (...)`, but the script only matched `duedate <= "..."` and `fixVersion IN (...)`, so it exited with `No 'duedate <= "YYYY-MM-DD"' clause found in the candidates JQL` even though the ticket had a due date.

This PR reads both spellings of the due date field and both shapes of the `fixVersion` clause, and stops treating a missing due date as fatal. Where no due date clause is found at all, the script now prompts for one as `YYYY-MM-DD` and records a `DATE PENDING` marker in the section heading when the answer is left empty. That marker follows the same pattern as the existing `VERSION PENDING` and `SHA PENDING` markers, and because re-running the target already refreshes the heading, a later run replaces it once the date is known. A missing `fixVersion` clause is likewise a warning rather than an exit, because that value only seeds a prompt that asks for the version anyway.

| Change | Where |
| --- | --- |
| `due` and `duedate` both read; last `<=` clause wins | `scripts/release/generate-patch-release-notes.sh` |
| Prompt, `PATCH_RELEASE_DATE`, and the `DATE PENDING` fallback | `scripts/release/generate-patch-release-notes.sh` |
| `fixVersion = X` accepted alongside `fixVersion IN (X)` | `scripts/release/generate-patch-release-notes.sh` |
| `PENDING_DATE` marker beside the existing markers | `scripts/release/utilities.sh` |
| `patch_release_date` form field wired to `PATCH_RELEASE_DATE` | `.github/workflows/generate_patch_release_notes.yaml` |
| The new prompt and the marker documented | `docs/contributing/release-process.md` |

Verified against the real candidates link that failed (extracts September 14, 2026 with no prompt), the older `duedate` / `IN (...)` shape, quoted and unquoted single fix versions, a missing due date clause attended and unattended, the prompt's retry and Ctrl-D paths, and rejected dates such as `2026`, `today`, and `2026-13-45`. That last set matters on macOS, where BSD `date -d` reads its argument as the daylight saving time flag and would otherwise turn an unparseable date into today's.

An unattended run with no `PATCH_RELEASE_DATE` records the pending marker rather than failing, which is a deliberate change to the workflow's behavior: a scheduled run on a ticket with no due date now produces a PR to fix up instead of a red job.

**Backports.** Only `backport-version-4-10` is labeled, because that branch is byte-identical to `master` for these four files and the bot can cherry-pick it cleanly. A test cherry-pick onto `version-4-9`, `4-8`, and `4-7` conflicts twice on each: those branches still define the `PENDING_*` markers inside the script rather than in `utilities.sh`, and their question table in `release-process.md` predates the per-architecture checksum rows. Both are pre-existing drift rather than anything this change introduces, so they are being raised as manual backports instead of labeled. `version-4-6` is skipped: its copy of the script is an older generation that has already missed several backports, so the fix would have to be rewritten rather than ported.

---

## 💻 Changed Pages

No user-facing changes. Only `docs/contributing/` and `scripts/` are touched, and the site builds from `docs/docs-content/` alone, so there is no preview URL for the changed page. The contributor documentation that changed is [docs/contributing/release-process.md](https://github.com/spectrocloud/librarium/blob/fix-patch-notes-due-date-optional/docs/contributing/release-process.md#patch-release-notes).

---

## 🎫 Jira Tickets

No corresponding Jira ticket. The bug surfaced while running the target for the patch release notes ticket DOC 3205, which this PR does not resolve.

_Related ticket keys are written unhyphenated and unlinked on purpose: the merge automation resolves every `browse/<KEY>` it finds in a PR body._
