### PR TITLE
[version-4-9] fix: make the patch release notes due date optional (#11951)

### DIFF
--- a/.github/workflows/generate_patch_release_notes.yaml
+++ b/.github/workflows/generate_patch_release_notes.yaml
@@ -14,6 +14,9 @@ on:
       patch_version:
         description: "Palette patch release version, for example 4.9.48. Use a placeholder such as 4.9.x while it is undecided. Empty takes the version from the candidates JQL."
         required: false
+      patch_release_date:
+        description: "Palette patch release date as YYYY-MM-DD, for example 2026-09-14. Empty takes the date from the candidates JQL, or records it as PENDING when that JQL has no due date."
+        required: false
       component_updates:
         description: "Tick when this patch adds a new CanvOS or Palette CLI version, or both. Leave clear to generate the release notes body only, in which case the two fields below are ignored."
         required: false
@@ -85,6 +88,7 @@ jobs:
           # nickfury repository that holds the component versions, so use the Vault token here.
           GITHUB_TOKEN: ${{ steps.import-secrets.outputs.VAULT_GITHUB_TOKEN }}
           PATCH_RELEASE_VERSION: ${{ github.event.inputs.patch_version }}
+          PATCH_RELEASE_DATE: ${{ github.event.inputs.patch_release_date }}
           NICKFURY_REF: ${{ github.event.inputs.nickfury_ref }}
           PATCH_PALETTE_CLI_SHA: ${{ github.event.inputs.palette_cli_sha }}
           PATCH_COMPONENT_UPDATES: ${{ github.event.inputs.component_updates }}

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -156,6 +156,7 @@ skipped when its environment variable is already set.
 | **Question**                                                      | **Answer**                                                                      | **Environment Variable**  |
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------- |
 | Do you know the Palette patch release version?                    | Yes, give the version. No, give a placeholder such as `4.9.x`.                  | `PATCH_RELEASE_VERSION`   |
+| The Palette patch release date                                    | Give it as `YYYY-MM-DD`, or leave it empty to record the date as pending.       | `PATCH_RELEASE_DATE`      |
 | Does this patch add a new CanvOS or Palette CLI version, or both? | No, only the release notes body is generated and no other page is touched.      | `PATCH_COMPONENT_UPDATES` |
 | Do you know the nickfury branch or tag name?                      | Yes, give the name. No, the pending markers are used instead.                   | `NICKFURY_REF`            |
 | The Palette CLI checksum                                          | Paste it from ReTool, type `derive`, or leave it empty to record it as pending. | `PATCH_PALETTE_CLI_SHA`   |
@@ -172,6 +173,13 @@ A patch ticket often names its `fixVersion` as a placeholder such as `4.9.x`, so
 prompt heads the new section. A placeholder is a valid answer, and pressing Enter accepts the one the candidates JQL
 reported. Re-running the target on the same ticket refreshes the section, including its heading, so you can draft the
 notes before the version is decided and re-run once it is confirmed.
+
+The section heading is dated from the end of the due date window that the candidates JQL searches. A ticket whose JQL
+searches on something else, or whose due date is not set yet, leaves the date unknown, so the target asks you for it.
+Leaving that answer empty heads the section with a `DATE PENDING` marker rather than stopping, and because a later run
+refreshes the heading, the run you make once the date is known replaces the marker. The target reads both spellings of
+the due date field, `due` and `duedate`, and both shapes of the `fixVersion` clause, a single value and a list, so a
+candidates link written either way is understood.
 
 Each generated section records the version it was built for in a `<!-- PATCH RELEASE VERSION: ... -->` comment. When a
 later run confirms a different version, the target removes the rows the earlier run wrote for the old one, so a

--- a/scripts/release/generate-patch-release-notes.sh
+++ b/scripts/release/generate-patch-release-notes.sh
@@ -36,6 +36,7 @@ DOWNLOADS_SHA_COLUMN=4
 PENDING_VERSION="VERSION PENDING"
 PENDING_URL="URL PENDING"
 PENDING_SHA="SHA PENDING"
+PENDING_DATE="DATE PENDING"
 
 if ! check_env "JIRA_EMAIL"; then
     echo "‼️  JIRA_EMAIL environment variable is not set. Please set it in your .env file. ‼️"
@@ -99,34 +100,104 @@ fi
 JQL=$(printf '%b' "${JQL_ENCODED//%/\\x}")
 JQL=${JQL//+/ }
 
-END_DATE=$(printf '%s' "$JQL" | sed -n 's/.*duedate <= "\([^"]*\)".*/\1/p')
+# Formats a YYYY-MM-DD date the way a release notes heading writes it, for example
+# "September 14, 2026". BSD date (macOS) is tried first and GNU date (Linux) second. An empty
+# date is refused rather than passed on, because the GNU fallback reads `date -d ""` as the
+# daylight saving time flag and silently returns today's date, which would date the release
+# notes wrongly instead of failing.
+# Params:
+# $1 - date in YYYY-MM-DD form
+# Prints the formatted date and returns 0, or returns 1 when the date cannot be parsed.
+format_release_date() {
+  local raw="$1"
 
-# Bail out on a missing due date rather than guessing one. On macOS the GNU fallback below
-# reads `date -d ""` as the daylight saving time flag and silently returns today's date,
-# which would date the release notes wrongly instead of failing.
+  if [[ -z "$raw" ]]; then
+    return 1
+  fi
+
+  if date -j -f "%Y-%m-%d" "$raw" +"%B %-d, %Y" 2>/dev/null; then
+    return 0
+  fi
+
+  if date -d "$raw" +"%B %-d, %Y" 2>/dev/null; then
+    return 0
+  fi
+
+  return 1
+}
+
+# The release date comes from the end of the due date window the candidates JQL searches. Jira
+# accepts both "duedate" and its "due" alias, and a candidates link can carry either, so both are
+# read. The last matching clause wins, because the window is written as a lower bound followed by
+# an upper one.
+END_DATE=$(printf '%s' "$JQL" \
+  | grep -oiE '(^|[^[:alnum:]_])due(date)?[[:space:]]*<=[[:space:]]*"[^"]+"' \
+  | tail -1 \
+  | sed -n 's/.*"\([^"]*\)".*/\1/p' || true)
+
+# A candidates JQL that searches on something other than a due date window, or whose due date is
+# not set yet, leaves the release date unknown. That is not a reason to stop, because the date is
+# only needed for the section heading, so ask for it instead. Leaving the answer empty records the
+# pending marker, and a later run refreshes the heading, so an unknown date is corrected the same
+# way a placeholder version is.
 if [[ -z "$END_DATE" ]]; then
-  echo "❌  No 'duedate <= \"YYYY-MM-DD\"' clause found in the candidates JQL" >&2
-  exit 1
+  echo "🟠 No 'due <= \"YYYY-MM-DD\"' clause found in the candidates JQL, so the release date is unknown." >&2
+
+  END_DATE="${PATCH_RELEASE_DATE:-}"
+
+  if [[ -z "$END_DATE" && -t 0 ]]; then
+    while true; do
+      if ! read -r -p "   Specify the release date as YYYY-MM-DD, or leave it empty to record '$PENDING_DATE': " END_DATE; then
+        # The input ended. Whatever was typed before it still counts as the reply, but there is
+        # no way to ask again, so an unusable one leaves the date pending rather than stopping.
+        if [[ -n "$END_DATE" ]] && ! format_release_date "$END_DATE" >/dev/null; then
+          echo "   '$END_DATE' is not a date in YYYY-MM-DD form, so the release date is left pending." >&2
+          END_DATE=""
+        fi
+
+        break
+      fi
+
+      if [[ -z "$END_DATE" ]] || format_release_date "$END_DATE" >/dev/null; then
+        break
+      fi
+
+      echo "   '$END_DATE' is not a date in YYYY-MM-DD form, for example 2026-09-14." >&2
+    done
+  fi
 fi
 
-# Try parsing with BSD date first (macOS), fallback to GNU date (Linux)
-if date -j -f "%Y-%m-%d" "$END_DATE" +"%B %-d, %Y" >/dev/null 2>&1; then
-  RELEASE_DATE=$(date -j -f "%Y-%m-%d" "$END_DATE" +"%B %-d, %Y")
-else
-  RELEASE_DATE=$(date -d "$END_DATE" +"%B %-d, %Y")
+if [[ -z "$END_DATE" ]]; then
+  RELEASE_DATE="$PENDING_DATE"
+  echo "ℹ️  No release date given, so the release notes heading records '$PENDING_DATE'. Re-run this script once the date is known to correct the heading."
+elif ! RELEASE_DATE=$(format_release_date "$END_DATE"); then
+  echo "❌  '$END_DATE' is not a date in YYYY-MM-DD form, for example 2026-09-14." >&2
+  exit 1
 fi
 
 # The fixVersion in the candidates JQL is often still a placeholder such as "4.9.x", so it
-# only seeds the release heading. The prompt below confirms the real version.
-RELEASE_PATCH=$(printf '%s' "$JQL" | sed -n 's/.*fixVersion IN (\([^)]*\)).*/\1/p')
+# only seeds the release heading. The prompt below confirms the real version. A candidates link
+# can name one version, "fixVersion = 4.9.x", or a list, "fixVersion IN (4.9.x)", so both are
+# read, and the value is unquoted either way.
+RELEASE_PATCH=$(printf '%s' "$JQL" | sed -n 's/.*fixVersion[[:space:]]*IN[[:space:]]*(\([^)]*\)).*/\1/p')
 
 if [[ -z "$RELEASE_PATCH" ]]; then
-  echo "❌  No 'fixVersion IN (...)' clause found in the candidates JQL" >&2
-  exit 1
+  RELEASE_PATCH=$(printf '%s' "$JQL" | sed -n 's/.*fixVersion[[:space:]]*=[[:space:]]*"\{0,1\}\([^"[:space:]]*\).*/\1/p')
+fi
+
+RELEASE_PATCH=${RELEASE_PATCH//\"/}
+
+# A clause in some other shape only costs the heading its seed, because the prompt below asks for
+# the version regardless, so say so and carry on rather than stopping.
+if [[ -z "$RELEASE_PATCH" ]]; then
+  echo "🟠 No fixVersion clause found in the candidates JQL, so the patch release version has to be given below." >&2
 fi
 
 echo "ℹ️  Extracted release date: $RELEASE_DATE."
-echo "ℹ️  Extracted release patch: $RELEASE_PATCH."
+
+if [[ -n "$RELEASE_PATCH" ]]; then
+  echo "ℹ️  Extracted release patch: $RELEASE_PATCH."
+fi
 
 # Reading nickfury needs a token that can see a private repository. Resolve it quietly here and
 # report on it only if the component versions are actually wanted, so a run that has none to record
@@ -149,11 +220,18 @@ fi
 RELEASE_PATCH_VERSION="${PATCH_RELEASE_VERSION:-}"
 
 if [[ -z "$RELEASE_PATCH_VERSION" && -t 0 ]]; then
+  # The placeholder prompt offers the version the candidates JQL reported, when it reported one.
+  if [[ -n "$RELEASE_PATCH" ]]; then
+    placeholder_hint=" [$RELEASE_PATCH]"
+  else
+    placeholder_hint=""
+  fi
+
   if confirm "Do you know the Palette patch release version?" y; then
     read -r -p "   Specify the Palette patch release version, for example 4.9.48: " RELEASE_PATCH_VERSION
   else
     echo "   The version heads the release notes section, so a placeholder stands in until it is known."
-    read -r -p "   Specify a placeholder version, for example 4.9.x [$RELEASE_PATCH]: " RELEASE_PATCH_VERSION
+    read -r -p "   Specify a placeholder version, for example 4.9.x$placeholder_hint: " RELEASE_PATCH_VERSION
   fi
 fi
 
@@ -161,6 +239,14 @@ fi
 # candidates JQL reported. That is usually a placeholder such as 4.9.x, which is a valid answer.
 if [[ -z "$RELEASE_PATCH_VERSION" ]]; then
   RELEASE_PATCH_VERSION="$RELEASE_PATCH"
+fi
+
+# With no version from either the prompt or the candidates JQL there is nothing to head the section
+# with, and unlike the release date a placeholder cannot be invented, because the version is the key
+# a later run matches the section on.
+if [[ -z "$RELEASE_PATCH_VERSION" ]]; then
+  echo "❌  No patch release version given. Specify one at the prompt, or set PATCH_RELEASE_VERSION." >&2
+  exit 1
 fi
 
 # A version is either a real patch release, such as 4.9.48, or a placeholder standing in for one,


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `version-4-9`:
 - [fix: make the patch release notes due date optional (#11951)](https://github.com/spectrocloud/librarium/pull/11951)

<!--- Backport version: manual -->

The auto-backport bot could not cherry-pick this cleanly, so it was resolved by hand. Two conflicts, both from pre-existing drift rather than from the change itself:

- `scripts/release/utilities.sh` — this branch keeps the `PENDING_*` markers in `scripts/release/generate-patch-release-notes.sh` rather than in `utilities.sh`, so the file is left untouched here and `PENDING_DATE="DATE PENDING"` is added to the marker block in the script instead. The script runs under `set -u` and the backported code reads `$PENDING_DATE`, so this part is required, not cosmetic.
- `docs/contributing/release-process.md` — this branch's question table predates the per-architecture checksum rows, so only the new release date row is added, in this branch's table shape. Master's three per-architecture rows are deliberately not brought across, because the script on this branch does not ask those questions.

Verified on the resolved tree: `bash -n` passes on both scripts, Prettier reports the changed page already conformant, and the date handling was exercised against the candidates JQL that prompted the fix (`due <= "..."`), the older `duedate <= "..."` shape, and a JQL with no due date clause at all, which records the pending marker instead of exiting.

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
